### PR TITLE
Replace deprecated commentId in talk-plugin-permalink

### DIFF
--- a/plugins/talk-plugin-permalink/client/components/PermalinkButton.js
+++ b/plugins/talk-plugin-permalink/client/components/PermalinkButton.js
@@ -62,7 +62,7 @@ export default class PermalinkButton extends React.Component {
 
   render () {
     const {copySuccessful, copyFailure, popoverOpen} = this.state;
-    const {asset} = this.props;
+    const {asset, comment} = this.props;
     return (
       <ClickOutside onClickOutside={this.handleClickOutside}>
         <div className={cn(`${name}-container`, styles.container)}>
@@ -83,7 +83,7 @@ export default class PermalinkButton extends React.Component {
               className={cn(styles.input, `${name}-copy-field`)}
               type='text'
               ref={(input) => this.permalinkInput = input}
-              defaultValue={`${asset.url}?commentId=${this.props.commentId}`}
+              defaultValue={`${asset.url}?commentId=${comment.id}`}
             />
 
             <Button


### PR DESCRIPTION
## What does this PR do?
- Replace deprecated `commentId` by `comment.id` in `talk-plugin-permalink`
- Fixes this:
![image](https://user-images.githubusercontent.com/14221600/28387620-1af5916a-6cd0-11e7-9da6-a324b11c8cc9.png)
