### PR TITLE
replace hard-coded string on all comments tab with translation

### DIFF
--- a/client/coral-embed-stream/src/components/Stream.js
+++ b/client/coral-embed-stream/src/components/Stream.js
@@ -160,7 +160,7 @@ class Stream extends React.Component {
           loading={loading}
           appendTabs={
             <Tab tabId={'all'} key='all'>
-              All Comments <TabCount active={activeStreamTab === 'all'} sub>{totalCommentCount}</TabCount>
+            {t('settings.all_comments')} <TabCount active={activeStreamTab === 'all'} sub>{totalCommentCount}</TabCount>
             </Tab>
           }
           appendTabPanes={


### PR DESCRIPTION
## What does this PR do?
Replaces the hard-coded string, "All Comments", with a translation string on the All Comments Pane Tab
## How do I test this PR?
Open an embed stream. Confirm that the text in All Comments the tab matches `settings.all_comments` for your language.
