### PR TITLE
Add a max-width to flag-reason text box to prevent cutoff

### DIFF
--- a/client/coral-embed-stream/style/default.css
+++ b/client/coral-embed-stream/style/default.css
@@ -270,6 +270,7 @@ button.comment__action-button[disabled],
   width: 75%;
   font-size: 16px;
   border: 1px solid #ccc;
+  max-width: calc(100% - 40px);
 }
 
 /* Close comments */


### PR DESCRIPTION
Fixes #1036 

Without a max-width a resizable textarea will expand into infinity. This fix doesn't allow it to expand beyond it's parent container.  

There is a margin left of 20px on the textarea the 100% - 40px is to maintain consistent gutters on both sides of the textarea. 

End result: 
<img width="556" alt="screen shot 2017-10-04 at 11 22 44 am" src="https://user-images.githubusercontent.com/1920934/31192598-8572cf82-a8f6-11e7-8575-76417082c692.png">

