### PR TITLE
Fix flagged comment queue bug

### DIFF
--- a/models/comment.js
+++ b/models/comment.js
@@ -201,7 +201,7 @@ CommentSchema.statics.findByActionType = (action_type) => Action
  * @return {Promise}
  */
 CommentSchema.statics.findIdsByActionType = (action_type) => Action
-  .findCommentsIdByActionType(action_type, 'comment')
+  .findCommentsIdByActionType(action_type, 'comments')
   .then((actions) => actions.map(a => a.item_id));
 
 /**

--- a/tests/models/comment.js
+++ b/tests/models/comment.js
@@ -73,12 +73,12 @@ describe('models.Comment', () => {
   const actions = [{
     action_type: 'flag',
     item_id: '3',
-    item_type: 'comment',
+    item_type: 'comments',
     user_id: '123'
   }, {
     action_type: 'like',
     item_id: '1',
-    item_type: 'comment',
+    item_type: 'comments',
     user_id: '456'
   }];
 

--- a/tests/routes/api/comments/index.js
+++ b/tests/routes/api/comments/index.js
@@ -58,11 +58,11 @@ describe('/api/v1/comments', () => {
     const actions = [{
       action_type: 'flag',
       item_id: 'abc',
-      item_type: 'comment'
+      item_type: 'comments'
     }, {
       action_type: 'like',
       item_id: 'hij',
-      item_type: 'comment'
+      item_type: 'comments'
     }];
 
     beforeEach(() => {


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where flagged comments do not appear in the moderation queue. (https://www.pivotaltracker.com/n/projects/1863625/stories/137404915)
This bug was caused by an inconsistency in `action_types`, they were plural (`comments`) on the frontend and singular (`comment`) in `Comment.findIdsByActionType`.

## How do I test this PR?

1. Flag a comment.
2. It should appear in the flagged comment queue.

## Note
If you approve a comment (for example, because premod is on) and then flag it it will not appear in the flagged queue. This is by design.
