### PR TITLE
Robust live reactions

### DIFF
--- a/client/coral-framework/graphql/fragments.js
+++ b/client/coral-framework/graphql/fragments.js
@@ -7,7 +7,7 @@ export default {
     'SuspendUserResponse',
     'RejectUsernameResponse',
     'SetUserStatusResponse',
-    'PostCommentResponse',
+    'CreateFlagResponse',
     'EditCommentResponse',
     'PostFlagResponse',
     'CreateDontAgreeResponse',
@@ -17,3 +17,4 @@ export default {
     'StopIgnoringUserResponse',
   )
 };
+

--- a/errors.js
+++ b/errors.js
@@ -104,6 +104,20 @@ class ErrAuthentication extends APIError {
   }
 }
 
+/**
+ * ErrAlreadyExists is returned when an attempt to create a resource failed due to an existing one.
+ */
+class ErrAlreadyExists extends APIError {
+  constructor(existing = null) {
+    super('authentication error occured', {
+      translation_key: 'ALREADY_EXISTS',
+      status: 400
+    }, {
+      existing
+    });
+  }
+}
+
 // ErrContainsProfanity is returned in the event that the middleware detects
 // profanity/wordlisted words in the payload.
 const ErrContainsProfanity = new APIError('This username contains elements which are not permitted in our community. If you think this is in error, please contact us or try again.', {
@@ -171,6 +185,7 @@ const ErrCommentTooShort = new APIError('Comment was too short', {
 module.exports = {
   ExtendableError,
   APIError,
+  ErrAlreadyExists,
   ErrPasswordTooShort,
   ErrSettingsNotInit,
   ErrMissingEmail,

--- a/errors.js
+++ b/errors.js
@@ -109,9 +109,9 @@ class ErrAuthentication extends APIError {
  */
 class ErrAlreadyExists extends APIError {
   constructor(existing = null) {
-    super('authentication error occured', {
+    super('resource already exists', {
       translation_key: 'ALREADY_EXISTS',
-      status: 400
+      status: 409
     }, {
       existing
     });

--- a/graph/mutators/action.js
+++ b/graph/mutators/action.js
@@ -36,7 +36,7 @@ const createAction = async ({user = {}}, {item_id, item_type, action_type, group
  * Deletes an action based on the user id if the user owns that action.
  * @param  {Object} user the user performing the request
  * @param  {String} id   the id of the action to delete
- * @return {Promise}     resolves when the action is deleted
+ * @return {Promise}     resolves to the deleted action, or null if not found.
  */
 const deleteAction = ({user}, {id}) => {
   return ActionModel.findOneAndRemove({

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -189,6 +189,7 @@ en:
     PASSWORD_REQUIRED: "Must input a password"
     COMMENTING_CLOSED: "Commenting is already closed"
     NOT_FOUND: "Resource not found"
+    ALREADY_EXISTS: "Resource already exists"
     INVALID_ASSET_URL: "Assert URL is invalid"
     email: "Not a valid E-Mail"
     confirm_password: "Passwords don't match. Please check again"


### PR DESCRIPTION
## What does this PR do?
- Prevent sending a reaction mutation, when another one is already running.
- Only publish live updates when a reaction was actually created or deleted.

## How do I test this PR?

- Speed clicking on a reaction should only cause one mutation.
- Posting a reaction to a comment, that was already reacted on should not update the counter for other users.
- Removing a reaction from a comment, that was already removed should not update the counter for other users.