### PR TITLE
dashboard refresh fix

### DIFF
--- a/client/coral-admin/src/components/CountdownTimer.js
+++ b/client/coral-admin/src/components/CountdownTimer.js
@@ -31,14 +31,18 @@ class CountdownTimer extends React.Component {
   }
 
   componentWillMount () {
-    setInterval(() => { // the countdown timer
+    this.interval = setInterval(() => { // the countdown timer
       let nextCount = this.state.secondsUntilRefresh - 1;
       if (nextCount < 0) {
         nextCount = refreshIntervalSeconds;
-        this.props.handleTimeout();
+        return this.props.handleTimeout();
       }
       this.setState({secondsUntilRefresh: nextCount});
     }, 1000);
+  }
+
+  componentWillUnmount () {
+    window.clearInterval(this.interval);
   }
 
   formatTime = () => {


### PR DESCRIPTION
## What does this PR do?

The Dashboard would freak out when the clock ran out before. I just added a lifecycle method to clean things up.

## How do I test this PR?

- view the dashboard.
- let the timer run out
- the page should refresh and not throw errors
