### PR TITLE
Mail Service Fix

### DIFF
--- a/config.js
+++ b/config.js
@@ -163,7 +163,7 @@ const CONFIG = {
   SMTP_FROM_ADDRESS: process.env.TALK_SMTP_FROM_ADDRESS,
   SMTP_HOST: process.env.TALK_SMTP_HOST,
   SMTP_PASSWORD: process.env.TALK_SMTP_PASSWORD,
-  SMTP_PORT: process.env.TALK_SMTP_PORT,
+  SMTP_PORT: process.env.TALK_SMTP_PORT ? parseInt(process.env.TALK_SMTP_PORT) : undefined,
   SMTP_USERNAME: process.env.TALK_SMTP_USERNAME,
 
   //------------------------------------------------------------------------------

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -64,7 +64,11 @@ const options = {
 };
 
 if (SMTP_PORT) {
-  options.port = SMTP_PORT;
+  try {
+    options.port = parseInt(SMTP_PORT);
+  } catch (e) {
+    throw new Error('TALK_SMTP_PORT is not an integer');
+  }
 } else {
   options.port = 25;
 }


### PR DESCRIPTION
## What does this PR do?

- Adds port number parsing for non-standard smtp ports

## How do I test this PR?

Provide the `TALK_SMTP_PORT` env var equal to a port number, watch it work!