### PR TITLE
Load username from graph and not auth

### DIFF
--- a/client/coral-settings/containers/ProfileContainer.js
+++ b/client/coral-settings/containers/ProfileContainer.js
@@ -53,7 +53,7 @@ class ProfileContainer extends Component {
   };
 
   render() {
-    const {auth, auth: {user}, showSignInDialog, root, data} = this.props;
+    const {auth, auth: {user: authUser}, showSignInDialog, root, data} = this.props;
     const {me} = this.props.root;
     const loading = this.props.data.loading;
 
@@ -65,14 +65,14 @@ class ProfileContainer extends Component {
       return <Spinner />;
     }
 
-    const localProfile = user.profiles.find(
+    const localProfile = authUser.profiles.find(
       (p) => p.provider === 'local'
     );
     const emailAddress = localProfile && localProfile.id;
 
     return (
       <div className='talk-embed-stream-profile-container'>
-        <h2>{user.username}</h2>
+        <h2>{me.username}</h2>
         {emailAddress ? <p>{emailAddress}</p> : null}
 
         <Slot
@@ -82,7 +82,6 @@ class ProfileContainer extends Component {
         />
 
         <hr />
-
         <h3>{t('framework.my_comments')}</h3>
         {me.comments.nodes.length
           ? <CommentHistory data={data} root={root} comments={me.comments} link={link} loadMore={this.loadMore}/>
@@ -140,6 +139,7 @@ const withProfileQuery = withQuery(
   query CoralEmbedStream_Profile {
     me {
       id
+      username
       comments(query: {limit: 10}) {
         ...TalkSettings_CommentConnectionFragment
       }


### PR DESCRIPTION
## What does this PR do?

- Load the user's Username from the graph and not the auth state.

## How do I test this PR?

Add:

```js
username() { return 'Falcon'; },
```

To `graph/resolvers/user.js`.

Then check that your `My Profile` tab says "Falcon" instead of your username.