### PR TITLE
Fix #1046 edit countdown

### DIFF
--- a/client/coral-embed-stream/src/components/CountdownSeconds.js
+++ b/client/coral-embed-stream/src/components/CountdownSeconds.js
@@ -35,16 +35,26 @@ export class CountdownSeconds extends React.Component {
     const {until, classNameForMsRemaining} = this.props;
     const msRemaining = until - now;
     const secRemaining = msRemaining / 1000;
-    const wholeSecRemaining = Math.floor(secRemaining);
-    const plural = secRemaining !== 1;
-    const units = t(plural ? 'edit_comment.seconds_plural' : 'edit_comment.second');
+    const minRemaining = secRemaining / 60;
+    const secAfterMinRemaining = secRemaining % 60;
+    const wholeMinRemaining = Math.floor(minRemaining);
+    const wholeSecRemaining = Math.floor(secAfterMinRemaining);
+    const secUnits = t(wholeSecRemaining !== 1 ? 'edit_comment.seconds_plural' : 'edit_comment.second');
+    const minUnits = t(wholeMinRemaining !== 1 ? 'edit_comment.minutes_plural' : 'edit_comment.minute');
     let classFromProp;
     if (typeof classNameForMsRemaining === 'function') {
       classFromProp = classNameForMsRemaining(msRemaining);
     }
+    if (wholeMinRemaining > 0) {
+      return (
+        <span className={classFromProp}>
+          {`${wholeMinRemaining} ${minUnits} ${wholeSecRemaining} ${secUnits}`}
+        </span>
+      );
+    }
     return (
       <span className={classFromProp}>
-        {`${wholeSecRemaining} ${units}`}
+        {`${wholeSecRemaining} ${secUnits}`}
       </span>
     );
   }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -170,6 +170,8 @@ en:
     edit_window_expired: "You can no longer edit this comment. The time window to do so has expired. Why not post another one?"
     edit_window_expired_close: "Close"
     edit_window_timer_prefix: "Edit Window: "
+    minute: "minute"
+    minutes_plural: "minutes"
     second: "second"
     seconds_plural: "seconds"
   email:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -169,6 +169,8 @@ es:
     edit_window_expired: "No se puede editar este comentario. El periodo de edición ya ha concluido. Podrías publicar uno nuevo :-)"
     edit_window_expired_close: "Cerrar"
     edit_window_timer_prefix: "Ventana Edición:"
+    minute: "minuto"
+    minutes_plural: "minutos"
     second: "segundo"
     seconds_plural: "segundos"
   email:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -138,6 +138,8 @@ fr:
     edit_window_expired: "Vous ne pouvez plus modifier ce commentaire. La fenêtre de temps pour le faire a expiré. Pourquoi ne pas en publier un autre ?"
     edit_window_expired_close: "Fermer"
     edit_window_timer_prefix: "Fenêtre d'édition :"
+    minute: "minute"
+    minutes_plural: "minutes"
     second: "seconde"
     seconds_plural: "secondes"
     unexpected_error: "Erreur inattendue lors de l'enregistrement des modifications. Désolé !"

--- a/locales/pt_BR.yml
+++ b/locales/pt_BR.yml
@@ -161,6 +161,8 @@ pt_BR:
     edit_window_expired: "Você não pode mais editar esse comentário. A janela de tempo para fazê-lo expirou. Por que não publicar outro?"
     edit_window_expired_close: "Fechar"
     edit_window_timer_prefix: "Para editar:"
+    minute: "minuto"
+    minutes_plural: "minutos"
     second: "segundo"
     seconds_plural: "segundos"
   email:


### PR DESCRIPTION
## What does this PR do?
Adds minutes to the countdown timer when editing a comment.

### Before
`Edit Window: 30 seconds`
` Edit Window: 1 second`

### After
`Edit Window: 2 minutes 30 seconds`
`Edit Window: 1 minute 1 second`

## How do I test this PR?
Configure the amount of time allowed for a user to edit a comment to more than 60 seconds.
Post a comment and observe the edit countdown timer.
