### PR TITLE
Adjust .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,14 +2,11 @@ root = true
 
 [*]
 indent_style = space
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-
-[{package.json,.*rc,*.yml}]
-indent_style = space
-indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
The `.editorconfig` does not set indent styles for all of our file extensions. This change defaults indent styles for all extensions to 2 spaces.