### PR TITLE
Temporarily disable username profanity check

### DIFF
--- a/services/users.js
+++ b/services/users.js
@@ -268,7 +268,7 @@ module.exports = class UsersService {
     if (checkAgainstWordlist) {
 
       // check for profanity
-      return Wordlist.usernameCheck(username);
+      console.log('Username profanity check disabled: ', Wordlist.usernameCheck(username));
     }
 
     // No errors found!


### PR DESCRIPTION
## What does this PR do?

This PR temporarily disables the username profanity check that is responsible for errors during the cli user create process.

## How do I test this PR?

Creating users via the cli should work. You should be notified via console log that this feature is disabled.
