### PR TITLE
style updates to flagged user names queue and updated translations

### DIFF
--- a/client/coral-admin/src/routes/Community/components/Community.css
+++ b/client/coral-admin/src/routes/Community/components/Community.css
@@ -175,7 +175,7 @@
      right: 0;
      height: 100%;
      top: 0;
-     padding: 40px 18px;
+     padding: 50px 18px;
      box-sizing: border-box;
    }
 
@@ -310,24 +310,33 @@
 .flaggedByCount {
   display: block;
   text-align: left;
+  margin-top: 5px;
+}
+
+.flaggedByCount i {
+  font-size: 14px;
+  margin-right: 10px;
 }
 
 .flaggedBy {
   display: inline;
   padding: 3px;
-  font-size: 16px;
+  font-size: 14px;
+  margin-left: 5px;
 }
 
 .flaggedByLabel {
-  font-weight: bold;
+  font-weight: 600;
   font-size: 14px;
 }
 
 .flaggedReasons {
-  padding-top: 15px;
   margin-left: 24px;
+  margin-top: 10px;
 }
 
-.flaggedByReason {
+p.flaggedByReason {
   font-size: 1tpx;
+  margin: 0px;
+  line-height: 1.4;
 }

--- a/client/coral-admin/src/routes/Community/components/styles.css
+++ b/client/coral-admin/src/routes/Community/components/styles.css
@@ -52,6 +52,10 @@ span {
   }
 }
 
+.approve {
+  margin-top: 10px;
+}
+
 .notFound {
   position: relative;
   margin: 20px auto;
@@ -193,7 +197,7 @@ span {
      top: 0;
      padding: 40px 18px;
      box-sizing: border-box;
-   }
+  }
 
   .itemHeader {
     display: flex;
@@ -254,6 +258,8 @@ span {
   }
 
 }
+
+
 
 .empty {
   color: #444;

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -42,17 +42,17 @@ en:
     banned: Banned
     banned_user: "Banned User"
     cancel: Cancel
-    dont_like_username: "I don't like this username"
+    dont_like_username: "Dislike username"
     flaggedaccounts: "Flagged Usernames"
     flags: Flags
-    impersonating: "This user is impersonating"
+    impersonating: "Impersonation"
     loading: "Loading results"
     moderator: Moderator
     newsroom_role: "Newsroom Role"
-    no_flagged_accounts: "The Account Flags queue is currently empty."
+    no_flagged_accounts: "The Flagged Usernames queue is currently empty."
     no_results: "No users found with that user name or email address. They're hiding!"
     note: "Note: Banning this user will not let them edit comment or remove anything."
-    offensive: "This comment is offensive"
+    offensive: "Offensive"
     other: Other
     people: People
     role: "Select role..."

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -44,14 +44,14 @@ es:
     dont_like_username: "No me gusta este nombre de usuario"
     flaggedaccounts: "Nombres de Usuario Reportados"
     flags: Reportes
-    impersonating: "El usuario esta suplantando identidad"
+    impersonating: Impersonando
     loading: "Cargando resultados"
     moderator: Moderator
     newsroom_role: "Rol en la redacción"
-    no_flagged_accounts: "No hay ninguna cuenta reportada en este momento."
+    no_flagged_accounts: "No hay ningún nombre de usario reportado en este momento."
     no_results: "No se encontraron usuarios con ese nombre o correo."
     note: "Nota: Suspender a este usuario no le va a permitir (al usuario) borrar ni editar ni comentar."
-    offensive: "Este comentario es ofensivo"
+    offensive: Ofensivo
     other: Otro
     people: Gente
     role: "Seleccionar rol..."


### PR DESCRIPTION
## What does this PR do?

Made style updates for "Flagged Usernames" queue on Community page.

Note:  There are two outstanding issues here that are outside of my skillz:
- Update the "ban user button" to be the "actions" (aka suspend/ban user) button (cc @cvle)
- Usernames that are flagged as "Offensive" are not returning the string to show "offensive" as the reason (was able to replicate on staging as well).  (cc @gabelula) 

## How do I test this PR?

- click a button
- view the cat
- see the cat meow
