### PR TITLE
Fix reply count polling

### DIFF
--- a/client/coral-embed-stream/src/containers/Stream.js
+++ b/client/coral-embed-stream/src/containers/Stream.js
@@ -19,24 +19,13 @@ const {showSignInDialog} = authActions;
 const {addNotification} = notificationActions;
 
 class StreamContainer extends React.Component {
-  getCounts = ({asset_id, limit, sort}) => {
+  getCounts = (variables) => {
     return this.props.data.fetchMore({
       query: LOAD_COMMENT_COUNTS_QUERY,
-      variables: {
-        asset_id,
-        limit,
-        sort,
-        excludeIgnored: this.props.data.variables.excludeIgnored,
-      },
-      updateQuery: (oldData, {fetchMoreResult:{asset}}) => {
-        return {
-          ...oldData,
-          asset: {
-            ...oldData.asset,
-            commentCount: asset.commentCount
-          }
-        };
-      }
+      variables,
+
+      // Apollo requires this, even though we don't use it...
+      updateQuery: data => data,
     });
   };
 
@@ -122,12 +111,7 @@ class StreamContainer extends React.Component {
       this.props.data.refetch();
     }
     this.countPoll = setInterval(() => {
-      const {asset} = this.props.root;
-      this.getCounts({
-        asset_id: asset.id,
-        limit: asset.comments.length,
-        sort: 'REVERSE_CHRONOLOGICAL'
-      });
+      this.getCounts(this.props.data.variables);
     }, NEW_COMMENT_COUNT_POLL_INTERVAL);
   }
 
@@ -141,13 +125,13 @@ class StreamContainer extends React.Component {
 }
 
 const LOAD_COMMENT_COUNTS_QUERY = gql`
-  query LoadCommentCounts($asset_id: ID, $limit: Int = 5, $sort: SORT_ORDER) {
-    asset(id: $asset_id) {
+  query LoadCommentCounts($assetUrl: String, $assetId: ID, $excludeIgnored: Boolean) {
+    asset(id: $assetId, url: $assetUrl) {
       id
-      commentCount
-      comments(sort: $sort, limit: $limit) {
+      commentCount(excludeIgnored: $excludeIgnored)
+      comments(limit: 10) {
         id
-        replyCount
+        replyCount(excludeIgnored: $excludeIgnored)
       }
     }
   }

--- a/client/coral-framework/graphql/mutations/index.js
+++ b/client/coral-framework/graphql/mutations/index.js
@@ -57,7 +57,7 @@ export const postComment = graphql(POST_COMMENT, {
                   ...oldData.asset,
                   comments: oldData.asset.comments.map((oldComment) => {
                     return oldComment.id === parent_id
-                      ? {...oldComment, replies: [...oldComment.replies, comment]}
+                      ? {...oldComment, replies: [...oldComment.replies, comment], replyCount: oldComment.replyCount + 1}
                       : oldComment;
                   })
                 }


### PR DESCRIPTION
## What does this PR do?
- Fix reply count polling.
- Fix issue when posting a reply did not increment `replyCount` which also hides the fact that there might be a __single__ new reply that can be loaded.

## How do I test this PR?

### Bug 1
Use two tabs and send replies on one, and check that the other receives a `view x replies` message.

### Bug 2
Use two tabs and send ___one___ reply to the other, check that it says `view x replies` on the other tab. Reply before clicking on the button and see how the number of total replies increments by one and the button does not dissappear.
