### PR TITLE
Fix wrong text on "premod if contains links" setting

### DIFF
--- a/client/coral-embed-stream/src/tabs/configure/components/Settings.js
+++ b/client/coral-embed-stream/src/tabs/configure/components/Settings.js
@@ -57,7 +57,7 @@ class Settings extends React.Component {
           <Configuration
             checked={premodLinksEnable}
             title={t('configure.enable_premod_links')}
-            description={t('configure.enable_premod_description')}
+            description={t('configure.enable_premod_links_description')}
             onCheckbox={onTogglePremodLinks}
           />
           <Configuration


### PR DESCRIPTION
## What does this PR do?

This fixes a wrong text for the "enable premod for comments with links" settings on the embed stream. The plain premod text was re-used which is incorrect.

## How do I test this PR?

- go to these settings
- see the correct text
