### PR TITLE
Prefix redux constants in plugins

### DIFF
--- a/plugins/coral-plugin-viewing-options/client/actions.js
+++ b/plugins/coral-plugin-viewing-options/client/actions.js
@@ -1,9 +1,9 @@
 import {OPEN_MENU, CLOSE_MENU} from './constants';
 
-export const openViewingOptions = () => ({
+export const openMenu = () => ({
   type: OPEN_MENU,
 });
 
-export const closeViewingOptions = () => ({
+export const closeMenu = () => ({
   type: CLOSE_MENU,
 });

--- a/plugins/coral-plugin-viewing-options/client/actions.js
+++ b/plugins/coral-plugin-viewing-options/client/actions.js
@@ -1,9 +1,9 @@
-import {VIEWING_OPTIONS_OPEN, VIEWING_OPTIONS_CLOSE} from './constants';
+import {OPEN_MENU, CLOSE_MENU} from './constants';
 
 export const openViewingOptions = () => ({
-  type: VIEWING_OPTIONS_OPEN
+  type: OPEN_MENU,
 });
 
 export const closeViewingOptions = () => ({
-  type: VIEWING_OPTIONS_CLOSE
+  type: CLOSE_MENU,
 });

--- a/plugins/coral-plugin-viewing-options/client/components/ViewingOptions.js
+++ b/plugins/coral-plugin-viewing-options/client/components/ViewingOptions.js
@@ -7,15 +7,15 @@ import {Icon} from 'plugin-api/beta/client/components/ui';
 const ViewingOptions = (props) => {
   const toggleOpen = () => {
     if (!props.open) {
-      props.openViewingOptions();
+      props.openMenu();
     } else {
-      props.closeViewingOptions();
+      props.closeMenu();
     }
   };
 
   const handleClickOutside = () => {
     if (props.open) {
-      props.closeViewingOptions();
+      props.closeMenu();
     }
   };
 

--- a/plugins/coral-plugin-viewing-options/client/constants.js
+++ b/plugins/coral-plugin-viewing-options/client/constants.js
@@ -1,2 +1,5 @@
-export const VIEWING_OPTIONS_OPEN = 'VIEWING_OPTIONS_OPEN';
-export const VIEWING_OPTIONS_CLOSE = 'VIEWING_OPTIONS_CLOSE';
+const prefix = 'TALK_VIEWING_OPTIONS';
+
+export const OPEN_MENU = `${prefix}_OPEN_MENU`;
+export const CLOSE_MENU = `${prefix}_CLOSE_MENU`;
+

--- a/plugins/coral-plugin-viewing-options/client/containers/ViewingOptions.js
+++ b/plugins/coral-plugin-viewing-options/client/containers/ViewingOptions.js
@@ -1,13 +1,13 @@
 import {connect} from 'plugin-api/beta/client/hocs';
 import {bindActionCreators} from 'redux';
 import ViewingOptions from '../components/ViewingOptions';
-import {openViewingOptions, closeViewingOptions} from '../actions';
+import {openMenu, closeMenu} from '../actions';
 
 const mapStateToProps = ({coralPluginViewingOptions: state}) => ({
   open: state.open
 });
 
 const mapDispatchToProps = (dispatch) =>
-  bindActionCreators({openViewingOptions, closeViewingOptions}, dispatch);
+  bindActionCreators({openMenu, closeMenu}, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ViewingOptions);

--- a/plugins/coral-plugin-viewing-options/client/reducer.js
+++ b/plugins/coral-plugin-viewing-options/client/reducer.js
@@ -1,17 +1,17 @@
-import {VIEWING_OPTIONS_OPEN, VIEWING_OPTIONS_CLOSE} from './constants';
+import {OPEN_MENU, CLOSE_MENU} from './constants';
 
 const initialState = {
   open: false
 };
 
-export default function offTopic (state = initialState, action) {
+export default function reducer(state = initialState, action) {
   switch (action.type) {
-  case VIEWING_OPTIONS_OPEN:
+  case OPEN_MENU:
     return {
       ...state,
       open: true
     };
-  case VIEWING_OPTIONS_CLOSE:
+  case CLOSE_MENU:
     return {
       ...state,
       open: false

--- a/plugins/talk-plugin-featured-comments/client/constants.js
+++ b/plugins/talk-plugin-featured-comments/client/constants.js
@@ -1,2 +1,4 @@
-export const SHOW_TOOLTIP = 'SHOW_TOOLTIP';
-export const HIDE_TOOLTIP = 'HIDE_TOOLTIP';
+const prefix = 'TALK_FEATURED_COMMENTS';
+
+export const SHOW_TOOLTIP = `${prefix}_SHOW_TOOLTIP`;
+export const HIDE_TOOLTIP = `${prefix}_HIDE_TOOLTIP`;


### PR DESCRIPTION
## What does this PR do?
- Redux constants must be unique across the whole application. Prefix plugin redux constants so that a name collision is less likely to happen.