### PR TITLE
"Don't agree" is not a flag action

### DIFF
--- a/client/talk-plugin-flags/components/FlagButton.js
+++ b/client/talk-plugin-flags/components/FlagButton.js
@@ -91,7 +91,7 @@ export default class FlagButton extends Component {
         reason: null,
         message
       };
-      if (reason === 'I don\'t agree with this comment') {
+      if (reason === 'COMMENT_NOAGREE') {
         postDontAgree(action)
         .then(({data}) => {
           if (itemType === 'COMMENTS') {


### PR DESCRIPTION
## What does this PR do?
- Restore "don't agree" functionality, as it was falsely posted as a flag.