### PR TITLE
Remove Tag should keep remaining tags

### DIFF
--- a/services/tags.js
+++ b/services/tags.js
@@ -205,8 +205,8 @@ class TagsService {
     return updateModel(item_type, query, {
       $pull: {
         tags: {
-          name: link.tag.name
-        }
+          'tag.name': link.tag.name,
+        },
       }
     });
   }

--- a/test/server/services/tags.js
+++ b/test/server/services/tags.js
@@ -27,7 +27,7 @@ describe('services.TagsService', () => {
       const id = comment.id;
       const name = 'BEST';
       const assigned_by = user.id;
-      
+
       await TagsService.add(id, 'COMMENTS', {
         tag: {
           name
@@ -45,7 +45,7 @@ describe('services.TagsService', () => {
       const id = comment.id;
       const name = 'BEST';
       const assigned_by = user.id;
-      
+
       await TagsService.add(id, 'COMMENTS', {
         tag: {
           name
@@ -101,6 +101,44 @@ describe('services.TagsService', () => {
       {
         const {tags} = await CommentsService.findById(id);
         expect(tags.length).to.equal(0);
+      }
+    });
+    it('removes a tag out of 2', async () => {
+      const id = comment.id;
+      const name = 'BEST';
+      const assigned_by = user.id;
+
+      await TagsService.add(id, 'COMMENTS', {
+        tag: {
+          name: 'ANOTHER'
+        },
+        assigned_by
+      });
+
+      await TagsService.add(id, 'COMMENTS', {
+        tag: {
+          name
+        },
+        assigned_by
+      });
+
+      {
+        const {tags} = await CommentsService.findById(id);
+        expect(tags.length).to.equal(2);
+      }
+
+      // ok now to remove it
+      await TagsService.remove(id, 'COMMENTS', {
+        tag: {
+          name
+        },
+        assigned_by
+      });
+
+      {
+        const {tags} = await CommentsService.findById(id);
+        expect(tags.length).to.equal(1);
+        expect(tags[0].tag.name).to.equal('ANOTHER');
       }
     });
   });


### PR DESCRIPTION
## What does this PR do?
Currently removing a tag always removes all available tags. E.g. removing featured tag also removes the staff tag. This fixes this behavior to keep the remaining tags.