### PR TITLE
Remove duplicate material.css

### DIFF
--- a/client/coral-admin/src/index.js
+++ b/client/coral-admin/src/index.js
@@ -7,7 +7,6 @@ import store from './services/store';
 
 import App from './components/App';
 
-import 'react-mdl/extra/material.css';
 import 'react-mdl/extra/material.js';
 
 render(

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -21,7 +21,7 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="https://code.getmdl.io/1.2.1/material.indigo-pink.min.css">
+    <link rel="stylesheet" href="https://code.getmdl.io/1.2.1/material.min.css">
     <style media="screen">
       body, #root {
         width: 100%;


### PR DESCRIPTION
## What does this PR do?

- Removes duplicate `material.css`. The css in the correct theme is already added here: https://github.com/coralproject/talk/blob/598fcc4cb0fa7f55185a037e4eff618d8f92c8fb/views/admin.ejs#L24

## How do I test this PR?

- Go to the admin area and everything should still look the same
