### PR TITLE
Adjusted session timeouts

### DIFF
--- a/app.js
+++ b/app.js
@@ -45,16 +45,15 @@ const session_opts = {
   secret: process.env.TALK_SESSION_SECRET,
   httpOnly: true,
   rolling: true,
-  saveUninitialized: false,
-  resave: false,
+  saveUninitialized: true,
+  resave: true,
   unset: 'destroy',
   name: 'talk.sid',
   cookie: {
     secure: false,
-    maxAge: 36000000, // 1 hour for expiry.
+    maxAge: 8.64e+7, // 24 hours for session token expiry
   },
   store: new RedisStore({
-    ttl: 1800,
     client: redis.createClient(),
   })
 };


### PR DESCRIPTION
## What does this PR do?

- Adjusts the session timeout to reflect a 24 rolling window

## How do I test this PR?

1. Empty cookies
2. Run the site with `yarn dev-start`
3. Visit http://localhost:3000
4. Check cookies, notice 24 hour expiry time
5. Check redis, ensure your session has a ttl ~ 24 hours