### PR TITLE
Fix test on Suspected words

### DIFF
--- a/routes/api/comments/index.js
+++ b/routes/api/comments/index.js
@@ -137,7 +137,7 @@ router.post('/', wordlist.filter('body'), (req, res, next) => {
   .then((comment) => {
     if (req.wordlist.suspect) {
       return Comment
-        .addAction(comment.id, null, 'flag', 'body', 'Matched suspect word filters.')
+        .addAction(comment.id, null, 'flag', {field: 'body', details: 'Matched suspect word filters.'})
         .then(() => comment);
     }
 

--- a/tests/routes/api/comments/index.js
+++ b/tests/routes/api/comments/index.js
@@ -225,8 +225,9 @@ describe('/api/v1/comments', () => {
           let action = actions[0];
 
           expect(action).to.have.property('item_id', comment.id);
-          expect(action).to.have.property('field', 'body');
-          expect(action).to.have.property('detail', 'Matched suspect word filters.');
+          expect(action).to.have.property('metadata');
+          expect(action.metadata).to.have.property('field', 'body');
+          expect(action.metadata).to.have.property('details', 'Matched suspect word filters.');
         });
     });
 


### PR DESCRIPTION
## What does this PR do?

When adding a flag action the metadata field was missing. This PR adds this field metadata (that contains field and details) and fix the test.

## How do I test this PR?

- npm test
