### PR TITLE
Password reset fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,13 +6,9 @@ const merge = require('lodash/merge');
 const helmet = require('helmet');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
-const {
-  BASE_URL,
-  BASE_PATH,
-  MOUNT_PATH,
-  STATIC_URL,
-  HELMET_CONFIGURATION,
-} = require('./url');
+const {HELMET_CONFIGURATION} = require('./config');
+const {MOUNT_PATH} = require('./url');
+const {applyLocals} = require('./services/locals');
 const routes = require('./routes');
 const debug = require('debug')('talk:app');
 
@@ -57,12 +53,8 @@ app.set('view engine', 'ejs');
 // ROUTES
 //==============================================================================
 
-// Apply the BASE_PATH, BASE_URL, and MOUNT_PATH on the app.locals, which will
-// make them available on the templates and the routers.
-app.locals.BASE_URL = BASE_URL;
-app.locals.BASE_PATH = BASE_PATH;
-app.locals.MOUNT_PATH = MOUNT_PATH;
-app.locals.STATIC_URL = STATIC_URL;
+// Add the locals to the app renderer.
+applyLocals(app.locals);
 
 debug(`mounting routes on the ${MOUNT_PATH} path`);
 

--- a/client/coral-embed-stream/src/components/Embed.js
+++ b/client/coral-embed-stream/src/components/Embed.js
@@ -29,7 +29,7 @@ export default class Embed extends React.Component {
   };
 
   render() {
-    const {activeTab, commentId, root, data, auth: {showSignInDialog, signInDialogFocus}, blurSignInDialog, focusSignInDialog, hideSignInDialog} = this.props;
+    const {activeTab, commentId, root, data, auth: {showSignInDialog, signInDialogFocus}, blurSignInDialog, focusSignInDialog, hideSignInDialog, router: {location: {query: {parentUrl}}}} = this.props;
     const {user} = this.props.auth;
     const hasHighlightedComment = !!commentId;
 
@@ -37,7 +37,7 @@ export default class Embed extends React.Component {
       <div className={cn('talk-embed-stream', {'talk-embed-stream-highlight-comment': hasHighlightedComment})}>
         <IfSlotIsNotEmpty slot="login">
           <Popup
-            href='embed/stream/login'
+            href={`embed/stream/login?parentUrl=${encodeURIComponent(parentUrl)}`}
             title='Login'
             features='menubar=0,resizable=0,width=500,height=550,top=200,left=500'
             open={showSignInDialog}

--- a/routes/api/account/index.js
+++ b/routes/api/account/index.js
@@ -50,21 +50,17 @@ router.post('/password/reset', async (req, res, next) => {
 
   try {
     let token = await UsersService.createPasswordResetToken(email, loc);
-    if (!token) {
-      res.status(204).end();
-      return;
+    if (token) {
+      await mailer.sendSimple({
+        template: 'password-reset',
+        locals: {
+          token,
+          rootURL: ROOT_URL
+        },
+        subject: 'Password Reset',
+        to: email
+      });
     }
-
-    // Send the password reset email.
-    await mailer.sendSimple({
-      template: 'password-reset',             // needed to know which template to render!
-      locals: {                                     // specifies the template locals.
-        token,
-        rootURL: ROOT_URL
-      },
-      subject: 'Password Reset',
-      to: email
-    });
 
     res.status(204).end();
   } catch (e) {

--- a/services/email/email-confirm.html.ejs
+++ b/services/email/email-confirm.html.ejs
@@ -1,3 +1,3 @@
 <p><%= t('email.confirm.has_been_requested') %> <b><%= email %></b>.</p>
-<p><%= t('email.confirm.to_confirm') %> <a href="<%= rootURL %>/admin/confirm-email#<%= token %>">Confirm Email</a></p>
+<p><%= t('email.confirm.to_confirm') %> <a href="<%= BASE_URL %>admin/confirm-email#<%= token %>">Confirm Email</a></p>
 <p><%= t('email.confirm.if_you_did_not') %></p>

--- a/services/email/email-confirm.txt.ejs
+++ b/services/email/email-confirm.txt.ejs
@@ -4,6 +4,6 @@
 
 <%= t('email.confirm.to_confirm') %>
 
-    <%= rootURL %>/confirm/endpoint#<%= token %>
+    <%= BASE_URL %>confirm/endpoint#<%= token %>
 
 <%= t('email.confirm.if_you_did_not') %>

--- a/services/email/password-reset.html.ejs
+++ b/services/email/password-reset.html.ejs
@@ -1,2 +1,2 @@
 <p><%= t('email.password_reset.we_received_a_request') %><br />
-<%= t('email.password_reset.if_you_did') %> <a href="<%= rootURL %>/admin/password-reset#<%= token %>"><%= t('email.password_reset.please_click') %></a>.</p>
+<%= t('email.password_reset.if_you_did') %> <a href="<%= BASE_URL %>admin/password-reset#<%= token %>"><%= t('email.password_reset.please_click') %></a>.</p>

--- a/services/email/password-reset.txt.ejs
+++ b/services/email/password-reset.txt.ejs
@@ -1,3 +1,3 @@
 <%= t('email.password_reset.we_received_a_request') %>. <%= t('email.password_reset.if_you_did') %> <%= t('email.password_reset.please_click') %>:
 
-<%= rootURL %>/admin/password-reset#<%= token %>
+<%= BASE_URL %>admin/password-reset#<%= token %>

--- a/services/locals.js
+++ b/services/locals.js
@@ -1,0 +1,20 @@
+const {
+  BASE_URL,
+  BASE_PATH,
+  MOUNT_PATH,
+  STATIC_URL,
+} = require('../url');
+
+const applyLocals = (locals) => {
+
+  // Apply the BASE_PATH, BASE_URL, and MOUNT_PATH on the app.locals, which will
+  // make them available on the templates and the routers.
+  locals.BASE_URL = BASE_URL;
+  locals.BASE_PATH = BASE_PATH;
+  locals.MOUNT_PATH = MOUNT_PATH;
+  locals.STATIC_URL = STATIC_URL;
+};
+
+module.exports = {
+  applyLocals,
+};

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -4,6 +4,7 @@ const kue = require('./kue');
 const path = require('path');
 const fs = require('fs');
 const _ = require('lodash');
+const {applyLocals} = require('./locals');
 
 const i18n = require('./i18n');
 
@@ -92,6 +93,9 @@ const mailer = module.exports = {
     // Prefix the subject with `[Talk]`.
     subject = `[Talk] ${subject}`;
 
+    applyLocals(locals);
+
+    // Attach the templating function.
     locals['t'] = i18n.t;
 
     return Promise.all([

--- a/services/users.js
+++ b/services/users.js
@@ -1,8 +1,6 @@
 const assert = require('assert');
 const uuid = require('uuid');
 const bcrypt = require('bcryptjs');
-const url = require('url');
-const Wordlist = require('./wordlist');
 const errors = require('../errors');
 
 const {
@@ -22,9 +20,10 @@ const USER_ROLES = require('../models/enum/user_roles');
 const RECAPTCHA_WINDOW_SECONDS = 60 * 10; // 10 minutes.
 const RECAPTCHA_INCORRECT_TRIGGER = 5; // after 3 incorrect attempts, recaptcha will be required.
 
-const SettingsService = require('./settings');
 const ActionsService = require('./actions');
 const MailerService = require('./mailer');
+const Wordlist = require('./wordlist');
+const Domainlist = require('./domainlist');
 
 const EMAIL_CONFIRM_JWT_SUBJECT = 'email_confirm';
 const PASSWORD_RESET_JWT_SUBJECT = 'password_reset';
@@ -557,11 +556,10 @@ module.exports = class UsersService {
 
     email = email.toLowerCase();
 
-    const [user, settings] = await Promise.all([
+    const [user, domainValidated] = await Promise.all([
       UserModel.findOne({profiles: {$elemMatch: {id: email}}}),
-      SettingsService.retrieve(),
+      Domainlist.urlCheck(loc),
     ]);
-
     if (!user) {
 
       // Since we don't want to reveal that the email does/doesn't exist
@@ -569,19 +567,11 @@ module.exports = class UsersService {
       // endpoint.
       return;
     }
-    let redirectDomain;
-    try {
-      const {hostname, port} = url.parse(loc);
-      redirectDomain = hostname;
-      if (port) {
-        redirectDomain += `:${port}`;
-      }
-    } catch (e) {
-      throw new Error('redirect location is invalid');
-    }
 
-    if (settings.domains.whitelist.indexOf(redirectDomain) === -1) {
-      throw new Error('redirect location is not on the list of acceptable domains');
+    // If the domain didn't match any of the whitelisted domains and if it
+    // didn't match the mount domain, then throw an error.
+    if (!domainValidated && !Domainlist.matchMount(loc)) {
+      throw new Error('user supplied location exists on non-permitted domain');
     }
 
     const payload = {
@@ -619,16 +609,14 @@ module.exports = class UsersService {
    * Verifies a jwt and returns the associated user.
    * @param {String} token the JSON Web Token to verify
    */
-  static verifyPasswordResetToken(token) {
-    return UsersService
-      .verifyToken(token, {
-        subject: PASSWORD_RESET_JWT_SUBJECT
-      })
+  static async verifyPasswordResetToken(token) {
+    const {userId, loc} = await UsersService.verifyToken(token, {
+      subject: PASSWORD_RESET_JWT_SUBJECT
+    });
 
-      // TODO: add search by __v as well
-      .then((decoded) => {
-        return Promise.all([UsersService.findById(decoded.userId), decoded.loc]);
-      });
+    const user = await UsersService.findById(userId);
+
+    return [user, loc];
   }
 
   /**

--- a/services/users.js
+++ b/services/users.js
@@ -610,11 +610,15 @@ module.exports = class UsersService {
    * @param {String} token the JSON Web Token to verify
    */
   static async verifyPasswordResetToken(token) {
-    const {userId, loc} = await UsersService.verifyToken(token, {
+    const {userId, loc, version} = await UsersService.verifyToken(token, {
       subject: PASSWORD_RESET_JWT_SUBJECT
     });
 
     const user = await UsersService.findById(userId);
+
+    if (version !== user.__v) {
+      throw new Error('password reset token has expired');
+    }
 
     return [user, loc];
   }

--- a/test/server/services/domainlist.js
+++ b/test/server/services/domainlist.js
@@ -26,13 +26,84 @@ describe('services.Domainlist', () => {
 
   });
 
+  describe('#parseURL', () => {
+    it('parses the domain correctly', () => {
+      [
+        ['http://google.ca/test', 'google.ca'],
+        ['http://google.ca:80/test', 'google.ca'],
+        ['https://google.ca/test', 'google.ca'],
+        ['https://google.ca:443/test', 'google.ca'],
+        ['//google.ca/test', 'google.ca'],
+        ['//google.ca:80/test', 'google.ca'],
+        ['//google.ca:443/test', 'google.ca'],
+        ['google.ca/test', 'google.ca'],
+        ['google.ca:80/test', 'google.ca'],
+        ['google.ca:443/test', 'google.ca'],
+        ['http://google.ca/', 'google.ca'],
+        ['http://google.ca:80/', 'google.ca'],
+        ['https://google.ca/', 'google.ca'],
+        ['https://google.ca:443/', 'google.ca'],
+        ['//google.ca/', 'google.ca'],
+        ['//google.ca:80/', 'google.ca'],
+        ['//google.ca:443/', 'google.ca'],
+        ['google.ca/', 'google.ca'],
+        ['google.ca:80/', 'google.ca'],
+        ['google.ca:443/', 'google.ca'],
+        ['google.ca', 'google.ca'],
+        ['http://google.ca', 'google.ca'],
+        ['http://google.ca:80', 'google.ca'],
+        ['https://google.ca', 'google.ca'],
+        ['https://google.ca:443', 'google.ca'],
+        ['//google.ca', 'google.ca'],
+        ['//google.ca:80', 'google.ca'],
+        ['//google.ca:443', 'google.ca'],
+        ['google.ca', 'google.ca'],
+        ['google.ca:80', 'google.ca'],
+        ['google.ca:443', 'google.ca'],
+        ['http://google.Ca/test', 'google.ca'],
+        ['http://google.ca:80/test', 'google.ca'],
+        ['https://google.Ca/test', 'google.ca'],
+        ['https://google.ca:443/test', 'google.ca'],
+        ['//google.Ca/test', 'google.ca'],
+        ['//google.Ca:80/test', 'google.ca'],
+        ['//google.Ca:443/test', 'google.ca'],
+        ['google.Ca/test', 'google.ca'],
+        ['google.ca:80/test', 'google.ca'],
+        ['google.ca:443/test', 'google.ca'],
+        ['http://Google.ca/', 'google.ca'],
+        ['http://google.Ca:80/', 'google.ca'],
+        ['https://Google.ca/', 'google.ca'],
+        ['https://google.Ca:443/', 'google.ca'],
+        ['//Google.ca/', 'google.ca'],
+        ['//google.Ca:80/', 'google.ca'],
+        ['//google.Ca:443/', 'google.ca'],
+        ['Google.ca/', 'google.ca'],
+        ['google.Ca:80/', 'google.ca'],
+        ['google.Ca:443/', 'google.ca'],
+        ['Google.ca', 'google.ca'],
+        ['http://Google.ca', 'google.ca'],
+        ['http://google.Ca:80', 'google.ca'],
+        ['https://Google.ca', 'google.ca'],
+        ['https://google.Ca:443', 'google.ca'],
+        ['//Google.ca', 'google.ca'],
+        ['//google.Ca:80', 'google.ca'],
+        ['//google.Ca:443', 'google.ca'],
+        ['Google.ca', 'google.ca'],
+        ['google.Ca:80', 'google.ca'],
+        ['google.Ca:443', 'google.ca'],
+      ].forEach(([domain, hostname]) => {
+        expect(Domainlist.parseURL(domain), `domain ${domain} should be parsed as ${hostname}`).to.equal(hostname);
+      });
+    });
+  });
+
   describe('#match', () => {
 
     const whiteList = Domainlist.parseList(domainlists['whitelist']);
 
     it('does match on an included domain', () => {
       [
-        'wapo.com',
+        'http://wapo.com',
         'nytimes.com'
       ].forEach((domain) => {
         expect(domainlist.match(whiteList, domain)).to.be.true;

--- a/views/admin/password-reset.ejs
+++ b/views/admin/password-reset.ejs
@@ -15,11 +15,13 @@
         background: #fff;
       }
 
-      #root form {
+      .container {
         max-width: 300px;
-        border: 1px solid lightgrey;
-        box-shadow: 0px 10px 24px 2px rgba(0,0,0,0.2);
         margin: 50px auto;
+      }
+
+      #root form {
+        display: none;
         padding: 15px;
       }
 
@@ -81,7 +83,8 @@
   </head>
   <body>
     <div id="root">
-      <form id="reset-password-form">
+      <div class="error-console container"></div>
+      <form id="reset-password-form" class="container">
         <legend class="legend">Set new password</legend>
         <label for="password">
           New password
@@ -94,14 +97,18 @@
           <input type="password" name="confirm-password" placeholder="confirm password" />
         </label>
         <button class="submit-password-reset" type="submit">Apply</button>
-        <div class="error-console">foo</div>
       </form>
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <script>
       $(function () {
-        function showError(message) {
-          $('.error-console').text(message).addClass('active');
+        function showError(error) {
+          try {
+            var err = JSON.parse(error);
+            $('.error-console').text(err.message).addClass('active');
+          } catch (err) {
+            $('.error-console').text(error).addClass('active');
+          }
         }
 
         function handleSubmit (e) {
@@ -111,8 +118,13 @@
           var password = $('[name="password"]').val();
           var confirm = $('[name="confirm-password"]').val();
 
-          if (password !== confirm || password === '' || password.length < 8) {
-            showError('passwords must match and be 8 characters.');
+          if (password === '' || password.length < 8) {
+            showError('Passwords must be at least 8 characters.');
+            return false;
+          }
+
+          if (password !== confirm) {
+            showError('New password and confirm password must match');
             return false;
           }
 
@@ -128,7 +140,17 @@
           });
         }
 
-        $('#reset-password-form').on('submit', handleSubmit);
+
+        $.ajax({
+          url: '<%= BASE_PATH %>api/v1/account/password/reset?check=true',
+          contentType: 'application/json',
+          method: 'PUT',
+          data: JSON.stringify({token: location.hash.replace('#', '')})
+        }).then(function () {
+          $('#reset-password-form').fadeIn().on('submit', handleSubmit);
+        }).catch(function (error) {
+          showError(error.responseText);
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
## What does this PR do?

- Cleanups around email checking.
- Added domain validation against the root domain as well as whitelisted domains to support the admin site, previously the whitelisted domains were the only ones checked, not the root.
- Added the `parentUrl` to the login container so that the password reset redirect goes to the article page and not the root comment domain.

## How do I test this PR?

1. Run Talk off of `127.0.0.1:3000`
2. Add any other domain to the whitelist
3. Go to `http://127.0.0.1/admin` and go through the password reset flow.
4. Email!