### PR TITLE
hide reply button if stream is closed

### DIFF
--- a/client/coral-embed-stream/src/Comment.js
+++ b/client/coral-embed-stream/src/Comment.js
@@ -43,6 +43,7 @@ class Comment extends React.Component {
 
     // id of currently opened ReplyBox. tracked in Stream.js
     activeReplyBox: PropTypes.string.isRequired,
+    disableReply: PropTypes.bool,
     setActiveReplyBox: PropTypes.func.isRequired,
     showSignInDialog: PropTypes.func.isRequired,
     postFlag: PropTypes.func.isRequired,
@@ -109,6 +110,7 @@ class Comment extends React.Component {
       deleteAction,
       addCommentTag,
       removeCommentTag,
+      disableReply,
     } = this.props;
 
     const like = getActionSummary('LikeActionSummary', comment);
@@ -166,13 +168,16 @@ class Comment extends React.Component {
                 showSignInDialog={showSignInDialog}
                 currentUser={currentUser} />
             </ActionButton>
-            <ActionButton>
-              <ReplyButton
-                onClick={() => setActiveReplyBox(comment.id)}
-                parentCommentId={parentId || comment.id}
-                currentUserId={currentUser && currentUser.id}
-                banned={false} />
-            </ActionButton>
+            {
+              !disableReply &&
+              <ActionButton>
+                <ReplyButton
+                  onClick={() => setActiveReplyBox(comment.id)}
+                  parentCommentId={parentId || comment.id}
+                  currentUserId={currentUser && currentUser.id}
+                  banned={false} />
+              </ActionButton>
+            }
             <ActionButton>
               <IfUserCanModifyBest user={currentUser}>
                 <BestButton

--- a/client/coral-embed-stream/src/Comment.js
+++ b/client/coral-embed-stream/src/Comment.js
@@ -222,6 +222,7 @@ class Comment extends React.Component {
           comment.replies.map(reply => {
             return <Comment
               setActiveReplyBox={setActiveReplyBox}
+              disableReply={disableReply}
               activeReplyBox={activeReplyBox}
               addNotification={addNotification}
               parentId={comment.id}

--- a/client/coral-embed-stream/src/Embed.js
+++ b/client/coral-embed-stream/src/Embed.js
@@ -202,6 +202,7 @@ class Embed extends Component {
               />
             <div className="embed__stream">
               <Stream
+                open={openStream}
                 addNotification={this.props.addNotification}
                 postItem={this.props.postItem}
                 setActiveReplyBox={this.setActiveReplyBox}

--- a/client/coral-embed-stream/src/Stream.js
+++ b/client/coral-embed-stream/src/Stream.js
@@ -8,6 +8,7 @@ class Stream extends React.Component {
     addNotification: PropTypes.func.isRequired,
     postItem: PropTypes.func.isRequired,
     asset: PropTypes.object.isRequired,
+    open: PropTypes.bool.isRequired,
     comments: PropTypes.array.isRequired,
     currentUser: PropTypes.shape({
       username: PropTypes.string,
@@ -15,10 +16,10 @@ class Stream extends React.Component {
     }),
 
     // dispatch action to add a tag to a comment
-    addCommentTag: React.PropTypes.func,
+    addCommentTag: PropTypes.func,
 
     // dispatch action to remove a tag from a comment
-    removeCommentTag: React.PropTypes.func,
+    removeCommentTag: PropTypes.func,
   }
 
   constructor(props) {
@@ -55,6 +56,7 @@ class Stream extends React.Component {
       addNotification,
       postFlag,
       postLike,
+      open,
       postDontAgree,
       loadMore,
       deleteAction,
@@ -68,6 +70,7 @@ class Stream extends React.Component {
         {
           comments.map(comment =>
             <Comment
+              disableReply={!open}
               setActiveReplyBox={this.props.setActiveReplyBox}
               activeReplyBox={this.props.activeReplyBox}
               addNotification={addNotification}


### PR DESCRIPTION
## What does this PR do?

Comments were already blocked on the backend for closed streams, but the reply box would still show up. This PR fixes this. #217 

## How do I test this PR?

- view a closed stream.
- the reply button should be missing
- re-open the stream
- the reply button should be there and you should be able to post a reply
