### PR TITLE
Don't show tombstone during "view context"

### DIFF
--- a/client/coral-embed-stream/src/components/Comment.js
+++ b/client/coral-embed-stream/src/components/Comment.js
@@ -341,8 +341,8 @@ export default class Comment extends React.Component {
       emit,
       commentClassNames = []
     } = this.props;
-    
-    if (this.commentIsRejected(comment)) {
+
+    if (!highlighted && this.commentIsRejected(comment)) {
       return <CommentTombstone action='reject' />;
     }
 


### PR DESCRIPTION
## What does this PR do?
- Don't show tombstone during "view context"
- https://www.pivotaltracker.com/story/show/151131601

## How to test this PR?
- Go to _rejected_ Mod Queue 
- Click on _view context_ on one of the comments.
- The comment show up and not hidden under a tombstone