### PR TITLE
Marking correct user as "Pending" on user flags.

### DIFF
--- a/graph/mutators/action.js
+++ b/graph/mutators/action.js
@@ -20,7 +20,7 @@ const createAction = ({user = {}}, {item_id, item_type, action_type, metadata = 
     metadata
   }).then((result) =>
     item_type === 'USERS' && action_type === 'FLAG' ?
-    UsersService.setStatus(user.id, 'PENDING').then(() => result)
+    UsersService.setStatus(item_id, 'PENDING').then(() => result)
     : result);
 };
 


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the wrong user was being marked as pending when flagging a bio.

## How do I test this PR?

1. Flag a bio or username on another user.
2. That user should appear in the moderation queue.
