### PR TITLE
Allow CSS overrides manifest for custom styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,6 @@ plugins/*
 !plugins/talk-plugin-flag-details
 !plugins/talk-plugin-slack-notifications
 
+css-overrides.json
+
 **/node_modules/*

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs-extra');
 const CompressionPlugin = require('compression-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const precss = require('precss');
@@ -133,6 +133,22 @@ const config = {
     ]
   }
 };
+
+//==============================================================================
+// CSS overrides resolver
+//==============================================================================
+const cssOverrides = fs.readJsonSync(path.resolve(__dirname, 'css-overrides.json'), { throws: false });
+if (cssOverrides && cssOverrides.length) {
+  cssOverrides.forEach(({ regExpStr, newRelPath }) => {
+    // Must be a CSS file
+    if (regExpStr.endsWith('.css')) {
+      config.plugins.push(new webpack.NormalModuleReplacementPlugin(
+        new RegExp(`${regExpStr}$`),
+        path.resolve(__dirname, newRelPath)
+      ));
+    }
+  });
+}
 
 //==============================================================================
 // Production configuration overrides

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -139,12 +139,16 @@ const config = {
 //==============================================================================
 const cssOverrides = fs.readJsonSync(path.resolve(__dirname, 'css-overrides.json'), { throws: false });
 if (cssOverrides && cssOverrides.length) {
-  cssOverrides.forEach(({ regExpStr, newRelPath }) => {
-    // Must be a CSS file
-    if (regExpStr.endsWith('.css')) {
+  cssOverrides.forEach(({ oldPath, newPath }) => {
+    // Must both be CSS files
+    if (oldPath.endsWith('.css') && newPath.endsWith('.css')) {
+      const regExpStr = oldPath
+        .split('/')
+        .join('\\/')
+        .replace('.css', '\\.css$')
       config.plugins.push(new webpack.NormalModuleReplacementPlugin(
-        new RegExp(`${regExpStr}$`),
-        path.resolve(__dirname, newRelPath)
+        new RegExp(regExpStr),
+        path.resolve(__dirname, newPath)
       ));
     }
   });


### PR DESCRIPTION
## What does this PR do?

_As a developer implementing Talk, I'd like to be able to override CSS module import paths so I can have more control over Talk's look._

Using Talk's admin option to load a CSS file is great for minor tweaks, but bigger modifications to the styling of the UI require a lot of style overrides and `!important`. 

This PR allows a developer to create a `css-overrides.json` file in the Talk root directory. This file contains an array of resources, each with relative paths from the Talk root to the "old" and "new" resources.

If `css-overrides.json` exists, is valid JSON, and is not empty, Talk's Webpack config will use the [`NormalModuleReplacementPlugin`](https://webpack.js.org/plugins/normal-module-replacement-plugin/) to override the original resource with the new one. _Both the original and replacement resources must be a CSS files._

### Example

In `css-overrides.json`:

```
[
  {
    "oldPath": "client/coral-embed-stream/src/components/Comment.css",
    "newPath": "plugins/my-cool-plugin/styles/Comment.css"
  }
]
```

Now `Comment.js` will [import](https://github.com/coralproject/talk/blob/master/client/coral-embed-stream/src/components/Comment.js#L11) its `styles` object from `plugins/my-cool-plugin/styles` instead of the origin `client/coral-embed-stream/src/components`.

### Note about selectors

The developer is responsible for making sure that all CSS selectors required by the React component (e.g. `Comment.js`) exist in the new CSS file. 

I.e. if `Comment.js` refers to `<div className={styles.anExample} >`, it's on you to make sure that `.anExample{ ... }` exists in your new `Comment.css`. If not, it will fail silently and be rendered as `<div class="undefined">`.

## How do I test this PR?

1. Create a file `css-overrides.json` in the Talk root using the above JSON snippet.
1. Copy `client/coral-embed-stream/src/components/Comment.css` to `plugins/my-cool-plugin/styles/Comment.css`
1. In the new `Comment.css`, add the property `color: orange` to the selector `.content`
1. `yarn build`
1. The text of comments in the embed stream should be orange.
1. `git status` should not show any tracked changes.

Edge-case handling:

* Edit `css-overrides.json` so that it is no longer valid JSON
* Edit `oldPath` so that it ends with `Comment.js`
* Edit `newPath` so that it ends with `Comment.js`

Then rebuild. In all cases, the Webpack build should complete without error but the styles will be inherited from the original CSS file, `coral-embed-stream/src/components/Comment.css`.