### PR TITLE
Fixes Featured Tag Permissions

### DIFF
--- a/plugins/talk-plugin-featured-comments/index.js
+++ b/plugins/talk-plugin-featured-comments/index.js
@@ -87,7 +87,7 @@ module.exports = {
       name: 'FEATURED',
       permissions: {
         public: true,
-        self: true,
+        self: false,
         roles: []
       },
       models: ['COMMENTS'],


### PR DESCRIPTION
## What does this PR do?

- When a comment is created, there is a possibility of injecting a tag into the payload, this removes that permission error