### PR TITLE
Invalidate old user data

### DIFF
--- a/client/coral-embed-stream/src/containers/Embed.js
+++ b/client/coral-embed-stream/src/containers/Embed.js
@@ -65,6 +65,7 @@ const EMBED_QUERY = gql`
       totalCommentCount(excludeIgnored: $excludeIgnored)
     }
     me {
+      id
       status
     }
     ...${getDefinitionName(Stream.fragments.root)}

--- a/client/coral-settings/containers/ProfileContainer.js
+++ b/client/coral-settings/containers/ProfileContainer.js
@@ -86,6 +86,7 @@ const withQuery = graphql(
   gql`
   query EmbedStreamProfileQuery {
     me {
+      id
       ignoredUsers {
         id,
         username,


### PR DESCRIPTION
## What does this PR do?
- Request `id` from the user object, to allow apollo automatically invalidate old data whenever the user object changes to a new user.

- Fixes the following bug:
  - Login to a user with posted comments and go to `My profile`.
  - Go to `Comments` and logout the user.
  - Login to another user in the `Comments` tab
  - Switching to `My profile` will display the comments of the previous user.

## How do I test this PR?

  - Login to a user with posted comments and go to `My profile`.
  - Go to `Comments` and logout the user.
  - Login to another user in the `Comments` tab
  - Switching to `My profile` will correctly display the comments of the new user.

