### PR TITLE
More reliable login support including IOS browsers

### DIFF
--- a/client/coral-framework/actions/auth.js
+++ b/client/coral-framework/actions/auth.js
@@ -39,10 +39,21 @@ export const showSignInDialog = () => dispatch => {
     'menubar=0,resizable=0,width=500,height=550,top=200,left=500'
   );
 
-  signInPopUp.onbeforeunload = () => {
-    dispatch(checkLogin());
-    fetchMe();
+  // Workaround odd behavior in older WebKit versions, where
+  // onunload is called twice. (Encountered in IOS 8.3)
+  let loaded = false;
+  signInPopUp.onload = () => {
+    loaded = true;
   };
+
+  // Use `onunload` instead of `onbeforeunload` which is not supported in IOS Safari.
+  signInPopUp.onunload = () => {
+    if (loaded) {
+      dispatch(checkLogin());
+      fetchMe();
+    }
+  };
+
   dispatch({type: actions.SHOW_SIGNIN_DIALOG});
 };
 export const hideSignInDialog = () => dispatch => {


### PR DESCRIPTION
## What does this PR do?
- Use more appropriate `onunload` instead of `onbeforeunload`.
- Workaround a bug in older WebKit versions including IOS 8.

## How do I test this PR?
- Check that login works across browsers.