### PR TITLE
Insert BASE_PATH on public assets

### DIFF
--- a/views/admin/confirm-email.ejs
+++ b/views/admin/confirm-email.ejs
@@ -6,7 +6,7 @@
     <title>Email Verification</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.2.1/material.indigo-pink.min.css">
-    <link rel="stylesheet" href="/public/css/admin.css">
+    <link rel="stylesheet" href="<%= BASE_PATH %>public/css/admin.css">
     <%_ if (locals.customCssUrl) { _%>
     <link href="<%= customCssUrl %>" rel="stylesheet" type="text/css">
     <%_ } _%>

--- a/views/admin/password-reset.ejs
+++ b/views/admin/password-reset.ejs
@@ -6,7 +6,7 @@
     <title>Password Reset</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.2.1/material.indigo-pink.min.css">
-    <link rel="stylesheet" href="/public/css/admin.css">
+    <link rel="stylesheet" href="<%= BASE_PATH %>public/css/admin.css">
     <%_ if (locals.customCssUrl) { _%>
     <link href="<%= customCssUrl %>" rel="stylesheet" type="text/css">
     <%_ } _%>


### PR DESCRIPTION
## What does this PR do?
Insert on files view of confirmation e-mail and forgot password the `BASE_PATH`, to prevent error on load the files when you're running Talk on `/something`



## How do I test this PR?

1. Set your environment as: TALK_ROOT_URL=http://localhost:4000/test
2. Set the SMTP configuration to send e-mails ([see here](https://coralproject.github.io/talk/advanced-configuration/#talk_smtp_from_address))
3. Proxy http://localhost:4000/test/ to http://localhost:3000/
4. Build and start server
5. Load http://localhost:8081/test/ unlogged

### Scenario 1

6. Register as new user with a valid e-mail
7. Check your e-mail and click on "Confirm e-mail" link
8. Verify that the public assets are loading correctly

### Scenario 2

6. Click on "forgot password" and provide a registered e-mail
7. Check your e-mail and click on "please click here to reset password." link
8. Verify that the public assets are loading correctly
