### PR TITLE
Default asset url

### DIFF
--- a/client/coral-framework/graphql/queries/index.js
+++ b/client/coral-framework/graphql/queries/index.js
@@ -22,7 +22,7 @@ const getAssetUrl = () => {
     return assetUrl;
   }
 
-  // if not asset url defined, use the pym parent url
+  // if no asset_url defined, use the pym parentUrl
   return getQueryVariable('parentUrl');
 };
 

--- a/client/coral-framework/graphql/queries/index.js
+++ b/client/coral-framework/graphql/queries/index.js
@@ -3,6 +3,7 @@ import STREAM_QUERY from './streamQuery.graphql';
 import MY_COMMENT_HISTORY from './myCommentHistory.graphql';
 
 function getQueryVariable(variable) {
+
   let query = window.location.search.substring(1);
   let vars = query.split('&');
   for (let i = 0; i < vars.length; i++) {
@@ -13,10 +14,22 @@ function getQueryVariable(variable) {
   }
 }
 
+const getAssetUrl = () => {
+  const assetUrl = getQueryVariable('asset_url');
+
+  // if there is an asset_url var, use this
+  if (assetUrl !== '' && typeof assetUrl !== 'undefined') {
+    return assetUrl;
+  }
+
+  // if not asset url defined, use the pym parent url
+  return getQueryVariable('parentUrl');
+};
+
 export const queryStream = graphql(STREAM_QUERY, {
   options: () => ({
     variables: {
-      asset_url: getQueryVariable('asset_url')
+      asset_url: getAssetUrl()
     }
   })
 });


### PR DESCRIPTION
## What does this PR do?

Defaults the asset_url to the pym generated parentUrl if asset_url isn't explicitly passed.

## How do I test this PR?

Embed this stream without an asset_url. The stream should reflect the parent's url.