### PR TITLE
Add supplied classes to tabbar/tabs

### DIFF
--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -41,7 +41,7 @@ export default class Embed extends React.Component {
     return (
       <div>
         <div className="commentStream">
-          <TabBar onChange={this.changeTab} activeTab={activeTab} cNames="tabbar">
+          <TabBar onChange={this.changeTab} activeTab={activeTab} cNames={'tabbar'}>
             <Tab cNames={`comment-count`}><Count count={totalCommentCount} /></Tab>
             <Tab cNames={`my-comments`}>{t('framework.my_profile')}</Tab>
             <Tab cNames={`comment-configuration`} restricted={!can(user, 'UPDATE_CONFIG')}>{t('framework.configure_stream')}</Tab>

--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -41,7 +41,7 @@ export default class Embed extends React.Component {
     return (
       <div>
         <div className="commentStream">
-          <TabBar onChange={this.changeTab} activeTab={activeTab} cNames={'tabbar'}>
+          <TabBar onChange={this.changeTab} activeTab={activeTab}>
             <Tab cNames={'comment-count'}><Count count={totalCommentCount} /></Tab>
             <Tab cNames={'comment-profile'}>{t('framework.my_profile')}</Tab>
             <Tab cNames={'comment-configuration'} restricted={!can(user, 'UPDATE_CONFIG')}>{t('framework.configure_stream')}</Tab>

--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -41,10 +41,10 @@ export default class Embed extends React.Component {
     return (
       <div>
         <div className="commentStream">
-          <TabBar onChange={this.changeTab} activeTab={activeTab}>
-            <Tab><Count count={totalCommentCount} /></Tab>
-            <Tab>{t('framework.my_profile')}</Tab>
-            <Tab restricted={!can(user, 'UPDATE_CONFIG')}>{t('framework.configure_stream')}</Tab>
+          <TabBar onChange={this.changeTab} activeTab={activeTab} cNames="tabbar">
+            <Tab cNames={`comment-count`}><Count count={totalCommentCount} /></Tab>
+            <Tab cNames={`my-comments`}>{t('framework.my_profile')}</Tab>
+            <Tab cNames={`comment-configuration`} restricted={!can(user, 'UPDATE_CONFIG')}>{t('framework.configure_stream')}</Tab>
           </TabBar>
           {commentId &&
             <Button

--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -10,7 +10,7 @@ import ProfileContainer from 'coral-settings/containers/ProfileContainer';
 import ConfigureStreamContainer
   from 'coral-configure/containers/ConfigureStreamContainer';
 
-export default class Embed extends React.Component {
+export default class Embed extends React.Component { 
   changeTab = (tab) => {
     switch (tab) {
     case 0:
@@ -42,9 +42,9 @@ export default class Embed extends React.Component {
       <div>
         <div className="commentStream">
           <TabBar onChange={this.changeTab} activeTab={activeTab} cNames={'tabbar'}>
-            <Tab cNames={`comment-count`}><Count count={totalCommentCount} /></Tab>
-            <Tab cNames={`my-comments`}>{t('framework.my_profile')}</Tab>
-            <Tab cNames={`comment-configuration`} restricted={!can(user, 'UPDATE_CONFIG')}>{t('framework.configure_stream')}</Tab>
+            <Tab cNames={'comment-count'}><Count count={totalCommentCount} /></Tab>
+            <Tab cNames={'comment-profile'}>{t('framework.my_profile')}</Tab>
+            <Tab cNames={'comment-configuration'} restricted={!can(user, 'UPDATE_CONFIG')}>{t('framework.configure_stream')}</Tab>
           </TabBar>
           {commentId &&
             <Button

--- a/client/coral-ui/components/Tab.js
+++ b/client/coral-ui/components/Tab.js
@@ -4,7 +4,7 @@ import styles from './Tab.css';
 export default ({children, tabId, active, onTabClick, cStyle = 'base', cNames}) => (
   <li
     key={tabId}
-    className={`${active ? styles[`${cStyle}--active`] : ''} tab ${cNames}`}
+    className={`${active ? styles[`${cStyle}--active`] : ''} tab ${cNames ? cNames : ''}`}
     onClick={() => onTabClick(tabId)}
   >
     {children}

--- a/client/coral-ui/components/Tab.js
+++ b/client/coral-ui/components/Tab.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import styles from './Tab.css';
 
-export default ({children, tabId, active, onTabClick, cStyle = 'base'}) => (
+export default ({children, tabId, active, onTabClick, cStyle = 'base', cNames}) => (
   <li
     key={tabId}
-    className={active ? styles[`${cStyle}--active`] : ''}
+    className={`${active ? styles[`${cStyle}--active`] : ''} tab ${cNames}`}
     onClick={() => onTabClick(tabId)}
   >
     {children}

--- a/client/coral-ui/components/TabBar.js
+++ b/client/coral-ui/components/TabBar.js
@@ -14,10 +14,10 @@ class TabBar extends React.Component {
   }
 
   render() {
-    const {children, activeTab, cStyle = 'base'} = this.props;
+    const {children, activeTab, cStyle = 'base', cNames} = this.props;
     return (
       <div>
-        <ul className={`${styles.base} ${cStyle ? styles[cStyle] : ''}`}>
+        <ul className={`${styles.base} ${cStyle ? styles[cStyle] : ''} ${cNames}`}>
           {React.Children.toArray(children)
             .filter((child) => !child.props.restricted)
             .map((child, tabId) =>

--- a/client/coral-ui/components/TabBar.js
+++ b/client/coral-ui/components/TabBar.js
@@ -17,7 +17,7 @@ class TabBar extends React.Component {
     const {children, activeTab, cStyle = 'base', cNames} = this.props;
     return (
       <div>
-        <ul className={`${styles.base} ${cStyle ? styles[cStyle] : ''} ${cNames}`}>
+        <ul className={`${styles.base} ${cStyle ? styles[cStyle] : ''} ${cNames ? cNames : 'tab-bar'}`}>
           {React.Children.toArray(children)
             .filter((child) => !child.props.restricted)
             .map((child, tabId) =>


### PR DESCRIPTION
## What does this PR do?
Support additional classes added to tabbar, tab.  

 - This will allow classes to be applied in stylesheets at a detailed level; currently, we can only apply classes to the dynamic classnames. 

 - this will also support reuse of TabBar componenet.

## How do I test this PR?
See that classes are supplied on tabbar and tab components 

- click a button
- view the cat
- see the cat meow
