### PR TITLE
Public path

### DIFF
--- a/docs/_docs/02-02-advanced-configuration.md
+++ b/docs/_docs/02-02-advanced-configuration.md
@@ -301,6 +301,11 @@ The keepalive timeout that should be used to send keep alive messages through
 the websocket to keep the socket alive, parsed by
 [ms](https://www.npmjs.com/package/ms){:target="_blank"}. (Default `30s`)
 
+## TALK_PUBLIC_PATH
+
+Used to set the public path where the static assets should be served from. This is used
+when you are running Talk not on root URL. (Default `/static/`)
+
 ## TALK_RECAPTCHA_PUBLIC
 
 Client secret used for enabling reCAPTCHA powered logins. If

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,10 @@ const buildTargets = [
 
 const buildEmbeds = ['stream'];
 
+// TALK_PUBLIC_PATH is a public path url to use on build webpack
+// Useful when Talk is running not on root directory
+const publicPath = process.env.TALK_PUBLIC_PATH || '/static/';
+
 // In production, default turn off source maps. In development, default use
 // 'cheap-module-source-map'.
 const DEFAULT_WEBPACK_SOURCE_MAP =
@@ -54,7 +58,7 @@ const config = {
   target: 'web',
   output: {
     path: path.join(__dirname, 'dist'),
-    publicPath: '/static/',
+    publicPath: publicPath,
     filename: '[name].js',
     chunkFilename: '[name].chunk.js',
   },


### PR DESCRIPTION
## What does this PR do?
Introduce a new environment variable `TALK_PUBLIC_PATH` to use on webpack config ans allow to set different static path. Useful when you're running the Talk not on root url. 

## How do I test this PR?

- Insert the variable `TALK_PUBLIC_PATH` on .env;
- Build and run Talk;
- Check if your public files are loading from your new path;

Also, It fix this issue: #1241 
