### PR TITLE
Adapt Class Names

### DIFF
--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -42,7 +42,7 @@ export default class Embed extends React.Component {
 
     return (
       <div className={cn('talk-embed-stream', {'talk-embed-stream-highlight-comment': hasHighlightedComment})}>
-        <TabBar onChange={this.changeTab} activeTab={activeTab} className='talk-embed-stream-tabbar'>
+        <TabBar onChange={this.changeTab} activeTab={activeTab} className='talk-embed-stream-tab-bar'>
           <Tab className={'talk-embed-stream-comments-tab'} id='stream'><Count count={totalCommentCount}/></Tab>
           <Tab className={'talk-embed-stream-profile-tab'} id='profile'>{t('framework.my_profile')}</Tab>
           <Tab className={'talk-embed-stream-configuration-tab'} id='config' restricted={!can(user, 'UPDATE_CONFIG')}>
@@ -54,7 +54,7 @@ export default class Embed extends React.Component {
             cStyle="darkGrey"
             style={{float: 'right'}}
             onClick={viewAllComments}
-            className={'talk-embed-stream-show-all-comments-button'}
+            className={'talk-stream-show-all-comments-button'}
           >
             {t('framework.show_all_comments')}
           </Button>}

--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -9,6 +9,7 @@ import Count from 'coral-plugin-comment-count/CommentCount';
 import ProfileContainer from 'coral-settings/containers/ProfileContainer';
 import ConfigureStreamContainer
   from 'coral-configure/containers/ConfigureStreamContainer';
+import cn from 'classnames';
 
 export default class Embed extends React.Component {
   changeTab = (tab) => {
@@ -37,34 +38,36 @@ export default class Embed extends React.Component {
     const {activeTab, viewAllComments, commentId} = this.props;
     const {asset: {totalCommentCount}} = this.props.root;
     const {user} = this.props.auth;
+    const hasHighlightedComment = !!commentId;
 
     return (
-      <div>
-        <div className="commentStream">
-          <TabBar onChange={this.changeTab} activeTab={activeTab} className='talk-stream-tabbar'>
-            <Tab className={'talk-stream-comment-count-tab'} id='stream'><Count count={totalCommentCount}/></Tab>
-            <Tab className={'talk-stream-profile-tab'} id='profile'>{t('framework.my_profile')}</Tab>
-            <Tab className={'talk-stream-configuration-tab'} id='config' restricted={!can(user, 'UPDATE_CONFIG')}>{t('framework.configure_stream')}</Tab>
-          </TabBar>
-          {commentId &&
-            <Button
-              cStyle="darkGrey"
-              style={{float: 'right'}}
-              onClick={viewAllComments}
-            >
-              {t('framework.show_all_comments')}
-            </Button>}
-          <Slot fill="embed" />
-          <TabContent show={activeTab === 'stream'}>
-            <Stream data={this.props.data} root={this.props.root} />
-          </TabContent>
-          <TabContent show={activeTab === 'profile'}>
-            <ProfileContainer />
-          </TabContent>
-          <TabContent show={activeTab === 'config'}>
-            <ConfigureStreamContainer />
-          </TabContent>
-        </div>
+      <div className={cn('talk-embed-stream', {'talk-embed-stream-highlight-comment': hasHighlightedComment})}>
+        <TabBar onChange={this.changeTab} activeTab={activeTab} className='talk-embed-stream-tabbar'>
+          <Tab className={'talk-embed-stream-comments-tab'} id='stream'><Count count={totalCommentCount}/></Tab>
+          <Tab className={'talk-embed-stream-profile-tab'} id='profile'>{t('framework.my_profile')}</Tab>
+          <Tab className={'talk-embed-stream-configuration-tab'} id='config' restricted={!can(user, 'UPDATE_CONFIG')}>
+            {t('framework.configure_stream')}
+          </Tab>
+        </TabBar>
+        {commentId &&
+          <Button
+            cStyle="darkGrey"
+            style={{float: 'right'}}
+            onClick={viewAllComments}
+            className={'talk-embed-stream-show-all-comments-button'}
+          >
+            {t('framework.show_all_comments')}
+          </Button>}
+        <Slot fill="embed" />
+        <TabContent show={activeTab === 'stream'}>
+          <Stream data={this.props.data} root={this.props.root} />
+        </TabContent>
+        <TabContent show={activeTab === 'profile'}>
+          <ProfileContainer />
+        </TabContent>
+        <TabContent show={activeTab === 'config'}>
+          <ConfigureStreamContainer />
+        </TabContent>
       </div>
     );
   }

--- a/client/coral-embed-stream/src/index.js
+++ b/client/coral-embed-stream/src/index.js
@@ -48,5 +48,5 @@ render(
   <ApolloProvider client={client} store={store}>
     <AppRouter />
   </ApolloProvider>
-  , document.querySelector('#coralStream')
+  , document.querySelector('#talk-embed-stream-container')
 );

--- a/client/coral-plugin-flags/components/FlagButton.js
+++ b/client/coral-plugin-flags/components/FlagButton.js
@@ -148,7 +148,7 @@ export default class FlagButton extends Component {
           <button
             ref={(ref) => this.flagButton = ref}
             onClick={!this.props.banned && !flaggedByCurrentUser && !localPost ? this.onReportClick : null}
-            className={cn(`${name}-button`, styles.button)}>
+            className={cn(`${name}-button`, {[`${name}-button-flagged`]: flagged}, styles.button)}>
             {
               flagged
               ? <span className={`${name}-button-text`}>{t('reported')}</span>

--- a/views/embed/stream.ejs
+++ b/views/embed/stream.ejs
@@ -15,7 +15,7 @@
   </head>
   <body>
 
-    <div id="coralStream"></div>
+    <div id="talk-embed-stream-container"></div>
     <script src="/client/embed/stream/bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## What does this PR do?
- This week we noticed that the CSS class names defined in the `Embed` component were semantically inaccurate. CSS class names are prefixed with `talk-stream-*`, which is in conflict with our `Stream` component that uses the same prefix. This becomes problematic as in #749 we will also have a tab bar in `Stream` and inevitable run into CSS class name conflicts. The proposed solution is to prefix the css class names in `Embed` with `talk-embed-stream-*`. 

- This PR also incorporates the new css classnames proposed by Erica in #748.

#### Changes

- `commentStream` -> `talk-embed-stream`
- `talk-stream-tabbar` -> `talk-embed-stream-tab-bar`
- `talk-stream-comment-count-tab` -> `talk-embed-stream-comments-tab`
- `talk-stream-profile-tab` -> `talk-embed-stream-profile-tab`
- `talk-stream-configuration-tab` -> `talk-embed-stream-configuration-tab`
- `#coralStream` > `#talk-embed-stream-container`

#### New Classes

- `talk-stream-show-all-comments-button` (This is not prefixed with `talk-embed-stream-*` because it is moved to the Stream Component in #749)
- `talk-embed-stream-highlight-comment` (Set when viewing stream using a permalink)
- `coral-plugin-flags-button-flagged` (Will change to `talk-plugin-flags-button-flagged` at a later refactor)

## How do I test this PR?

- Load a stream for a particular commentId
  - Inspect the Show All Comments button and the embed for classes `talk-stream-show-all-comments-button` and `talk-embed-stream-highlight-comment`, respectively
  - Inspect the `button.coral-plugin-flags-button` element does NOT have the class `coral-plugin-flags-button-flagged`
- Load a stream without a commentId
  - Inspect the embed to confirm that `talk-embed-stream-highlight-comment` class in NOT present
- Report a comment or username
  - Inspect the `button.coral-plugin-flags-button` element for class `coral-plugin-flags-button-flagged`