### PR TITLE
Provides username for subscription fields

### DIFF
--- a/client/coral-admin/src/routes/Moderation/graphql.js
+++ b/client/coral-admin/src/routes/Moderation/graphql.js
@@ -407,6 +407,7 @@ export const subscriptionFields = `
     type
     assigned_by {
       id
+      username
     }
     created_at
   }


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where usernames in events for moderated comments across multiple sessions show as `undefined`

![image](https://user-images.githubusercontent.com/3921894/35890026-245123ee-0b5b-11e8-8b4b-e11a582e9a60.png)

## How do I test this PR?

- Open two instances of the administration interface, both with different logins 
- Open the same queue with both (e.g., rejected)
- Perform an action on one item, such as approve
- You should see the username appear with the rest of the message
