### PR TITLE
Expiry Parsing Bug

### DIFF
--- a/graph/loaders/util.js
+++ b/graph/loaders/util.js
@@ -72,8 +72,10 @@ class SharedCacheDataLoader extends DataLoader {
   constructor(prefix, expiry, batchLoadFn, options) {
     super(SharedCacheDataLoader.batchLoadFn(prefix, expiry, batchLoadFn), options);
 
+    // Expiry is provided as a number in ms, we're using commands optimized for
+    // seconds, so convert this to seconds.
+    this._expiry = Math.floor(expiry / 1000);
     this._prefix = prefix;
-    this._expiry = expiry;
     this._keyFunc = SharedCacheDataLoader.keyFunc(this._prefix);
   }
 


### PR DESCRIPTION
Credit goes to @erikreyna for discovering this issue!

## What does this PR do?

Previously, we parsed the expiry date using the `ms` package, yet the services consuming this value assumed seconds. This PR adjusts those services to ensure that while the input is parsed from ms, we convert to seconds before using.