### PR TITLE
prevent Talk from collapsing from custom css

### DIFF
--- a/client/coral-embed-stream/style/default.css
+++ b/client/coral-embed-stream/style/default.css
@@ -16,6 +16,7 @@ body {
   font-size: 14px;
   margin: 0px;
   padding: 0px 0px 50px 0px;
+  height: auto !important;
 }
 
 .expandForSignin {


### PR DESCRIPTION
## What does this PR do?

Some styles would cascade to the iframe (but not all styles?) and cause the comment stream to collapse to `height: 100%` whatever that is.

## How do I test this PR?

- in your admin config, set the custom css to be `https://blog.coralproject.net/wp-content/themes/coralnewsblocks/style.min.css?ver=1.39`
- go to your stream
- it should be styled like the coral blog, but you should be able to see all the comments
