### PR TITLE
disable report button when comment already reported

### DIFF
--- a/client/talk-plugin-flags/components/FlagButton.js
+++ b/client/talk-plugin-flags/components/FlagButton.js
@@ -158,9 +158,16 @@ export default class FlagButton extends Component {
       <ClickOutside onClickOutside={this.handleClickOutside}>
         <div className={`${name}-container`}>
           <button
+            disabled={flagged}
             ref={(ref) => this.flagButton = ref}
             onClick={!this.props.banned && !flaggedByCurrentUser && !localPost ? this.onReportClick : null}
-            className={cn(`${name}-button`, {[`${name}-button-flagged`]: flagged}, styles.button)}>
+            className={
+              cn(`${name}-button`, {
+                [`${name}-button-flagged`]: flagged,
+                [styles.flaggedButton]: flagged
+              },
+              styles.button)}
+          >
             {
               flagged
                 ? <span className={`${name}-button-text`}>{t('reported')}</span>

--- a/client/talk-plugin-flags/components/styles.css
+++ b/client/talk-plugin-flags/components/styles.css
@@ -3,6 +3,10 @@
   margin: 5px 0px 5px 10px;
 }
 
+button[disabled] {
+  cursor: default;
+}
+
 .flaggedIcon {
   color: #f00
 }


### PR DESCRIPTION
## What does this PR do?

Disabled the report button if the comment has already been reported. Fixes #1044 

## How do I test this PR?

Report a comment and see that the report button pointer is now default and the button is disabled.

Before changes
![image](https://user-images.githubusercontent.com/3145921/32152652-71ef03e0-bce2-11e7-8dcd-771e278b6850.png)

After changes
![image](https://user-images.githubusercontent.com/3145921/32152664-81ba29b2-bce2-11e7-9339-f53831d292c7.png)
