### PR TITLE
Removed LikeAction from core typeName interface resolver

### DIFF
--- a/graph/resolvers/action.js
+++ b/graph/resolvers/action.js
@@ -5,8 +5,6 @@ const Action = {
       return 'DontAgreeAction';
     case 'FLAG':
       return 'FlagAction';
-    case 'LIKE':
-      return 'LikeAction';
     }
   },
 


### PR DESCRIPTION
## What does this PR do?

- Removes `LikeAction` from the root `Action` resolver, this is added via a hook in the like plugin.

## How do I test this PR?

- Have a database containing likes
- Disable like plugin
- Rebuild static assets `yarn build`
- Restart server `CTRL-C` + `yarn dev-start`
- Load the moderation panel
- Notice now that the stream can load!