### PR TITLE
only trigger a re-flow when the height actually changes

### DIFF
--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -31,13 +31,14 @@ function buildStreamIframeUrl(talkBaseUrl, asset_url, comment, asset_id) {
 function configurePymParent(pymParent, asset_url) {
   let notificationOffset = 200;
   let ready = false;
+  let cachedHeight;
 
   // Resize parent iframe height when child height changes
   pymParent.onMessage('height', function(height) {
-
-    // TODO: In local testing, this is firing nonstop. Maybe there's a bug on the inside?
-    // Or it's by design of pym... but that's very wasteful of CPU and DOM reflows (jank)
-    pymParent.el.querySelector('iframe').height = `${height  }px`;
+    if (height !== cachedHeight) {
+      pymParent.el.querySelector('iframe').height = `${height  }px`;
+      cachedHeight = height;
+    }
   });
 
   // Helps child show notifications at the right scrollTop

--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -36,7 +36,7 @@ function configurePymParent(pymParent, asset_url) {
   // Resize parent iframe height when child height changes
   pymParent.onMessage('height', function(height) {
     if (height !== cachedHeight) {
-      pymParent.el.querySelector('iframe').height = `${height  }px`;
+      pymParent.el.firstChild.style.height = `${height}px`;
       cachedHeight = height;
     }
   });


### PR DESCRIPTION
## What does this PR do?

We were punishing everyone's machines by triggering a re-flow many times a second due to the way pym reports height. This might just be putting a bandaid on the react app redrawing constantly, but this should help with dev tools hanging and stuff.

## How do I test this PR?

- nothing should change, but your computer will run faster.
