### PR TITLE
add host and port because GCP is silly

### DIFF
--- a/services/mailer.js
+++ b/services/mailer.js
@@ -1,27 +1,34 @@
 const nodemailer = require('nodemailer');
 
-const smtpProps = [
+const smtpRequiredProps = [
   'TALK_SMTP_USERNAME',
-  'TALK_SMTP_PASSWORD',
-  'TALK_SMTP_HOST',
-  'TALK_SMTP_PORT'
+  'TALK_SMTP_PASSWORD'
 ];
 
-smtpProps.forEach(prop => {
+smtpRequiredProps.forEach(prop => {
   if (!process.env[prop]) {
     console.error(`process.env.${prop} should be defined if you would like to send password reset emails from Talk`);
   }
 });
 
-const defaultTransporter = nodemailer.createTransport({
-  // https://github.com/nodemailer/nodemailer-wellknown#supported-services
-  host: process.env.TALK_SMTP_HOST,
-  port: process.env.TALK_SMTP_PORT,
+// https://github.com/nodemailer/nodemailer-wellknown#supported-services
+const options = {
+  service: 'SendGrid',
   auth: {
     user: process.env.TALK_SMTP_USERNAME,
     pass: process.env.TALK_SMTP_PASSWORD
   }
-});
+};
+
+if (process.env.TALK_SMTP_PORT) {
+  options.port = process.env.TALK_SMTP_PORT;
+}
+
+if (process.env.TALK_SMTP_HOST) {
+  options.host = process.env.TALK_SMTP_HOST;
+}
+
+const defaultTransporter = nodemailer.createTransport(options);
 
 const mailer = {
 

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -2,7 +2,8 @@ const nodemailer = require('nodemailer');
 
 const smtpRequiredProps = [
   'TALK_SMTP_USERNAME',
-  'TALK_SMTP_PASSWORD'
+  'TALK_SMTP_PASSWORD',
+  'TALK_SMTP_PROVIDER'
 ];
 
 smtpRequiredProps.forEach(prop => {
@@ -11,9 +12,10 @@ smtpRequiredProps.forEach(prop => {
   }
 });
 
-// https://github.com/nodemailer/nodemailer-wellknown#supported-services
 const options = {
-  service: 'SendGrid',
+  // list of providers here:
+  // https://github.com/nodemailer/nodemailer-wellknown#supported-services
+  service: process.env.TALK_SMTP_PROVIDER,
   auth: {
     user: process.env.TALK_SMTP_USERNAME,
     pass: process.env.TALK_SMTP_PASSWORD

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -1,12 +1,22 @@
 const nodemailer = require('nodemailer');
 
-if (!process.env.TALK_SMTP_USERNAME || !process.env.TALK_SMTP_PASSWORD) {
-  console.error('TALK_SMTP_USERNAME and TALK_SMTP_PASSWORD should be defined if you would like to send password reset emails from Talk');
-}
+const smtpProps = [
+  'TALK_SMTP_USERNAME',
+  'TALK_SMTP_PASSWORD',
+  'TALK_SMTP_HOST',
+  'TALK_SMTP_PORT'
+];
+
+smtpProps.forEach(prop => {
+  if (!process.env[prop]) {
+    console.error(`process.env.${prop} should be defined if you would like to send password reset emails from Talk`);
+  }
+});
 
 const defaultTransporter = nodemailer.createTransport({
   // https://github.com/nodemailer/nodemailer-wellknown#supported-services
-  service: 'SendGrid',
+  host: process.env.TALK_SMTP_HOST,
+  port: process.env.TALK_SMTP_PORT,
   auth: {
     user: process.env.TALK_SMTP_USERNAME,
     pass: process.env.TALK_SMTP_PASSWORD


### PR DESCRIPTION
## What does this PR do?

GCP blocks port 25 and 587 by default because why not. This PR allows you to set an optional custom port and hostname for smtp.

## How do I test this PR?

- add `TALK_SMTP_PROVIDER`, `TALK_SMTP_HOST` and `TALK_SMTP_PORT` to your config
- try to send a password reset email
