### PR TITLE
fix a bug per wyatt advice

### DIFF
--- a/graph/resolvers/user.js
+++ b/graph/resolvers/user.js
@@ -7,7 +7,7 @@ const User = {
     // If the user is not an admin, only return comment list for the owner of
     // the comments.
     if (user && (user.hasRoles('ADMIN') || user.id === id)) {
-      return Comments.getByAuthorID.load(id);
+      return Comments.getByQuery({author_id: id});
     }
 
     return null;


### PR DESCRIPTION
## What does this PR do?

Makes the Settings tab load for non-admin users.

## How do I test this PR?

- click Settings
- it should not throw graphQL errors in the console
