### PR TITLE
make the settings routes actually work

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ const bodyParser = require('body-parser');
 
 const app = express();
 
-app.use(bodyParser.urlencoded({extended: true}));
 app.use(bodyParser.json());
 
 app.use('/api/v1', require('./routes/api'));

--- a/app.js
+++ b/app.js
@@ -2,8 +2,12 @@
 
 // Initialize application framework.
 const express = require('express');
+const bodyParser = require('body-parser');
 
 const app = express();
+
+app.use(bodyParser.urlencoded({extended: true}));
+app.use(bodyParser.json());
 
 app.use('/api/v1', require('./routes/api'));
 

--- a/models/setting.js
+++ b/models/setting.js
@@ -27,7 +27,6 @@ SettingSchema.statics.getSettings = function () {
  */
 SettingSchema.statics.updateSettings = function (setting) {
   // there should only ever be one record unless something has gone wrong.
-  console.log('new setting', setting);
   return this.findOneAndUpdate({id: '1'}, {$set: setting}, {new: true});
 };
 

--- a/models/setting.js
+++ b/models/setting.js
@@ -12,12 +12,22 @@ const SettingSchema = new Schema({
   }
 });
 
+/**
+ * gets the entire settings record and sends it back
+ * @return {Promise} settings the whole settings record
+ */
 SettingSchema.statics.getSettings = function () {
-  return this.findOne();
+  return this.findOne({id: '1'});
 };
 
+/**
+ * this will update the settings object with whatever you pass in
+ * @param  {object} setting a hash of whatever settings you want to update
+ * @return {Promise} settings Promise that resolves to the entire (updated) settings object.
+ */
 SettingSchema.statics.updateSettings = function (setting) {
   // there should only ever be one record unless something has gone wrong.
+  console.log('new setting', setting);
   return this.findOneAndUpdate({id: '1'}, {$set: setting}, {new: true});
 };
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "homepage": "https://github.com/coralproject/talk#readme",
   "dependencies": {
+    "body-parser": "^1.15.2",
     "debug": "^2.2.0",
     "express": "^4.14.0",
     "mongoose": "^4.6.5"

--- a/routes/api/settings/index.js
+++ b/routes/api/settings/index.js
@@ -7,7 +7,7 @@ router.get('/', (req, res, next) => {
 });
 
 router.put('/', (req, res, next) => {
-  Setting.updateSettings(req.body).then(settings => res.json(settings)).catch(next);
+  Setting.updateSettings(req.body).then(() => res.status(204).end()).catch(next);
 });
 
 module.exports = router;

--- a/routes/api/settings/index.js
+++ b/routes/api/settings/index.js
@@ -3,11 +3,11 @@ const router = express.Router();
 const Setting = require('../../../models/setting');
 
 router.get('/', (req, res, next) => {
-  Setting.getSettings().then(res.json.bind(res)).catch(next);
+  Setting.getSettings().then(settings => res.json(settings)).catch(next);
 });
 
 router.put('/', (req, res, next) => {
-  Setting.updateSettings(req.body).then(res.json.bind(res)).catch(next);
+  Setting.updateSettings(req.body).then(settings => res.json(settings)).catch(next);
 });
 
 module.exports = router;

--- a/routes/api/settings/index.js
+++ b/routes/api/settings/index.js
@@ -3,11 +3,11 @@ const router = express.Router();
 const Setting = require('../../../models/setting');
 
 router.get('/', (req, res, next) => {
-  Setting.getSettings().then(res.json).catch(next);
+  Setting.getSettings().then(res.json.bind(res)).catch(next);
 });
 
 router.put('/', (req, res, next) => {
-  Setting.updateSettings(req.body).then(res.json).catch(next);
+  Setting.updateSettings(req.body).then(res.json.bind(res)).catch(next);
 });
 
 module.exports = router;

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -162,12 +162,6 @@ paths:
       responses:
         204:
           description: Updated Setting
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Setting'
-
-
 
 definitions:
   Item:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -150,14 +150,22 @@ paths:
       description: Settings
       responses:
         200:
-          description: OK
+          description: Get Setting
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Setting'
     put:
       tags:
         - Settings
       description: Settings
       responses:
         204:
-          description: OK
+          description: Updated Setting
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Setting'
 
 
 
@@ -212,3 +220,21 @@ definitions:
         type: string
       user_id:
         type: string
+  Setting:
+    type: object
+    properties:
+      id:
+        type: string
+      moderation:
+        type: string
+        enum:
+            - pre
+            - post
+      created_at:
+        type: string
+        format: date-time
+        description: Creation Date-Time
+      updated_at:
+        type: string
+        format: date-time
+        description: Updated Date-Time


### PR DESCRIPTION
## What does this PR do?

adds ability to pull json directly off `req.body` by adding some middleware. Add some doc blocks.

## How do I test this PR?

- make a GET request to `/api/v1/settings/` and you should get the current settings (assuming you've run `/bin/init.js`
- make a PUT request to `/api/v1/settings/` with a json payload of something like `{"moderation": "post"}` and you should get back the updated settings object.

@coralproject/tech

