### PR TITLE
Add settings to stream return

### DIFF
--- a/routes/api/stream/index.js
+++ b/routes/api/stream/index.js
@@ -1,44 +1,46 @@
+
 const express = require('express');
+const router = express.Router();
 
 const Comment = require('../../../models/comment');
 const User = require('../../../models/user');
 const Action = require('../../../models/action');
-
 const Setting = require('../../../models/setting');
 
-const router = express.Router();
 
-// Find all the comments by a specific asset_id.
+// Find all the comments, users, actions by a specific asset_id + settings.
 //  . if pre: get the comments that are accepted.
 //  . if post: get the comments that are new and accepted.
 router.get('/', (req, res, next) => {
-  const commentsPromise = Setting.getModerationSetting().then(({moderation}) => {
-    switch(moderation){
-    case 'pre':
-      return Comment.findAcceptedByAssetId(req.query.asset_id);
-    case 'post':
-      return  Comment.findAcceptedAndNewByAssetId(req.query.asset_id);
-    default:
-      throw new Error('Moderation setting not found.');
-    }
-  });
 
-  // Get all the users and actions for those comments.
+  const commentsPromise = Setting.getModerationSetting()
+    .then(({moderation}) => {
+      switch(moderation){
+      case 'pre':
+        return Comment.findAcceptedByAssetId(req.query.asset_id);
+      case 'post':
+        return  Comment.findAcceptedAndNewByAssetId(req.query.asset_id);
+      default:
+        throw new Error('Moderation setting not found.');
+      }
+    });
+
+  // Get all the users and actions for those comments + the settings.
   commentsPromise.then(comments => {
     return Promise.all([
       comments,
       User.findByIdArray(comments.map((comment) => comment.author_id)),
-      Action.getActionSummaries(comments.map((comment) => comment.id))
+      Action.getActionSummaries(comments.map((comment) => comment.id)),
+      Setting.getModerationSetting()
     ]);
-  }).then(([comments, users, actions]) => {
+  }).then(([comments, users, actions, settings]) => {
     res.json({
       comments,
       users,
-      actions
+      actions,
+      settings
     });
-  }).catch(error => {
-    next(error);
-  });
+  }).catch(next);
 });
 
 module.exports = router;

--- a/routes/api/stream/index.js
+++ b/routes/api/stream/index.js
@@ -7,7 +7,6 @@ const User = require('../../../models/user');
 const Action = require('../../../models/action');
 const Setting = require('../../../models/setting');
 
-
 // Find all the comments, users, actions by a specific asset_id + settings.
 //  . if pre: get the comments that are accepted.
 //  . if post: get the comments that are new and accepted.

--- a/tests/routes/api/stream/index.js
+++ b/tests/routes/api/stream/index.js
@@ -83,7 +83,7 @@ describe('api/stream: routes', () => {
 
   });
 
-  it('should return a stream with comments, users and actions', () => {
+  it('should return a stream with comments, users, actions and settings', () => {
     return chai.request(app)
       .get('/api/v1/stream')
       .query({'asset_id': 'asset'})
@@ -92,6 +92,7 @@ describe('api/stream: routes', () => {
         expect(res.body.comments.length).to.equal(1);
         expect(res.body.users.length).to.equal(1);
         expect(res.body.actions.length).to.equal(1);
+        expect(res.body.settings.moderation).to.equal('pre');
       });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds a settings object to the response of the GET stream endpoint. The settings object currently contains the pre/post moderation setting, which the FE needs to know how to message the user upon posting. This object will contain future settings and may be used to serve dynamic settings per asset or user in the future.

## How do I test this PR?

npm run test

or

look for the settings object in your friendly neighborhood `/api/v1/stream?asset_id=xxx` response.

@coralproject/tech

