### PR TITLE
fix hidden shortcut icon

### DIFF
--- a/client/coral-admin/src/components/ui/Header.css
+++ b/client/coral-admin/src/components/ui/Header.css
@@ -26,7 +26,7 @@
 .header > div {
   position: relative;
   padding: 0;
-  width: 1280px;
+  max-width: 1280px;
   margin: 0 auto;
   height: 58px;
 }


### PR DESCRIPTION
## What does this PR do?
Fixes hidden settings icon when less than 1280px

I believe the combination of this and my last PR (#1056) fixes #1019. Either that, or I can't reproduce it 😃  
### Before
<img width="878" alt="screen shot 2017-10-05 at 8 48 17 pm" src="https://user-images.githubusercontent.com/10946524/31258727-59811d6a-aa0f-11e7-8b87-77d17068a86d.png">

### After
<img width="944" alt="screen shot 2017-10-05 at 8 50 30 pm" src="https://user-images.githubusercontent.com/10946524/31258736-60596688-aa0f-11e7-914a-6545c54771ea.png">
