### PR TITLE
Slack notifications plugin for new comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ plugins/*
 !plugins/talk-plugin-deep-reply-count
 !plugins/talk-plugin-subscriber
 !plugins/talk-plugin-flag-details
+!plugins/talk-plugin-slack-notifications
 
 **/node_modules/*

--- a/plugins/talk-plugin-slack-notifications/.eslintrc.json
+++ b/plugins/talk-plugin-slack-notifications/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@coralproject/eslint-config-talk"
+}

--- a/plugins/talk-plugin-slack-notifications/index.js
+++ b/plugins/talk-plugin-slack-notifications/index.js
@@ -1,0 +1,5 @@
+const hooks = require('./server/hooks');
+
+module.exports = {
+  hooks,
+};

--- a/plugins/talk-plugin-slack-notifications/package.json
+++ b/plugins/talk-plugin-slack-notifications/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@coralproject/talk-plugin-slack-notifications",
+  "pluginName": "talk-plugin-slack-notifications",
+  "version": "0.0.1",
+  "description": "Posts new comments to Slack via a webhook",
+  "main": "index.js",
+  "author": "The Coral Project Team <coral@mozillafoundation.org>",
+  "license": "Apache-2.0"
+}

--- a/plugins/talk-plugin-slack-notifications/server/config.js
+++ b/plugins/talk-plugin-slack-notifications/server/config.js
@@ -1,0 +1,11 @@
+const config = {
+  SLACK_WEBHOOK_URL: process.env.TALK_SLACK_WEBHOOK_URL,
+  SLACK_WEBHOOK_TIMEOUT: process.env.TALK_SLACK_WEBHOOK_TIMEOUT || 5000,
+};
+
+if (process.env.NODE_ENV !== 'test' && !config.SLACK_WEBHOOK_URL) {
+  // TODO this error should point users to Talk's Slack app once that's in place
+  throw new Error('Please set the TALK_SLACK_WEBHOOK_URL environment variable to use the slack-notifications plugin.');
+}
+
+module.exports = config;

--- a/plugins/talk-plugin-slack-notifications/server/hooks.js
+++ b/plugins/talk-plugin-slack-notifications/server/hooks.js
@@ -19,24 +19,26 @@ module.exports = {
           }
         } = result;
         const username = context.user.username;
-        const response = await fetch(SLACK_WEBHOOK_URL, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          timeout: SLACK_WEBHOOK_TIMEOUT,
-          body: JSON.stringify({
-            attachments: [{
-              text: text,
-              footer: `Comment by ${username}`,
-              ts: Math.floor(Date.parse(createdAt) / 1000),
-            }]
-          }),
+        process.nextTick(async () => {
+          const response = await fetch(SLACK_WEBHOOK_URL, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            timeout: SLACK_WEBHOOK_TIMEOUT,
+            body: JSON.stringify({
+              attachments: [{
+                text: text,
+                footer: `Comment by ${username}`,
+                ts: Math.floor(Date.parse(createdAt) / 1000),
+              }]
+            }),
+          });
+          if (!response.ok) {
+            const responseText = await response.text();
+            console.trace(`Posting to Slack failed with HTTP code ${response.status} and body '${responseText}'`);
+          }
         });
-        if (!response.ok) {
-          const responseText = await response.text();
-          console.trace(`Posting to Slack failed with HTTP code ${response.status} and body '${responseText}'`);
-        }
         return result;
       },
     },

--- a/plugins/talk-plugin-slack-notifications/server/hooks.js
+++ b/plugins/talk-plugin-slack-notifications/server/hooks.js
@@ -1,0 +1,44 @@
+const fetch = require('node-fetch');
+const {SLACK_WEBHOOK_URL, SLACK_WEBHOOK_TIMEOUT} = require('./config');
+const debug = require('debug')('talk:plugin:slack-notifications');
+
+// We don't add the hooks during _test_ as the Slack API is not available.
+if (process.env.NODE_ENV === 'test') {
+  return null;
+}
+
+module.exports = {
+  RootMutation: {
+    createComment: {
+      async post(_, {input}, context, _info, result) {
+        debug(`Posting notification to Slack webhook: ${SLACK_WEBHOOK_URL}`);
+        const {
+          comment: {
+            body: text,
+            created_at: createdAt
+          }
+        } = result;
+        const username = context.user.username;
+        const response = await fetch(SLACK_WEBHOOK_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          timeout: SLACK_WEBHOOK_TIMEOUT,
+          body: JSON.stringify({
+            attachments: [{
+              text: text,
+              footer: `Comment by ${username}`,
+              ts: Math.floor(Date.parse(createdAt) / 1000),
+            }]
+          }),
+        });
+        if (!response.ok) {
+          const responseText = await response.text();
+          console.trace(`Posting to Slack failed with HTTP code ${response.status} and body '${responseText}'`);
+        }
+        return result;
+      },
+    },
+  },
+};


### PR DESCRIPTION
Closes #1016.

## What does this PR do?

Adds `talk-plugin-slack-notifications` which posts all new comments to the given [Slack Webhook](https://api.slack.com/incoming-webhooks).

## How do I test this PR?

1. Create a [new Slack app](https://api.slack.com/apps/new) and connect it to any one of your Slack workspaces for testing.
2. In the app configuration, enable "Incoming Webhooks".
3. In the Webhook settings, click "Add New Webhook to Workspace". Slack will open an OAuth dialog requesting access to your development workspace (the one we linked in step 1). Click Authorize.
4. Back on the Webhook settings page, you should now have a valid webhook URL. Try the sample curl request and make sure the Webhook is working - you should see posted messages in your Slack channel/DM.
5. Add the webhook to your .env file (`TALK_SLACK_WEBHOOK_URL=https://<your_webhook_url>`) and restart the server.
6. Post a new comment and it should appear in Slack.

I've tested these cases:

- Many kinds of inputs in a comment: punctuation, unicode symbols, emoji, large comments (4500 chars) - all of it reached Slack verbatim
- Plugin enabled but `TALK_SLACK_WEBHOOK_URL` not set - a descriptive error is thrown

## What remains to be done

- Set up an official Slack app for Talk, and update the error message in `config.js` to point to it. Additionally update docs if needed. (*deferred*)

## Notes

- Performance: The request to Slack takes ~1.5 sec, but I assume that's not a problem because of Node's non-blocking I/O? (NOTE: I'm in India and Slack doesn't have regional servers here apparently). I've set the default timeout to 5000 ms for this reason, but that can be changed.
- I tried 2 different designs and went with the latter one below - feedback is welcome.
- The notification could be made richer by perma-linking it to the comment, but I couldn't figure out how to access the asset URL in the `createComment` hook - probably need a loader or resolver, not sure which.
- The plugin could behave differently when the toxic comments plugin is enabled, e.g., so only comments above the toxic threshold would be posted to Slack, or toxic comments would be [colored](https://api.slack.com/docs/message-attachments#attachment_structure) red, etc.

![talk-slack-title](https://user-images.githubusercontent.com/439616/31206132-a8b4e438-a993-11e7-844c-5073d48b376e.png)

![talk-slack-footer](https://user-images.githubusercontent.com/439616/31206135-ad158dac-a993-11e7-92f0-23da8006440e.png)