### PR TITLE
Reply update

### DIFF
--- a/client/coral-embed-stream/src/CommentStream.js
+++ b/client/coral-embed-stream/src/CommentStream.js
@@ -162,7 +162,7 @@ class CommentStream extends Component {
                       let reply = this.props.items.comments[replyId];
                       return <div className="reply" key={replyId}>
                         <hr aria-hidden={true}/>
-                        <AuthorName author={users[comment.author_id]}/>
+                        <AuthorName author={users[reply.author_id]}/>
                         <PubDate created_at={reply.created_at}/>
                         <Content body={reply.body}/>
                         <div className="replyActionsLeft">

--- a/client/coral-embed-stream/src/CommentStream.js
+++ b/client/coral-embed-stream/src/CommentStream.js
@@ -121,7 +121,8 @@ class CommentStream extends Component {
                 <div className="commentActionsLeft">
                   <ReplyButton
                     updateItem={this.props.updateItem}
-                    id={commentId}/>
+                    id={commentId}
+                    showReply={comment.showReply}/>
                   <LikeButton
                     addNotification={this.props.addNotification}
                     id={commentId}
@@ -168,7 +169,8 @@ class CommentStream extends Component {
                         <div className="replyActionsLeft">
                             <ReplyButton
                               updateItem={this.props.updateItem}
-                              parent_id={reply.parent_id}/>
+                              id={replyId}
+                              showReply={reply.showReply}/>
                             <LikeButton
                               addNotification={this.props.addNotification}
                               id={replyId}
@@ -194,6 +196,17 @@ class CommentStream extends Component {
                                 asset_id={rootItemId}
                                 />
                           </div>
+                          <ReplyBox
+                            addNotification={this.props.addNotification}
+                            postItem={this.props.postItem}
+                            appendItemArray={this.props.appendItemArray}
+                            updateItem={this.props.updateItem}
+                            id={rootItemId}
+                            author={user}
+                            parent_id={commentId}
+                            child_id={replyId}
+                            premod={this.props.config.moderation}
+                            showReply={reply.showReply}/>
                       </div>;
                     })
                 }

--- a/client/coral-plugin-commentbox/CommentBox.js
+++ b/client/coral-plugin-commentbox/CommentBox.js
@@ -22,7 +22,7 @@ class CommentBox extends Component {
   }
 
   postComment = () => {
-    const {postItem, updateItem, id, parent_id, addNotification, appendItemArray, premod, author} = this.props;
+    const {postItem, updateItem, id, parent_id, child_id, addNotification, appendItemArray, premod, author} = this.props;
     let comment = {
       body: this.state.body,
       asset_id: id,
@@ -38,7 +38,7 @@ class CommentBox extends Component {
       related = 'comments';
       parent_type = 'assets';
     }
-    updateItem(parent_id, 'showReply', false, 'comments');
+    updateItem(child_id || parent_id, 'showReply', false, 'comments');
     postItem(comment, 'comments')
     .then((comment_id) => {
       if (premod === 'pre') {

--- a/client/coral-plugin-replies/ReplyButton.js
+++ b/client/coral-plugin-replies/ReplyButton.js
@@ -6,7 +6,7 @@ const name = 'coral-plugin-replies';
 
 const ReplyButton = (props) => <button
     className={`${name}-reply-button`}
-    onClick={() => props.updateItem(props.id || props.parent_id, 'showReply', true, 'comments')}>
+    onClick={() => props.updateItem(props.id, 'showReply', !props.showReply, 'comments')}>
     {lang.t('reply')}
     <i className={`${name}-icon material-icons`}
       aria-hidden={true}>reply</i>


### PR DESCRIPTION
## What does this PR do?

- Moves reply box underneath child replies.
- Hides reply box when the user clicks "reply" a second time.
- Addresses bug where comment author appears as reply author.

## How do I test this PR?

- Click the `Reply` button on a reply. An input box should appear directly under that button.
- Replies should have the appropriate authors, not the author of their parent comment.
- Click any `Reply` button twice. The reply box should appear and then disappear.

@coralproject/tech
