### PR TITLE
Apply button overlapped text

### DIFF
--- a/client/coral-configure/components/ConfigureCommentStream.css
+++ b/client/coral-configure/components/ConfigureCommentStream.css
@@ -3,10 +3,8 @@
 }
 
 .apply {
-  position: absolute;
-  top: 38%;
-  transform: translateX(-50%);
-  right: 0;
+  float: right;
+  margin: 0 10px;
 }
 
 .wrapper ul {

--- a/client/coral-configure/components/ConfigureCommentStream.js
+++ b/client/coral-configure/components/ConfigureCommentStream.js
@@ -12,7 +12,6 @@ export default ({handleChange, handleApply, changed, ...props}) => (
     <div className={styles.wrapper}>
       <div className={styles.container}>
         <h3>{lang.t('configureCommentStream.title')}</h3>
-        <p>{lang.t('configureCommentStream.description')}</p>
         <Button
           type="submit"
           className={styles.apply}
@@ -20,6 +19,7 @@ export default ({handleChange, handleApply, changed, ...props}) => (
           cStyle={changed ? 'green' : 'darkGrey'} >
           {lang.t('configureCommentStream.apply')}
         </Button>
+        <p>{lang.t('configureCommentStream.description')}</p>
       </div>
       <ul>
         <li>


### PR DESCRIPTION
## What does this PR do?

The settings Apply button was being positioned with css transforms and `postition: absolute`. This takes it out of the css flow and does weird things with text. `float: right;` is just fine and will give the desired behavior.

## How do I test this PR?

- view the stream settings on mobile.
- the Apply button no longer obscures the description.
