### PR TITLE
Premod queue fix

### DIFF
--- a/client/coral-admin/src/containers/ModerationQueue/components/Comment.js
+++ b/client/coral-admin/src/containers/ModerationQueue/components/Comment.js
@@ -21,8 +21,13 @@ const lang = new I18n(translations);
 const Comment = ({actions = [], comment, ...props}) => {
   const links = linkify.getMatches(comment.body);
   const linkText = links ? links.map(link => link.raw) : [];
-  const flagActionSummaries = getActionSummary('FlagActionSummary', comment);
-  const flagActions = comment.actions && comment.actions.filter(a => a.__typename === 'FlagAction');
+
+  let flagActionSummaries;
+  let flagActions;
+  if (comment.action_summaries) { // this might be missing if we're on the pre-mod tab
+    flagActionSummaries = getActionSummary('FlagActionSummary', comment);
+    flagActions = comment.actions && comment.actions.filter(a => a.__typename === 'FlagAction');
+  }
 
   return (
     <li tabIndex={props.index} className={`mdl-card ${props.selected ? 'mdl-shadow--8dp' : 'mdl-shadow--2dp'} ${styles.Comment} ${styles.listItem}`}>

--- a/client/coral-admin/src/containers/ModerationQueue/components/Comment.js
+++ b/client/coral-admin/src/containers/ModerationQueue/components/Comment.js
@@ -21,13 +21,8 @@ const lang = new I18n(translations);
 const Comment = ({actions = [], comment, ...props}) => {
   const links = linkify.getMatches(comment.body);
   const linkText = links ? links.map(link => link.raw) : [];
-
-  let flagActionSummaries;
-  let flagActions;
-  if (comment.action_summaries) { // this might be missing if we're on the pre-mod tab
-    flagActionSummaries = getActionSummary('FlagActionSummary', comment);
-    flagActions = comment.actions && comment.actions.filter(a => a.__typename === 'FlagAction');
-  }
+  const flagActionSummaries = getActionSummary('FlagActionSummary', comment);
+  const flagActions = comment.actions && comment.actions.filter(a => a.__typename === 'FlagAction');
 
   return (
     <li tabIndex={props.index} className={`mdl-card ${props.selected ? 'mdl-shadow--8dp' : 'mdl-shadow--2dp'} ${styles.Comment} ${styles.listItem}`}>

--- a/client/coral-admin/src/graphql/fragments/commentView.graphql
+++ b/client/coral-admin/src/graphql/fragments/commentView.graphql
@@ -12,6 +12,12 @@ fragment commentView on Comment {
       id
       title
     }
+    action_summaries {
+      count
+      ... on FlagActionSummary {
+        reason
+      }
+    }
     actions {
       ... on FlagAction {
         reason

--- a/client/coral-admin/src/graphql/queries/modQueueQuery.graphql
+++ b/client/coral-admin/src/graphql/queries/modQueueQuery.graphql
@@ -15,12 +15,6 @@ query ModQueue ($asset_id: ID, $sort: SORT_ORDER) {
         sort: $sort
     }) {
         ...commentView
-        action_summaries {
-          count
-          ... on FlagActionSummary {
-            reason
-          }
-        }
     }
     rejected: comments(query: {
         statuses: [REJECTED],


### PR DESCRIPTION
## What does this PR do?

I broke the pre-mod queue because I assumed that `action_summaries` would always be there. The way our query is set up, there are no `action_summaries` requested on pre-mod stream. at first I fixed it by just not showing flags if the object as `undefined`, but then I realized that pre-mod queues could potentially have flags if there was a plugin that did this (like Sherloq) and you'd want to see them. So I just changed the commentView fragment.

## How do I test this PR?

- view all the moderation queues
- they should work.
