### PR TITLE
Add missing fragment field to Comment

### DIFF
--- a/client/coral-embed-stream/src/containers/Comment.js
+++ b/client/coral-embed-stream/src/containers/Comment.js
@@ -96,6 +96,7 @@ const withCommentFragments = withFragments({
   asset: gql`
     fragment CoralEmbedStream_Comment_asset on Asset {
       __typename
+      id
       ${getSlotFragmentSpreads(slots, 'asset')}
     }
     `,


### PR DESCRIPTION
## What does this PR do?
- The field `asset.id` is used in the Comment Component but was not requested.
- Embed will fail to render when no other plugin require this field.
