### PR TITLE
make the admin screen load

### DIFF
--- a/client/coral-admin/src/components/CommentList.js
+++ b/client/coral-admin/src/components/CommentList.js
@@ -21,6 +21,7 @@ export default class CommentList extends React.Component {
     comments: PropTypes.object.isRequired,
     users: PropTypes.object.isRequired,
     onClickAction: PropTypes.func,
+    
     // list of actions (flags, etc) associated with the comments
     modActions: PropTypes.arrayOf(PropTypes.string).isRequired,
     loading: PropTypes.bool,

--- a/client/coral-admin/src/components/CommentList.js
+++ b/client/coral-admin/src/components/CommentList.js
@@ -21,12 +21,11 @@ export default class CommentList extends React.Component {
     comments: PropTypes.object.isRequired,
     users: PropTypes.object.isRequired,
     onClickAction: PropTypes.func,
-    modActions: PropTypes.arrayOf(PropTypes.string),
+    // list of actions (flags, etc) associated with the comments
+    modActions: PropTypes.arrayOf(PropTypes.string).isRequired,
     loading: PropTypes.bool,
 
-    // list of actions (flags, etc) associated with the comments
-    actions: PropTypes.arrayOf(PropTypes.string),
-    suspectWords: PropTypes.arrayOf(PropTypes.string)
+    suspectWords: PropTypes.arrayOf(PropTypes.string).isRequired
   }
 
   constructor (props) {

--- a/client/coral-admin/src/containers/ModerationQueue/ModerationContainer.js
+++ b/client/coral-admin/src/containers/ModerationQueue/ModerationContainer.js
@@ -80,6 +80,7 @@ class ModerationContainer extends React.Component {
 
 const mapStateToProps = state => ({
   comments: state.comments.toJS(),
+  settings: state.settings.toJS(),
   users: state.users.toJS()
 });
 

--- a/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.js
+++ b/client/coral-admin/src/containers/ModerationQueue/ModerationQueue.js
@@ -23,6 +23,7 @@ export default ({onTabClick, ...props}) => (
       </div>
       <div className={`mdl-tabs__panel is-active ${styles.listContainer}`} id='pending'>
         <CommentList
+          suspectWords={props.settings.settings.wordlist.suspect}
           isActive={props.activeTab === 'pending'}
           singleView={props.singleView}
           commentIds={props.premodIds}
@@ -30,7 +31,7 @@ export default ({onTabClick, ...props}) => (
           users={props.users.byId}
           onClickAction={props.updateStatus}
           onClickShowBanDialog={props.showBanUserDialog}
-          actions={['reject', 'approve', 'ban']}
+          modActions={['reject', 'approve', 'ban']}
           loading={props.comments.loading}/>
         <BanUserDialog
           open={props.comments.showBanUserDialog}
@@ -41,25 +42,27 @@ export default ({onTabClick, ...props}) => (
       </div>
       <div className={`mdl-tabs__panel ${styles.listContainer}`} id='rejected'>
         <CommentList
+          suspectWords={props.settings.settings.wordlist.suspect}
           isActive={props.activeTab === 'rejected'}
           singleView={props.singleView}
           commentIds={props.rejectedIds}
           comments={props.comments.byId}
           users={props.users.byId}
           onClickAction={props.updateStatus}
-          actions={['approve']}
+          modActions={['approve']}
           loading={props.comments.loading}
         />
       </div>
       <div className={`mdl-tabs__panel ${styles.listContainer}`} id='flagged'>
         <CommentList
+          suspectWords={props.settings.settings.wordlist.suspect}
           isActive={props.activeTab === 'rejected'}
           singleView={props.singleView}
           commentIds={props.flaggedIds}
           comments={props.comments.byId}
           users={props.users.byId}
           onClickAction={props.updateStatus}
-          actions={['reject', 'approve']}
+          modActions={['reject', 'approve']}
           loading={props.comments.loading}/>
       </div>
       <ModerationKeysModal open={props.modalOpen} onClose={props.closeModal} />

--- a/client/coral-admin/src/reducers/settings.js
+++ b/client/coral-admin/src/reducers/settings.js
@@ -37,7 +37,7 @@ const updateSettings = (state, action) => {
 
 // any nested settings must have a specialized setter
 const updateWordlist = (state, action) => {
-  return state.setIn(['settings', 'wordlist', action.listName], action.wordlist);
+  return state.setIn(['settings', 'wordlist', action.listName], action.list);
 };
 
 const saveComplete = (state, action) => {


### PR DESCRIPTION
## What does this PR do?

I think some changes got overwritten with old code. I re-added some state and got it updated. I clicked around and I think everything else is still working.

## How do I test this PR?

- admin pages should load
- go to Configure > Banned & Suspect words
- add some words to the Suspect words list. it should not blow up
- if you have a comment with those suspect words, they should be highlighted in the moderation queue.
- `npm test`
