### PR TITLE
Disable plugin components via plugin_config

### DIFF
--- a/client/coral-framework/helpers/plugins.js
+++ b/client/coral-framework/helpers/plugins.js
@@ -7,17 +7,29 @@ import flatten from 'lodash/flatten';
 import flattenDeep from 'lodash/flattenDeep';
 import {getDefinitionName, mergeDocuments} from 'coral-framework/utils';
 import {loadTranslations} from 'coral-framework/services/i18n';
-import {injectReducers} from 'coral-framework/services/store';
+import {injectReducers, getStore} from 'coral-framework/services/store';
 import camelize from './camelize';
+
+function getSlotComponents(slot) {
+  const pluginConfig = getStore().getState().config.plugin_config;
+  return flatten(plugins
+
+    // Filter out components that have been disabled in `plugin_config`
+    .filter((o) => !pluginConfig[o.plugin] || !pluginConfig[o.plugin].disable_components)
+
+    .filter((o) => o.module.slots[slot])
+    .map((o) => o.module.slots[slot]));
+}
+
+export function isSlotEmpty(slot) {
+  return !!getSlotComponents(slot).length;
+}
 
 /**
  * Returns React Elements for given slot.
  */
 export function getSlotElements(slot, props = {}) {
-  const components = flatten(plugins
-    .filter((o) => o.module.slots[slot])
-    .map((o) => o.module.slots[slot]));
-  return components
+  return getSlotComponents(slot)
     .map((component, i) => React.createElement(component, {key: i, ...props}));
 }
 

--- a/plugin-api/beta/client/services/index.js
+++ b/plugin-api/beta/client/services/index.js
@@ -1,2 +1,3 @@
 export {t} from 'coral-framework/services/i18n';
 export {can} from 'coral-framework/services/perms';
+export {isSlotEmpty} from 'coral-framework/helpers/plugins';

--- a/views/article.ejs
+++ b/views/article.ejs
@@ -31,6 +31,13 @@
         asset_id: '<%= asset_id ? asset_id : '' %>',
         auth_token: '',
         plugin_config: {
+          /**
+           *  You can disable rendering slot components of a plugin by doing:
+           *
+           *  'coral-plugin-love': {
+           *    disable_components: true,
+           *  },
+           */
           test: 'data',
           debug: false
         }


### PR DESCRIPTION
## What does this PR do?
- Allow disabling components of a plugin via `plugin_config`
- Provide  `isSlotEmpty(slot: string): boolean` in `plugin-api/beta/client/services`

## Example config:

```json
{
  "plugin_config": {
    "coral-plugin-love": {
      "disable_components": true,
    }
  }
}
```