### PR TITLE
Don't show popup when empty

### DIFF
--- a/client/coral-framework/actions/auth.js
+++ b/client/coral-framework/actions/auth.js
@@ -7,8 +7,12 @@ import pym from '../services/PymConnection';
 
 import {resetWebsocket} from 'coral-framework/services/client';
 import t from 'coral-framework/services/i18n';
+import {isSlotEmpty} from 'plugin-api/beta/client/services';
 
 export const showSignInDialog = () => (dispatch, getState) => {
+  if (isSlotEmpty('login')) {
+    return;
+  }
   const signInPopUp = window.open(
     '/embed/stream/login',
     'Login',


### PR DESCRIPTION
## What does this PR do?
- Depends on https://github.com/coralproject/talk/pull/733
- Don't show login popup when `login` slot is empty.