### PR TITLE
Update forgot password flow to match site styling

### DIFF
--- a/plugins/talk-plugin-auth/client/components/ForgotContent.js
+++ b/plugins/talk-plugin-auth/client/components/ForgotContent.js
@@ -1,13 +1,26 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './styles.css';
-import {Button} from 'plugin-api/beta/client/components/ui';
+import {Button, TextField} from 'plugin-api/beta/client/components/ui';
 import t from 'coral-framework/services/i18n';
 
 class ForgotContent extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      value: '',
+    };
+  }
+
   handleSubmit = (e) => {
     e.preventDefault();
-    this.props.fetchForgotPassword(this.emailInput.value);
+    this.props.fetchForgotPassword(this.state.value);
   };
+
+  handleChangEmail = (e) => {
+    const {value} = e.target;
+    this.setState({value});
+  }
 
   render() {
     const {changeView, auth} = this.props;
@@ -20,13 +33,13 @@ class ForgotContent extends React.Component {
         </div>
         <form onSubmit={this.handleSubmit}>
           <div className={styles.textField}>
-            <label htmlFor="email">{t('sign_in.email')}</label>
-            <input
-              ref={(input) => (this.emailInput = input)}
-              type="text"
+            <TextField
+              type="email"
               style={{fontSize: 16}}
               id="email"
               name="email"
+              label={t('sign_in.email')}
+              onChange={this.handleChangEmail}
             />
           </div>
           <Button
@@ -68,5 +81,11 @@ class ForgotContent extends React.Component {
     );
   }
 }
+
+ForgotContent.propTypes = {
+  auth: PropTypes.object,
+  changeView: PropTypes.func,
+  fetchForgotPassword: PropTypes.func,
+};
 
 export default ForgotContent;

--- a/plugins/talk-plugin-auth/client/components/ForgotContent.js
+++ b/plugins/talk-plugin-auth/client/components/ForgotContent.js
@@ -5,19 +5,15 @@ import {Button, TextField} from 'plugin-api/beta/client/components/ui';
 import t from 'coral-framework/services/i18n';
 
 class ForgotContent extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      value: '',
-    };
-  }
+  
+  state = {value: ''};
 
   handleSubmit = (e) => {
     e.preventDefault();
     this.props.fetchForgotPassword(this.state.value);
   };
 
-  handleChangEmail = (e) => {
+  handleChangeEmail = (e) => {
     const {value} = e.target;
     this.setState({value});
   }
@@ -39,7 +35,8 @@ class ForgotContent extends React.Component {
               id="email"
               name="email"
               label={t('sign_in.email')}
-              onChange={this.handleChangEmail}
+              onChange={this.handleChangeEmail}
+              value={this.state.value}
             />
           </div>
           <Button


### PR DESCRIPTION
Fixes #1024 

Converted standard DOM input to use coral-ui `TextField`. TextField didn't seem to handle ref correctly so I also had to convert it from using the ref value to submit to using state value. I've also added prop-types validation to this component as none existed. 

Screenshot:
![screen shot 2017-10-05 at 5 39 49 pm](https://user-images.githubusercontent.com/1920934/31258862-2a240df6-a9f7-11e7-84e4-2df9bf63c103.png)
