### PR TITLE
i18n + Email Support

### DIFF
--- a/config.js
+++ b/config.js
@@ -20,6 +20,9 @@ const CONFIG = {
   // WEBPACK indicates when webpack is currently building.
   WEBPACK: process.env.WEBPACK === 'TRUE',
 
+  // EMAIL_SUBJECT_PREFIX is the string before emails in the subject.
+  EMAIL_SUBJECT_PREFIX: process.env.TALK_EMAIL_SUBJECT_PREFIX || '[Talk]',
+
   // When TRUE, it ensures that database indexes created in core will not add
   // indexes.
   CREATE_MONGO_INDEXES: process.env.DISABLE_CREATE_MONGO_INDEXES !== 'TRUE',

--- a/config.js
+++ b/config.js
@@ -23,6 +23,10 @@ const CONFIG = {
   // EMAIL_SUBJECT_PREFIX is the string before emails in the subject.
   EMAIL_SUBJECT_PREFIX: process.env.TALK_EMAIL_SUBJECT_PREFIX || '[Talk]',
 
+  // DEFAULT_LANG is the default language used for server sent emails and
+  // rendered text.
+  DEFAULT_LANG: process.env.TALK_DEFAULT_LANG || 'en',
+
   // When TRUE, it ensures that database indexes created in core will not add
   // indexes.
   CREATE_MONGO_INDEXES: process.env.DISABLE_CREATE_MONGO_INDEXES !== 'TRUE',

--- a/docs/_docs/02-02-advanced-configuration.md
+++ b/docs/_docs/02-02-advanced-configuration.md
@@ -461,3 +461,9 @@ Could be read as:
 
 When `TRUE`, staff members will have their accounts and comments moderated the
 same as any other user in the system. (Default `FALSE`)
+
+## TALK_EMAIL_SUBJECT_PREFIX
+
+The prefix for the subject of emails sent. An email with the specified subject
+of `Email Confirmation` would then be sent as `[Talk] Email Confirmation`.
+(Default `[Talk]`)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -166,6 +166,11 @@ en:
     minute: "minute"
     minutes_plural: "minutes"
   email:
+    suspended:
+      subject: "Your account has been suspended"
+    banned:
+      subject: "Your account has been banned"
+      body: "In accordance with The Coral Project’s community guidelines, your account has been banned. You are now longer allowed to comment, flag or engage with our community."
     confirm:
       has_been_requested: "A email confirmation has been requested for the following account:"
       to_confirm: "To confirm the account, please visit the following link:"

--- a/middleware/i18n.js
+++ b/middleware/i18n.js
@@ -1,0 +1,6 @@
+const i18n = require('../services/i18n');
+
+module.exports = (req, res, next) => {
+  res.locals.t = i18n.request(req);
+  next();
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,7 +7,7 @@ const debug = require('debug')('talk:routes');
 const enabled = require('debug').enabled;
 const errors = require('../errors');
 const express = require('express');
-const i18n = require('../services/i18n');
+const i18n = require('../middleware/i18n');
 const path = require('path');
 const plugins = require('../services/plugins');
 const pubsub = require('../middleware/pubsub');
@@ -64,6 +64,9 @@ if (!DISABLE_STATIC_SERVER) {
   router.get('/embed.js.map', serveFile('../dist/embed.js.map'));
 }
 
+// Add the i18n middleware to all routes.
+router.use(i18n);
+
 //==============================================================================
 // STATIC ROUTES
 //==============================================================================
@@ -116,18 +119,18 @@ if (process.env.NODE_ENV !== 'production') {
     });
   });
 
-  // GraphQL documention.
+  // GraphQL documentation.
   router.get('/admin/docs', (req, res) => {
     res.render('admin/docs');
   });
 
 }
 
+router.use('/api/v1', require('./api'));
+
 //==============================================================================
 // ROUTES
 //==============================================================================
-
-router.use('/api/v1', require('./api'));
 
 // Development routes.
 if (process.env.NODE_ENV !== 'production') {
@@ -183,8 +186,6 @@ router.use('/', (err, req, res, next) => {
   if (err !== errors.ErrNotFound) {
     console.error(err);
   }
-
-  i18n.init(req);
 
   if (err instanceof errors.APIError) {
     res.status(err.status);

--- a/services/email/email-confirm.html.ejs
+++ b/services/email/email-confirm.html.ejs
@@ -1,3 +1,3 @@
 <p><%= t('email.confirm.has_been_requested') %> <b><%= email %></b>.</p>
-<p><%= t('email.confirm.to_confirm') %> <a href="<%= BASE_URL %>admin/confirm-email#<%= token %>">Confirm Email</a></p>
+<p><%= t('email.confirm.to_confirm') %> <a href="<%= BASE_URL %>admin/confirm-email#<%= token %>"><%= t('email.confirm.confirm_email') %></a></p>
 <p><%= t('email.confirm.if_you_did_not') %></p>

--- a/services/i18n.js
+++ b/services/i18n.js
@@ -41,7 +41,7 @@ const loadPluginTranslations = () => {
   }
 
   // Load the plugin translations.
-  plugins.forEach('server', 'translations').forEach(({plugin, translations: filename}) => {
+  plugins.get('server', 'translations').forEach(({plugin, translations: filename}) => {
     debug(`added plugin '${plugin.name}'`);
 
     const pack = yaml.parse(fs.readFileSync(filename, 'utf8'));
@@ -62,11 +62,6 @@ const i18n = {
    * Create the new Task kue.
    */
   init(req) {
-
-    // Loads the translations into the translations array from plugins. This is
-    // done lazily to ensure that we don't have an import cycle.
-    loadPluginTranslations();
-
     const lang = accepts(req).language(languages);
     language = lang ? lang : defaultLanguage;
   },
@@ -75,6 +70,10 @@ const i18n = {
    * Translates a key.
    */
   t(key, ...replacements) {
+
+    // Loads the translations into the translations array from plugins. This is
+    // done lazily to ensure that we don't have an import cycle.
+    loadPluginTranslations();
 
     // Check if the translation exists on the object.
     if (_.has(translations[language], key)) {

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -99,8 +99,8 @@ const mailer = module.exports = {
 
     attachLocals(locals);
 
-    // Attach the templating function.
-    locals['t'] = i18n.t;
+    // Attach the translation function.
+    locals.t = i18n.t;
 
     return Promise.all([
 
@@ -112,7 +112,7 @@ const mailer = module.exports = {
     ])
       .then(([html, text]) => {
 
-      // Create the job.
+        // Create the job.
         return mailer.task.create({
           title: 'Mail',
           message: {

--- a/services/mailer.js
+++ b/services/mailer.js
@@ -13,7 +13,8 @@ const {
   SMTP_USERNAME,
   SMTP_PORT,
   SMTP_PASSWORD,
-  SMTP_FROM_ADDRESS
+  SMTP_FROM_ADDRESS,
+  EMAIL_SUBJECT_PREFIX,
 } = require('../config');
 
 // load all the templates as strings
@@ -95,7 +96,7 @@ const mailer = module.exports = {
     }
 
     // Prefix the subject with `[Talk]`.
-    subject = `[Talk] ${subject}`;
+    subject = `${EMAIL_SUBJECT_PREFIX} ${subject}`;
 
     attachLocals(locals);
 

--- a/services/users.js
+++ b/services/users.js
@@ -24,6 +24,7 @@ const RECAPTCHA_INCORRECT_TRIGGER = 5; // after 3 incorrect attempts, recaptcha 
 const ActionsService = require('./actions');
 const MailerService = require('./mailer');
 const Wordlist = require('./wordlist');
+const i18n = require('./i18n');
 const Domainlist = require('./domainlist');
 const {escapeRegExp} = require('./regex');
 
@@ -430,16 +431,14 @@ module.exports = class UsersService {
     if (status === 'BANNED') {
       let localProfile = user.profiles.find((profile) => profile.provider === 'local');
       if (localProfile) {
-        const options =
-          {
-            template: 'banned',              // needed to know which template to render!
-            locals: {                            // specifies the template locals.
-              body: 'In accordance with The Coral Project’s community guidelines, your account has been banned. You are now longer allowed to comment, flag or engage with our community.'
-            },
-            subject: 'Your account has been banned',
-            to: localProfile.id  // This only works if the user has registered via e-mail.
-            // We may want a standard way to access a user's e-mail address in the future
-          };
+        const options = {
+          template: 'banned',
+          locals: {
+            body: i18n.t('email.banned.body'),
+          },
+          subject: i18n.t('email.banned.subject'),
+          to: localProfile.id
+        };
         await MailerService.sendSimple(options);
       }
     }
@@ -467,16 +466,14 @@ module.exports = class UsersService {
     if (message) {
       let localProfile = user.profiles.find((profile) => profile.provider === 'local');
       if (localProfile) {
-        const options =
-          {
-            template: 'suspension',              // needed to know which template to render!
-            locals: {                            // specifies the template locals.
-              body: message
-            },
-            subject: 'Your account has been suspended',
-            to: localProfile.id  // This only works if the user has registered via e-mail.
-            // We may want a standard way to access a user's e-mail address in the future
-          };
+        const options = {
+          template: 'suspension',
+          locals: {
+            body: message
+          },
+          subject: i18n.t('email.suspended.subject'),
+          to: localProfile.id,
+        };
 
         await MailerService.sendSimple(options);
       }
@@ -509,7 +506,7 @@ module.exports = class UsersService {
           locals: {                            // specifies the template locals.
             body: message
           },
-          subject: 'Email Suspension',
+          subject: i18n.t('email.suspended.subject'),
           to: localProfile.id  // This only works if the user has registered via e-mail.
           // We may want a standard way to access a user's e-mail address in the future
         };


### PR DESCRIPTION
## What does this PR do?

- Support new server side plugin for translations:

> When a plugin provides a `translations` hook, they provide an absolute filename path to the translation yaml file that should be included, example: `translations: path.join(__dirname, 'client/translations.yml')`.

- Supports a new `TALK_EMAIL_SUBJECT_PREFIX` config that allows configuration of the email prefix. Defaults to `[Talk]`
- Supports sending emails in the default language selected with the `TALK_DEFAULT_LANG` config.