### PR TITLE
#1043 - Better error message for 1 character comments

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -186,7 +186,7 @@ en:
   embedlink:
     copy: "Copy to Clipboard"
   error:
-    COMMENT_TOO_SHORT: "Your comment must have something in it"
+    COMMENT_TOO_SHORT: "Comments should be more than one character, please revise your comment and try again."
     NOT_AUTHORIZED: "You are not authorized to perform this action."
     NO_SPECIAL_CHARACTERS: "Usernames can contain letters numbers and _ only"
     PASSWORD_LENGTH: "Password is too short"


### PR DESCRIPTION
Addressing issue #1043  

## What does this PR do?
Adds a more verbose error message when attempting to post a comment fewer than two characters

## How do I test this PR?
- Post a 1-character comment, or a 1-character reply to a comment
- New error message will be displayed