### PR TITLE
Fix emit showMoreReplies event

### DIFF
--- a/client/coral-embed-stream/src/components/Comment.js
+++ b/client/coral-embed-stream/src/components/Comment.js
@@ -180,6 +180,9 @@ export default class Comment extends React.Component {
 
     // edit a comment, passed (id, asset_id, { body })
     editComment: PropTypes.func,
+
+    // emit custom events
+    emit: PropTypes.func.isRequired,
   }
 
   editComment = (...args) => {
@@ -207,7 +210,7 @@ export default class Comment extends React.Component {
   }
 
   loadNewReplies = () => {
-    const {replies, replyCount, id} = this.props.comment;
+    const {comment: {replies, replyCount, id}, emit} = this.props;
     if (replyCount > replies.nodes.length) {
       this.setState({loadingState: 'loading'});
       this.props.loadMore(id)
@@ -221,10 +224,11 @@ export default class Comment extends React.Component {
           this.setState({loadingState: 'error'});
           forEachError(error, ({msg}) => {this.props.addNotification('error', msg);});
         });
+      emit('ui.Comment.showMoreReplies', {id});
       return;
     }
     this.setState(resetCursors);
-    this.props.emit('ui.Comment.showMoreReplies');
+    emit('ui.Comment.showMoreReplies', {id});
   };
 
   showReplyBox = () => {
@@ -315,6 +319,7 @@ export default class Comment extends React.Component {
       showSignInDialog,
       liveUpdates,
       commentIsIgnored,
+      emit,
       commentClassNames = []
     } = this.props;
 
@@ -568,6 +573,7 @@ export default class Comment extends React.Component {
                 reactKey={reply.id}
                 key={reply.id}
                 comment={reply}
+                emit={emit}
               />;
         })}
         </TransitionGroup>

--- a/client/coral-embed-stream/src/components/Stream.js
+++ b/client/coral-embed-stream/src/components/Stream.js
@@ -99,7 +99,8 @@ class Stream extends React.Component {
       loadMoreComments,
       viewAllComments,
       auth: {loggedIn, user},
-      editName
+      editName,
+      emit,
     } = this.props;
     const {keepCommentBox} = this.state;
     const open = !asset.isClosed;
@@ -234,6 +235,7 @@ class Stream extends React.Component {
                 charCountEnable={asset.settings.charCountEnable}
                 maxCharCount={asset.settings.charCount}
                 editComment={editComment}
+                emit={emit}
                 liveUpdates={true}
               />
             </div>
@@ -292,7 +294,7 @@ class Stream extends React.Component {
                     charCountEnable={asset.settings.charCountEnable}
                     maxCharCount={asset.settings.charCount}
                     editComment={editComment}
-                    emit={this.props.emit}
+                    emit={emit}
                   />
                 </TabPane>
               </TabContent>


### PR DESCRIPTION
## What does this PR do?
- Fix emitting `ui.Comment.showMoreReplies` event.

## How do I test this PR?
- Uncomment this in `views/article.ejs`
```js
/**
 *  You can listen to events using the example below.
 *  The argument passed is the event emitter from
 *  https://github.com/asyncly/EventEmitter2
 *
 *  events: function(events) {
 *    events.onAny(function(eventName, data) {
 *      console.log(eventName, data);
 *    });
 *  },
 */
```
- Click on `show more replies` and see the an `ui.Comment.showMoreReplies` entry in the console.
- Click on `show more replies` from a live update and see the an `ui.Comment.showMoreReplies` entry in the console.