### PR TITLE
Added support for keep alive websocket frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ sign and verify tokens via a `HS256` algorithm.
 - `TALK_RECAPTCHA_SECRET` (*required for reCAPTCHA support*) - server secret used for enabling reCAPTCHA powered logins. If not provided it will instead default to providing only a time based lockout.
 - `TALK_RECAPTCHA_PUBLIC` (*required for reCAPTCHA support*) - client secret used for enabling reCAPTCHA powered logins. If not provided it will instead default to providing only a time based lockout.
 - `TALK_PLUGINS_JSON` (_optional_) - used to specify the plugin config via the environment
+- `TALK_KEEP_ALIVE` (_optional_) - The keepalive timeout that should be used to send keep alive messages through the websocket to keep the socket alive. (Default `30s`)
 
 Refer to the wiki page on [Configuration Loading](https://github.com/coralproject/talk/wiki/Configuration-Loading) for
 alternative methods of loading configuration during development.

--- a/config.js
+++ b/config.js
@@ -56,7 +56,11 @@ const CONFIG = {
 
   // The URL for this Talk Instance as viewable from the outside.
   ROOT_URL: process.env.TALK_ROOT_URL,
-  
+
+  // The keepalive timeout (in ms) that should be used to send keep alive
+  // messages through the websocket to keep the socket alive.
+  KEEP_ALIVE: process.env.TALK_KEEP_ALIVE || '30s',
+
   //------------------------------------------------------------------------------
   // Recaptcha configuration
   //------------------------------------------------------------------------------

--- a/graph/subscriptions.js
+++ b/graph/subscriptions.js
@@ -10,6 +10,11 @@ const plugins = require('../services/plugins');
 
 const {deserializeUser} = require('../services/subscriptions');
 
+const ms = require('ms');
+const {
+  KEEP_ALIVE
+} = require('../config');
+
 const {
   SUBSCRIBE_COMMENT_ACCEPTED,
   SUBSCRIBE_COMMENT_REJECTED,
@@ -119,7 +124,8 @@ const createSubscriptionManager = (server) => new SubscriptionServer({
     };
 
     return baseParams;
-  }
+  },
+  keepAlive: ms(KEEP_ALIVE)
 }, {
   server,
   path: '/api/v1/live'


### PR DESCRIPTION
## What does this PR do?

Adds a configurable web socket timeout option that will send `{"type":"ka"}` over the web socket (default 30s) to prevent load balancers from terminating the connection.

## How do I test this PR?

1. Open the page in Chrome
2. Look under Network -> WS -> /live
3. Select the "Frames" tab
4. Wait 30+ seconds, notice at least 1 `{"type":"ka"}` frame.