### PR TITLE
Fix Moderate → link by setting to "All" for that story

### DIFF
--- a/client/coral-admin/src/routes/Moderation/components/Comment.js
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.js
@@ -129,7 +129,7 @@ class Comment extends React.Component {
           <div className={styles.moderateArticle}>
             Story: {comment.asset.title}
             {!props.currentAsset &&
-              <Link to={`/admin/moderate/${comment.asset.id}`}>{t('modqueue.moderate')}</Link>}
+              <Link to={`/admin/moderate/all/${comment.asset.id}`}>{t('modqueue.moderate')}</Link>}
           </div>
           <CSSTransitionGroup
             component={'div'}


### PR DESCRIPTION
## What does this PR do?
This looked like a bug to me: https://github.com/coralproject/talk/issues/702, so here's the simple fix if that's the case.

## How do I test this PR?
Click Moderate → link for a story and notice it no longer blanks out the comments and loses the tab. Notice Path 1 and Path 2 from https://github.com/coralproject/talk/issues/702 now do the same thing.

The issue just seems to have been a bad link.