### PR TITLE
Make highlight suspect/banned words regex case insensitive

### DIFF
--- a/client/coral-admin/src/routes/Moderation/components/Comment.js
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.js
@@ -54,7 +54,7 @@ class Comment extends React.Component {
     // currently the highlighter plugin does not support out of the box.
     const searchWords = [...suspectWords, ...bannedWords]
       .filter((w) => {
-        return new RegExp(`(^|\\s)${w}(\\s|$)`).test(comment.body);
+        return new RegExp(`(^|\\s)${w}(\\s|$)`, 'i').test(comment.body);
       })
       .concat(linkText);
 


### PR DESCRIPTION
## What does this PR do?
Fixes: https://www.pivotaltracker.com/story/show/147775935

## How do I test this PR?
- Configure > Moderation Settings > Add to Suspect words list "fishy" and "amenabar"
- create (non-admin) comments with "Fishy", "Amenabar", "fishy", "amenabar"
- notice they are now all highlighted regardless of casing

![screen shot 2017-06-24 at 3 44 12 pm](https://user-images.githubusercontent.com/10943083/27511576-57983f76-58f5-11e7-92d9-b21219804187.png)


