### PR TITLE
enable css modules

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ app.use('/api/v1', require('./routes/api'));
 // Static Routes.
 app.use('/client/', express.static(path.join(__dirname, 'dist')));
 
-app.get('/admin/*', (req, res) => {
+app.get('/admin*', (req, res) => {
   res.render('admin', {basePath: '/client/coral-admin'});
 });
 

--- a/client/coral-admin/webpack.config.dev.js
+++ b/client/coral-admin/webpack.config.dev.js
@@ -14,7 +14,7 @@ module.exports = {
     loaders: [
       { test: /.js$/, loader: 'babel', include: path.join(__dirname, 'src'), exclude: /node_modules/ },
       { test: /\.json$/, loaders: 'json', include: __dirname, exclude: /node_modules/ },
-      { test: /.css$/, loaders: ['style-loader', 'css-loader?importLoaders=1', 'postcss-loader'] }
+      { test: /.css$/, loaders: ['style-loader', 'css-loader?modules&localIdentName=[name]__[local]___[hash:base64:5]', 'postcss-loader'] }
     ]
   },
   plugins: [ autoprefixer, precss ],

--- a/client/coral-admin/webpack.config.js
+++ b/client/coral-admin/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = Object.assign({}, devConfig, {
     loaders: [
       { test: /.js$/, loader: 'babel', include: [path.join(__dirname, 'src'), path.join(__dirname, '../', 'coral-framework')], exclude: /node_modules/ },
       { test: /.json$/, loader: 'json', include: __dirname, exclude: /node_modules/ },
-      { test: /.css$/, loaders: ['style-loader', 'css-loader?importLoaders=1', 'postcss-loader'] }
+      { test: /.css$/, loaders: ['style-loader', 'css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]', 'postcss-loader'] }
     ]
   },
   plugins: [

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "uuid": "^2.0.3"
   },
   "devDependencies": {
+    "autoprefixer": "6.5.0",
     "babel-core": "6.14.0",
     "babel-jest": "^15.0.0",
     "babel-loader": "6.2.5",
@@ -66,6 +67,7 @@
     "chai": "^3.5.0",
     "chai-http": "^3.0.0",
     "copy-webpack-plugin": "^3.0.1",
+    "css-loader": "0.25.0",
     "eslint": "^3.9.1",
     "exports-loader": "^0.6.3",
     "immutable": "^3.8.1",
@@ -73,6 +75,9 @@
     "json-loader": "^0.5.4",
     "mocha": "^3.1.2",
     "mocha-junit-reporter": "^1.12.1",
+    "postcss-loader": "0.13.0",
+    "postcss-modules": "0.5.2",
+    "precss": "1.4.0",
     "pre-git": "^3.10.0",
     "pym.js": "^1.1.1",
     "react": "15.3.2",
@@ -81,6 +86,7 @@
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
     "regenerator": "^0.8.46",
+    "style-loader": "0.13.1",
     "supertest": "^2.0.1",
     "timeago.js": "^2.0.3",
     "webpack": "^1.13.2",


### PR DESCRIPTION
## What does this PR do?

enables our css modules to work correctly in the webpack build

## How do I test this PR?

- `npm install` maybe?
- `npm run build`
- styles should now work in admin

@coralproject/tech

