### PR TITLE
Missing reducer in Talk Installer

### DIFF
--- a/client/coral-admin/src/reducers/index.js
+++ b/client/coral-admin/src/reducers/index.js
@@ -3,11 +3,13 @@ import assets from './assets';
 import settings from './settings';
 import community from './community';
 import moderation from './moderation';
+import install from './install';
 
 export default {
   auth,
   assets,
   settings,
   community,
-  moderation
+  moderation,
+  install
 };


### PR DESCRIPTION
Master triggers an error because a reducer is missing.

This is the fix for it.

## Test it
- Dump your DB
- Go to `/admin/install`
- Run the installer
- If it works, merge.