### PR TITLE
More classnames from erica

### DIFF
--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -51,6 +51,7 @@ export default class Embed extends React.Component {
               cStyle="darkGrey"
               style={{float: 'right'}}
               onClick={viewAllComments}
+              className={'talk-stream-show-all-comments-button'}
             >
               {t('framework.show_all_comments')}
             </Button>}

--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -40,7 +40,7 @@ export default class Embed extends React.Component {
 
     return (
       <div>
-        <div className="commentStream">
+        <div className={`commentStream ${commentId ? 'talk-permalink-stream' : ''}`}>
           <TabBar onChange={this.changeTab} activeTab={activeTab} className='talk-stream-tabbar'>
             <Tab className={'talk-stream-comment-count-tab'} id='stream'><Count count={totalCommentCount}/></Tab>
             <Tab className={'talk-stream-profile-tab'} id='profile'>{t('framework.my_profile')}</Tab>

--- a/client/coral-plugin-flags/components/FlagButton.js
+++ b/client/coral-plugin-flags/components/FlagButton.js
@@ -148,7 +148,7 @@ export default class FlagButton extends Component {
           <button
             ref={(ref) => this.flagButton = ref}
             onClick={!this.props.banned && !flaggedByCurrentUser && !localPost ? this.onReportClick : null}
-            className={cn(`${name}-button`, styles.button)}>
+            className={cn(`${name}-button`, `${name}-button${flagged ? '-flagged' : '-unflagged'}`, styles.button)}>
             {
               flagged
               ? <span className={`${name}-button-text`}>{t('reported')}</span>


### PR DESCRIPTION
## What does this PR do?
- Adds semantic classnames to:
  - The "Show All Comments" button
  - The comment stream when the request contains a commentId (ie. is a permalink request)
  - The FlagButton component to reflect whether flagged or unflagged (which allows developers to override styles on the entire button conditional on state)
## How do I test this PR?
- Load a stream for a particular commentId
  - Inspect the Show All Comments button and the commentStream for classes `talk-stream-show-all-comments-button` and `talk-permalink-stream`, respectively
  - Inspect the `button.coral-plugin-flags-button` element for class `coral-plugin-flags-button-unflagged`
- Load a stream without a commentId
  - Inspect the commentStream to confirm that `talk-permalink-stream` class in NOT present
- Report a comment or username
  - Inspect the `button.coral-plugin-flags-button` element for class `coral-plugin-flags-button-flagged`