### PR TITLE
Added dev-start and --config flag

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -1,16 +1,12 @@
 #!/usr/bin/env node
 
-// Perform rewrites to the runtime environment variables based on the contents
-// of the process.env.REWRITE_ENV if it exists. This is done here as it is the
-// entrypoint for the entire application.
-require('env-rewrite').rewrite();
-
 /**
  * Module dependencies.
  */
 
 const program = require('commander');
 const pkg = require('../package.json');
+const dotenv = require('dotenv');
 
 //==============================================================================
 // Setting up the program command line arguments.
@@ -18,6 +14,25 @@ const pkg = require('../package.json');
 
 program
   .version(pkg.version)
+  .option('-c, --config [path]', 'Specify the configuration file to load')
+  .parse(process.argv);
+
+if (program.config) {
+  let r = dotenv.config({
+    path: program.config
+  });
+
+  if (r.error) {
+    throw r.error;
+  }
+}
+
+// Perform rewrites to the runtime environment variables based on the contents
+// of the process.env.REWRITE_ENV if it exists. This is done here as it is the
+// entrypoint for the entire application.
+require('env-rewrite').rewrite();
+
+program
   .command('serve', 'serve the application')
   .command('assets', 'interact with assets')
   .command('settings', 'work with the application settings')

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "./bin/cli serve --jobs",
+    "dev-start": "nodemon --exec \"./bin/cli -c .env serve --jobs\"",
     "build": "NODE_ENV=production webpack --config webpack.config.js --bail",
     "build-watch": "NODE_ENV=development webpack --config webpack.config.dev.js --watch",
     "lint": "eslint bin/* .",
@@ -54,6 +55,7 @@
     "connect-redis": "^3.1.0",
     "csurf": "^1.9.0",
     "debug": "^2.2.0",
+    "dotenv": "^4.0.0",
     "ejs": "^2.5.2",
     "env-rewrite": "^1.0.2",
     "express": "^4.14.0",
@@ -121,6 +123,7 @@
     "mocha-junit-reporter": "^1.12.1",
     "nightwatch": "^0.9.11",
     "node-fetch": "^1.6.3",
+    "nodemon": "^1.11.0",
     "postcss-loader": "^1.1.0",
     "postcss-modules": "^0.5.2",
     "postcss-smart-import": "^0.5.1",


### PR DESCRIPTION
## What does this PR do?

Adds a new `dev-start` script which runs the server with `nodemon` and specifies a `.env` configuration file with the new `-c, --config` flag.
