### PR TITLE
button text was wrapping in firefox

### DIFF
--- a/client/coral-admin/src/components/ModerationList.css
+++ b/client/coral-admin/src/components/ModerationList.css
@@ -186,4 +186,5 @@
 .actionButton {
   transform: scale(.8);
   margin: 0;
+  width: 140px;
 }


### PR DESCRIPTION
## What does this PR do?

The text was wrapping on the Approve/Reject buttons in the moderation queue in firefox. This PR just makes the buttons a bit wider, sidestepping the css issue.

## How do I test this PR?

- view the moderation queue in Firefox.
- the Approve button should have visible text in it.
