### PR TITLE
Make permalink readonly

### DIFF
--- a/plugins/talk-plugin-permalink/client/components/PermalinkButton.js
+++ b/plugins/talk-plugin-permalink/client/components/PermalinkButton.js
@@ -84,6 +84,7 @@ export default class PermalinkButton extends React.Component {
               type='text'
               ref={(input) => this.permalinkInput = input}
               defaultValue={`${asset.url}?commentId=${comment.id}`}
+              readOnly
             />
 
             <Button


### PR DESCRIPTION
## What does this PR do?
![image](https://user-images.githubusercontent.com/14221600/28389524-c89bcc8e-6cd6-11e7-9f32-aa0cc1344d32.png)

- Makes the perma link url read only so no one can accidentally delete it.