### PR TITLE
Fix translations keys and add german translations to facebook plugin

### DIFF
--- a/plugins/talk-plugin-facebook-auth/client/translations.yml
+++ b/plugins/talk-plugin-facebook-auth/client/translations.yml
@@ -4,17 +4,21 @@ en:
     sign_up: "Sign up with Facebook"
 es:
   talk-plugin-facebook-auth:
-    facebook_sign_in: "Entrar con Facebook"
-    facebook_sign_up: "Registrarse con Facebook"
+    sign_in: "Entrar con Facebook"
+    sign_up: "Registrarse con Facebook"
 fr:
   talk-plugin-facebook-auth:
-    facebook_sign_in: "Connectez-vous avec Facebook"
-    facebook_sign_up: "Inscrivez-vous avec Facebook"
+    sign_in: "Connectez-vous avec Facebook"
+    sign_up: "Inscrivez-vous avec Facebook"
 zh_CN:
   talk-plugin-facebook-auth:
-    facebook_sign_in: "使用 Facebook 帐号"
-    facebook_sign_up: "使用 Facebook 帐号"
+    sign_in: "使用 Facebook 帐号"
+    sign_up: "使用 Facebook 帐号"
 zh_TW:
   talk-plugin-facebook-auth:
-    facebook_sign_in: "使用 Facebook 帳號"
-    facebook_sign_up: "使用 Facebook 帳號"
+    sign_in: "使用 Facebook 帳號"
+    sign_up: "使用 Facebook 帳號"
+de:
+  talk-plugin-facebook-auth:
+    sign_in: "Mit Facebook anmelden"
+    sign_up: "Mit Facebook registrieren"


### PR DESCRIPTION
## What does this PR do?
Correct translations keys from `talk-plugin-facebook-auth` and add German translations.

## How do I test this PR?
- Run Talk on German language and enable `talk-plugin-facebook-auth` 
- Check Facebook login/register buttons
