### PR TITLE
sort the stories by date

### DIFF
--- a/client/coral-admin/src/containers/Stories/Stories.js
+++ b/client/coral-admin/src/containers/Stories/Stories.js
@@ -2,13 +2,14 @@ import React, {Component} from 'react';
 import styles from './Stories.css';
 import {connect} from 'react-redux';
 import I18n from 'coral-framework/modules/i18n/i18n';
-import {fetchAssets, updateAssetState} from '../../actions/assets';
-import translations from '../../translations.json';
+import {fetchAssets, updateAssetState} from 'coral-admin/src/actions/assets';
+import translations from 'coral-admin/src/translations.json';
 import {Link} from 'react-router';
 
 import {Pager, Icon} from 'coral-ui';
 import {DataTable, TableHeader, RadioGroup, Radio} from 'react-mdl';
 import EmptyCard from 'coral-admin/src/components/EmptyCard';
+import sortBy from 'lodash/sortBy';
 
 const limit = 25;
 
@@ -104,7 +105,11 @@ class Stories extends Component {
     const {search, sort, filter} = this.state;
     const {assets} = this.props;
 
-    const assetsIds = assets.ids.map((id) => assets.byId[id]);
+    const assetsIds = sortBy(assets.ids.map((id) => assets.byId[id]), 'publication_date');
+
+    if (this.state.sort === 'desc') {
+      assetsIds.reverse();
+    }
 
     return (
       <div className={styles.container}>

--- a/client/coral-admin/src/reducers/assets.js
+++ b/client/coral-admin/src/reducers/assets.js
@@ -23,8 +23,13 @@ export default function assets (state = initialState, action) {
 }
 
 const replaceAssets = (action, state) => {
-  const assets = fromJS(action.assets.reduce((prev, curr) => { prev[curr.id] = curr; return prev; }, {}));
-  return state.set('byId', assets)
-  .set('count', action.count)
-  .set('ids', List(assets.keys()));
+  const assets = fromJS(action.assets.reduce((prev, curr) => {
+    prev[curr.id] = curr;
+    return prev;
+  }, {}));
+
+  return state
+    .set('byId', assets)
+    .set('count', action.count)
+    .set('ids', List(assets.keys()));
 };


### PR DESCRIPTION
## What does this PR do?

Before, the stories were not being sorted (or were being hashed and lost their sorting) on the Stories page. I added a manual sort.

## How do I test this PR?

- view a list of stories WITH DIFFERENT `publication_date`s (if the meta tag for publication date was not provided in the template, all the stories had identical publication dates.
- change the sort by Newest/Oldest. they should re-sort
