### PR TITLE
Sort enhancements

### DIFF
--- a/client/coral-embed-stream/src/components/Stream.js
+++ b/client/coral-embed-stream/src/components/Stream.js
@@ -13,7 +13,7 @@ import t, {timeago} from 'coral-framework/services/i18n';
 import CommentBox from 'talk-plugin-commentbox/CommentBox';
 import QuestionBox from 'talk-plugin-questionbox/QuestionBox';
 import {isCommentActive} from 'coral-framework/utils';
-import {Spinner, Button, Tab, TabCount, TabPane} from 'coral-ui';
+import {Button, Tab, TabCount, TabPane} from 'coral-ui';
 import cn from 'classnames';
 
 import {getTopLevelParent, attachCommentToParent} from '../graphql/utils';
@@ -22,8 +22,6 @@ import AutomaticAssetClosure from '../containers/AutomaticAssetClosure';
 import StreamTabPanel from '../containers/StreamTabPanel';
 
 import styles from './Stream.css';
-
-const SpinnerWhenLoading = ({loading, children}) => loading ? <Spinner /> : <div>{children}</div>;
 
 class Stream extends React.Component {
 
@@ -144,6 +142,7 @@ class Stream extends React.Component {
       emit,
       sortOrder,
       sortBy,
+      loading,
     } = this.props;
 
     const slotProps = {data};
@@ -171,6 +170,7 @@ class Stream extends React.Component {
           tabPaneSlot={'streamTabPanes'}
           slotProps={slotProps}
           queryData={slotQueryData}
+          loading={loading}
           appendTabs={
             <Tab tabId={'all'} key='all'>
               All Comments <TabCount active={activeStreamTab === 'all'} sub>{totalCommentCount}</TabCount>
@@ -223,7 +223,6 @@ class Stream extends React.Component {
       viewAllComments,
       auth: {loggedIn, user},
       editName,
-      loading,
     } = this.props;
     const {keepCommentBox} = this.state;
     const open = !asset.isClosed;
@@ -310,12 +309,10 @@ class Stream extends React.Component {
           />
         )}
 
-        <SpinnerWhenLoading loading={loading}>
-          {highlightedComment
-            ? this.renderHighlightedComment()
-            : this.renderTabPanel()
-          }
-        </SpinnerWhenLoading>
+        {highlightedComment
+          ? this.renderHighlightedComment()
+          : this.renderTabPanel()
+        }
       </div>
     );
   }

--- a/client/coral-embed-stream/src/components/StreamTabPanel.css
+++ b/client/coral-embed-stream/src/components/StreamTabPanel.css
@@ -1,0 +1,3 @@
+.spinnerContainer {
+  margin-top: 16px;
+}

--- a/client/coral-embed-stream/src/components/StreamTabPanel.js
+++ b/client/coral-embed-stream/src/components/StreamTabPanel.js
@@ -1,19 +1,23 @@
 import React from 'react';
-import {TabBar, TabContent} from 'coral-ui';
+import {Spinner, TabBar, TabContent} from 'coral-ui';
 import PropTypes from 'prop-types';
+import styles from './StreamTabPanel.css';
 
 class StreamTabPanel extends React.Component {
 
   render() {
-    const {activeTab, setActiveTab, tabs, tabPanes, sub} = this.props;
+    const {activeTab, setActiveTab, tabs, tabPanes, sub, loading} = this.props;
     return (
       <div>
         <TabBar activeTab={activeTab} onTabClick={setActiveTab} sub={sub}>
           {tabs}
         </TabBar>
-        <TabContent activeTab={activeTab} sub={sub}>
-          {tabPanes}
-        </TabContent>
+        {loading
+          ? <div className={styles.spinnerContainer}><Spinner /></div>
+          : <TabContent activeTab={activeTab} sub={sub}>
+              {tabPanes}
+            </TabContent>
+        }
       </div>
     );
   }

--- a/client/coral-embed-stream/src/containers/Stream.js
+++ b/client/coral-embed-stream/src/containers/Stream.js
@@ -84,6 +84,10 @@ class StreamContainer extends React.Component {
           return prev;
         }
 
+        // Newest top-level comments are only added when sorting by 'newest first'.
+        if (!commentAdded.parent && !this.isSortedByNewestFirst()) {
+          return prev;
+        }
         return insertCommentIntoEmbedQuery(prev, commentAdded);
       },
     });
@@ -163,32 +167,9 @@ class StreamContainer extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const prevSortedNewest = this.isSortedByNewestFirst(this.props);
-    const nextSortedNewest = this.isSortedByNewestFirst(nextProps);
-
-    // When switching to 'Newest first' we refetch and subscribe so that
-    // we always have the newest comments.
-    if (!prevSortedNewest && nextSortedNewest) {
+    if (this.props.sortOrder !== nextProps.sortOrder || this.props.sortBy !== nextProps.sortBy) {
       nextProps.data.refetch();
-      this.subscribeToCommentsAdded();
     }
-
-    // When switching away from 'Newest first' unsubscribe from newest comments.
-    if (prevSortedNewest && !nextSortedNewest) {
-      this.unsubscribeCommentsAdded();
-    }
-  }
-
-  shouldComponentUpdate(nextProps) {
-    const prevSortedNewest = this.isSortedByNewestFirst(this.props);
-    const nextSortedNewest = this.isSortedByNewestFirst(nextProps);
-    if (!prevSortedNewest && nextSortedNewest) {
-
-      // When switching to 'Newest first' we refetch => skip
-      // rendering this frame and wait for refetch to kick in.
-      return false;
-    }
-    return true;
   }
 
   userIsDegraged({auth: {user}} = this.props) {

--- a/client/coral-embed-stream/src/containers/StreamTabPanel.js
+++ b/client/coral-embed-stream/src/containers/StreamTabPanel.js
@@ -86,6 +86,7 @@ class StreamTabPanelContainer extends React.Component {
         setActiveTab={this.props.setActiveTab}
         tabs={this.getPluginTabElements().concat(this.props.appendTabs)}
         tabPanes={this.getPluginTabPaneElements().concat(this.props.appendTabPanes)}
+        loading={this.props.loading}
         sub={this.props.sub}
       />
     );
@@ -110,6 +111,7 @@ StreamTabPanelContainer.propTypes = {
   queryData: PropTypes.object,
   className: PropTypes.string,
   sub: PropTypes.bool,
+  loading: PropTypes.bool,
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
## What does this PR do?
- Always refetch when changing `sortOrder` or `sortBy` to get most current state.
- Only exclude newly added top-level comments in sorts other than _newest first_
- Move Spinner down to `TabContent` to make the UX experience nicer.
