### PR TITLE
Fix contains links styling

### DIFF
--- a/client/coral-admin/src/routes/Moderation/components/Comment.css
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.css
@@ -159,9 +159,10 @@
 
 .hasLinks {
   color: #f00;
-  text-align: right;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  margin-right: 14px;
 
   i {
     margin-right: 5px;


### PR DESCRIPTION
## What does this PR do?
- Tiny styling fix for `contains link` marker on comments on the mod queue.
https://www.pivotaltracker.com/story/show/151270671
