### PR TITLE
Subscription Connection Plugin Hooks

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -57,6 +57,10 @@ const hookSchemas = {
   resolvers: Joi.object().pattern(/\w/, Joi.object().pattern(/(?:__resolveType|\w+)/, Joi.func())),
   typeDefs: Joi.string(),
   schemaLevelResolveFunction: Joi.func(),
+  websockets: Joi.object({
+    onConnect: Joi.func(),
+    onDisconnect: Joi.func(),
+  }),
 };
 
 /**


### PR DESCRIPTION
Adds support for plugin hooks on the websocket connections to support a plugin like the following:

```js
const ms = require('ms');
const clients = new Map();

module.exports = {
  websockets: {
    onConnect: async (params, websocket) => {
      clients.set(websocket, {subscribed: Date.now()});
      console.log(`${clients.size} clients - new client connected`);
    },
    onDisconnect: async (websocket) => {
      if (clients.has(websocket)) {
        const client = clients.get(websocket);
        clients.delete(websocket);
        console.log(`${clients.size} clients - client disconnected after ${ms(Date.now() - client.subscribed)}`);
      }
    },
  },
};

```