### PR TITLE
Update docker-compose sample configs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,6 +72,11 @@ services:
     environment:
       - TALK_MONGO_URL=mongodb://mongo/talk
       - TALK_REDIS_URL=redis://redis
+      - TALK_SESSION_SECRET=this_is_a_secret_string
+      - TALK_ROOT_URL=http://localhost
+      - TALK_FACEBOOK_APP_ID=none
+      - TALK_FACEBOOK_APP_SECRET=none
+      - NODE_ENV=development
   mongo:
     image: mongo:3.2
     restart: always

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,8 +74,7 @@ services:
       - TALK_REDIS_URL=redis://redis
       - TALK_SESSION_SECRET=this_is_a_secret_string
       - TALK_ROOT_URL=http://localhost
-      - TALK_FACEBOOK_APP_ID=none
-      - TALK_FACEBOOK_APP_SECRET=none
+      - TALK_PLUGINS_JSON={}
       - NODE_ENV=development
   mongo:
     image: mongo:3.2

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,6 +120,10 @@ services:
     environment:
       - TALK_MONGO_URL=mongodb://mongo/talk
       - TALK_REDIS_URL=redis://redis
+      - TALK_SESSION_SECRET=this_is_a_secret_string
+      - TALK_ROOT_URL=http://localhost
+      - TALK_PLUGINS_JSON={}
+      - NODE_ENV=development
   talk-jobs:
     image: coralproject/talk:1.5
     command: cli jobs process
@@ -132,6 +136,10 @@ services:
     environment:
       - TALK_MONGO_URL=mongodb://mongo/talk
       - TALK_REDIS_URL=redis://redis
+      - TALK_SESSION_SECRET=this_is_a_secret_string
+      - TALK_ROOT_URL=http://localhost
+      - TALK_PLUGINS_JSON={}
+      - NODE_ENV=development
   mongo:
     image: mongo:3.2
     restart: always

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To launch a Talk server of your own from your browser without any need to muck a
 
 ### Configuration
 
-The Talk application looks for the following configuration values either as environment variables:
+The Talk application looks for the following configuration values as environment variables:
 
 - `TALK_MONGO_URL` (*required*) - the database connection string for the MongoDB database.
 - `TALK_REDIS_URL` (*required*) - the database connection string for the Redis database.
@@ -38,6 +38,7 @@ available in the format: `<scheme>://<host>` without the path.
 - `TALK_RECAPTCHA_SECRET` (*required for reCAPTCHA support*) - server secret used for enabling reCAPTCHA powered logins. If not provided it will instead default to providing only a time based lockout.
 - `TALK_RECAPTCHA_PUBLIC` (*required for reCAPTCHA support*) - client secret used for enabling reCAPTCHA powered logins. If not provided it will instead default to providing only a time based lockout.
 - `TALK_PLUGINS_JSON` (_optional_) - used to specify the plugin config via the environment
+- `NODE_ENV` (*required*) - either 'development' or 'production'
 
 Refer to the wiki page on [Configuration Loading](https://github.com/coralproject/talk/wiki/Configuration-Loading) for
 alternative methods of loading configuration during development.


### PR DESCRIPTION
## What does this PR do?

Updates README.md and INSTALL.md with information on running the docker-compose samples by noting the requirement of `NODE_ENV` in README.md and by adding `NODE_ENV`, `TALK_SESSION_SECRET`, `TALK_ROOT_URL`, and `TALK_PLUGINS_JSON` (which when set to {} disables Facebook integration) to the sample configurations in INSTALL.md.

## How do I test this PR?

Do `docker-compose up` on both of the new sample configurations.