### PR TITLE
hasRoles is no longer a function

### DIFF
--- a/graph/resolvers/root_query.js
+++ b/graph/resolvers/root_query.js
@@ -86,7 +86,7 @@ const RootQuery = {
 
   // this returns an arbitrary user
   user(_, {id}, {user, loaders: {Users}}) {
-    if (user == null || !user.hasRoles('ADMIN')) {
+    if (user == null || !user.can(SEARCH_OTHER_USERS)) {
       return null;
     }
 

--- a/graph/resolvers/user.js
+++ b/graph/resolvers/user.js
@@ -1,5 +1,11 @@
 const KarmaService = require('../../services/karma');
-const {SEARCH_ACTIONS, SEARCH_OTHERS_COMMENTS, UPDATE_USER_ROLES} = require('../../perms/constants');
+const {
+  SEARCH_ACTIONS,
+  SEARCH_OTHER_USERS,
+  SEARCH_OTHERS_COMMENTS,
+  UPDATE_USER_ROLES,
+  SEARCH_COMMENT_METRICS
+} = require('../../perms/constants');
 
 const User = {
   action_summaries({id}, _, {loaders: {Actions}}) {
@@ -14,7 +20,7 @@ const User = {
 
   },
   created_at({roles, created_at}, _, {user}) {
-    if (user && user.hasRoles('ADMIN')) {
+    if (user && user.can(SEARCH_OTHER_USERS)) {
       return created_at;
     }
 
@@ -33,7 +39,7 @@ const User = {
   profiles({profiles}, _, {user}) {
 
     // if the user is not an admin, do not return the profiles
-    if (user && user.hasRoles('ADMIN')) {
+    if (user && user.can(SEARCH_OTHER_USERS)) {
       return profiles;
     }
 
@@ -43,7 +49,7 @@ const User = {
 
     // Only allow a logged in user that is either the current user or is a staff
     // member to access the ignoredUsers of a given user.
-    if (!user || ((user.id !== id) && !(user.hasRoles('ADMIN') || user.hasRoles('MODERATOR')))) {
+    if (!user || ((user.id !== id) && !user.can(SEARCH_OTHER_USERS))) {
       return null;
     }
 
@@ -66,7 +72,7 @@ const User = {
 
   // Extract the reliability from the user metadata if they have permission.
   reliable(user, _, {user: requestingUser}) {
-    if (requestingUser && requestingUser.hasRoles('ADMIN')) {
+    if (requestingUser && requestingUser.can(SEARCH_COMMENT_METRICS)) {
       return KarmaService.model(user);
     }
   }


### PR DESCRIPTION
## What does this PR do?

I'm not sure if there was a regression, or I just missed these the first time around. `hasRoles` is no longer a member of UserService, so all the old way of handling roles will fail if you hit these points on the graph.

## How do I test this PR?

- move through the admin, everything should work as expected.
