### PR TITLE
expose talk-stream-comment-container class

### DIFF
--- a/client/coral-embed-stream/src/components/Comment.js
+++ b/client/coral-embed-stream/src/components/Comment.js
@@ -406,7 +406,7 @@ export default class Comment extends React.Component {
             inline
           />
 
-          <div className={styles.commentContainer}>
+          <div className={`${styles.commentContainer} talk-stream-comment-container`}>
 
             <div className={styles.header}>
               <AuthorName author={comment.user} className={'talk-stream-comment-user-name'} />


### PR DESCRIPTION
## What does this PR do?

This PR implements class `talk-stream-comment-container` into the commentContainer div.

In order to implement wapo designs for avatars, I need to be able to set the commentContainer to `display: inline-block`.