### PR TITLE
Added fix for flag actions

### DIFF
--- a/graph/resolvers/flag_action.js
+++ b/graph/resolvers/flag_action.js
@@ -8,7 +8,9 @@ const FlagAction = {
     return group_id;
   },
   user({user_id}, _, {loaders: {Users}}) {
-    return Users.getByID.load(user_id);
+    if (user_id) {
+      return Users.getByID.load(user_id);
+    }
   },
 };
 


### PR DESCRIPTION
## What does this PR do?

When an action is created by the system, the flag `user_id` is null, because the system made it. Therefore, when a action is loaded when the user is not found, instead return undefined instead of trying to use the dataloader.