### PR TITLE
fetch settings on mod queue load

### DIFF
--- a/client/coral-admin/src/containers/ModerationQueue/ModerationContainer.js
+++ b/client/coral-admin/src/containers/ModerationQueue/ModerationContainer.js
@@ -9,6 +9,7 @@ import {
   fetchModerationQueueComments
 } from 'actions/comments';
 import {userStatusUpdate} from 'actions/users';
+import {fetchSettings} from 'actions/settings';
 
 import ModerationQueue from './ModerationQueue';
 
@@ -29,6 +30,7 @@ class ModerationContainer extends React.Component {
 
   componentWillMount() {
     this.props.fetchModerationQueueComments();
+    this.props.fetchSettings();
     key('s', () => this.setState({singleView: !this.state.singleView}));
     key('shift+/', () => this.setState({modalOpen: true}));
     key('esc', () => this.setState({modalOpen: false}));
@@ -86,6 +88,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => {
   return {
+    fetchSettings: () => dispatch(fetchSettings()),
     fetchModerationQueueComments: () => dispatch(fetchModerationQueueComments()),
     showBanUserDialog: (userId, userName, commentId) => dispatch(showBanUserDialog(userId, userName, commentId)),
     hideBanUserDialog: () => dispatch(hideBanUserDialog(false)),


### PR DESCRIPTION
## What does this PR do?

we were getting a weird situation where if you loaded the mod queue first, the suspect words were not being highlighted. If you went to the Config screen and back to the mod queue, they would be highlighted. The solution was to use the `fetchSettings` on the mod queue init.

## How do I test this PR?

- create a comment with a suspect word
- go to `/admin` and reload.
- the suspect word should be highlighted.
