### PR TITLE
Use correct event name in queries

### DIFF
--- a/client/coral-framework/hocs/withQuery.js
+++ b/client/coral-framework/hocs/withQuery.js
@@ -69,7 +69,7 @@ export default (document, config = {}) => hoistStatics((WrappedComponent) => {
       const status = networkStatusToString(networkStatus);
 
       const {root} = separateDataAndRoot(data);
-      this.context.eventEmitter.emit(`query.${name}.${status}`, {variables, data: root});
+      this.context.eventEmitter.emit(`query.${this.name}.${status}`, {variables, data: root});
     }
 
     nextData(data) {
@@ -121,7 +121,7 @@ export default (document, config = {}) => hoistStatics((WrappedComponent) => {
             const resolvedDocument = this.resolveDocument(lmArgs.query);
             const fetchName = getDefinitionName(resolvedDocument);
             this.context.eventEmitter.emit(
-              `query.${name}.fetchMore.${fetchName}.begin`,
+              `query.${this.name}.fetchMore.${fetchName}.begin`,
               {variables: lmArgs.variables});
 
             // Resolve document fragments before passing it to `apollo-client`.
@@ -131,13 +131,13 @@ export default (document, config = {}) => hoistStatics((WrappedComponent) => {
             })
               .then((res) => {
                 this.context.eventEmitter.emit(
-                  `query.${name}.fetchMore.${fetchName}.success`,
+                  `query.${this.name}.fetchMore.${fetchName}.success`,
                   {variables: lmArgs.variables, data: res.data});
                 return Promise.resolve(res);
               })
               .catch((err) => {
                 this.context.eventEmitter.emit(
-                  `query.${name}.fetchMore.${fetchName}.error`,
+                  `query.${this.name}.fetchMore.${fetchName}.error`,
                   {variables: lmArgs.variables, error: err});
                 throw err;
               });
@@ -168,7 +168,7 @@ export default (document, config = {}) => hoistStatics((WrappedComponent) => {
       const base = (typeof this.wrappedConfig.options === 'function')
         ? this.wrappedConfig.options(data)
         : this.wrappedConfig.options;
-      const configs = this.graphqlRegistry.getQueryOptions(name);
+      const configs = this.graphqlRegistry.getQueryOptions(this.name);
       const reducerCallbacks =
         [base.reducer || ((i) => i)]
           .concat(...configs.map((cfg) => cfg.reducer))


### PR DESCRIPTION
## What does this PR do?
- Restore correct name for query events
