### PR TITLE
Fixes for report dialog

### DIFF
--- a/graph/resolvers/root_mutation.js
+++ b/graph/resolvers/root_mutation.js
@@ -23,7 +23,7 @@ const RootMutation = {
     { flag: { item_id, item_type, reason, message } },
     { mutators: { Action } }
   ) => ({
-    flag: Action.create({
+    flag: await Action.create({
       item_id,
       item_type,
       action_type: 'FLAG',

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -336,6 +336,7 @@ en:
   no_agree_comment: "I don't agree with this comment"
   no_like_bio: "I don't like this bio"
   no_like_username: "I don't like this username"
+  already_flagged_username: "You already flagged this username"
   other: Other
   permalink: Share
   personal_info: "This comment reveals personally identifiable information"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -336,7 +336,7 @@ en:
   no_agree_comment: "I don't agree with this comment"
   no_like_bio: "I don't like this bio"
   no_like_username: "I don't like this username"
-  already_flagged_username: "You already flagged this username"
+  already_flagged_username: "You have already flagged this username."
   other: Other
   permalink: Share
   personal_info: "This comment reveals personally identifiable information"


### PR DESCRIPTION
## What does this PR do?
- When a user is flagged twice with the same reason show `You have already flagged this username.` instead of `Resource already exists`.
- Prevent dialog from progressing when no items where selected
- Previously when a comment was flagged or the username was flagged, the same button used to perform this action, will not execute any other mutation, even though the UI suggests that it does and successfully so. This patch contains changes to actually perform the mutations as the ui suggests.
- Fix bug where error messages where not translated anymore.
- https://www.pivotaltracker.com/story/show/154524763
- https://www.pivotaltracker.com/story/show/152472590

## How do I test this PR?

- Test 1
  - Flag a username  
  - Flag same username with the same reasons
  - It should yield `You have already flagged this username`

- Test 2
  - Click on continue on the report dialog without selecting any items.
  - It should not proceed

