### PR TITLE
add some styles so mobile doesn't zoom the text box

### DIFF
--- a/client/coral-embed-stream/style/default.css
+++ b/client/coral-embed-stream/style/default.css
@@ -194,7 +194,8 @@ hr {
   padding: 5px;
   min-height: 100px;
   margin-top: 10px;
-  font-size: 14px;
+  font-size: 16px;
+  border: 1px solid #ccc;
 }
 
 .coral-plugin-commentbox-button-container {
@@ -278,13 +279,13 @@ hr {
 .commentActionsRight, .replyActionsRight {
   display: flex;
   justify-content: flex-end;
-  width: 30%;
+  width: 50%;
 }
 .commentActionsLeft, .replyActionsLeft {
   display: flex;
   justify-content: flex-start;
   float: left;
-  width: 70%;
+  width: 50%;
 }
 
 .comment__action-container .material-icons {


### PR DESCRIPTION
## What does this PR do?

- Prevents forced browser zoom when you type in the comment box on mobile.
- makes the left and right buttons below the comment box the same width in an attempt to fix a WaPo bug
- add a border to the comment box textarea since sometimes it was borderless

## How do I test this PR?

- view comments
- the comment box should look nice and not zoom when you enter text
- the buttons below the comments should not wrap or anything on mobile devices

- click a button
- view the cat
- see the cat meow
