### PR TITLE
restoring the scroll to comment functionality

### DIFF
--- a/client/coral-embed-stream/style/default.css
+++ b/client/coral-embed-stream/style/default.css
@@ -113,7 +113,6 @@ hr {
 
 /* Comment styles */
 .comment {
-  position: relative;
   margin-bottom: 10px;
   position: relative;
 }


### PR DESCRIPTION
## What does this PR do?

Someone was probably merging conflicts and accidentally nuked the Permalink scroll to comment functionality. This PR restores that amazing, golden code.

## How do I test this PR?

- get a permalink
- open it in a new tab, it should scroll to your comment

