### PR TITLE
Added message to Extendable Errors

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -5,7 +5,7 @@
 class ExtendableError {
   constructor(message = null) {
     this.message = message;
-    this.stack = (new Error()).stack;
+    this.stack = (new Error(message)).stack;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Changes the output of graph errors from:

```
Error
    at APIError.ExtendableError (/Users/wyatt/Code/github.com/coralproject/talk/errors.js:8:19)
    at APIError (/Users/wyatt/Code/github.com/coralproject/talk/errors.js:19:5)
    at Object.<anonymous> (/Users/wyatt/Code/github.com/coralproject/talk/errors.js:133:28)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/wyatt/Code/github.com/coralproject/talk/services/settings.js:2:16)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
```

To the much nicer:

```
Error: asset_url is invalid
    at APIError.ExtendableError (/Users/wyatt/Code/github.com/coralproject/talk/errors.js:8:19)
    at APIError (/Users/wyatt/Code/github.com/coralproject/talk/errors.js:19:5)
    at Object.<anonymous> (/Users/wyatt/Code/github.com/coralproject/talk/errors.js:133:28)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/wyatt/Code/github.com/coralproject/talk/services/settings.js:2:16)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
```

## How do I test this PR?

Call this in your terminal (while Talk is running):

```bash
curl 'http://localhost:3000/api/v1/graph/ql?' \
-XPOST \
-H 'Content-Type: application/json' \
-H 'Accept: application/json' \
--data-binary '{"query":"{\n  asset(url: \"http://google.ca/\") {\n    id\n  }\n}","variables":null,"operationName":null}'
```

And note that you get the above error, with the string `asset_url is invalid` included.