### PR TITLE
show the total comment count instead of the parent count

### DIFF
--- a/client/coral-embed-stream/src/Embed.js
+++ b/client/coral-embed-stream/src/Embed.js
@@ -120,7 +120,7 @@ class Embed extends Component {
       <div style={expandForLogin}>
         <div className="commentStream">
           <TabBar onChange={this.changeTab} activeTab={activeTab}>
-            <Tab><Count count={asset.commentCount}/></Tab>
+            <Tab><Count count={asset.totalCommentCount}/></Tab>
             <Tab>{lang.t('MY_COMMENTS')}</Tab>
             <Tab restricted={!isAdmin}>Configure Stream</Tab>
           </TabBar>

--- a/client/coral-framework/graphql/queries/streamQuery.graphql
+++ b/client/coral-framework/graphql/queries/streamQuery.graphql
@@ -29,6 +29,7 @@ query AssetQuery($asset_id: ID, $asset_url: String!, $comment_id: ID!, $has_comm
             requireEmailConfirmation
         }
         commentCount
+        totalCommentCount
         comments(limit: 10) {
             ...commentView
             replyCount


### PR DESCRIPTION
## What does this PR do?

the comment count on the first tab now includes replies.

## How do I test this PR?

- view the comment stream
- the count now reflects all comments including replies
