### PR TITLE
talk-plugin-translations - A plugin to override core translations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,5 +14,6 @@ plugins/*
 !plugins/coral-plugin-comment-content
 !plugins/talk-plugin-permalink
 !plugins/talk-plugin-featured-comments
+!plugins/talk-plugin-translations
 
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ plugins/*
 !plugins/coral-plugin-comment-content
 !plugins/talk-plugin-permalink
 !plugins/talk-plugin-featured-comments
+!plugins/talk-plugin-translations
 
 **/node_modules/*

--- a/plugins/talk-plugin-translations/client/.babelrc
+++ b/plugins/talk-plugin-translations/client/.babelrc
@@ -1,0 +1,14 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "add-module-exports",
+    "transform-class-properties",
+    "transform-decorators-legacy",
+    "transform-object-assign",
+    "transform-object-rest-spread",
+    "transform-async-to-generator",
+    "transform-react-jsx"
+  ]
+}

--- a/plugins/talk-plugin-translations/client/.eslintrc.json
+++ b/plugins/talk-plugin-translations/client/.eslintrc.json
@@ -1,0 +1,23 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
+    }
+  },
+  "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
+  "rules": {
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+    "no-console": ["warn", { "allow": ["warn", "error"] }]
+  }
+}

--- a/plugins/talk-plugin-translations/client/index.js
+++ b/plugins/talk-plugin-translations/client/index.js
@@ -1,0 +1,7 @@
+/** This plugin overrides core translations **/
+
+import translations from './translations.yml';
+
+export default {
+  translations
+};

--- a/plugins/talk-plugin-translations/client/translations.yml
+++ b/plugins/talk-plugin-translations/client/translations.yml
@@ -1,0 +1,9 @@
+# This file overrides core translations
+#
+# This will override the first tab of the embed - "Comments" with "Override Comment Tab"
+# Go to locales/ to check all the core translations
+
+en:
+  embed_comments_tab: Override Comment Tab
+es:
+  embed_comments_tab: Override Tab de Comentarios

--- a/plugins/talk-plugin-translations/index.js
+++ b/plugins/talk-plugin-translations/index.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
## talk-plugin-translations - A plugin to override core translations

This PR adds an example of plugin for translations. This plugin overrides core translations.



## What does this PR do?
- Adds `talk-plugin-translations`



**This is just an example. Feel free to close the PR if we don't need this in our core plugins.**

