### PR TITLE
Plugin Working Directory

### DIFF
--- a/bin/cli-plugins
+++ b/bin/cli-plugins
@@ -15,9 +15,9 @@ const inquirer = require('inquirer');
 require('colors');
 const emoji = require('node-emoji');
 
-const dir = process.cwd();
 const fs = require('fs-extra');
 const path = require('path');
+const dir = path.resolve(__dirname, '..');
 const spawn = require('cross-spawn');
 const semver = require('semver');
 const resolve = require('resolve');

--- a/plugins.js
+++ b/plugins.js
@@ -110,7 +110,7 @@ function pluginPath(name) {
     try {
       return resolve.sync(name, {
         moduleDirectory: 'plugins',
-        basedir: process.cwd(),
+        basedir: __dirname,
       });
     } catch (e) {
       console.warn(e);
@@ -119,7 +119,7 @@ function pluginPath(name) {
   }
 
   try {
-    return resolve.sync(name, { basedir: process.cwd() });
+    return resolve.sync(name, { basedir: __dirname });
   } catch (e) {
     return undefined;
   }


### PR DESCRIPTION
## What does this PR do?

- Plugins are now relative to the installation directory rather than the current working directory, improving the plugin experience