### PR TITLE
Turn toxic comment group_id into a constant

### DIFF
--- a/plugins/talk-plugin-toxic-comments/server/hooks.js
+++ b/plugins/talk-plugin-toxic-comments/server/hooks.js
@@ -37,7 +37,7 @@ module.exports = {
           input.actions.push({
             action_type: 'FLAG',
             user_id: null,
-            group_id: 'Comment contains toxic language',
+            group_id: 'TOXIC_COMMENT',
             metadata: {}
           });
         }


### PR DESCRIPTION
## What does this PR do?
- Turn toxic comment group_id into a constant