### PR TITLE
Provide stable keys for slot elements

### DIFF
--- a/client/coral-embed-stream/src/containers/StreamTabPanel.js
+++ b/client/coral-embed-stream/src/containers/StreamTabPanel.js
@@ -26,8 +26,8 @@ class StreamTabPanelContainer extends React.Component {
     // it does not result in a change of slot children.
     const changes = getShallowChanges(this.props, next);
     if (changes.length === 1 && changes[0] === 'reduxState') {
-      const prevUuid = this.getSlotComponents(this.props.tabSlot, this.props).map((cmp) => cmp.talkUuid);
-      const nextUuid = this.getSlotComponents(next.tabSlot, next).map((cmp) => cmp.talkUuid);
+      const prevUuid = this.getSlotElements(this.props.tabSlot, this.props).map((el) => el.type.talkUuid);
+      const nextUuid = this.getSlotElements(next.tabSlot, next).map((el) => el.type.talkUuid);
       return !isEqual(prevUuid, nextUuid);
     }
 
@@ -37,42 +37,33 @@ class StreamTabPanelContainer extends React.Component {
 
   fallbackAllTab(props = this.props) {
     if (props.activeTab !== props.fallbackTab) {
-      const slotPlugins = this.getSlotComponents(props.tabSlot, props).map((c) => c.talkPluginName);
+      const slotPlugins = this.getSlotElements(props.tabSlot, props).map((el) => el.type.talkPluginName);
       if (slotPlugins.indexOf(props.activeTab) === -1) {
         props.setActiveTab(props.fallbackTab);
       }
     }
   }
 
-  getSlotComponents(slot, props = this.props) {
+  getSlotElements(slot, props = this.props) {
     const {plugins} = this.context;
-    return plugins.getSlotComponents(slot, props.reduxState, props.slotProps, props.queryData);
+    return plugins.getSlotElements(slot, props.reduxState, props.slotProps, props.queryData);
   }
 
   getPluginTabElements(props = this.props) {
-    const {plugins} = this.context;
-    return this.getSlotComponents(props.tabSlot).map((PluginComponent) => {
-      const pluginProps = plugins.getSlotComponentProps(PluginComponent, props.reduxState, props.slotProps, props.queryData);
+    return this.getSlotElements(props.tabSlot).map((el) => {
       return (
-        <Tab tabId={PluginComponent.talkPluginName} key={PluginComponent.talkPluginName}>
-          <PluginComponent
-            {...pluginProps}
-            active={this.props.activeTab === PluginComponent.talkPluginName}
-          />
+        <Tab tabId={el.type.talkPluginName} key={el.type.talkPluginName}>
+          {React.cloneElement(el, {active: this.props.activeTab === el.type.talkPluginName})}
         </Tab>
       );
     });
   }
 
   getPluginTabPaneElements(props = this.props) {
-    const {plugins} = this.context;
-    return this.getSlotComponents(props.tabPaneSlot).map((PluginComponent) => {
-      const pluginProps = plugins.getSlotComponentProps(PluginComponent, props.reduxState, props.slotProps, props.queryData);
+    return this.getSlotElements(props.tabPaneSlot).map((el) => {
       return (
-        <TabPane tabId={PluginComponent.talkPluginName} key={PluginComponent.talkPluginName}>
-          <PluginComponent
-            {...pluginProps}
-          />
+        <TabPane tabId={el.type.talkPluginName} key={el.type.talkPluginName}>
+          {el}
         </TabPane>
       );
     });

--- a/client/coral-embed-stream/src/containers/StreamTabPanel.js
+++ b/client/coral-embed-stream/src/containers/StreamTabPanel.js
@@ -26,9 +26,9 @@ class StreamTabPanelContainer extends React.Component {
     // it does not result in a change of slot children.
     const changes = getShallowChanges(this.props, next);
     if (changes.length === 1 && changes[0] === 'reduxState') {
-      const prevUuid = this.getSlotElements(this.props.tabSlot, this.props).map((el) => el.type.talkUuid);
-      const nextUuid = this.getSlotElements(next.tabSlot, next).map((el) => el.type.talkUuid);
-      return !isEqual(prevUuid, nextUuid);
+      const prevKeys = this.getSlotElements(this.props.tabSlot, this.props).map((el) => el.key);
+      const nextKeys = this.getSlotElements(next.tabSlot, next).map((el) => el.key);
+      return !isEqual(prevKeys, nextKeys);
     }
 
     // Prevent Slot from rerendering when no props has shallowly changed.

--- a/client/coral-framework/components/Slot.js
+++ b/client/coral-framework/components/Slot.js
@@ -20,9 +20,9 @@ class Slot extends React.Component {
     // it does not result in a change of slot children.
     const changes = getShallowChanges(this.props, next);
     if (changes.length === 1 && changes[0] === 'reduxState') {
-      const prevChildrenUuid = this.getChildren(this.props).map((child) => child.type.talkUuid);
-      const nextChildrenUuid = this.getChildren(next).map((child) => child.type.talkUuid);
-      return !isEqual(prevChildrenUuid, nextChildrenUuid);
+      const prevChildrenKeys = this.getChildren(this.props).map((child) => child.key);
+      const nextChildrenKeys = this.getChildren(next).map((child) => child.key);
+      return !isEqual(prevChildrenKeys, nextChildrenKeys);
     }
 
     // Prevent Slot from rerendering when no props has shallowly changed.

--- a/client/coral-framework/services/plugins.js
+++ b/client/coral-framework/services/plugins.js
@@ -77,30 +77,8 @@ class PluginsService {
     addMetaDataToSlotComponents(plugins);
   }
 
-  _getSlotComponents(slot, reduxState, props = {}, queryData = {}) {
-    const pluginConfig = reduxState.config.plugin_config || emptyConfig;
-    return flatten(this.plugins
-
-      // Filter out components that have slots and have been disabled in `plugin_config`
-      .filter((o) => o.module.slots && (!pluginConfig || !pluginConfig[o.name] || !pluginConfig[o.name].disable_components))
-
-      .filter((o) => o.module.slots[slot])
-      .map((o) => o.module.slots[slot])
-    )
-      .filter((component) => {
-        if(!component.isExcluded) {
-          return true;
-        }
-        let resolvedProps = this.getSlotComponentProps(component, reduxState, props, queryData);
-        if (component.mapStateToProps) {
-          resolvedProps = {...resolvedProps, ...component.mapStateToProps(reduxState)};
-        }
-        return !component.isExcluded(resolvedProps);
-      });
-  }
-
   isSlotEmpty(slot, reduxState, props = {}, queryData = {}) {
-    return this._getSlotComponents(slot, reduxState, props, queryData).length === 0;
+    return this.getSlotElements(slot, reduxState, props, queryData).length === 0;
   }
 
   /**

--- a/client/coral-framework/services/plugins.js
+++ b/client/coral-framework/services/plugins.js
@@ -8,7 +8,6 @@ import flatten from 'lodash/flatten';
 import mapValues from 'lodash/mapValues';
 import {getDisplayName} from 'coral-framework/helpers/hoc';
 import camelize from '../helpers/camelize';
-import uuid from 'uuid/v4';
 
 // This is returned for pluginConfig when it is empty.
 const emptyConfig = {};
@@ -63,9 +62,6 @@ function addMetaDataToSlotComponents(plugins) {
 
         // Attach plugin name to the component
         component.talkPluginName = plugin.name;
-
-        // Attach uuid to the component
-        component.talkUuid = uuid();
       });
     });
   });


### PR DESCRIPTION
## What does this PR do?
- Provide stable keys for slot elements. The key should not change when other slot elements are removed (e.g. through `excludeIf` HOC`)
- remove `getSlotComponents` from plugins service.

## How do I test this PR?
- Check if the hiding of the `featured` tab when empty is still working
- Check that viewing options still detects empty categories (by not rendering them at all, you'll see no artefacts)