### PR TITLE
Use translate-able `sign_out`

### DIFF
--- a/client/coral-admin/src/components/Drawer.js
+++ b/client/coral-admin/src/components/Drawer.js
@@ -44,7 +44,7 @@ const CoralDrawer = ({ handleLogout, auth = {} }) => (
               {t('configure.configure')}
             </Link>
           )}
-          <a onClick={handleLogout}>Sign Out</a>
+          <a onClick={handleLogout}>{t('configure.sign_out')}</a>
           <span>{`v${process.env.VERSION}`}</span>
         </Navigation>
       </div>


### PR DESCRIPTION
## What does this PR do?

Switches `sign_out` to use the translated string

## How do I test this PR?

- Log in as an administrator to /admin
- In English, continue to see "Sign Out" in the admin drawer
- In other languages, see the appropriate string (e.g., "Se Déconnecter" in French)