### PR TITLE
retreiving comments based on settings was backwards

### DIFF
--- a/routes/api/stream/index.js
+++ b/routes/api/stream/index.js
@@ -40,7 +40,7 @@ router.get('/', (req, res, next) => {
     // Fetch the appropriate comments stream.
     let comments;
 
-    if (settings.moderation === 'post') {
+    if (settings.moderation === 'pre') {
       comments = Comment.findAcceptedByAssetId(asset.id);
     } else {
       comments = Comment.findAcceptedAndNewByAssetId(asset.id);

--- a/tests/routes/api/stream/index.js
+++ b/tests/routes/api/stream/index.js
@@ -17,7 +17,7 @@ describe('/api/v1/stream', () => {
 
   const settings = {
     id: '1',
-    moderation: 'pre'
+    moderation: 'post'
   };
 
   const comments = [{
@@ -73,7 +73,7 @@ describe('/api/v1/stream', () => {
         .findOrCreateByUrl('http://coralproject.net/asset2')
         .then((asset) => {
           return Asset
-            .overrideSettings(asset.id, {moderation: 'post'})
+            .overrideSettings(asset.id, {moderation: 'pre'})
             .then(() => asset);
         })
     ])
@@ -108,7 +108,7 @@ describe('/api/v1/stream', () => {
           expect(res.body.comments.length).to.equal(2);
           expect(res.body.users.length).to.equal(2);
           expect(res.body.actions.length).to.equal(1);
-          expect(res.body.settings).to.have.property('moderation', 'pre');
+          expect(res.body.settings).to.have.property('moderation', 'post');
         });
     });
 
@@ -121,7 +121,7 @@ describe('/api/v1/stream', () => {
           expect(res.body.assets.length).to.equal(1);
           expect(res.body.comments.length).to.equal(1);
           expect(res.body.users.length).to.equal(1);
-          expect(res.body.settings).to.have.property('moderation', 'post');
+          expect(res.body.settings).to.have.property('moderation', 'pre');
         });
     });
   });


### PR DESCRIPTION
## What does this PR do?

The stream endpoint was returning the wrong comments e.g. `pre` comments when `post` was set. This PR fixes it and updates the tests.

## How do I test this PR?

- remove all your comments
- have moderation to `post`
- make a comment. it should appear
- refresh the page. it should still be there.

