### PR TITLE
i18n Default Language Fix

### DIFF
--- a/services/i18n.js
+++ b/services/i18n.js
@@ -32,6 +32,14 @@ let translations = fs.readdirSync(resolve())
 // Create a list of all supported translations.
 const languages = Object.keys(translations);
 
+// Move the default language to the front.
+if (languages.includes(DEFAULT_LANG)) {
+  const from = languages.indexOf(DEFAULT_LANG);
+  languages.splice(from, 1);
+  languages.splice(0, 0, DEFAULT_LANG);
+}
+debug(`loaded language sets for ${languages}`);
+
 let loadedPluginTranslations = false;
 const loadPluginTranslations = () => {
   if (loadedPluginTranslations) {
@@ -80,8 +88,11 @@ const t = (language) => (key, ...replacements) => {
  */
 const i18n = {
   request(req) {
+    debug(`possible languages given request '${accepts(req).languages()}'`);
     const lang = accepts(req).language(languages);
+    debug(`parsed request language as '${lang}'`);
     const language = lang ? lang : DEFAULT_LANG;
+    debug(`decided language as '${language}'`);
 
     return t(language);
   },


### PR DESCRIPTION
## What was wrong?

When a request comes in that doesn't specify a language, the first language in the array of languages is selected, in this case, Danish.

## What was changed?

We re-sorted the list of languages to have the default language (as indicated by the `TALK_DEFAULT_LANG` environment variable, which is defaulted to `en`) as the first language, thereby alleviating the problem.

## How do I test this PR?

1. Set your TALK_DEFAULT_LANG to `en`.
2. Register for an account with the email enabled.
3. See that the email is now in english.
