### PR TITLE
incorrectly using dispatch now that we do pym directly

### DIFF
--- a/client/coral-embed-stream/src/Embed.js
+++ b/client/coral-embed-stream/src/Embed.js
@@ -256,7 +256,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   requestConfirmEmail: () => dispatch(requestConfirmEmail()),
   loadAsset: (asset) => dispatch(fetchAssetSuccess(asset)),
-  addNotification: (type, text) => dispatch(addNotification(type, text)),
+  addNotification: (type, text) => addNotification(type, text),
   clearNotification: () => dispatch(clearNotification()),
   editName: (username) => dispatch(editName(username)),
   showSignInDialog: (offset) => dispatch(showSignInDialog(offset)),


### PR DESCRIPTION
## What does this PR do?

the new way we do notifications doesn't actually return an action, so `dispatch` is confused. This removes the warning.

## How do I test this PR?

- go to embed stream
- enter a banned word to trigger a notification
- there should not be errors in the console
