### PR TITLE
reply box is squished on long comments in Firefox

### DIFF
--- a/client/coral-embed-stream/style/default.css
+++ b/client/coral-embed-stream/style/default.css
@@ -187,6 +187,7 @@ hr {
 /* Comment Box Styles */
 .coral-plugin-commentbox-container {
   display: flex;
+  width: 100%;
 }
 
 .coral-plugin-commentbox-textarea {


### PR DESCRIPTION
## What does this PR do?

FF reply box was really wide on long comments. No more!

## How do I test this PR?

- get some lipsum and make a really long top-level comment
- click Reply in FF; the comment box should look normal
