### PR TITLE
FROM field in pw reset email should be an environment variable

### DIFF
--- a/routes/api/users/index.js
+++ b/routes/api/users/index.js
@@ -119,7 +119,7 @@ router.post('/request-password-reset', (req, res, next) => {
 
       const options = {
         subject: 'Password Reset Requested - Talk',
-        from: 'noreply@coralproject.net',
+        from: process.env.TALK_SMTP_FROM_ADDRESS,
         to: email,
         html: resetEmailTemplate({
           token,

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -1,6 +1,7 @@
 const nodemailer = require('nodemailer');
 
 const smtpRequiredProps = [
+  'TALK_SMTP_FROM_ADDRESS',
   'TALK_SMTP_USERNAME',
   'TALK_SMTP_PASSWORD',
   'TALK_SMTP_HOST'


### PR DESCRIPTION
## What does this PR do?

allows users to set the "from" field on the password reset emails. (currently hardcoded)

## How do I test this PR?

- start the app. it should warn you about not having `process.env.TALK_SMTP_FROM_ADDRESS` set
- set that environment variable and restart the app
- send yourself a password reset email
- the "from" field should be whatever you set it to ✨ 
