### PR TITLE
show login page instead of communicorn :'(

### DIFF
--- a/client/coral-admin/src/actions/auth.js
+++ b/client/coral-admin/src/actions/auth.js
@@ -9,7 +9,7 @@ const checkLoginFailure = error => ({type: actions.CHECK_LOGIN_FAILURE, error});
 
 export const checkLogin = () => dispatch => {
   dispatch(checkLoginRequest());
-  coralApi('/auth')
+  return coralApi('/auth')
     .then(result => {
       const isAdmin = !!result.user.roles.filter(i => i === 'ADMIN').length;
       dispatch(checkLoginSuccess(result.user, isAdmin));

--- a/client/coral-admin/src/containers/LayoutContainer.js
+++ b/client/coral-admin/src/containers/LayoutContainer.js
@@ -8,7 +8,11 @@ import {PermissionRequired} from '../components/PermissionRequired';
 class LayoutContainer extends Component {
   componentWillMount () {
     const {checkLogin} = this.props;
-    checkLogin();
+    checkLogin().then(() => {
+      if (!this.props.auth.isAdmin) {
+        location.href = '/admin/login';
+      }
+    });
   }
   render () {
     const {isAdmin, loggedIn, loadingUser} = this.props.auth;


### PR DESCRIPTION
## What does this PR do?

Redirect to the `/login` page instead of showing the Communicorn.

## How do I test this PR?

- logout
- try to view the admin
- login
- view dashboard
- logout
- login as non-admin user
- fail 😭
