### PR TITLE
Translation typo is breaking Akismet

### DIFF
--- a/plugins/talk-plugin-akismet/client/translations.yml
+++ b/plugins/talk-plugin-akismet/client/translations.yml
@@ -68,7 +68,7 @@ nl_NL:
     spam_comment: "Spam"
     detected: "Gedetecteerd door Akismet"
     still_spam: |
-    Dank je wel. Ons moderatieteam zal je reactie beoordelen.
+      Dank je wel. Ons moderatieteam zal je reactie beoordelen.
   flags:
     reasons:
       comment:


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in translations that breaks the build if the Akismet plugin is enabled.

## How do I test this PR?

- Run `yarn && yarn watch` and ensure there are no errors.
