### PR TITLE
Provide a valid comment status in optimistic response

### DIFF
--- a/client/coral-embed-stream/src/graphql/index.js
+++ b/client/coral-embed-stream/src/graphql/index.js
@@ -162,7 +162,7 @@ const extension = {
               },
               __typename: 'TagLink'
             })),
-            status: null,
+            status: 'NONE',
             replyCount: 0,
             parent: parent_id
               ? {id: parent_id}


### PR DESCRIPTION
## What does this PR do?
- Fixes this error when posting a comment with the _All Comments_ tab being active.

![image](https://user-images.githubusercontent.com/14221600/28834090-a1c10588-76e1-11e7-9501-97c4bb62f52d.png)
