### PR TITLE
Fix email address env var in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ sign and verify tokens via a `HS256` algorithm.
 - `TALK_JWT_EXPIRY` (_optional_) - the expiry duration (`exp`) for the tokens issued for logged in sessions (Default `1 day`)
 - `TALK_JWT_ISSUER` (_optional_) - the issuer (`iss`) claim for login JWT tokens (Default `process.env.TALK_ROOT_URL`)
 - `TALK_JWT_AUDIENCE` (_optional_) - the audience (`aud`) claim for login JWT tokens (Default `talk`)
-- `TALK_SMTP_EMAIL` (*required for email*) - the address to send emails from using the
+- `TALK_SMTP_FROM_ADDRESS` (*required for email*) - the address to send emails from using the
   SMTP provider.
 - `TALK_SMTP_USERNAME` (*required for email*) - username of the SMTP provider you are using.
 - `TALK_SMTP_PASSWORD` (*required for email*) - password for the SMTP provider you are using.


### PR DESCRIPTION
## What does this PR do?

Update docs

## How do I test this PR?

The variable mentioned (`TALK_SMTP_EMAIL`) doesn't exist, but `TALK_SMTP_FROM_ADDRESS ` does at https://github.com/coralproject/talk/blob/244d421eda6829280a6639875b2abb4794c47ec3/config.js#L76