### PR TITLE
Fixed bug in loading more comments

### DIFF
--- a/client/coral-framework/graphql/queries/index.js
+++ b/client/coral-framework/graphql/queries/index.js
@@ -39,7 +39,7 @@ export const getCounts = (data) => ({asset_id, limit, sort}) => {
   });
 };
 
-export const loadMore = (data) => ({limit, cursor, parent_id, asset_id, sort}, newComments) => {
+export const loadMore = (data) => ({limit, cursor, parent_id = null, asset_id, sort}, newComments) => {
   return data.fetchMore({
     query: LOAD_MORE,
     variables: {


### PR DESCRIPTION
## What does this PR do?

- Top level comments require a `null` for `$parent_id`, this adds it

Resolves: https://www.pivotaltracker.com/story/show/141945585