### PR TITLE
let ApolloClient know which types are interfaces

### DIFF
--- a/client/coral-admin/src/services/client.js
+++ b/client/coral-admin/src/services/client.js
@@ -1,7 +1,9 @@
 import ApolloClient, {addTypename} from 'apollo-client';
 import getNetworkInterface from './transport';
+import fragmentMatcher from './fragmentMatcher';
 
 export const client = new ApolloClient({
+  fragmentMatcher,
   addTypename: true,
   queryTransformer: addTypename,
   dataIdFromObject: (result) => {

--- a/client/coral-admin/src/services/fragmentMatcher.js
+++ b/client/coral-admin/src/services/fragmentMatcher.js
@@ -1,0 +1,33 @@
+import {IntrospectionFragmentMatcher} from 'apollo-client';
+
+// TODO this is a short-term fix
+// we need to set up something to query the server for the schema before ApolloClient initialization
+// https://github.com/apollographql/apollo-client/issues/1555#issuecomment-295834774
+const fm = new IntrospectionFragmentMatcher({
+  introspectionQueryResultData: {
+    __schema: {
+      types: [
+        {
+          kind: 'INTERFACE',
+          name: 'Action',
+          possibleTypes: [
+            {name: 'FlagAction'},
+            {name: 'LikeAction'},
+            {name: 'DontAgreeAction'}
+          ],
+        },
+        {
+          kind: 'INTERFACE',
+          name: 'ActionSummary',
+          possibleTypes: [
+            {name: 'FlagActionSummary'},
+            {name: 'LikeActionSummary'},
+            {name: 'DontAgreeActionSummary'}
+          ],
+        }
+      ],
+    },
+  }
+});
+
+export default fm;


### PR DESCRIPTION
## What does this PR do?

the ApolloClient did not know that `FlagAction` is an `Action` unless it's told so. Apparently there's some under-the-hood stuff that happens so apollo knows the mutations have acutally mutated anything. This caused `updateQueries` not to run after accepting/rejecting comments.

https://github.com/apollographql/apollo-client/issues/1555#issuecomment-295834774

This is a stop gap PR. we're going to have to figure out a solution where the client queries for the schema before initialization, otherwise we're going to run into this again, and potentially every time someone adds a plugin.

## How do I test this PR?

- view the moderation stream
- accept/reject a comment. it should disappear from the queue.
