### PR TITLE
Add translation keys for suspend error message

### DIFF
--- a/locales/da.yml
+++ b/locales/da.yml
@@ -236,6 +236,7 @@ da:
     password: "Adgangskoden skal være mindst 8 tegn"
     username: "Brugernavne kan kun indeholde bogstaver og _"
     unexpected: "Der opstod en uventet fejl. Undskyld!"
+    temporarily_suspended: "Your account is currently suspended. It will be reactivated {0}. Please contact us if you have any questions."
   flag_comment: "Rapportér kommentar"
   flag_reason: "Årsag til rapportering (Valgfrit)"
   flag_username: "Rapporter brugernavn"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -236,6 +236,7 @@ es:
     password: "La contraseña debe tener por lo menos 8 caracteres"
     username: "Los nombres pueden contener letras números y _"
     unexpected: "Lo siento. Ha habido un error no previsto."
+    temporarily_suspended: "Your account is currently suspended. It will be reactivated {0}. Please contact us if you have any questions."
   flag_comment: "Reportar este comentario"
   flag_reason: "Razón por la que hacer este reporte (Opcional)"
   flag_username: "Reportar el nombre de usuario"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -236,6 +236,7 @@ fr:
     password: "Le mot de passe doit être d'au moins 8 caractères"
     username: "Les noms d'utilisateur ne peuvent contenir que des chiffres, des lettres et \"_\""
     unexpected: "Unexpected error occurred. Sorry!"
+    temporarily_suspended: "Your account is currently suspended. It will be reactivated {0}. Please contact us if you have any questions."
   flag_comment: "Signaler un commentaire"
   flag_reason: "Motif du signalement (facultatif)"
   flag_username: "Signaler un nom d'utilisateur"

--- a/locales/nl_NL.yml
+++ b/locales/nl_NL.yml
@@ -236,6 +236,7 @@ nl_NL:
     password: "Wachtwoord moet minimaal 8 karakters lang zijn"
     username: "Gebruikersnamen kunnen alleen cijfers, letters en _ bevatten."
     unexpected: "Onverwachte fout opgetreden. Sorry!"
+    temporarily_suspended: "Your account is currently suspended. It will be reactivated {0}. Please contact us if you have any questions."
   flag_comment: "Rapporteer reactie"
   flag_reason: "Reden voor rapporteren (optioneel)"
   flag_username: "Rapporteer gebruikersnaam"

--- a/locales/zh_CN.yml
+++ b/locales/zh_CN.yml
@@ -236,6 +236,7 @@ zh_CN:
     password: "密码长度须至少为 8 字符"
     username: "用户名只能包含字母、数字跟下划线"
     unexpected: "发生了异常错误。对不起！"
+    temporarily_suspended: "Your account is currently suspended. It will be reactivated {0}. Please contact us if you have any questions."
   flag_comment: "举报评论"
   flag_reason: "举报理由（可选）"
   flag_username: "举报用户名"

--- a/locales/zh_TW.yml
+++ b/locales/zh_TW.yml
@@ -236,6 +236,7 @@ zh_TW:
     password: "密碼必須至少8個字符"
     username: "用戶名只能包含字母、數字和下劃線。"
     unexpected: "發生了意外錯誤。抱歉!"
+    temporarily_suspended: "Your account is currently suspended. It will be reactivated {0}. Please contact us if you have any questions."
   flag_comment: "舉報評論"
   flag_reason: "舉報原因（可選）"
   flag_username: "舉報用戶名"


### PR DESCRIPTION
## What does this PR do?

We were missing one line from a new PR that was submitted.

## How do I test this PR?

- Check the message that appears when you try and post when you're suspended is translated correctly.
