### PR TITLE
Cookie updates

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,6 +7,8 @@
 // entrypoint for the entire applications configuration.
 require('env-rewrite').rewrite();
 
+const uniq = require('lodash/uniq');
+
 //==============================================================================
 // CONFIG INITIALIZATION
 //==============================================================================
@@ -30,6 +32,13 @@ const CONFIG = {
   // JWT_COOKIE_NAME is the name of the cookie optionally containing the JWT
   // token.
   JWT_COOKIE_NAME: process.env.TALK_JWT_COOKIE_NAME || 'authorization',
+
+  // JWT_SIGNING_COOKIE_NAME will be the cookie set when cookies are issued.
+  // This defaults to the TALK_JWT_COOKIE_NAME value.
+  JWT_SIGNING_COOKIE_NAME: process.env.TALK_JWT_SIGNING_COOKIE_NAME || process.env.TALK_JWT_COOKIE_NAME || 'authorization',
+
+  // JWT_COOKIE_NAMES declares the many cookie names used for verification.
+  JWT_COOKIE_NAMES: process.env.TALK_JWT_COOKIE_NAMES || null,
 
   // JWT_CLEAR_COOKIE_LOGOUT specifies whether the named cookie should be
   // cleared when the user is logged out.
@@ -164,6 +173,16 @@ if (CONFIG.JWT_DISABLE_AUDIENCE) {
 if (CONFIG.JWT_DISABLE_ISSUER) {
   CONFIG.JWT_ISSUER = undefined;
 }
+
+// Parse and handle cookie names.
+if (CONFIG.JWT_COOKIE_NAMES) {
+  CONFIG.JWT_COOKIE_NAMES = CONFIG.JWT_COOKIE_NAMES.split(',');
+} else {
+  CONFIG.JWT_COOKIE_NAMES = [];
+}
+
+// Add in the default cookie names and strip duplicates.
+CONFIG.JWT_COOKIE_NAMES = uniq(CONFIG.JWT_COOKIE_NAMES.concat([CONFIG.JWT_COOKIE_NAME, CONFIG.JWT_SIGNING_COOKIE_NAME]));
 
 //------------------------------------------------------------------------------
 // External database url's

--- a/docs/_docs/02-01-configuration.md
+++ b/docs/_docs/02-01-configuration.md
@@ -123,6 +123,14 @@ will be used:
 }
 ```
 
+When our passport middleware checks for JWT tokens, it searches in the following
+order:
+
+1. Custom cookies named from the list in `TALK_JWT_COOKIE_NAMES`.
+2. Default cookies named `TALK_JWT_COOKIE_NAME` then `TALK_JWT_SIGNING_COOKIE_NAME`.
+3. Query parameter `?access_token={TOKEN}`.
+4. Header: `Authorization: Bearer {TOKEN}`.
+
 ### Email
 
 - `TALK_SMTP_EMAIL` (*required for email*) - the address to send emails from

--- a/docs/_docs/02-01-configuration.md
+++ b/docs/_docs/02-01-configuration.md
@@ -87,8 +87,16 @@ on the contents of those variables.**
 These are advanced settings for fine tuning the auth integration, and
 is not needed in most situations.
 
-- `TALK_JWT_COOKIE_NAME` (_optional_) - the name of the cookie to extract the
-  JWT from (Default `authorization`)
+- `TALK_JWT_COOKIE_NAME` (_optional_) - the default cookie name to check for a
+  valid JWT token to use for verifying a user. (Default `authorization`)
+- `TALK_JWT_SIGNING_COOKIE_NAME` (_optional_) - the default cookie name that is
+  use to set a cookie containing a JWT that was issued by Talk.
+  (Default `process.env.TALK_JWT_COOKIE_NAME`)
+- `TALK_JWT_COOKIE_NAMES` (_optional_) - the different cookie names to check for
+  a JWT token in, seperated by `,`. By default, we always use the
+  `process.env.TALK_JWT_COOKIE_NAME` and `process.env.TALK_JWT_SIGNING_COOKIE_NAME`
+  for this value. Any additional cookie names specified here will be appended to
+  the list of cookie names to inspect.
 - `TALK_JWT_CLEAR_COOKIE_LOGOUT` (_optional_) - when `FALSE`, Talk will not
   clear the cookie with name `TALK_JWT_COOKIE_NAME` when logging out (Default
   `TRUE`)

--- a/services/passport.js
+++ b/services/passport.js
@@ -210,14 +210,20 @@ const CheckBlacklisted = async (jwt) => {
 const JwtStrategy = require('passport-jwt').Strategy;
 const ExtractJwt = require('passport-jwt').ExtractJwt;
 
-let cookieExtractor = (cookieName) => (req) => {
-  let token = null;
-
+let cookieExtractor = (req) => {
   if (req && req.cookies) {
-    token = req.cookies[cookieName];
+
+    // Walk over all the cookie names in JWT_COOKIE_NAMES.
+    for (const cookieName of JWT_COOKIE_NAMES) {
+
+      // Check to see if that cookie is set.
+      if (cookieName in req.cookies && req.cookies[cookieName] !== null && req.cookies[cookieName].length > 0) {
+        return req.cookies[cookieName];
+      }
+    }
   }
 
-  return token;
+  return null;
 };
 
 // Override the JwtVerifier method on the JwtStrategy so we can pack the
@@ -238,7 +244,7 @@ passport.use(new JwtStrategy({
 
   // Prepare the extractor from the header.
   jwtFromRequest: ExtractJwt.fromExtractors([
-    ...JWT_COOKIE_NAMES.map(cookieExtractor),
+    cookieExtractor,
     ExtractJwt.fromUrlQueryParameter('access_token'),
     ExtractJwt.fromAuthHeaderWithScheme('Bearer')
   ]),


### PR DESCRIPTION
## What does this PR do?

Adds support for changing the cookie's name for any cookie we set related to the auth state by introducing the following new configuration parameters:

- `TALK_JWT_SIGNING_COOKIE_NAME` (_optional_) - the default cookie name that is use to set a cookie containing a JWT that was issued by Talk.  (Default `process.env.TALK_JWT_COOKIE_NAME`)
- `TALK_JWT_COOKIE_NAMES` (_optional_) - the different cookie names to check for a JWT token in, seperated by `,`. By default, we always use the `process.env.TALK_JWT_COOKIE_NAME` and `process.env.TALK_JWT_SIGNING_COOKIE_NAME` for this value. Any additional cookie names specified here will be appended to the list of cookie names to inspect.

When a request comes in, it will be verified against the following order:

1. Custom cookies named from the list in `TALK_JWT_COOKIE_NAMES`.
2. Default cookies named `TALK_JWT_COOKIE_NAME` then `TALK_JWT_SIGNING_COOKIE_NAME`.
3. Query parameter `?access_token={TOKEN}`.
4. Header: `Authorization: Bearer {TOKEN}`.

## How to test it?

1. Clear all browser cookies and local storage.
2. Set `TALK_JWT_COOKIE_NAME=auth` and restart Talk.
3. Login to Talk in Safari via the /admin route.
4. Check the cookies on the request by looking in the web inspector, ensure that you can see a cookie named `auth`.
5. Set `TALK_JWT_SIGNING_COOKIE_NAME=superauth` and restart Talk.
6. Refresh the page with Talk and ensure that you are still logged in.
7. Logout of Talk.
8. Clear all browser cookies and local storage.
9. Login to Talk in Safari via the /admin route.
10. Check the cookies on the request by looking in the web inspector, ensure that you can see a cookie named `superauth`.