### PR TITLE
Comment Stream Bugfix

### DIFF
--- a/client/coral-embed-stream/src/Comment.js
+++ b/client/coral-embed-stream/src/Comment.js
@@ -156,8 +156,6 @@ class Comment extends React.Component {
           : null }
         <PubDate created_at={comment.created_at} />
 
-        <p>parent_id {comment.parent ? comment.parent.id : 'no parent'}</p>
-        <p>id: {comment.id}</p>
         <Content body={comment.body} />
           <div className="commentActionsLeft comment__action-container">
             <ActionButton>

--- a/client/coral-embed-stream/src/Comment.js
+++ b/client/coral-embed-stream/src/Comment.js
@@ -155,6 +155,9 @@ class Comment extends React.Component {
           ? <TagLabel><BestIndicator /></TagLabel>
           : null }
         <PubDate created_at={comment.created_at} />
+
+        <p>parent_id {comment.parent ? comment.parent.id : 'no parent'}</p>
+        <p>id: {comment.id}</p>
         <Content body={comment.body} />
           <div className="commentActionsLeft comment__action-container">
             <ActionButton>
@@ -232,7 +235,7 @@ class Comment extends React.Component {
               removeCommentTag={removeCommentTag}
               showSignInDialog={showSignInDialog}
               reactKey={reply.id}
-              key={`${reply.id}:${depth}`}
+              key={reply.id}
               comment={reply} />;
           })
         }

--- a/client/coral-embed-stream/src/Embed.js
+++ b/client/coral-embed-stream/src/Embed.js
@@ -224,7 +224,7 @@ class Embed extends Component {
             topLevel={true}
             assetId={asset.id}
             comments={asset.comments}
-            moreComments={asset.commentCount > asset.comments.length}
+            moreComments={countCache[asset.id] > asset.comments.length}
             loadMore={this.props.loadMore}/>
         </TabContent>
          <TabContent show={activeTab === 1}>

--- a/client/coral-embed-stream/src/LoadMore.js
+++ b/client/coral-embed-stream/src/LoadMore.js
@@ -7,15 +7,12 @@ const lang = new I18n(translations);
 
 const loadMoreComments = (assetId, comments, loadMore, parentId) => {
 
-  console.log('loadMoreComments', comments, comments.length);
-
-  if (!comments.length) {
-    return;
+  let cursor = null;
+  if (comments.length) {
+    cursor = parentId
+      ? comments[0].created_at
+      : comments[comments.length - 1].created_at;
   }
-
-  const cursor = parentId
-    ? comments[0].created_at
-    : comments[comments.length - 1].created_at;
 
   loadMore({
     limit: ADDTL_COMMENTS_ON_LOAD_MORE,
@@ -50,7 +47,6 @@ class LoadMore extends React.Component {
       ? <Button
         className='coral-load-more'
         onClick={() => {
-          console.log('loadMore clicked');
           this.initialState = false;
           loadMoreComments(assetId, comments, loadMore, parentId);
         }}>

--- a/client/coral-embed-stream/src/LoadMore.js
+++ b/client/coral-embed-stream/src/LoadMore.js
@@ -17,7 +17,7 @@ const loadMoreComments = (assetId, comments, loadMore, parentId) => {
   loadMore({
     limit: ADDTL_COMMENTS_ON_LOAD_MORE,
     cursor,
-    assetId,
+    asset_id: assetId,
     parent_id: parentId,
     sort: parentId ? 'CHRONOLOGICAL' : 'REVERSE_CHRONOLOGICAL'
   });

--- a/client/coral-embed-stream/src/LoadMore.js
+++ b/client/coral-embed-stream/src/LoadMore.js
@@ -7,6 +7,8 @@ const lang = new I18n(translations);
 
 const loadMoreComments = (assetId, comments, loadMore, parentId) => {
 
+  console.log('loadMoreComments', comments, comments.length);
+
   if (!comments.length) {
     return;
   }
@@ -48,6 +50,7 @@ class LoadMore extends React.Component {
       ? <Button
         className='coral-load-more'
         onClick={() => {
+          console.log('loadMore clicked');
           this.initialState = false;
           loadMoreComments(assetId, comments, loadMore, parentId);
         }}>

--- a/client/coral-framework/graphql/fragments/commentView.graphql
+++ b/client/coral-framework/graphql/fragments/commentView.graphql
@@ -3,6 +3,9 @@
 fragment commentView on Comment {
     id
     body
+    parent {
+      id
+    }
     created_at
     status
     tags {

--- a/client/coral-framework/graphql/fragments/commentView.graphql
+++ b/client/coral-framework/graphql/fragments/commentView.graphql
@@ -3,9 +3,6 @@
 fragment commentView on Comment {
     id
     body
-    parent {
-      id
-    }
     created_at
     status
     tags {

--- a/client/coral-framework/graphql/queries/index.js
+++ b/client/coral-framework/graphql/queries/index.js
@@ -42,7 +42,6 @@ export const getCounts = (data) => ({asset_id, limit, sort}) => {
 };
 
 export const loadMore = (data) => ({limit, cursor, parent_id, asset_id, sort}, newComments) => {
-  console.log('loadMore query', data);
   return data.fetchMore({
     query: LOAD_MORE,
     variables: {
@@ -63,7 +62,7 @@ export const loadMore = (data) => ({limit, cursor, parent_id, asset_id, sort}, n
           ...oldData,
           asset: {
             ...oldData.asset,
-            comments: oldData.asset.comments.map((comment) => {
+            comments: oldData.asset.comments.map(comment => {
 
               // since the dipslayed replies and the returned replies can overlap,
               // pull out the unique ones.

--- a/client/coral-framework/graphql/queries/index.js
+++ b/client/coral-framework/graphql/queries/index.js
@@ -3,6 +3,8 @@ import STREAM_QUERY from './streamQuery.graphql';
 import LOAD_MORE from './loadMore.graphql';
 import GET_COUNTS from './getCounts.graphql';
 import MY_COMMENT_HISTORY from './myCommentHistory.graphql';
+import uniqBy from 'lodash/uniqBy';
+import sortBy from 'lodash/sortBy';
 
 function getQueryVariable(variable) {
   let query = window.location.search.substring(1);
@@ -40,6 +42,7 @@ export const getCounts = (data) => ({asset_id, limit, sort}) => {
 };
 
 export const loadMore = (data) => ({limit, cursor, parent_id, asset_id, sort}, newComments) => {
+  console.log('loadMore query', data);
   return data.fetchMore({
     query: LOAD_MORE,
     variables: {
@@ -60,10 +63,18 @@ export const loadMore = (data) => ({limit, cursor, parent_id, asset_id, sort}, n
           ...oldData,
           asset: {
             ...oldData.asset,
-            comments: oldData.asset.comments.map((comment) =>
-              comment.id === parent_id
-              ? {...comment, replies: [...comment.replies, ...new_top_level_comments]}
-              : comment)
+            comments: oldData.asset.comments.map((comment) => {
+
+              // since the dipslayed replies and the returned replies can overlap,
+              // pull out the unique ones.
+              const uniqueReplies = uniqBy([...new_top_level_comments, ...comment.replies], 'id');
+
+              // since we just gave the returned replies precedence, they're now out of order.
+              // resort according to date.
+              return comment.id === parent_id
+                ? {...comment, replies: sortBy(uniqueReplies, 'created_at')}
+                : comment;
+            })
           }
         };
       } else {


### PR DESCRIPTION
## What does this PR do?

Let's say that you're viewing a stream with a single top level comment. Elsewhere, someone makes one or more replies to that comment. The View Replies button appears for you and you click it, excited to see the freshest conversation happening about [Chinese Crested dogs](http://www.vetstreet.com/dogs/chinese-crested), but nothing happens. But with this PR, you'll be able to enjoy comments about ugly dogs on the information superhighway!

## How do I test this PR?

- have two tabs open (maybe with different accounts) to the same article
- reply a couple times to a comment, or to a reply WITH NO PRE-EXISTING COMMENTS
- switch to the second tab and wait for the View Replies button to appear.
- click it. replies should appear.
