### PR TITLE
asset_url and canonical link tags

### DIFF
--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -167,7 +167,16 @@ Talk.render = function (el, opts) {
     el.id = `_${Math.random()}`;
   }
 
-  let asset_url = opts.asset_url || window.location.href.split('#')[0];
+  let asset_url = opts.asset_url;
+  if (!asset_url) {
+    try {
+      asset_url = document.querySelector('link[rel="canonical"]').href;
+    } catch (e) {
+      console.warn('This page does not include a canonical link tag. Talk has inferred this asset_url from the window object. Query params have been stripped, which may cause a single thread to be present across multiple pages.');
+      asset_url = window.location.origin + window.location.pathname;
+    }
+  }
+
   let comment = window.location.hash.slice(1);
 
   let query = {

--- a/views/article.ejs
+++ b/views/article.ejs
@@ -27,7 +27,7 @@
     <script src="/embed.js" async onload="
       Coral.Talk.render(document.getElementById('coralStreamEmbed'), {
         talk: '/',
-        asset: '<%= asset_url ? asset_url : '' %>'
+        asset_url: '<%= asset_url ? asset_url : '' %>'
       })
     "></script>
   </main>


### PR DESCRIPTION
## What does this PR do?

Better prompting for configuring Talk in its host page. Prompt for `asset_url`, and if not, use the [canonical link tag](https://moz.com/blog/canonical-url-tag-the-most-important-advancement-in-seo-practices-since-sitemaps) and if _that_ fails, just use `location.origin + location.pathname` with a warning.

## How do I test this PR?

- view a page.
- you should get a warning in the console with our current setup.
