### PR TITLE
Update CSS classname

### DIFF
--- a/client/talk-plugin-flags/components/FlagButton.js
+++ b/client/talk-plugin-flags/components/FlagButton.js
@@ -207,7 +207,7 @@ export default class FlagButton extends Component {
                     }
                     {
                       this.state.reason && <div>
-                        <label htmlFor={'message'} className={`${name}-popup-radio-label`}>
+                        <label htmlFor={'message'} className={`${name}-popup-textarea-label`}>
                           {t('flag_reason')}
                         </label><br/>
                         <textarea


### PR DESCRIPTION
## What does this PR do?

- Fixes #1188 
- Change `${name}-popup-radio-label` to `${name}-popup-textarea-label`

