### PR TITLE
initialize settings in an init file before app accepts requests

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -13,27 +13,31 @@ process.env.DEBUG = process.env.TALK_DEBUG;
 const app = require('../app');
 const debug = require('debug')('talk:server');
 const http = require('http');
+const initPromise = require('../init');
+let server;
 
-/**
- * Get port from environment and store in Express.
- */
+initPromise.then(() => {
+  /**
+  * Get port from environment and store in Express.
+  */
 
-const port = normalizePort(process.env.TALK_PORT || '3000');
-app.set('port', port);
+  const port = normalizePort(process.env.TALK_PORT || '3000');
+  app.set('port', port);
 
-/**
- * Create HTTP server.
- */
+  /**
+  * Create HTTP server.
+  */
 
-const server = http.createServer(app);
+  server = http.createServer(app);
 
-/**
- * Listen on provided port, on all network interfaces.
- */
+  /**
+  * Listen on provided port, on all network interfaces.
+  */
 
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+  server.listen(port);
+  server.on('error', onError);
+  server.on('listening', onListening);
+});
 
 /**
  * Normalize a port into a number, string, or false.

--- a/bin/www
+++ b/bin/www
@@ -14,31 +14,32 @@ const app = require('../app');
 const debug = require('debug')('talk:server');
 const http = require('http');
 const initPromise = require('../init');
+const port = normalizePort(process.env.TALK_PORT || '3000');
+
 let server;
 
 initPromise
-.then(() => {
-  /**
-  * Get port from environment and store in Express.
-  */
+  .then(() => {
+    /**
+    * Get port from environment and store in Express.
+    */
 
-  const port = normalizePort(process.env.TALK_PORT || '3000');
-  app.set('port', port);
+    app.set('port', port);
 
-  /**
-  * Create HTTP server.
-  */
+    /**
+    * Create HTTP server.
+    */
 
-  server = http.createServer(app);
+    server = http.createServer(app);
 
-  /**
-  * Listen on provided port, on all network interfaces.
-  */
+    /**
+    * Listen on provided port, on all network interfaces.
+    */
 
-  server.listen(port);
-  server.on('error', onError);
-  server.on('listening', onListening);
-});
+    server.listen(port);
+    server.on('error', onError);
+    server.on('listening', onListening);
+  });
 
 /**
  * Normalize a port into a number, string, or false.

--- a/bin/www
+++ b/bin/www
@@ -16,7 +16,8 @@ const http = require('http');
 const initPromise = require('../init');
 let server;
 
-initPromise.then(() => {
+initPromise
+.then(() => {
   /**
   * Get port from environment and store in Express.
   */

--- a/init.js
+++ b/init.js
@@ -1,0 +1,6 @@
+const Setting = require('./models/setting');
+
+const defaults = {id: '1', moderation: 'pre'};
+module.exports = Setting.init(defaults);
+
+// presumably this file will grow, which is why I've broken it out.

--- a/models/setting.js
+++ b/models/setting.js
@@ -12,6 +12,14 @@ const SettingSchema = new Schema({
 });
 
 /**
+ * this is run once when the app starts to ensure settings are populated
+ * @return {Promise} null initialize the global settings object
+ */
+SettingSchema.statics.init = function (defaults) {
+  return this.update({id: '1'}, {$setOnInsert: defaults}, {upsert: true});
+};
+
+/**
  * gets the entire settings record and sends it back
  * @return {Promise} settings the whole settings record
  */


### PR DESCRIPTION
## What does this PR do?

It was extremely frustrating to try and debug a problem and it ended up being that the tests nuked the db and settings were missing. This happened a few times a day, wasting time. I've moved the init script into the app start-up lifecycle, so the app will not accept requests until it's all ready to go.

## How do I test this PR?

- `npm start`
- curl `http://localhost:3000/api/v1/settings`
- response should not be `null`

@coralproject/tech

#48 
