### PR TITLE
Search dropdown: clear search when closed

### DIFF
--- a/client/coral-admin/src/routes/Moderation/components/StorySearch.js
+++ b/client/coral-admin/src/routes/Moderation/components/StorySearch.js
@@ -81,7 +81,7 @@ const StorySearch = (props) => {
           </div>
         </div>
       </div>
-      <div className={styles.overlay} onClick={props.closeSearch} />
+      <div className={styles.overlay} onClick={props.clearAndCloseSearch} />
     </div>
   );
 };
@@ -89,7 +89,7 @@ const StorySearch = (props) => {
 StorySearch.propTypes = {
   search: PropTypes.func.isRequired,
   goToStory: PropTypes.func.isRequired,
-  closeSearch: PropTypes.func.isRequired,
+  clearAndCloseSearch: PropTypes.func.isRequired,
   moderation: PropTypes.object.isRequired,
   handleSearchChange: PropTypes.func.isRequired,
   assetId: PropTypes.string

--- a/client/coral-admin/src/routes/Moderation/containers/StorySearch.js
+++ b/client/coral-admin/src/routes/Moderation/containers/StorySearch.js
@@ -13,6 +13,21 @@ class StorySearchContainer extends React.Component {
     };
   }
 
+  componentWillUnmount() {
+    this.props.storySearchChange('');
+  }
+
+  clearSearch = () => {
+    this.setState({searchValue: ''}, () => {
+      this.search();
+    });
+  }
+
+  clearAndCloseSearch = () => {
+    this.clearSearch();
+    this.props.closeSearch();
+  }
+
   handleSearchChange = (e) => {
     const {value} = e.target;
     this.setState({
@@ -23,7 +38,7 @@ class StorySearchContainer extends React.Component {
   handleEsc = (e) => {
     if (e.key === 'Escape') {
       e.preventDefault();
-      this.props.closeSearch();
+      this.clearAndCloseSearch();
     }
   }
 
@@ -40,15 +55,15 @@ class StorySearchContainer extends React.Component {
   }
 
   goToStory = (id) => {
-    const {router, closeSearch} = this.props;
+    const {router} = this.props;
     router.push(`/admin/moderate/all/${id}`);
-    closeSearch();
+    this.clearAndCloseSearch();
   }
 
   goToModerateAll = () => {
-    const {router, closeSearch} = this.props;
+    const {router} = this.props;
     router.push('/admin/moderate/all');
-    closeSearch();
+    this.clearAndCloseSearch();
   }
 
   render () {
@@ -61,6 +76,7 @@ class StorySearchContainer extends React.Component {
         handleEnter={this.handleEnter}
         searchValue={this.state.searchValue}
         handleSearchChange={this.handleSearchChange}
+        clearAndCloseSearch={this.clearAndCloseSearch}
         {...this.props}
       />
     );

--- a/client/coral-admin/src/routes/Moderation/containers/StorySearch.js
+++ b/client/coral-admin/src/routes/Moderation/containers/StorySearch.js
@@ -3,6 +3,7 @@ import {compose, gql} from 'react-apollo';
 import StorySearch from '../components/StorySearch';
 import {withRouter} from 'react-router';
 import withQuery from 'coral-framework/hocs/withQuery';
+import {isEmpty} from 'lodash';
 
 class StorySearchContainer extends React.Component {
   constructor(props) {
@@ -24,7 +25,9 @@ class StorySearchContainer extends React.Component {
   }
 
   clearAndCloseSearch = () => {
-    this.clearSearch();
+    if (!isEmpty(this.state.searchValue)) {
+      this.clearSearch();
+    }
     this.props.closeSearch();
   }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1863625/stories/147545927

## What does this PR do?
The search dropdown now clears when closed.

![clear-search](https://user-images.githubusercontent.com/10943083/27419939-78af18fc-56f1-11e7-8cdb-21ceeace4ede.gif)

## How do I test this PR?
- open search dropdown
- type something in the input
- search if you want

try one of the following:
- close search dropdown by clicking out of it
- close search dropdown by pressing Esc
- close search dropdown by clicking a Story
- close search dropdown by clicking "Moderate comments on All Stories"
- close search dropdown by clicking top navigation tabs e.g. Moderate -> Stories

then:
- open search dropdown again
- notice search was cleared