### PR TITLE
Safari IOS ignores width=100% in iframes

### DIFF
--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -57,6 +57,10 @@ function configurePymParent(pymParent) {
 
   window.document.body.appendChild(snackbar);
 
+  // Workaround: IOS Safari ignores `width` but respects `min-width` value.
+  pymParent.el.firstChild.style.width = '1px';
+  pymParent.el.firstChild.style.minWidth = '100%';
+
   // Resize parent iframe height when child height changes
   pymParent.onMessage('height', function(height) {
     if (height !== cachedHeight) {


### PR DESCRIPTION
## What does this PR do?
- Safari IOS automatically resizes iframe to fit content and doesn't restrain to the parent width, see: http://stackoverflow.com/questions/23865899/how-to-set-the-width-of-an-iframe-in-ios6
- Uses workaround by using `min-width: 100%` instead of `width: 100%`.
- Disqus uses the same technique.

## How do I test this PR?

- Write a comment with a looooooooooooooooooooooooong word without spaces.
- The iframe width should not expand beyond viewport.