### PR TITLE
Fix double preposition in string

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -92,7 +92,7 @@ en:
     comment_count_text_pre: "Comments will be limited to"
     comment_settings: Settings
     comment_stream: "Comment Stream"
-    comment_stream_will_close: "The comment stream will close in"
+    comment_stream_will_close: "The comment stream will close"
     community: Community
     configure: Configure
     copy_and_paste: "Copy and paste code below into your CMS to embed your comment box in your articles"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -78,7 +78,7 @@ fr:
     comment_count_text_pre: "Les commentaires seront limités à"
     comment_settings: Paramètres
     comment_stream: "Fil de commentaires"
-    comment_stream_will_close: "Le fil de commentaires va se fermer dans"
+    comment_stream_will_close: "Le fil de commentaires va se fermer"
     community: Communauté
     configure: Configurer
     copy_and_paste: "Copiez et collez le code ci-dessous dans votre CMS pour intégrer votre boîte de commentaires dans vos articles."

--- a/locales/pt_BR.yml
+++ b/locales/pt_BR.yml
@@ -87,7 +87,7 @@ pt_BR:
     comment_count_text_pre: "Os comentários serão limitados a"
     comment_settings: Configurações
     comment_stream: "Hilo de comentários"
-    comment_stream_will_close: "O hilo de comentários será fechado em"
+    comment_stream_will_close: "O hilo de comentários será fechado"
     community: Comunidade
     configure: Configurar
     copy_and_paste: "Copie e cole o código abaixo em seu CMS para incorporar sua caixa de comentários em seus artigos."


### PR DESCRIPTION
Minor string fix for this error on the Configure tab:

```
The comment stream will close in in 1 week.
```

The second "in" comes from `timeago`.

Also updated the French and Portuguese translations with help from Google Translate, but someone who actually speaks those should maybe double-check :smile: