### PR TITLE
Top-level comments by ignored user are tombstoned, but replies should be as well

### DIFF
--- a/client/coral-embed-stream/src/containers/Comment.js
+++ b/client/coral-embed-stream/src/containers/Comment.js
@@ -91,6 +91,11 @@ const singleCommentFragment = gql`
 const withCommentFragments = withFragments({
   root: gql`
     fragment CoralEmbedStream_Comment_root on RootQuery {
+      me {
+        ignoredUsers {
+          id
+        }
+      }
       __typename
       ${getSlotFragmentSpreads(slots, 'root')}
     }


### PR DESCRIPTION
## What does this PR do?
- Solves this issue https://www.pivotaltracker.com/story/show/150605584
- Requesting me from `Comment` updates the props and triggers a re render.

_Note: I didn't move `commentIsIgnored` fn because `AllCommentsPane` component is using it_