### PR TITLE
Auth login fixes

### DIFF
--- a/client/coral-framework/actions/auth.js
+++ b/client/coral-framework/actions/auth.js
@@ -267,8 +267,8 @@ export const fetchForgotPassword = (email) => (dispatch) => {
 
 export const logout = () => (dispatch) => {
   return coralApi('/auth', {method: 'DELETE'}).then(() => {
-    dispatch({type: actions.LOGOUT});
     Storage.removeItem('token');
+    dispatch({type: actions.LOGOUT});
   });
 };
 

--- a/client/coral-settings/containers/ProfileContainer.js
+++ b/client/coral-settings/containers/ProfileContainer.js
@@ -25,6 +25,14 @@ class ProfileContainer extends Component {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.auth.loggedIn !== nextProps.auth.loggedIn) {
+
+      // Refetch after login/logout.
+      this.props.data.refetch();
+    }
+  }
+
   handleTabChange = (tab) => {
     this.setState({
       activeTab: tab
@@ -39,7 +47,7 @@ class ProfileContainer extends Component {
       return <NotLoggedIn showSignInDialog={showSignInDialog} />;
     }
 
-    if (data.loading) {
+    if (!me || data.loading) {
       return <Spinner />;
     }
 


### PR DESCRIPTION
## What does this PR do?
- Fixes logout query refetch failure by clearing the token before logout action is dispatched.
- Readd login fixes for `My profile`.

## How do I test this PR?

- Login and logout in the embed stream, there should be no errors in the console.
- Refresh, go to `My profile` and login, the login should succeed.