### PR TITLE
Hide comment box during perm view

### DIFF
--- a/client/coral-embed-stream/src/components/Stream.js
+++ b/client/coral-embed-stream/src/components/Stream.js
@@ -100,6 +100,7 @@ class Stream extends React.Component {
               {loggedIn &&
                 !banned &&
                 !temporarilySuspended &&
+                !highlightedComment &&
                 <CommentBox
                   addNotification={this.props.addNotification}
                   postComment={this.props.postComment}


### PR DESCRIPTION
## What does this PR do?
- Hide comment box when viewing a single comment using a permalink.

## How do I test this PR?

- View a comment using a permalink. 
- There should be no comment box.