### PR TITLE
Fix admin user stream bug

### DIFF
--- a/graph/loaders/comments.js
+++ b/graph/loaders/comments.js
@@ -100,7 +100,7 @@ const getCommentsByQuery = ({user}, {ids, statuses, asset_id, parent_id, author_
     });
   }
 
-  if (user && (user.hasRoles('ADMIN') || user.id === author_id)) {
+  if (user && (user.hasRoles('ADMIN') || user.id === author_id) && author_id != null) {
     comments = comments.where({author_id});
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug that hides all comments in streams from admin users.

## How do I test this PR?

Log in as an ADMIN and look at a stream. If you see comments there this worked.