### PR TITLE
Fixed path joining for embed link

### DIFF
--- a/client/coral-admin/src/routes/Configure/components/EmbedLink.js
+++ b/client/coral-admin/src/routes/Configure/components/EmbedLink.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import t from 'coral-framework/services/i18n';
+import {join} from 'path';
 import styles from './Configure.css';
 import {Button, Card} from 'coral-ui';
 import {BASE_URL} from 'coral-framework/constants/url';
@@ -25,7 +26,7 @@ class EmbedLink extends Component {
   }
 
   render () {
-    const coralJsUrl = [BASE_URL, '/embed.js'].join('');
+    const coralJsUrl = join(BASE_URL, '/embed.js');
     const nonce = String(Math.random()).slice(2);
     const streamElementId = `coral_talk_${nonce}`;
     const embedText = `


### PR DESCRIPTION
## What does this PR do?

- Fixes embed link joining

Related: https://www.pivotaltracker.com/story/show/150596069

## How do I test this PR?

1. Set your TALK_ROOT_URL to something including a trailing `/`.
2. Go to the embed link and notice the lack of double `//`!