### PR TITLE
Fixed bug with status changes in the graph

### DIFF
--- a/graph/mutators/comment.js
+++ b/graph/mutators/comment.js
@@ -180,9 +180,9 @@ const createPublicComment = (context, commentInput) => {
  * @param {String} status      the new status of the comment
  */
 
-const setCommentStatus = ({loaders: {Comments}}, {id, status}) => {
+const setCommentStatus = ({user, loaders: {Comments}}, {id, status}) => {
   return CommentsService
-    .setStatus(id, status)
+    .pushStatus(id, status, user ? user.id : null)
     .then((comment) => {
 
       // If the loaders are present, clear the caches for these values because we

--- a/services/comments.js
+++ b/services/comments.js
@@ -213,7 +213,15 @@ module.exports = class CommentsService {
    * @return {Promise}
    */
   static pushStatus(id, status, assigned_by = null) {
-    return CommentModel.update({id}, {
+
+    // Check to see if the comment status is in the allowable set of statuses.
+    if (STATUSES.indexOf(status) === -1) {
+
+      // Comment status is not supported! Error out here.
+      return Promise.reject(new Error(`status ${status} is not supported`));
+    }
+
+    return CommentModel.findOneAndUpdate({id}, {
       $push: {
         status_history: {
           type: status,
@@ -291,26 +299,5 @@ module.exports = class CommentsService {
     }
 
     return CommentModel.find(query);
-  }
-
-  /**
-   * Sets Comment Status
-   * @param {String} id          identifier of the comment  (uuid)
-   * @param {String} status      the new status of the comment
-   * @return {Promise}
-   */
-
-  static setStatus(id, status) {
-
-    // Check to see if the comment status is in the allowable set of statuses.
-    if (STATUSES.indexOf(status) === -1) {
-
-      // Comment status is not supported! Error out here.
-      return Promise.reject(new Error(`status ${status} is not supported`));
-    }
-
-    return CommentModel.findOneAndUpdate({id}, {
-      $set: {status}
-    });
   }
 };


### PR DESCRIPTION
## What does this PR do?

Previously, when a comment was approved/rejected, status changes were not pushed into history. This resolves that.

## How do I test this PR?

- Create a comment
- Report it
- Reject/Approve it
- Check in the db, notice that the `status_history` field has those updates in it