### PR TITLE
Cleanup to Edit/Premod logic

### DIFF
--- a/services/comments.js
+++ b/services/comments.js
@@ -167,46 +167,6 @@ module.exports = class CommentsService {
       created_at: new Date(),
     });
 
-    // We should adjust the comment's status such that if it was approved
-    // previously, we should mark the comment as 'NONE' or 'PREMOD', which ever
-    // was most recent if the new comment is destined to be `NONE` or `PREMOD`.
-    if (originalComment.status === 'ACCEPTED' && status === 'NONE') {
-      const lastUnmoderatedStatus = CommentsService.lastUnmoderatedStatus(
-        originalComment
-      );
-
-      // If the last moderated status was found and the current comment doesn't
-      // match this already.
-      if (lastUnmoderatedStatus && status !== lastUnmoderatedStatus) {
-        // Update the comment model (if at this point, the status is still
-        // accepted) with the previously unmoderated status
-        await CommentModel.update(
-          {
-            id,
-            status,
-          },
-          {
-            $set: {
-              status: lastUnmoderatedStatus,
-            },
-            $push: {
-              status_history: {
-                type: lastUnmoderatedStatus,
-                created_at: new Date(),
-              },
-            },
-          }
-        );
-
-        // Update the returned comment.
-        editedComment.status = lastUnmoderatedStatus;
-        editedComment.status_history.push({
-          type: lastUnmoderatedStatus,
-          created_at: new Date(),
-        });
-      }
-    }
-
     await events.emitAsync(COMMENTS_EDIT, originalComment, editedComment);
 
     return editedComment;

--- a/test/server/services/comments.js
+++ b/test/server/services/comments.js
@@ -227,12 +227,12 @@ describe('services.CommentsService', () => {
         id: originalComment.id,
         author_id: '123',
         body: 'This is a body!',
-        status: 'NONE',
+        status: 'PREMOD',
       });
 
       expect(editedComment).to.have.property('status', 'PREMOD');
-      expect(editedComment.status_history).to.have.length(4);
-      expect(editedComment.status_history[3]).to.have.property(
+      expect(editedComment.status_history).to.have.length(3);
+      expect(editedComment.status_history[2]).to.have.property(
         'type',
         'PREMOD'
       );
@@ -240,8 +240,8 @@ describe('services.CommentsService', () => {
       retrivedComment = await CommentsService.findById(originalComment.id);
 
       expect(retrivedComment).to.have.property('status', 'PREMOD');
-      expect(retrivedComment.status_history).to.have.length(4);
-      expect(retrivedComment.status_history[3]).to.have.property(
+      expect(retrivedComment.status_history).to.have.length(3);
+      expect(retrivedComment.status_history[2]).to.have.property(
         'type',
         'PREMOD'
       );


### PR DESCRIPTION
## What does this PR do?

- Removes double set of status after comment is edited