### PR TITLE
Use new import path for coral-ui

### DIFF
--- a/plugins/coral-plugin-viewing-options/client/components/ViewingOptions.js
+++ b/plugins/coral-plugin-viewing-options/client/components/ViewingOptions.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import cn from 'classnames';
 import styles from './ViewingOptions.css';
-import {Slot, Icon} from 'plugin-api/beta/client/components';
+import {Slot} from 'plugin-api/beta/client/components';
+import {Icon} from 'plugin-api/beta/client/components/ui';
 
 const ViewingOptions = (props) => {
   const toggleOpen = () => {


### PR DESCRIPTION
## What does this PR do?
- Use new import path for coral-ui
