### PR TITLE
Fix logic to generate asset_url even if the asset_id is provided

### DIFF
--- a/client/coral-embed/src/index.js
+++ b/client/coral-embed/src/index.js
@@ -70,10 +70,9 @@ export class Talk {
     // Extract the asset url.
     if (opts.asset_url) {
       query.asset_url = opts.asset_url;
-    } else if (!opts.asset_id) {
+    } else {
 
-      // The asset url was not provided and the asset id was also not provided,
-      // we need to infer the asset url from details on the page.
+      // The asset url was not provided so we need to infer the asset url from // details on the page.
 
       try {
         query.asset_url = document.querySelector('link[rel="canonical"]').href;


### PR DESCRIPTION
an error is avoided

## What does this PR do?
Prior to this commit, the embed logic would only generate an `asset_url` if one wasn't provided and the `asset_id` also wasn't provided. This commit changes the logic so that the `asset_url` is generated if one is provided regardless of whether and `asset_id` is provided.

This is needed to support plugins that use fallback logic to create/load an asset by url if the asset id is invalid.

