### PR TITLE
Modqueue fixes and enhancements

### DIFF
--- a/client/coral-admin/src/routes/Moderation/components/ModerationQueue.js
+++ b/client/coral-admin/src/routes/Moderation/components/ModerationQueue.js
@@ -190,28 +190,22 @@ class ModerationQueue extends React.Component {
   componentDidUpdate (prev) {
     const {commentCount, selectedCommentId} = this.props;
 
-    // Switching to multi mode.
-    if (prev.singleView && !this.props.singleView) {
+    const switchedToMultiMode = prev.singleView && !this.props.singleView;
+    const switchedMode = prev.singleView !== this.props.singleView;
+    const selectedDifferentComment = prev.selectedCommentId !== selectedCommentId && selectedCommentId;
+    const moderatedLastComment = prev.comments.length > 0 && this.getCommentCountWithoutDagling() === 0;
+
+    if (switchedToMultiMode) {
 
       // Reflow virtual list.
       this.reflowList();
     }
 
-    if (
-
-      // Switching mode.
-      prev.singleView !== this.props.singleView ||
-
-      // Select different comment.
-      prev.selectedCommentId !== selectedCommentId && selectedCommentId
-    ) {
+    if (switchedMode || selectedDifferentComment) {
       this.scrollToSelectedComment();
     }
 
-    // If the user just moderated the last (visible) comment
-    // AND there are more comments available on the server,
-    // go ahead and load more comments
-    if (prev.comments.length > 0 && this.getCommentCountWithoutDagling() === 0 && commentCount > 0) {
+    if (moderatedLastComment && commentCount > 0) {
       this.props.loadMore();
     }
   }

--- a/client/coral-admin/src/routes/Moderation/components/ModerationQueue.js
+++ b/client/coral-admin/src/routes/Moderation/components/ModerationQueue.js
@@ -195,22 +195,17 @@ class ModerationQueue extends React.Component {
 
       // Reflow virtual list.
       this.reflowList();
-
-      // Scroll to selected comment.
-      if (this.props.selectedCommentId) {
-        const view = this.state.view;
-        const index = view.findIndex(({id}) => id === selectedCommentId);
-        this.listRef.scrollToRow(index);
-      }
     }
 
-    // Switching to single mode.
-    if (!prev.singleView && this.props.singleView) {
+    if (
 
-      // Scroll to comment.
-      if (this.props.selectedCommentId) {
-        document.querySelector(`#comment_${this.props.selectedCommentId}`).scrollIntoView();
-      }
+      // Switching mode.
+      prev.singleView !== this.props.singleView ||
+
+      // Select different comment.
+      prev.selectedCommentId !== selectedCommentId && selectedCommentId
+    ) {
+      this.scrollToSelectedComment();
     }
 
     // If the user just moderated the last (visible) comment
@@ -218,15 +213,6 @@ class ModerationQueue extends React.Component {
     // go ahead and load more comments
     if (prev.comments.length > 0 && this.getCommentCountWithoutDagling() === 0 && commentCount > 0) {
       this.props.loadMore();
-    }
-
-    // Scroll to new selected comment.
-    if (prev.selectedCommentId !== selectedCommentId && this.listRef) {
-
-      const view = this.state.view;
-      const index = view.findIndex(({id}) => id === selectedCommentId);
-
-      this.listRef.scrollToRow(index);
     }
   }
 
@@ -264,6 +250,17 @@ class ModerationQueue extends React.Component {
   handleListRef = (list) => {
     this.listRef = list;
   };
+
+  scrollToSelectedComment = (props = this.props, state = this.state) => {
+    if (props.singleMode) {
+      document.querySelector(`#comment_${props.selectedCommentId}`).scrollIntoView();
+    }
+    else if(this.listRef) {
+      const view = state.view;
+      const index = view.findIndex(({id}) => id === props.selectedCommentId);
+      this.listRef.scrollToRow(index);
+    }
+  }
 
   viewNewComments = (callback) => {
     this.setState(resetCursors, () => {

--- a/client/coral-admin/src/routes/Moderation/components/ModerationQueue.js
+++ b/client/coral-admin/src/routes/Moderation/components/ModerationQueue.js
@@ -194,6 +194,7 @@ class ModerationQueue extends React.Component {
     const switchedMode = prev.singleView !== this.props.singleView;
     const selectedDifferentComment = prev.selectedCommentId !== selectedCommentId && selectedCommentId;
     const moderatedLastComment = prev.comments.length > 0 && this.getCommentCountWithoutDagling() === 0;
+    const hasMoreComment = commentCount > 0;
 
     if (switchedToMultiMode) {
 
@@ -205,7 +206,7 @@ class ModerationQueue extends React.Component {
       this.scrollToSelectedComment();
     }
 
-    if (moderatedLastComment && commentCount > 0) {
+    if (moderatedLastComment && hasMoreComment) {
       this.props.loadMore();
     }
   }

--- a/client/coral-admin/src/routes/Moderation/components/ModerationQueue.js
+++ b/client/coral-admin/src/routes/Moderation/components/ModerationQueue.js
@@ -190,6 +190,29 @@ class ModerationQueue extends React.Component {
   componentDidUpdate (prev) {
     const {commentCount, selectedCommentId} = this.props;
 
+    // Switching to multi mode.
+    if (prev.singleView && !this.props.singleView) {
+
+      // Reflow virtual list.
+      this.reflowList();
+
+      // Scroll to selected comment.
+      if (this.props.selectedCommentId) {
+        const view = this.state.view;
+        const index = view.findIndex(({id}) => id === selectedCommentId);
+        this.listRef.scrollToRow(index);
+      }
+    }
+
+    // Switching to single mode.
+    if (!prev.singleView && this.props.singleView) {
+
+      // Scroll to comment.
+      if (this.props.selectedCommentId) {
+        document.querySelector(`#comment_${this.props.selectedCommentId}`).scrollIntoView();
+      }
+    }
+
     // If the user just moderated the last (visible) comment
     // AND there are more comments available on the server,
     // go ahead and load more comments
@@ -197,7 +220,7 @@ class ModerationQueue extends React.Component {
       this.props.loadMore();
     }
 
-    // Scroll to selected comment.
+    // Scroll to new selected comment.
     if (prev.selectedCommentId !== selectedCommentId && this.listRef) {
 
       const view = this.state.view;
@@ -372,6 +395,7 @@ class ModerationQueue extends React.Component {
             rejectComment={props.rejectComment}
             currentAsset={props.currentAsset}
             currentUserId={this.props.currentUserId}
+            dangling={!this.props.commentBelongToQueue(this.props.activeTab, comment)}
           />;
         </div>
       );


### PR DESCRIPTION
## What does this PR do?
- Mark single dangling comments
- Reflow when switching from single mode to multi mode
- Scroll to selected comment when switching from single mode to multi mode and vice versa
- Fixes
  - https://www.pivotaltracker.com/story/show/153825286
  - https://www.pivotaltracker.com/story/show/153851539
  - https://www.pivotaltracker.com/story/show/153851551

## How do I test this PR?

- Mark single dangling comments 
  - Make a dangling comment by moderating a comment in the active queue using another moderator
  - Select dangling comment and go to single mode
  - Comment should keep the greyed out background
- Reflow when switching from single mode to multi mode
  - Go to single mode
  - Moderate this comment using another moderator 
  - Switch to multi mode, the list should be rendered correctly
- Scroll to selected comment when switching from single mode to multi mode and vice versa
  - Switch to single mode, notice a scroll to the selected comment
  - Switch to multi mode, notice a scroll to the selected comment