### PR TITLE
comments not showing on embed page

### DIFF
--- a/client/coral-embed-stream/src/CommentStream.js
+++ b/client/coral-embed-stream/src/CommentStream.js
@@ -61,7 +61,11 @@ class CommentStream extends Component {
     // Set up messaging between embedded Iframe an parent component
     this.pym = new Pym.Child({polling: 100});
 
-    const path = this.pym.parentUrl.split('#')[0];
+    let path = this.pym.parentUrl.split('#')[0];
+
+    if (!path) {
+      path = window.location.href.split('#')[0];
+    }
 
     this.props.getStream(path || window.location);
     this.path = path;


### PR DESCRIPTION
## What does this PR do?

if you linked to a comment created on `/embed/stream` it would not show up. Now it does ✨ 

## How do I test this PR?

- create a comment from `localhost:3000/embed/stream`
- open a Permalink or view your comments in Settings and navigate to that link
- it should show the stream of comments previously attached to `localhost:3000/embed/stream`

