### PR TITLE
allow people to be downgraded to regular commenter

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -6,6 +6,7 @@ const can = require('../perms');
 
 // USER_ROLES is the array of roles that is permissible as a user role.
 const USER_ROLES = [
+  '',
   'ADMIN',
   'MODERATOR',
   'STAFF'


### PR DESCRIPTION
## What does this PR do?

the list of acceptable roles did not include `""` which is just a regular commenter. You could be created as such, but not be downgraded to that.

## How do I test this PR?

- change a user that has `ADMINISTRATOR`, `MODERATOR` or `STAFF` to the `.` role in admin
- it should stick
