### PR TITLE
Admin Mod Queue Slots and Coral Plugin Mod example 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,6 @@ plugins/*
 !plugins/coral-plugin-respect
 !plugins/coral-plugin-offtopic
 !plugins/coral-plugin-like
+!plugins/coral-plugin-mod
 
 **/node_modules/*

--- a/client/coral-admin/src/containers/ModerationQueue/components/Comment.js
+++ b/client/coral-admin/src/containers/ModerationQueue/components/Comment.js
@@ -1,16 +1,17 @@
 import React, {PropTypes} from 'react';
 import timeago from 'timeago.js';
+import {Link} from 'react-router';
 import Linkify from 'react-linkify';
 import Highlighter from 'react-highlight-words';
-import {Link} from 'react-router';
 
 import styles from './styles.css';
 import {Icon} from 'coral-ui';
 import FlagBox from './FlagBox';
 import CommentType from './CommentType';
+import Slot from 'coral-framework/components/Slot';
+import {getActionSummary} from 'coral-framework/utils';
 import ActionButton from 'coral-admin/src/components/ActionButton';
 import BanUserButton from 'coral-admin/src/components/BanUserButton';
-import {getActionSummary} from 'coral-framework/utils';
 
 const linkify = new Linkify();
 
@@ -50,6 +51,10 @@ const Comment = ({actions = [], comment, ...props}) => {
               {lang.t('comment.banned_user')}
             </span>
             : null}
+          <Slot
+            fill="adminCommentInfoBar"
+            comment={comment}
+          />
         </div>
         <div className={styles.moderateArticle}>
           Story: {comment.asset.title}
@@ -62,6 +67,10 @@ const Comment = ({actions = [], comment, ...props}) => {
             <Highlighter
               searchWords={[...props.suspectWords, ...props.bannedWords, ...linkText]}
               textToHighlight={comment.body} />
+            <Slot
+              fill="adminCommentContent"
+              comment={comment}
+            />
           </p>
           <div className={styles.sideActions}>
             {links ? <span className={styles.hasLinks}><Icon name='error_outline'/> Contains Link</span> : null}
@@ -78,8 +87,18 @@ const Comment = ({actions = [], comment, ...props}) => {
                   rejectComment={() => props.rejectComment({commentId: comment.id})} />;
               })}
             </div>
+            <Slot
+              fill="adminSideActions"
+              comment={comment}
+            />
           </div>
         </div>
+      </div>
+      <div>
+        <Slot
+          fill="adminCommentDetailArea"
+          comment={comment}
+        />
       </div>
       {
         flagActions && flagActions.length

--- a/plugins/coral-plugin-mod/client/.babelrc
+++ b/plugins/coral-plugin-mod/client/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "add-module-exports",
+    "transform-class-properties",
+    "transform-decorators-legacy",
+    "transform-object-assign",
+    "transform-object-rest-spread",
+    "transform-async-to-generator",
+    "transform-react-jsx"
+  ]
+}

--- a/plugins/coral-plugin-mod/client/.eslintrc.json
+++ b/plugins/coral-plugin-mod/client/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
+    }
+  },
+  "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
+  "rules": {
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+    "no-console": ["warn", { "allow": ["warn", "error"] }]
+  }
+}

--- a/plugins/coral-plugin-mod/client/components/Box.js
+++ b/plugins/coral-plugin-mod/client/components/Box.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import styles from './styles.css'
+
+export default (props) => (
+  <div className={styles.box}>
+    Comment Status: {props.comment.status}
+  </div>
+)

--- a/plugins/coral-plugin-mod/client/components/Container.js
+++ b/plugins/coral-plugin-mod/client/components/Container.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Box from './Box';
+import {Button} from 'coral-ui'
+import styles from './styles.css';
+
+export default class Footer extends React.Component {
+  constructor() {
+    super();
+
+    this.state = {
+      show: false
+    };
+  }
+
+  handleClick = () => {
+    this.setState(state => ({
+      show: !state.show
+    }))
+  }
+
+  render() {
+    const {show} = this.state;
+    return (
+      <div className={styles.container}>
+        <Button cStyle="darkGrey" onClick={this.handleClick}>
+          Show Comment Status
+        </Button>
+        {show ? <Box comment={this.props.comment} /> : null}
+      </div>
+    );
+  }
+}

--- a/plugins/coral-plugin-mod/client/components/styles.css
+++ b/plugins/coral-plugin-mod/client/components/styles.css
@@ -1,0 +1,8 @@
+.container {
+    padding: 0 14px 10px;
+}
+
+.box {
+    font-size: 12px;
+    padding: 10px 14px;
+}

--- a/plugins/coral-plugin-mod/client/index.js
+++ b/plugins/coral-plugin-mod/client/index.js
@@ -1,0 +1,7 @@
+import Container from './components/Container';
+
+export default {
+  slots: {
+    adminCommentDetailArea: [Container],
+  }
+};

--- a/plugins/coral-plugin-mod/index.js
+++ b/plugins/coral-plugin-mod/index.js
@@ -1,0 +1,4 @@
+const {readFileSync} = require('fs');
+const path = require('path');
+
+module.exports = {};


### PR DESCRIPTION
# Admin Mod Queue Slots 
This PR adds:

- Slots for the admin queues

- An example plugin Coral Plugin Mod


## Slots added

- `adminCommentInfoBar`

- `adminCommentContent `

- `adminSideActions`

- `adminCommentDetailArea`


## Test 
- Add `coral-plugin-mod` to your `plugins.json` in`client`
- You should see a button on the footer of the comments in the Mod queues