### PR TITLE
Increase/Decrease totalCommentCount after mutation

### DIFF
--- a/client/coral-embed-stream/src/graphql/utils.js
+++ b/client/coral-embed-stream/src/graphql/utils.js
@@ -28,6 +28,14 @@ function findAndInsertComment(parent, id, comment) {
 }
 
 export function insertCommentIntoEmbedQuery(root, id, comment) {
+
+  // Increase total comment count by one.
+  root = update(root, {
+    asset: {
+      totalCommentCount: {$apply: (c) => c + 1},
+    },
+  });
+
   if (root.comment) {
     if (root.comment.parent) {
       return update(root, {
@@ -76,6 +84,14 @@ function findAndRemoveComment(parent, id) {
 }
 
 export function removeCommentFromEmbedQuery(root, id) {
+
+  // Decrease total comment by one.
+  root = update(root, {
+    asset: {
+      totalCommentCount: {$apply: (c) => c - 1},
+    },
+  });
+
   if (root.comment) {
     if (root.comment.parent) {
       return update(root, {


### PR DESCRIPTION
## What does this PR do?
- Increase `totalCommentCount` when posting a comment
- Decrease `totalCommentCount` when comment is removed from stream (e.g. due to an edit).

## How do I test this PR?

- Post a comment -> See that the comment counter on the tab increases
- Edit a comment with premod enabled -> See that the comment counter on the tab decreases
