### PR TITLE
Exclude generateIntrospectionResult from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,10 @@
 # excluded because we'll likely need to rebuild this.
 node_modules
 
-# scripts are used during development and testing, not
+# most scripts are used during development and testing, not
 # production.
 scripts
+!scripts/generateIntrospectionResult.js
 
 # documentation should not be visable in production.
 docs


### PR DESCRIPTION
## What does this PR do?
- Don't exclude `./scripts/generateIntrospectionResult.js` during docker build.