### PR TITLE
Add padding to flagged user

### DIFF
--- a/client/coral-admin/src/routes/Community/components/FlaggedUser.css
+++ b/client/coral-admin/src/routes/Community/components/FlaggedUser.css
@@ -10,7 +10,7 @@
   margin: 0 auto;
   position: relative;
   transition: background 200ms, box-shadow 200ms, margin-bottom 200ms;
-  padding: 10px 0 0;
+  padding: 10px 0 10px;
   min-height: 220px;
 
   &:hover {


### PR DESCRIPTION
## What does this PR do?
![image](https://user-images.githubusercontent.com/14221600/35337811-69601d4e-011c-11e8-82a1-5a31ddb4332c.png)

- Just adds a little padding to the end
