### PR TITLE
always show moderation link to admins

### DIFF
--- a/client/coral-embed-stream/src/Embed.js
+++ b/client/coral-embed-stream/src/Embed.js
@@ -160,7 +160,6 @@ class Embed extends Component {
                         charCount={asset.settings.charCountEnable && asset.settings.charCount} />
                      : null
                    }
-                   <ModerationLink assetId={asset.id} isAdmin={isAdmin} />
                  </RestrictedContent>
                  </div>
                : <p>{asset.settings.closedMessage}</p>
@@ -170,6 +169,7 @@ class Embed extends Component {
               refetch={refetch}
               offset={signInOffset}/>}
             {loggedIn &&  user && <ChangeUsernameContainer loggedIn={loggedIn} offset={signInOffset} user={user} />}
+            {loggedIn && <ModerationLink assetId={asset.id} isAdmin={isAdmin} />}
             {
               highlightedComment &&
               <Comment


### PR DESCRIPTION
## What does this PR do?

show moderation link even on closed streams.

## How do I test this PR?

- view an open stream
- Moderation link should appear
- close the stream, moderation link should still be there
- be logged in with a non-admin user. moderation link should not be there
