### PR TITLE
Use same lifespan for cookies as for tokens

### DIFF
--- a/bin/cli-assets
+++ b/bin/cli-assets
@@ -5,7 +5,7 @@
  */
 
 const program = require('./commander');
-const parseDuration = require('parse-duration');
+const parseDuration = require('ms');
 const Table = require('cli-table');
 const AssetModel = require('../models/asset');
 const mongoose = require('../services/mongoose');

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "node-emoji": "^1.5.1",
     "node-fetch": "^1.6.3",
     "nodemailer": "^2.6.4",
-    "parse-duration": "^0.1.1",
     "passport": "^0.3.2",
     "passport-jwt": "^2.2.1",
     "passport-local": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "minimist": "^1.2.0",
     "mongoose": "^4.9.8",
     "morgan": "^1.8.1",
+    "ms": "^2.0.0",
     "natural": "^0.5.0",
     "node-emoji": "^1.5.1",
     "node-fetch": "^1.6.3",

--- a/services/passport.js
+++ b/services/passport.js
@@ -10,6 +10,7 @@ const uuid = require('uuid');
 const debug = require('debug')('talk:passport');
 const {createClient} = require('./redis');
 const bowser = require('bowser');
+const ms = require('ms');
 
 // Create a redis client to use for authentication.
 const client = createClient();
@@ -39,7 +40,7 @@ const SetTokenForSafari = (req, res, token) => {
   if (browser.ios || browser.safari) {
     res.cookie('authorization', token, {
       httpOnly: true,
-      expires: new Date(Date.now() + 900000)
+      expires: new Date(Date.now() + ms(JWT_EXPIRY))
     });
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5365,6 +5365,10 @@ ms@0.7.3, ms@^0.7.1:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
 
+ms@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 muri@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/muri/-/muri-1.2.1.tgz#ec7ea5ce6ca6a523eb1ab35bacda5fa816c9aa3c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5865,10 +5865,6 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
-parse-duration@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-0.1.1.tgz#13114ddc9891c1ecd280036244554de43647a226"
-
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"


### PR DESCRIPTION
## What does this PR do?
- Uses the same lifespan for safari login cookies as for jwt tokens

## How do I test this PR?

- Login with Safari
- Inspect cookie in `storage` tab and check the expiry time to match the JWT token expiry time.