### PR TITLE
Flag queue Load More fix

### DIFF
--- a/client/coral-admin/src/graphql/queries/index.js
+++ b/client/coral-admin/src/graphql/queries/index.js
@@ -45,7 +45,7 @@ export const loadMore = (fetchMore) => ({limit = 10, cursor, sort, tab, asset_id
     variables.statuses = null;
     break;
   case 'accepted':
-    varaibles.statuses = ['ACCEPTED'];
+    variables.statuses = ['ACCEPTED'];
     break;
   case 'premod':
     variables.statuses = ['PREMOD'];

--- a/client/coral-admin/src/graphql/queries/index.js
+++ b/client/coral-admin/src/graphql/queries/index.js
@@ -33,34 +33,34 @@ export const getMetrics = graphql(METRICS, {
   }
 });
 
-export const loadMore = (fetchMore) => ({limit, cursor, sort, tab, asset_id}) => {
-  let statuses;
+export const loadMore = (fetchMore) => ({limit = 10, cursor, sort, tab, asset_id}) => {
+  let variables = {
+    limit,
+    cursor,
+    sort,
+    asset_id
+  };
   switch(tab) {
   case 'all':
-    statuses = null;
+    variables.statuses = null;
     break;
   case 'accepted':
-    statuses = ['ACCEPTED'];
+    varaibles.statuses = ['ACCEPTED'];
     break;
   case 'premod':
-    statuses = ['PREMOD'];
+    variables.statuses = ['PREMOD'];
     break;
   case 'flagged':
-    statuses = ['NONE', 'PREMOD'];
+    variables.statuses = ['NONE', 'PREMOD'];
+    variables.action_type = 'FLAG';
     break;
   case 'rejected':
-    statuses = ['REJECTED'];
+    variables.statuses = ['REJECTED'];
     break;
   }
   return fetchMore({
     query: MOD_QUEUE_LOAD_MORE,
-    variables: {
-      limit,
-      cursor,
-      sort,
-      statuses,
-      asset_id
-    },
+    variables,
     updateQuery: (oldData, {fetchMoreResult:{comments}}) => {
       return {
         ...oldData,

--- a/client/coral-admin/src/graphql/queries/loadMore.graphql
+++ b/client/coral-admin/src/graphql/queries/loadMore.graphql
@@ -1,7 +1,7 @@
 #import "../fragments/commentView.graphql"
 
-query LoadMoreModQueue($limit: Int = 10, $cursor: Date, $sort: SORT_ORDER, $asset_id: ID, $statuses:[COMMENT_STATUS!]) {
-  comments(query: {limit: $limit, cursor: $cursor, asset_id: $asset_id, statuses: $statuses, sort: $sort}) {
+query LoadMoreModQueue($limit: Int = 10, $cursor: Date, $sort: SORT_ORDER, $asset_id: ID, $statuses:[COMMENT_STATUS!], $action_type: ACTION_TYPE) {
+  comments(query: {limit: $limit, cursor: $cursor, asset_id: $asset_id, statuses: $statuses, sort: $sort, action_type: $action_type}) {
     ...commentView
     action_summaries {
       count


### PR DESCRIPTION
## What does this PR do?

when you tried to load more in the flagged queue, the returned comments might not be flagged.

## How do I test this PR?

- have more than 10 flagged comments that are not ACCEPTED
- click the Load More button
- only flagged comments should appear.
