### PR TITLE
add a non-breaking space in between username and pubdate

### DIFF
--- a/client/coral-embed-stream/src/Comment.js
+++ b/client/coral-embed-stream/src/Comment.js
@@ -108,6 +108,7 @@ class Comment extends React.Component {
         { isStaff(comment.tags)
           ? <TagLabel isStaff={true}/>
           : null }
+        {'\u00a0'}
         <PubDate created_at={comment.created_at} />
         <Content body={comment.body} />
           <div className="commentActionsLeft">

--- a/client/coral-embed-stream/src/Comment.js
+++ b/client/coral-embed-stream/src/Comment.js
@@ -108,7 +108,6 @@ class Comment extends React.Component {
         { isStaff(comment.tags)
           ? <TagLabel isStaff={true}/>
           : null }
-        {'\u00a0'}
         <PubDate created_at={comment.created_at} />
         <Content body={comment.body} />
           <div className="commentActionsLeft">

--- a/client/coral-plugin-author-name/styles.css
+++ b/client/coral-plugin-author-name/styles.css
@@ -1,7 +1,7 @@
 .authorName {
   color: black;
   display: inline-block;
-  margin: 10px 0;
+  margin: 10px 5px 10px 0;
 }
 
 .hasBio {


### PR DESCRIPTION
## What does this PR do?

There was no space between the author name and the published date on a comment. Fixed.

## How do I test this PR?

- gaze upon any comment
- see that there is a space in between the author name and "a day ago" or whatever
