### PR TITLE
Disabling Firefox/Edge on E2E until fix pass

### DIFF
--- a/scripts/e2e-ci.sh
+++ b/scripts/e2e-ci.sh
@@ -8,7 +8,10 @@ E2E_MAX_RETRIES=${E2E_MAX_RETRIES:-1}
 
 # Safari >= 8 has issues connecting to browserstack-local. Safari < 8 is too old.
 # IE 64bit has issues with receiving keyboard input. Let's wait for them to fix it.
-BROWSERS="chrome,firefox,edge" #ie safari
+
+# FIXME: disabled firefox,edge until fixing pass is done
+# BROWSERS="chrome,firefox,edge" #ie safari
+BROWSERS="chrome"
 
 if [[ "${CIRCLE_BRANCH}" == "master" && -n "$BROWSERSTACK_KEY" ]]; then
   echo Testing on browserstack


### PR DESCRIPTION
## What does this PR do?

- Disables e2e testing on Firefox/Edge until fixes are applied on client side e2e code