### PR TITLE
Adding show shortcuts button and minor fixes

### DIFF
--- a/client/coral-admin/src/components/BanUserDialog.js
+++ b/client/coral-admin/src/components/BanUserDialog.js
@@ -14,7 +14,7 @@ const BanUserDialog = ({open, handleClose, onClickBanUser, user = {}}) => {
 
   return (
     <Dialog className={styles.dialog} open={open} onClose={() => handleClose()} onCancel={() => handleClose()} title={lang.t('bandialog.ban_user')}>
-    <span className={styles.close} onClick={() => handleClose()}>×</span>
+      <span className={styles.close} onClick={() => handleClose()}>×</span>
       <div>
         <div className={styles.header}>
           <h3>

--- a/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.css
+++ b/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.css
@@ -14,6 +14,18 @@
   color: white;
 }
 
+.showShortcuts {
+  position: absolute;
+  right: 130px;
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+
+  span {
+    margin-left: 7px;
+  }
+}
+
 @media (--big-viewport) {
   .tab {
     flex: none;

--- a/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.js
+++ b/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.js
@@ -72,7 +72,7 @@ class ModerationQueue extends React.Component {
   }
 
   showShortcuts () {
-    this.setState({ modalOpen: true });
+    this.setState({modalOpen: true});
   }
 
   onTabClick (activeTab) {

--- a/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.js
+++ b/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
+import {Icon} from 'react-mdl';
 import key from 'keymaster';
 
 import ModerationKeysModal from 'components/ModerationKeysModal';
@@ -70,6 +71,10 @@ class ModerationQueue extends React.Component {
     this.props.dispatch(banUser('banned', userId, commentId));
   }
 
+  showShortcuts () {
+    this.setState({ modalOpen: true });
+  }
+
   onTabClick (activeTab) {
     this.setState({activeTab});
   }
@@ -93,6 +98,11 @@ class ModerationQueue extends React.Component {
               className={`mdl-tabs__tab ${styles.tab}`}>{lang.t('modqueue.rejected')}</a>
             <a href='#flagged' onClick={() => this.onTabClick('flagged')}
               className={`mdl-tabs__tab ${styles.tab}`}>{lang.t('modqueue.flagged')}</a>
+            <a href='#' onClick={() => this.showShortcuts()}
+              className={`mdl-tabs__tab ${styles.tab} ${styles.showShortcuts}`}>
+              <Icon name='keyboard' />
+              <span>{lang.t('modqueue.showshortcuts')}</span>
+            </a>
           </div>
           <div className={`mdl-tabs__panel is-active ${styles.listContainer}`} id='pending'>
             <CommentList

--- a/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.js
+++ b/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.js
@@ -71,7 +71,7 @@ class ModerationQueue extends React.Component {
     this.props.dispatch(banUser('banned', userId, commentId));
   }
 
-  showShortcuts () {
+  showShortcuts = () => {
     this.setState({modalOpen: true});
   }
 
@@ -98,7 +98,7 @@ class ModerationQueue extends React.Component {
               className={`mdl-tabs__tab ${styles.tab}`}>{lang.t('modqueue.rejected')}</a>
             <a href='#flagged' onClick={() => this.onTabClick('flagged')}
               className={`mdl-tabs__tab ${styles.tab}`}>{lang.t('modqueue.flagged')}</a>
-            <a href='#' onClick={() => this.showShortcuts()}
+            <a href='#' onClick={this.showShortcuts}
               className={`mdl-tabs__tab ${styles.tab} ${styles.showShortcuts}`}>
               <Icon name='keyboard' />
               <span>{lang.t('modqueue.showshortcuts')}</span>

--- a/client/coral-admin/src/translations.json
+++ b/client/coral-admin/src/translations.json
@@ -28,7 +28,8 @@
       "nextcomment": "Go to the next comment",
       "prevcomment": "Go to the previous comment",
       "singleview": "Toggle single comment edit view",
-      "thismenu": "Open this menu"
+      "thismenu": "Open this menu",
+      "showshortcuts": "Show Shortcuts"
     },
     "comment": {
       "flagged": "flagged",
@@ -95,7 +96,8 @@
       "rejected": "rechazado",
       "flagged": "marcado",
       "shortcuts": "Atajos de teclado",
-      "close": "Cerrar"
+      "close": "Cerrar",
+      "showshortcuts": "Mostrar atajos"
     },
     "comment": {
       "flagged": "marcado",

--- a/client/coral-plugin-commentbox/CommentBox.js
+++ b/client/coral-plugin-commentbox/CommentBox.js
@@ -103,7 +103,7 @@ class CommentBox extends Component {
         <div className={`${name}-button-container`}>
           { author && (
               <Button
-                cStyle={length > charCount ? 'lightGrey' : 'darkGrey'}
+                cStyle={!length || (charCount && length > charCount) ? 'lightGrey' : 'darkGrey'}
                 className={`${name}-button`}
                 onClick={this.postComment}>
                 {lang.t('post')}

--- a/client/coral-ui/components/Dialog.js
+++ b/client/coral-ui/components/Dialog.js
@@ -1,5 +1,4 @@
 import React, {Component, PropTypes} from 'react';
-import ReactDOM from 'react-dom';
 import dialogPolyfill from 'dialog-polyfill';
 import 'dialog-polyfill/dialog-polyfill.css';
 

--- a/client/coral-ui/components/Dialog.js
+++ b/client/coral-ui/components/Dialog.js
@@ -19,7 +19,7 @@ export default class Dialog extends Component {
   };
 
   componentDidMount(){
-    const dialog = ReactDOM.findDOMNode(this.refs.dialog);
+    const dialog = this.dialog;
     dialogPolyfill.registerDialog(dialog);
 
     if (this.props.open) {
@@ -31,7 +31,7 @@ export default class Dialog extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const dialog = ReactDOM.findDOMNode(this.refs.dialog);
+    const dialog = this.dialog;
     if (this.props.open !== prevProps.open) {
       if (this.props.open) {
         dialog.showModal();
@@ -42,7 +42,7 @@ export default class Dialog extends Component {
   }
 
   componentWillUnmount() {
-    const dialog = ReactDOM.findDOMNode(this.refs.dialog);
+    const dialog = this.dialog;
     dialog.removeEventListener('cancel', this.props.onCancel);
   }
 
@@ -51,7 +51,7 @@ export default class Dialog extends Component {
 
     return (
       <dialog
-        ref="dialog"
+        ref={el => { this.dialog = el; }}
         className={`mdl-dialog ${className}`}
         {...rest}
       >


### PR DESCRIPTION
## What does this PR do?

- Adds a `Show shortcuts` button on the moderation queue admin
- Fixes the post button disable logic on the comment stream
- Fixes the use of refs in Dialog.js on coral-ui

## How do I test this PR?

### Adds a `Show shortcuts` button on the moderation queue admin

- Go to the moderation admin
- Click on the Show Shortcuts button at the top right
- Enjoy our cool keyboard shortcuts

### Fixes the post button disable logic on the comment stream

- Go to the comment stream
- Write a comment, it should disable the post button when it makes sense (if you ran out of characters or the comment has no length)