### PR TITLE
don't show unpublished comments in My Comments

### DIFF
--- a/models/comment.js
+++ b/models/comment.js
@@ -282,8 +282,16 @@ CommentSchema.statics.all = () => Comment.find();
  * probably to be paginated at some point in the future
  * @return {Promise} array resolves to an array of comments by that user
  */
-CommentSchema.statics.findByUserId = function (author_id) {
-  return Comment.find({author_id});
+CommentSchema.statics.findByUserId = function (author_id, admin = false) {
+
+  // do not return un-published comments for non-admins
+  let query = {author_id};
+
+  if (!admin) {
+    query.$nor = [{status: 'premod'}, {status: 'rejected'}];
+  }
+
+  return Comment.find(query);
 };
 
 // Comment model.

--- a/routes/api/comments/index.js
+++ b/routes/api/comments/index.js
@@ -48,7 +48,7 @@ router.get('/', (req, res, next) => {
   // otherwise this will be a vulnerability if you pass user_id and something else,
   // the app will return admin-level data without the proper checks
   if (user_id) {
-    query = Comment.findByUserId(user_id);
+    query = Comment.findByUserId(user_id, authorization.has(req.user, 'admin'));
   } else if (status) {
     query = assetIDWrap(Comment.findByStatus(status === 'new' ? null : status));
   } else if (action_type) {

--- a/tests/models/comment.js
+++ b/tests/models/comment.js
@@ -209,6 +209,23 @@ describe('models.Comment', () => {
     });
   });
 
+  describe('#findByUserId', () => {
+    it('should return all comments if admin', () => {
+      return Comment.findByUserId('456', true)
+        .then(comments => {
+          expect(comments).to.have.length(4);
+        });
+    });
+
+    it('should not return premod and rejected comments if not admin', () => {
+      return Comment.findByUserId('456')
+        .then(comments => {
+          expect(comments).to.have.length(1);
+        });
+    });
+
+  });
+
   describe('#changeStatus', () => {
 
     it('should change the status of a comment from no status', () => {

--- a/tests/routes/api/comments/index.js
+++ b/tests/routes/api/comments/index.js
@@ -83,15 +83,14 @@ describe('/api/v1/comments', () => {
       ]);
     });
 
-    it('should return only the owner’s comments if the user is not an admin', () => {
+    it('should return only the owner’s published comments if the user is not an admin', () => {
       return chai.request(app)
         .get('/api/v1/comments?user_id=456')
         .set(passport.inject({id: '456', roles: []}))
         .then(res => {
           expect(res).to.have.status(200);
-          expect(res.body.comments).to.have.length(2);
+          expect(res.body.comments).to.have.length(1);
           expect(res.body.comments[0]).to.have.property('author_id', '456');
-          expect(res.body.comments[1]).to.have.property('author_id', '456');
         });
     });
 


### PR DESCRIPTION
## What does this PR do?

Updates the `Comment.findByUserId` method to only return published comments unless you're an admin

## How do I test this PR?

- make a non-admin user
- make two comments. approve one of the comments with your other admin account
- go to the non-admin profile page. only the approved comment should show up
- rejected comments should similarly not show up.
