### PR TITLE
Fixing notification langauge.

### DIFF
--- a/client/coral-plugin-commentbox/translations.json
+++ b/client/coral-plugin-commentbox/translations.json
@@ -5,7 +5,7 @@
     "comment": "Comment",
     "name": "Name",
     "comment-post-notif": "Your comment has been posted.",
-    "comment-post-notif-premod": "Thank you for reporting this comment. Our moderation team has been notified and will review it shortly."
+    "comment-post-notif-premod": "Thank you for posting. Our moderation team will review your comment shortly."
   },
   "es": {
     "post": "Publicar",


### PR DESCRIPTION
## What does this PR do?

Fixes language on premod notification.

## How do I test this PR?

1. Post a comment when premod is on.
2. Notification should read: 'Thank you for posting. Our moderation team will review your comment shortly.'

@coralproject/tech

