### PR TITLE
enable load more on accepted queue

### DIFF
--- a/client/coral-admin/src/graphql/queries/index.js
+++ b/client/coral-admin/src/graphql/queries/index.js
@@ -39,6 +39,9 @@ export const loadMore = (fetchMore) => ({limit, cursor, sort, tab, asset_id}) =>
   case 'all':
     statuses = null;
     break;
+  case 'accepted':
+    statuses = ['ACCEPTED'];
+    break;
   case 'premod':
     statuses = ['PREMOD'];
     break;


### PR DESCRIPTION
## What does this PR do?

Load more button probably didn't work on `master` for Accepted queue.

## How do I test this PR?

- have a bunch of Accepted comments
- click the Load more button
- the correct comments should load, instead of comments from the All Queue
