### PR TITLE
Added new TALK_DISABLE_AUTOFLAG_SUSPECT_WORDS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ sign and verify tokens via a `HS256` algorithm.
 - `TALK_SMTP_PASSWORD` (*required for email*) - password for the SMTP provider you are using.
 - `TALK_SMTP_HOST` (*required for email*) - SMTP host url with format `smtp.domain.com`.
 - `TALK_SMTP_PORT` (*required for email*) - SMTP port.
-- `TALK_INSTALL_LOCK` (_optional for dynamic setup_) - Defaults to `FALSE`. When `TRUE`, disables the dynamic setup endpoint.
+- `TALK_INSTALL_LOCK` (_optional for dynamic setup_) - When `TRUE`, disables the dynamic setup endpoint. (Default `FALSE`)
 - `TALK_RECAPTCHA_SECRET` (*required for reCAPTCHA support*) - server secret used for enabling reCAPTCHA powered logins. If not provided it will instead default to providing only a time based lockout.
 - `TALK_RECAPTCHA_PUBLIC` (*required for reCAPTCHA support*) - client secret used for enabling reCAPTCHA powered logins. If not provided it will instead default to providing only a time based lockout.
 - `TALK_PLUGINS_JSON` (_optional_) - used to specify the plugin config via the environment
 - `TALK_KEEP_ALIVE` (_optional_) - The keepalive timeout that should be used to send keep alive messages through the websocket to keep the socket alive. (Default `30s`)
+- `TALK_DISABLE_AUTOFLAG_SUSPECT_WORDS` (_optional_)  When `TRUE`, disables flagging of comments that match the suspect word filter. (Default `FALSE`)
 
 Refer to the wiki page on [Configuration Loading](https://github.com/coralproject/talk/wiki/Configuration-Loading) for
 alternative methods of loading configuration during development.

--- a/config.js
+++ b/config.js
@@ -77,7 +77,15 @@ const CONFIG = {
   SMTP_HOST: process.env.TALK_SMTP_HOST,
   SMTP_PASSWORD: process.env.TALK_SMTP_PASSWORD,
   SMTP_PORT: process.env.TALK_SMTP_PORT,
-  SMTP_USERNAME: process.env.TALK_SMTP_USERNAME
+  SMTP_USERNAME: process.env.TALK_SMTP_USERNAME,
+
+  //------------------------------------------------------------------------------
+  // Flagging Config
+  //------------------------------------------------------------------------------
+
+  // DISABLE_AUTOFLAG_SUSPECT_WORDS is true when the suspect words that are
+  // matched should not be flagged.
+  DISABLE_AUTOFLAG_SUSPECT_WORDS: process.env.TALK_DISABLE_AUTOFLAG_SUSPECT_WORDS === 'TRUE'
 };
 
 //==============================================================================

--- a/graph/mutators/comment.js
+++ b/graph/mutators/comment.js
@@ -15,6 +15,10 @@ const {
   EDIT_COMMENT
 } = require('../../perms/constants');
 
+const {
+  DISABLE_AUTOFLAG_SUSPECT_WORDS
+} = require('../../config');
+
 const debug = require('debug')('talk:graph:mutators:tags');
 const plugins = require('../../services/plugins');
 
@@ -297,7 +301,10 @@ const createPublicComment = async (context, commentInput) => {
   // Otherwise just return the new comment.
 
   // TODO: Check why the wordlist is undefined
-  if (wordlist != null && wordlist.suspect != null) {
+
+  // If the wordlist has matched the suspect word filter and we haven't disabled
+  // auto-flagging suspect words, then we should flag the comment!
+  if (wordlist != null && wordlist.suspect != null && !DISABLE_AUTOFLAG_SUSPECT_WORDS) {
 
     // TODO: this is kind of fragile, we should refactor this to resolve
     // all these const's that we're using like 'COMMENTS', 'FLAG' to be


### PR DESCRIPTION
## What does this PR do?

Adds support for the TALK_DISABLE_AUTOFLAG_SUSPECT_WORDS config option to disable auto flagging.

## How do I test this PR?

1. Enable this option by setting `TALK_DISABLE_AUTOFLAG_SUSPECT_WORDS = TRUE`.
2. Add a suspect word to the suspect word list.
3. Comment with another user account using a suspect word.
4. Notice it doesn't appear in the suspect word list!