### PR TITLE
fix very annoying Like bug

### DIFF
--- a/client/coral-plugin-likes/LikeButton.js
+++ b/client/coral-plugin-likes/LikeButton.js
@@ -42,8 +42,8 @@ class LikeButton extends Component {
       if (currentUser.banned) {
         return;
       }
-      if (!liked) {
-        this.setState({localPost: 'temp', localDelete: false});
+      if (!liked) { // this comment has not yet been liked by this user.
+        this.setState({localPost: 'temp'});
         postLike({
           item_id: id,
           item_type: 'COMMENTS'
@@ -58,11 +58,7 @@ class LikeButton extends Component {
 
     return <div className={`${name}-container`}>
       <button onClick={onLikeClick} className={`${name}-button ${liked && 'likedButton'}`}>
-        {
-          liked
-          ? <span className={`${name}-button-text`}>{lang.t('liked')}</span>
-        : <span className={`${name}-button-text`}>{lang.t('like')}</span>
-        }
+        <span className={`${name}-button-text`}>{lang.t(liked ? 'liked' : 'like')}</span>
         <i className={`${name}-icon material-icons`}
           aria-hidden={true}>thumb_up</i>
         <span className={`${name}-like-count`}>{count > 0 && count}</span>


### PR DESCRIPTION
## What does this PR do?

Before, if you had liked a comment, and then unliked and re-liked (who knows) the like count would be wrong. This PR fixes this issue. fixes #301 

## How do I test this PR?

- Like a comment
- reload
- unlike the comment and re-like. the like count on the comment should make sense.
- liking/unliking elsewhere should still work.
