### PR TITLE
Replace hard-coded string on all comments tab with translation

### DIFF
--- a/client/coral-embed-stream/src/components/Stream.js
+++ b/client/coral-embed-stream/src/components/Stream.js
@@ -160,7 +160,7 @@ class Stream extends React.Component {
           loading={loading}
           appendTabs={
             <Tab tabId={'all'} key='all'>
-              All Comments <TabCount active={activeStreamTab === 'all'} sub>{totalCommentCount}</TabCount>
+              {t('stream.all_comments')} <TabCount active={activeStreamTab === 'all'} sub>{totalCommentCount}</TabCount>
             </Tab>
           }
           appendTabPanes={

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -313,7 +313,6 @@ en:
   report_notif_remove: "Your report has been removed."
   reported: Reported
   settings:
-    all_comments: "All Comments"
     from_settings_page: "From the Profile Page you can see your comment history."
     my_comment_history: "My comment History"
     profile: Profile
@@ -322,6 +321,7 @@ en:
     to_access: "to access Profile"
     user_no_comment: "You've never left a comment. Join the conversation!"
   stream:
+    all_comments: "All Comments"
     temporarily_suspended: "In accordance with {0}'s community guidelines, your account has been temporarily suspended. Please rejoin the conversation {1}."
     comment_not_found: "Comment was not found"
   step_1_header: "Report an issue"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -305,7 +305,6 @@ es:
   report_notif_remove: "Tu reporte ha sido eliminado."
   reported: "Reportado"
   settings:
-    all_comments: "Todos los comentarios"
     from_settings_page: "Desde la página de configuración puedes ver tu historial de comentarios."
     my_comment_history: "Mi historial de comentarios"
     profile: Perfil
@@ -348,6 +347,7 @@ es:
   step_2_header: "Ayúdanos a comprender"
   step_3_header: "Gracias por tu participación"
   stream:
+    all_comments: "Todos los comentarios"
     temporarily_suspended: "De acuerdo con la guía de la comunidad de {0}, su cuenta ha sido temporalmente suspendida. Por favor unirse a la conversación {1}."
     comment_not_found: "Comentario no encontrado"
   streams:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -263,7 +263,6 @@ fr:
   reported: Signalé
   set_best: "Sélectionner comme le meilleur"
   settings:
-    all_comments: "Tous les commentaires"
     from_settings_page: "Dans la page Profil, vous pouvez voir l'historique de vos commentaires."
     my_comment_history: "Mon historique de commentaires"
     profile: Profil
@@ -272,6 +271,7 @@ fr:
     to_access: "Accéder au profil"
     user_no_comment: "Vous n'avez jamais laissé de commentaire. Rejoignez la conversation!"
   stream:
+    all_comments: "Tous les commentaires"
     temporarily_suspended: "Conformément à la charte d'utilisation des commentaires de {0}, votre compte a été temporairement suspendu. Merci de revenir dans la conversation {1}."
   step_1_header: "Signaler un problème"
   step_2_header: "Aidez-nous à comprendre"

--- a/locales/pt_BR.yml
+++ b/locales/pt_BR.yml
@@ -303,7 +303,6 @@ pt_BR:
   report_notif_remove: "Seu marcado foi removido."
   reported: Reportado
   settings:
-    all_comments: "Todos os comentários"
     from_settings_page: "Na página de Perfil, você pode ver seu histórico de comentários."
     my_comment_history: "Histórico de comentários"
     profile: Perfil
@@ -312,8 +311,8 @@ pt_BR:
     to_access: "para acessar o perfil"
     user_no_comment: "Você nunca deixou um comentário. Participe da conversa!"
   stream:
-    temporarily_suspended: "
-    De acordo com as diretrizes da comunidade de {0}, sua conta foi temporariamente suspensa. Por favor, volte para a conversa {1}."
+    all_comments: "Todos os comentários"
+    temporarily_suspended: "De acordo com as diretrizes da comunidade de {0}, sua conta foi temporariamente suspensa. Por favor, volte para a conversa {1}."
   step_1_header: "Relatar um problema"
   step_2_header: "Ajude-nos a entender"
   step_3_header: "Obrigdo por sua contribuição"


### PR DESCRIPTION
## What does this PR do?
- Continued work of https://github.com/coralproject/talk/pull/964 (credits: @ebirving )
- Replaces the hard-coded string, "All Comments", with a translation string on the All Comments Pane Tab

## How do I test this PR?
Open an embed stream. Confirm that the text in All Comments the tab matches `stream.all_comments` for your language.
