### PR TITLE
Making user action item_type 'users' for consistency.

### DIFF
--- a/client/coral-plugin-flags/FlagButton.js
+++ b/client/coral-plugin-flags/FlagButton.js
@@ -47,7 +47,7 @@ class FlagButton extends Component {
       case 'comments':
         item_id = id;
         break;
-      case 'user':
+      case 'users':
         item_id = author_id;
         break;
       }
@@ -72,7 +72,7 @@ class FlagButton extends Component {
   onPopupOptionClick = (sets) => (e) => {
 
     // If flagging a user, indicate that this is referencing the username rather than the bio
-    if(sets === 'itemType' && e.target.value === 'user') {
+    if(sets === 'itemType' && e.target.value === 'users') {
       this.setState({field: 'username'});
     }
 

--- a/client/coral-plugin-flags/FlagComment.js
+++ b/client/coral-plugin-flags/FlagComment.js
@@ -10,7 +10,7 @@ const getPopupMenu = [
     return {
       header: lang.t('step-1-header'),
       options: [
-        {val: 'user', text: lang.t('flag-username')},
+        {val: 'users', text: lang.t('flag-username')},
         {val: 'comments', text: lang.t('flag-comment')}
       ],
       button: lang.t('continue'),


### PR DESCRIPTION
## What does this PR do?

Updates user action itemTypes to 'users' rather than 'user' for consistency.

## How do I test this PR?

1) Flag a username or bio.
2) The api call should return `201`