### PR TITLE
Updating signup endpoint to reflect current api.

### DIFF
--- a/client/coral-framework/actions/auth.js
+++ b/client/coral-framework/actions/auth.js
@@ -73,7 +73,7 @@ const signUpFailure = error => ({type: actions.FETCH_SIGNUP_FAILURE, error});
 
 export const fetchSignUp = formData => dispatch => {
   dispatch(signUpRequest());
-  coralApi('/user', {method: 'POST', body: formData})
+  coralApi('/users', {method: 'POST', body: formData})
     .then(({user}) => {
       dispatch(signUpSuccess(user));
       setTimeout(() =>{


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the user cannot sign up for a new account. This is caused by an out-of-date api path in the auth actions file.

## How do I test this PR?

1. Sign up for a new account.
2. It should work.