### PR TITLE
fix Reply bug

### DIFF
--- a/client/coral-plugin-commentbox/CommentBox.js
+++ b/client/coral-plugin-commentbox/CommentBox.js
@@ -30,6 +30,7 @@ class CommentBox extends Component {
       postItem,
       assetId,
       updateCountCache,
+      isReply,
       countCache,
       parentId,
       addNotification,
@@ -46,17 +47,17 @@ class CommentBox extends Component {
     if (this.props.charCount && this.state.body.length > this.props.charCount) {
       return;
     }
-    updateCountCache(assetId, countCache + 1);
+    !isReply && updateCountCache(assetId, countCache + 1);
     postItem(comment, 'comments')
       .then(({data}) => {
         const postedComment = data.createComment.comment;
 
         if (postedComment.status === 'REJECTED') {
           addNotification('error', lang.t('comment-post-banned-word'));
-          updateCountCache(assetId, countCache);
+          !isReply && updateCountCache(assetId, countCache);
         } else if (postedComment.status === 'PREMOD') {
           addNotification('success', lang.t('comment-post-notif-premod'));
-          updateCountCache(assetId, countCache);
+          !isReply && updateCountCache(assetId, countCache);
         } else {
           addNotification('success', 'Your comment has been posted.');
         }


### PR DESCRIPTION
## What does this PR do?

fixes a bug where you couldn't post a reply.

## weirdness for a second PR
if you have the stream open on a second tab, and you post a reply on the first tab, the second tab will show "View more commments" on the reply thread, but clicking the button doesn't do anything. This can be addressed once this PR is merged.

## How do I test this PR?

- post a reply
- it should show up.
