### PR TITLE
Expose Helmet configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const morgan = require('morgan');
 const path = require('path');
+const merge = require('lodash/merge');
 const helmet = require('helmet');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
@@ -10,6 +11,7 @@ const {
   BASE_PATH,
   MOUNT_PATH,
   STATIC_URL,
+  HELMET_CONFIGURATION,
 } = require('./url');
 const routes = require('./routes');
 const debug = require('debug')('talk:app');
@@ -31,9 +33,9 @@ app.set('trust proxy', 1);
 
 // Enable a suite of security good practices through helmet. We disable
 // frameguard to allow crossdomain injection of the embed.
-app.use(helmet({
+app.use(helmet(merge(HELMET_CONFIGURATION, {
   frameguard: false,
-}));
+})));
 
 // Compress the responses if appropriate.
 app.use(compression());

--- a/config.js
+++ b/config.js
@@ -80,6 +80,14 @@ const CONFIG = {
   INSTALL_LOCK: process.env.TALK_INSTALL_LOCK === 'TRUE',
 
   //------------------------------------------------------------------------------
+  // Middleware Configuration
+  //------------------------------------------------------------------------------
+
+  // HELMET_CONFIGURATION provides the entrypoint to override options for the
+  // helmet middleware used.
+  HELMET_CONFIGURATION: JSON.parse(process.env.TALK_HELMET_CONFIGURATION || '{}'),
+
+  //------------------------------------------------------------------------------
   // External database url's
   //------------------------------------------------------------------------------
 

--- a/docs/_docs/00-01-faq.md
+++ b/docs/_docs/00-01-faq.md
@@ -3,6 +3,21 @@ title: Frequently Asked Questions
 permalink: /docs/faq/
 ---
 
+{% include toc %}
+
+### My site doesn't use HSTS headers, how do I stop Talk from sending them too?
+
+You can specify the configuration option `TALK_HELMET_CONFIGURATION` and set it
+to:
+
+```
+TALK_HELMET_CONFIGURATION={"hsts": false}
+```
+
+Which will disable the HSTS module. See the
+[helmet](https://github.com/helmetjs/helmet) repository for more information on
+how to configure other security middleware used by default.
+
 ### How are new stories/assets added to Talk? Is there an API?
 
 There are three ways that new assets can make their way into Talk:

--- a/docs/_docs/02-01-configuration.md
+++ b/docs/_docs/02-01-configuration.md
@@ -96,6 +96,12 @@ These are only used during the webpack build.
   and you would then specify the CDN/Storage url. (Default `process.env.TALK_ROOT_URL`)
 - `TALK_DISABLE_STATIC_SERVER` (_optional_) - When `TRUE`, it will not mount the
   static asset serving routes on the router. (Default `FALSE`)
+- `TALK_HELMET_CONFIGURATION` (_optional_) - A JSON string representing the
+  configuration passed to the
+  [helmet](https://github.com/helmetjs/helmet) middleware. It can be used to
+  disable features like [HSTS](https://helmetjs.github.io/docs/hsts/) and others
+  by simply providing the configuration as detailed on the
+  [helmet README](https://github.com/helmetjs/helmet). (Default `{}`)
 
 ### Word Filter
 


### PR DESCRIPTION
## What does this PR do?

- Fixes #962

## How do I test this PR?

1. Run the talk server.
2. Run `curl -v http://localhost:3000/api/v1/auth`, notice the lack of `X-Powered-By: Express`
3. Set `TALK_HELMET_CONFIGURATION` environment variable to `{"hidePoweredBy": false}`
4. Run `curl -v http://localhost:3000/api/v1/auth`, notice the `X-Powered-By: Express` header