### PR TITLE
Pass onAuthChange callback into embed

### DIFF
--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -54,6 +54,10 @@ function configurePymParent(pymParent, opts) {
     pymParent.sendMessage('config', JSON.stringify(config));
   }
 
+  pymParent.onMessage('checkLogin', function(result) {
+    console.log(JSON.parse(result));
+  });
+
   // Sends config to the child
   pymParent.onMessage('getConfig', function() {
     sendConfig(opts || {});

--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -55,7 +55,9 @@ function configurePymParent(pymParent, opts) {
   }
 
   pymParent.onMessage('checkLogin', function(result) {
-    console.log(JSON.parse(result));
+    if (opts.onAuthChange) {
+      opts.onAuthChange(JSON.parse(result));
+    }
   });
 
   // Sends config to the child

--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -54,15 +54,11 @@ function configurePymParent(pymParent, opts) {
     pymParent.sendMessage('config', JSON.stringify(config));
   }
 
-  function onAuthChanged(message) {
+  pymParent.onMessage('coral-auth-changed', function(message) {
     if (opts.onAuthChanged) {
       opts.onAuthChanged(message ? JSON.parse(message) : null);
     }
-  }
-
-  pymParent.onMessage('coral-login', onAuthChanged);
-
-  pymParent.onMessage('coral-logout', onAuthChanged);
+  });
 
   // Sends config to the child
   pymParent.onMessage('getConfig', function() {

--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -54,11 +54,15 @@ function configurePymParent(pymParent, opts) {
     pymParent.sendMessage('config', JSON.stringify(config));
   }
 
-  pymParent.onMessage('coral-check-login', function(result) {
-    if (opts.onCheckLogin) {
-      opts.onCheckLogin(JSON.parse(result));
+  function onAuthChanged(message) {
+    if (opts.onAuthChanged) {
+      opts.onAuthChanged(message ? JSON.parse(message) : null);
     }
-  });
+  }
+
+  pymParent.onMessage('coral-login', onAuthChanged);
+
+  pymParent.onMessage('coral-logout', onAuthChanged);
 
   // Sends config to the child
   pymParent.onMessage('getConfig', function() {

--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -54,9 +54,9 @@ function configurePymParent(pymParent, opts) {
     pymParent.sendMessage('config', JSON.stringify(config));
   }
 
-  pymParent.onMessage('checkLogin', function(result) {
-    if (opts.onAuthChange) {
-      opts.onAuthChange(JSON.parse(result));
+  pymParent.onMessage('coral-check-login', function(result) {
+    if (opts.onCheckLogin) {
+      opts.onCheckLogin(JSON.parse(result));
     }
   });
 

--- a/client/coral-framework/actions/auth.js
+++ b/client/coral-framework/actions/auth.js
@@ -285,6 +285,7 @@ export const logout = () => (dispatch) => {
     resetWebsocket();
 
     dispatch({type: actions.LOGOUT});
+    pym.sendMessage('coral-logout');
   });
 };
 
@@ -305,7 +306,6 @@ export const checkLogin = () => (dispatch) => {
   dispatch(checkLoginRequest());
   coralApi('/auth')
     .then((result) => {
-      pym.sendMessage('coral-check-login', JSON.stringify(result));
 
       if (!result.user) {
         if (!bowser.safari && !bowser.ios) {
@@ -318,6 +318,7 @@ export const checkLogin = () => (dispatch) => {
       resetWebsocket();
 
       dispatch(checkLoginSuccess(result.user));
+      pym.sendMessage('coral-login', JSON.stringify(result.user));
 
       // Display create username dialog if necessary.
       if (result.user.canEditName && result.user.status !== 'BANNED') {

--- a/client/coral-framework/actions/auth.js
+++ b/client/coral-framework/actions/auth.js
@@ -301,10 +301,12 @@ const checkLoginSuccess = (user, isAdmin) => ({
   isAdmin
 });
 
-export const checkLogin = () => (dispatch, getState) => {
+export const checkLogin = () => (dispatch) => {
   dispatch(checkLoginRequest());
   coralApi('/auth')
     .then((result) => {
+      pym.sendMessage('coral-check-login', JSON.stringify(result));
+
       if (!result.user) {
         if (!bowser.safari && !bowser.ios) {
           Storage.removeItem('token');
@@ -325,9 +327,6 @@ export const checkLogin = () => (dispatch, getState) => {
     .catch((error) => {
       console.error(error);
       dispatch(checkLoginFailure(`${error.translation_key}`));
-    })
-    .then(() => {
-      pym.sendMessage('checkLogin', JSON.stringify(getState().auth));
     });
 };
 

--- a/client/coral-framework/actions/auth.js
+++ b/client/coral-framework/actions/auth.js
@@ -3,6 +3,7 @@ import bowser from 'bowser';
 import * as actions from '../constants/auth';
 import * as Storage from '../helpers/storage';
 import coralApi, {base} from '../helpers/request';
+import pym from '../services/PymConnection';
 
 import {resetWebsocket} from 'coral-framework/services/client';
 import t from 'coral-framework/services/i18n';
@@ -300,7 +301,7 @@ const checkLoginSuccess = (user, isAdmin) => ({
   isAdmin
 });
 
-export const checkLogin = () => (dispatch) => {
+export const checkLogin = () => (dispatch, getState) => {
   dispatch(checkLoginRequest());
   coralApi('/auth')
     .then((result) => {
@@ -324,6 +325,9 @@ export const checkLogin = () => (dispatch) => {
     .catch((error) => {
       console.error(error);
       dispatch(checkLoginFailure(`${error.translation_key}`));
+    })
+    .then(() => {
+      pym.sendMessage('checkLogin', JSON.stringify(getState().auth));
     });
 };
 

--- a/client/coral-framework/actions/auth.js
+++ b/client/coral-framework/actions/auth.js
@@ -285,7 +285,7 @@ export const logout = () => (dispatch) => {
     resetWebsocket();
 
     dispatch({type: actions.LOGOUT});
-    pym.sendMessage('coral-logout');
+    pym.sendMessage('coral-auth-changed');
   });
 };
 
@@ -306,7 +306,6 @@ export const checkLogin = () => (dispatch) => {
   dispatch(checkLoginRequest());
   coralApi('/auth')
     .then((result) => {
-
       if (!result.user) {
         if (!bowser.safari && !bowser.ios) {
           Storage.removeItem('token');
@@ -318,7 +317,7 @@ export const checkLogin = () => (dispatch) => {
       resetWebsocket();
 
       dispatch(checkLoginSuccess(result.user));
-      pym.sendMessage('coral-login', JSON.stringify(result.user));
+      pym.sendMessage('coral-auth-changed', JSON.stringify(result.user));
 
       // Display create username dialog if necessary.
       if (result.user.canEditName && result.user.status !== 'BANNED') {


### PR DESCRIPTION
## What does this PR do?

Allows the host page to provide a callback that fires on the parent page when the Talk auth state changes. 

## How do I test this PR?

- embed a talk stream with an onAuthChange callback:
```
<div id="coral_talk_8938213609030934"></div>
<script src="http://localhost:5000/embed.js" async onload="
  Coral.Talk.render(document.getElementById('coral_talk_8938213609030934'), {
    talk: 'http://localhost:5000',
    onAuthChange: function(auth) {
      console.log(auth);
    }
  });
"></script>
```
- log in through Talk
- see the auth state logged in the console from the parent page
