### PR TITLE
Fix a variable name for redis client configuration

### DIFF
--- a/docs/_docs/02-02-advanced-configuration.md
+++ b/docs/_docs/02-02-advanced-configuration.md
@@ -319,7 +319,7 @@ default to providing only a time based lockout. Refer to
 [reCAPTCHA](https://www.google.com/recaptcha/intro/index.html) for information
 on getting an account setup.
 
-## TALK_REDIS_CLIENT_CONFIG
+## TALK_REDIS_CLIENT_CONFIGURATION
 
 Configuration overrides for the redis client configuration in a JSON encoded
 string. Configuration is overridden as the second parameter to the redis client


### PR DESCRIPTION
The documentation incorrectly stated that the advanced Redis Client configuration could be set using `TALK_REDIS_CLIENT_CONFIG`, while, in fact, the correct variable is `TALK_REDIS_CLIENT_CONFIGURATION`, as it parsed in https://github.com/coralproject/talk/blob/master/config.js#L114

## What does this PR do?

This PR fixes the documentation to be consistent with the actual code

## How do I test this PR?

Compare the documentation with https://github.com/coralproject/talk/blob/master/config.js#L114