### PR TITLE
format mod queue counts

### DIFF
--- a/client/coral-admin/src/containers/ModerationQueue/components/CommentCount.js
+++ b/client/coral-admin/src/containers/ModerationQueue/components/CommentCount.js
@@ -1,9 +1,25 @@
 import React, {PropTypes} from 'react';
 import styles from './CommentCount.css';
+import I18n from 'coral-framework/modules/i18n/i18n';
+import translations from 'coral-admin/src/translations.json';
+const lang = new I18n(translations);
 
-const CommentCount = props => (
-  <span className={styles.count}>{props.count}</span>
-);
+const CommentCount = ({count}) => {
+  let number = count;
+
+  // shorten large counts to abbreviations
+  if (number / 1e9 > 1) {
+    number = `${(number / 1e9).toFixed(1)}${lang.t('modqueue.billion')}`;
+  } else if (number / 1e6 > 1) {
+    number = `${(number / 1e6).toFixed(1)}${lang.t('modqueue.million')}`;
+  } else if (number / 1e3 > 1) {
+    number = `${(number / 1e3).toFixed(1)}${lang.t('modqueue.thousand')}`;
+  }
+
+  return (
+    <span className={styles.count}>{number}</span>
+  );
+};
 
 CommentCount.propTypes = {
   count: PropTypes.number.isRequired

--- a/client/coral-admin/src/translations.json
+++ b/client/coral-admin/src/translations.json
@@ -63,7 +63,10 @@
       "impersonating": "Impersonating",
       "offensive": "Offensive",
       "spam/ads": "Spam/Ads",
-      "other": "Other"
+      "other": "Other",
+      "thousand": "k",
+      "million": "M",
+      "billion": "B"
     },
     "comment": {
       "flagged": "flagged",
@@ -248,7 +251,10 @@
       "impersonating": "Suplantación",
       "offensive": "Ofensivo",
       "spam/ads": "Spam/Propaganda",
-      "other": "Otros"
+      "other": "Otros",
+      "thousand": "m",
+      "million": "M",
+      "billion": "B"
     },
     "comment": {
       "flagged": "marcado",


### PR DESCRIPTION
## What does this PR do?

shorten `4500000` comments in the mod queue tabs to `4.5m`. Currently rounded to one place after the decimal.

## How do I test this PR?

- view the comment stream with thousands, millions, or billions of comments.
