### PR TITLE
Utilize a different database for testing

### DIFF
--- a/services/mongoose.js
+++ b/services/mongoose.js
@@ -32,7 +32,7 @@ let url = process.env.TALK_MONGO_URL;
 // Reset the mongo url in the event it hasn't been overrided and we are in a
 // testing environment. Every new mongo instance comes with a test database by
 // default, this is consistent with common testing and use case practices.
-if (process.env.NODE_ENV === 'test' && !url) {
+if (process.env.NODE_ENV === 'test') {
   url = 'mongodb://localhost/test';
 }
 

--- a/services/mongoose.js
+++ b/services/mongoose.js
@@ -29,8 +29,8 @@ const enabled = require('debug').enabled;
 // Pull the mongo url out of the environment.
 let url = process.env.TALK_MONGO_URL;
 
-// Reset the mongo url in the event it hasn't been overrided and we are in a
-// testing environment. Every new mongo instance comes with a test database by
+// Reset the mongo url if we are in a testing environment.
+// Every new mongo instance comes with a test database by
 // default, this is consistent with common testing and use case practices.
 if (process.env.NODE_ENV === 'test') {
   url = 'mongodb://localhost/test';


### PR DESCRIPTION
## What does this PR do?

Recent updates to the database handler cause us to use the same database for testing and for development. This is not a best practice and inconveniently causes the development DB to be cleared every time tests are run. This change ensures that tests are always run in a separate database.

## How do I test this PR?

1) Create a user and post a comment
2) Run `npm test`
3) The user and comment should still exist.