### PR TITLE
Change text wrapping of Stories table

### DIFF
--- a/client/coral-admin/src/routes/Stories/components/Stories.css
+++ b/client/coral-admin/src/routes/Stories/components/Stories.css
@@ -56,6 +56,7 @@
   width: 100%;
   border-left: none;
   border-right: none;
+  white-space: pre-wrap;
 
   a {
     color: rgb(44, 44, 44);


### PR DESCRIPTION
## What does this PR do?

Changes how text wraps on /admin/stories

## How do I test this PR?

Just visit /admin/stories on an install with long story names. 

Before:

![screen shot 2018-02-01 at 1 30 24 pm](https://user-images.githubusercontent.com/20201/35696003-1ba1e3f6-0754-11e8-8223-82e5f74e836b.png)

After:

![screen shot 2018-02-01 at 1 30 16 pm](https://user-images.githubusercontent.com/20201/35696012-21993d40-0754-11e8-841f-749a5f6dc7de.png)

