### PR TITLE
only refetch the comments if you're an admin

### DIFF
--- a/client/coral-embed-stream/src/Embed.js
+++ b/client/coral-embed-stream/src/Embed.js
@@ -41,9 +41,10 @@ class Embed extends Component {
   state = {activeTab: 0, showSignInDialog: false, activeReplyBox: ''};
 
   changeTab = (tab) => {
+    const {isAdmin} = this.props.auth;
 
     // Everytime the comes from another tab, the Stream needs to be updated.
-    if (tab === 0) {
+    if (tab === 0 && isAdmin) {
       this.props.data.refetch();
     }
 


### PR DESCRIPTION
## What does this PR do?

if you're a regular user, it would be annoying to have the entire comment stream refresh if you just changed your settings on another tab. Before, when you returned to the stream, all the replies were collapsed. This PR makes it so that this is only true for admins.

## How do I test this PR?

- be logged in as a non-admin user
- view a stream with lots of comments and replies
- expand some old comments and replies
- click to settings
- click back. you should still see the expanded comments as before.
