### PR TITLE
Fix paths when TALK_ROOT_URL_MOUNT_PATH is set to true

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,10 +5,9 @@ const path = require('path');
 const helmet = require('helmet');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
-const {ROOT_URL, ROOT_URL_MOUNT_PATH} = require('./config');
+const {BASE_URL, BASE_PATH, MOUNT_PATH} = require('./url');
 const routes = require('./routes');
 const debug = require('debug')('talk:app');
-const {URL} = require('url');
 
 const app = express();
 
@@ -50,17 +49,6 @@ app.set('view engine', 'ejs');
 //==============================================================================
 // ROUTES
 //==============================================================================
-
-// Set the BASE_URL as the ROOT_URL, here we derive the root url by ensuring
-// that it ends in a `/`.
-const BASE_URL = ROOT_URL && ROOT_URL.length > 0 && ROOT_URL[ROOT_URL.length - 1] === '/' ? ROOT_URL : `${ROOT_URL}/`;
-
-// The BASE_PATH is simply the path component of the BASE_URL.
-const BASE_PATH = new URL(BASE_URL).pathname;
-
-// The MOUNT_PATH is derived from the BASE_PATH, if it is provided and enabled.
-// This will mount all the application routes onto it.
-const MOUNT_PATH = ROOT_URL_MOUNT_PATH ? BASE_PATH : '/';
 
 // Apply the BASE_PATH, BASE_URL, and MOUNT_PATH on the app.locals, which will
 // make them available on the templates and the routers.

--- a/client/talk-plugin-moderation/ModerationLink.js
+++ b/client/talk-plugin-moderation/ModerationLink.js
@@ -2,10 +2,11 @@ import React, {PropTypes} from 'react';
 import styles from './styles.css';
 
 import t from 'coral-framework/services/i18n';
+import {BASE_PATH} from 'coral-framework/constants/url';
 
 const ModerationLink = (props) => props.isAdmin ? (
     <div className={styles.moderationLink}>
-      <a href={`/admin/moderate/${props.assetId}`} target="_blank">
+      <a href={`${BASE_PATH}admin/moderate/${props.assetId}`} target="_blank">
         {t('moderate_this_stream')}
       </a>
     </div>

--- a/graph/subscriptions.js
+++ b/graph/subscriptions.js
@@ -174,7 +174,7 @@ const createSubscriptionManager = (server) => new SubscriptionServer({
   keepAlive: ms(KEEP_ALIVE)
 }, {
   server,
-  path: '${BASE_PATH}api/v1/live'
+  path: `${BASE_PATH}api/v1/live`
 });
 
 module.exports = {

--- a/graph/subscriptions.js
+++ b/graph/subscriptions.js
@@ -26,6 +26,8 @@ const {
   SUBSCRIBE_ALL_USERNAME_REJECTED,
 } = require('../perms/constants');
 
+const {BASE_PATH} = require('../url');
+
 /**
  * Plugin support requires that we merge in existing setupFunctions with our new
  * plugin based ones. This allows plugins to extend existing setupFunctions as well
@@ -172,7 +174,7 @@ const createSubscriptionManager = (server) => new SubscriptionServer({
   keepAlive: ms(KEEP_ALIVE)
 }, {
   server,
-  path: '/api/v1/live'
+  path: '${BASE_PATH}api/v1/live'
 });
 
 module.exports = {

--- a/url.js
+++ b/url.js
@@ -16,4 +16,4 @@ module.exports = {
   BASE_URL: BASE_URL,
   BASE_PATH: BASE_PATH,
   MOUNT_PATH: MOUNT_PATH,
-}
+};

--- a/url.js
+++ b/url.js
@@ -1,0 +1,19 @@
+const {ROOT_URL, ROOT_URL_MOUNT_PATH} = require('./config');
+const {URL} = require('url');
+
+// Set the BASE_URL as the ROOT_URL, here we derive the root url by ensuring
+// that it ends in a `/`.
+const BASE_URL = ROOT_URL && ROOT_URL.length > 0 && ROOT_URL[ROOT_URL.length - 1] === '/' ? ROOT_URL : `${ROOT_URL}/`;
+
+// The BASE_PATH is simply the path component of the BASE_URL.
+const BASE_PATH = new URL(BASE_URL).pathname;
+
+// The MOUNT_PATH is derived from the BASE_PATH, if it is provided and enabled.
+// This will mount all the application routes onto it.
+const MOUNT_PATH = ROOT_URL_MOUNT_PATH ? BASE_PATH : '/';
+
+module.exports = {
+  BASE_URL: BASE_URL,
+  BASE_PATH: BASE_PATH,
+  MOUNT_PATH: MOUNT_PATH,
+}

--- a/views/article.ejs
+++ b/views/article.ejs
@@ -22,7 +22,7 @@
   <main>
     <h1><%= title %></h1>
     <p><%= body %></p>
-    <p><a href="admin">Admin</a> - <a href="assets">All Assets</a></p>
+    <p><a href="<%= BASE_PATH %>admin">Admin</a> - <a href="<%= BASE_PATH %>assets">All Assets</a></p>
     <div id='coralStreamEmbed'></div>
     <script src="<%= BASE_URL %>embed.js" async onload="
       window.TalkEmbed = Coral.Talk.render(document.getElementById('coralStreamEmbed'), {


### PR DESCRIPTION
## What does this PR do?

This PR fixes paths not resolving correctly when `TALK_ROOT_URL_MOUNT_PATH` is set to `TRUE`.

- WebSockets `SubscriptionServer` path
- `ModerationLink` plugin
- `Admin` and `All Assets` links in `article` view

## How do I test this PR?

1. Run Talk with `TALK_ROOT_URL_MOUNT_PATH=TRUE` and `TALK_ROOT_URL=http://host:port/some/path`
2. Check that the WebSockets connection and links resolve correctly
