### PR TITLE
Deprecate body-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "^6.23.0",
     "bcryptjs": "^2.4.3",
-    "body-parser": "1.18.2",
     "bowser": "^1.7.2",
     "cli-table": "^0.3.1",
     "clipboard": "^1.7.1",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,6 @@
 const accepts = require('accepts');
 const apollo = require('graphql-server-express');
 const authentication = require('../middleware/authentication');
-const bodyParser = require('body-parser');
 const cookieParser = require('cookie-parser');
 const debug = require('debug')('talk:routes');
 const enabled = require('debug').enabled;
@@ -82,7 +81,7 @@ router.use('/embed', staticTemplate, require('./embed'));
 router.use(cookieParser());
 
 // Parse the body json if it's there.
-router.use(bodyParser.json());
+router.use(express.json());
 
 const passportDebug = require('debug')('talk:passport');
 


### PR DESCRIPTION
## What does this PR do?

- Deprecates `body-parser` in favor of `express.json()`