### PR TITLE
Staff members cannot be ignored. Issue #1023

### DIFF
--- a/plugins/talk-plugin-ignore-user/client/containers/IgnoreUserConfirmation.js
+++ b/plugins/talk-plugin-ignore-user/client/containers/IgnoreUserConfirmation.js
@@ -8,17 +8,25 @@ import {notify} from 'plugin-api/beta/client/actions/notification';
 import {t} from 'plugin-api/beta/client/services';
 import {getErrorMessages} from 'plugin-api/beta/client/utils';
 
+const isStaff = (tags) => !tags.every((t) => t.tag.name !== 'STAFF');
+
 class IgnoreUserConfirmationContainer extends React.Component {
 
   ignoreUser = () => {
     const {ignoreUser, notify, comment, closeMenu} = this.props;
-    ignoreUser(comment.user.id)
-      .then(() => {
-        notify('success', t('talk-plugin-ignore-user.notify_success', comment.user.username));
-      })
-      .catch((err) => {
-        notify('error', getErrorMessages(err));
-      });
+    if (isStaff(comment.tags)) {
+      notify('error', t('talk-plugin-ignore-user.notify_ignore_staff'));
+    }
+    else
+    {
+      ignoreUser(comment.user.id)
+        .then(() => {
+          notify('success', t('talk-plugin-ignore-user.notify_success', comment.user.username));
+        })
+        .catch((err) => {
+          notify('error', getErrorMessages(err));
+        });
+    }
     closeMenu();
   };
 
@@ -47,6 +55,12 @@ const withIgnoreUserConfirmationFragments = withFragments({
       user {
         id
         username
+      }
+      tags {
+        tag {
+          name
+          created_at
+        }
       }
     }`,
 });

--- a/plugins/talk-plugin-ignore-user/client/translations.yml
+++ b/plugins/talk-plugin-ignore-user/client/translations.yml
@@ -11,10 +11,12 @@ en:
     notify_success: |
       You are now ignoring {0}. You can undo this action from My Profile.
     confirmation_title: Ignore {0}?
+    notify_ignore_staff: Staff members cannot be ignored.
 es:
   talk-plugin-ignore-user:
     section_title: "Usuarios ignorados"
     stop_ignoring: "No ignorar más"
+    notify_ignore_staff: Los miembros del personal no pueden ser ignorados.
 fr:
   talk-plugin-ignore-user:
     section_title: "Utilisateurs ignorés"


### PR DESCRIPTION
## What does this PR do?
 - This PR prevent readers to ignore staff members
## How do I test this PR?
 - Try to ignore a staff member, should show a notification "Staff members cannot be ignored" and the staff member will not ignored. 
