### PR TITLE
Making the User Info Tooltip more readable and friendly

### DIFF
--- a/client/coral-admin/src/components/UserInfoTooltip.css
+++ b/client/coral-admin/src/components/UserInfoTooltip.css
@@ -28,8 +28,8 @@
   box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12), 0 3px 1px -2px rgba(0,0,0,0.2);
   z-index: 10;
   top: 32px;
-  right: 0px;
-  width: 140px;
+  left: -10px;
+  width: 200px;
   text-align: left;
   color: #616161;
 }
@@ -39,7 +39,7 @@
   border: 10px solid transparent;
   border-top-color: #999;
   position: absolute;
-  right: 0px;
+  left: 8px;
   top: -20px;
   transform: rotate(180deg);
 }
@@ -49,7 +49,7 @@
   border: 10px solid transparent;
   border-top-color: white;
   position: absolute;
-  right: 0px;
+  left: 8px;
   top: -19px;
   transform: rotate(180deg);
 }

--- a/client/coral-admin/src/components/UserInfoTooltip.css
+++ b/client/coral-admin/src/components/UserInfoTooltip.css
@@ -28,7 +28,7 @@
   box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14), 0 1px 5px 0 rgba(0,0,0,0.12), 0 3px 1px -2px rgba(0,0,0,0.2);
   z-index: 10;
   top: 32px;
-  left: -10px;
+  left: -100px;
   width: 200px;
   text-align: left;
   color: #616161;
@@ -39,7 +39,7 @@
   border: 10px solid transparent;
   border-top-color: #999;
   position: absolute;
-  left: 8px;
+  left: 96px;
   top: -20px;
   transform: rotate(180deg);
 }
@@ -49,7 +49,7 @@
   border: 10px solid transparent;
   border-top-color: white;
   position: absolute;
-  left: 8px;
+  left: 96px;
   top: -19px;
   transform: rotate(180deg);
 }

--- a/client/coral-admin/src/components/UserInfoTooltip.js
+++ b/client/coral-admin/src/components/UserInfoTooltip.js
@@ -67,7 +67,7 @@ class UserInfoTooltip extends React.Component {
                           new Date(
                             this.getLastHistoryItem(user, 'banned').created_at
                           )
-                        ).format('MMMM Do YYYY, h:mm:ss a')}
+                        ).format('MMM Do YYYY, h:mm:ss a')}
                       </span>
                     </li>
                     <li
@@ -139,7 +139,7 @@ class UserInfoTooltip extends React.Component {
                               'suspension'
                             ).created_at
                           )
-                        ).format('MMMM Do YYYY, h:mm:ss a')}
+                        ).format('MMM Do YYYY, h:mm:ss a')}
                       </span>
                     </li>
                     <li
@@ -154,7 +154,7 @@ class UserInfoTooltip extends React.Component {
                           new Date(
                             this.getLastHistoryItem(user, 'suspension').until
                           )
-                        ).format('MMMM Do YYYY, h:mm:ss a')}
+                        ).format('MMM Do YYYY, h:mm:ss a')}
                       </span>
                     </li>
                   </ul>


### PR DESCRIPTION
Tiny change to make the User Info Tooltip more readable and friendly.

Before:
<img width="227" alt="screen shot 2018-02-19 at 12 28 20 pm" src="https://user-images.githubusercontent.com/1401559/36385155-863eb5a2-1570-11e8-8f93-f4d9c4457349.png">

After: 
<img width="343" alt="screen shot 2018-02-19 at 12 27 39 pm" src="https://user-images.githubusercontent.com/1401559/36385154-861675ec-1570-11e8-99d9-1894db6c7377.png">

Go to the User drawer and check it out. Feedback is welcome!
