### PR TITLE
slotSize Slot

### DIFF
--- a/client/coral-embed-stream/src/tabs/stream/components/Comment.js
+++ b/client/coral-embed-stream/src/tabs/stream/components/Comment.js
@@ -604,7 +604,7 @@ export default class Comment extends React.Component {
                     defaultComponent={CommentContent}
                     {...slotProps}
                     queryData={queryData}
-                    singleSlot
+                    slotSize={1}
                   />
                 </div>
               )}

--- a/client/coral-embed-stream/src/tabs/stream/components/Comment.js
+++ b/client/coral-embed-stream/src/tabs/stream/components/Comment.js
@@ -604,6 +604,7 @@ export default class Comment extends React.Component {
                     defaultComponent={CommentContent}
                     {...slotProps}
                     queryData={queryData}
+                    singleSlot
                   />
                 </div>
               )}

--- a/client/coral-framework/components/Slot.js
+++ b/client/coral-framework/components/Slot.js
@@ -38,7 +38,7 @@ class Slot extends React.Component {
       'inline',
       'className',
       'reduxState',
-      'singleSlot',
+      'slotSize',
       'defaultComponent_',
       'queryData',
       'childFactory',
@@ -47,7 +47,7 @@ class Slot extends React.Component {
   }
 
   getChildren(props = this.props) {
-    const { singleSlot = false } = props;
+    const { slotSize = 0 } = props;
     const { plugins } = this.context;
 
     return plugins.getSlotElements(
@@ -55,7 +55,7 @@ class Slot extends React.Component {
       props.reduxState,
       this.getSlotProps(props),
       props.queryData,
-      { singleSlot }
+      { slotSize }
     );
   }
 
@@ -113,9 +113,9 @@ Slot.propTypes = {
   defaultComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 
   /**
-   * When true, only the first plugin will take the slot.
+   * Specifies the number of children that can fill the slot.
    */
-  singleSlot: PropTypes.bool,
+  slotSize: PropTypes.number,
 
   /**
    * You may specify the component to use as the root wrapper.

--- a/client/coral-framework/components/Slot.js
+++ b/client/coral-framework/components/Slot.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import isEqual from 'lodash/isEqual';
 import get from 'lodash/get';
 import { getShallowChanges } from 'coral-framework/utils';
+import omit from 'lodash/omit';
 
 const emptyConfig = {};
 
@@ -32,27 +33,29 @@ class Slot extends React.Component {
   }
 
   getSlotProps(props = this.props) {
-    const {
-      fill: _a,
-      inline: _b,
-      className: _c,
-      reduxState: _d,
-      defaultComponent_: _e,
-      queryData: _f,
-      childFactory: _g,
-      component: _h,
-      ...rest
-    } = props;
-    return rest;
+    return omit(props, [
+      'fill',
+      'inline',
+      'className',
+      'reduxState',
+      'singleSlot',
+      'defaultComponent_',
+      'queryData',
+      'childFactory',
+      'component',
+    ]);
   }
 
   getChildren(props = this.props) {
+    const { singleSlot = false } = props;
     const { plugins } = this.context;
+
     return plugins.getSlotElements(
       props.fill,
       props.reduxState,
       this.getSlotProps(props),
-      props.queryData
+      props.queryData,
+      { singleSlot }
     );
   }
 
@@ -108,6 +111,11 @@ Slot.propTypes = {
   className: PropTypes.string,
   reduxState: PropTypes.object,
   defaultComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+
+  /**
+   * When true, only the first plugin will take the slot.
+   */
+  singleSlot: PropTypes.bool,
 
   /**
    * You may specify the component to use as the root wrapper.

--- a/client/coral-framework/components/Slot.js
+++ b/client/coral-framework/components/Slot.js
@@ -39,7 +39,7 @@ class Slot extends React.Component {
       'className',
       'reduxState',
       'slotSize',
-      'defaultComponent_',
+      'defaultComponent',
       'queryData',
       'childFactory',
       'component',

--- a/client/coral-framework/services/plugins.js
+++ b/client/coral-framework/services/plugins.js
@@ -94,11 +94,19 @@ class PluginsService {
     };
   }
 
+  getSlotElement(slot, reduxState, props = {}, queryData = {}, options = {}) {
+    return this.getSlotElements(slot, reduxState, props, queryData, {
+      ...options,
+      singleSlot: true,
+    });
+  }
+
   /**
    * Returns React Elements for given slot.
    */
-  getSlotElements(slot, reduxState, props = {}, queryData = {}) {
+  getSlotElements(slot, reduxState, props = {}, queryData = {}, options = {}) {
     const pluginConfig = get(reduxState, 'config.plugin_config') || emptyConfig;
+    const { singleSlot = false } = options;
 
     const isDisabled = component => {
       if (
@@ -129,11 +137,13 @@ class PluginsService {
       return false;
     };
 
-    return flatten(
+    const slots = flatten(
       this.plugins
         .filter(o => o.module.slots && o.module.slots[slot])
         .map(o => o.module.slots[slot])
-    )
+    );
+
+    return (singleSlot ? slots.slice(0, 1) : slots)
       .map((component, i) => ({
         component,
         disabled: isDisabled(component),

--- a/client/coral-framework/services/plugins.js
+++ b/client/coral-framework/services/plugins.js
@@ -94,19 +94,12 @@ class PluginsService {
     };
   }
 
-  getSlotElement(slot, reduxState, props = {}, queryData = {}, options = {}) {
-    return this.getSlotElements(slot, reduxState, props, queryData, {
-      ...options,
-      singleSlot: true,
-    });
-  }
-
   /**
    * Returns React Elements for given slot.
    */
   getSlotElements(slot, reduxState, props = {}, queryData = {}, options = {}) {
     const pluginConfig = get(reduxState, 'config.plugin_config') || emptyConfig;
-    const { singleSlot = false } = options;
+    const { slotSize = 0 } = options;
 
     const isDisabled = component => {
       if (
@@ -143,7 +136,7 @@ class PluginsService {
         .map(o => o.module.slots[slot])
     );
 
-    return (singleSlot ? slots.slice(0, 1) : slots)
+    return (slotSize > 0 ? slots.slice(0, slotSize) : slots)
       .map((component, i) => ({
         component,
         disabled: isDisabled(component),

--- a/client/coral-framework/services/plugins.js
+++ b/client/coral-framework/services/plugins.js
@@ -135,9 +135,13 @@ class PluginsService {
         .filter(o => o.module.slots && o.module.slots[slot])
         .map(o => o.module.slots[slot])
     );
-      
+
     if (slotSize > 0 && slots.length > slotSize) {
-      console.warn(`Slot[${slot}] supports a maximum of ${slotSize} plugins providing slots, got ${slots.length}, will only use the first ${slotSize}`);
+      console.warn(
+        `Slot[${slot}] supports a maximum of ${slotSize} plugins providing slots, got ${
+          slots.length
+        }, will only use the first ${slotSize}`
+      );
     }
 
     return (slotSize > 0 ? slots.slice(0, slotSize) : slots)

--- a/client/coral-framework/services/plugins.js
+++ b/client/coral-framework/services/plugins.js
@@ -135,6 +135,10 @@ class PluginsService {
         .filter(o => o.module.slots && o.module.slots[slot])
         .map(o => o.module.slots[slot])
     );
+      
+    if (slotSize > 0 && slots.length > slotSize) {
+      console.warn(`Slot[${slot}] supports a maximum of ${slotSize} plugins providing slots, got ${slots.length}, will only use the first ${slotSize}`);
+    }
 
     return (slotSize > 0 ? slots.slice(0, slotSize) : slots)
       .map((component, i) => ({


### PR DESCRIPTION
## What does this PR do?

In some slots, it only makes sense to load a specific number of plugins for a slot (like 1). While this can be addressed with not enabling duplicate plugins that interface with the same slot, it's also possible to assist this on the client by limiting the visible slots by a single one if needed.

## How do I test this PR?

1. Create a plugin that implements the `commentContent` slot (a slot that has `slotSize={1}` set)
2. Enable it and the `talk-plugin-comment-content`
3. Notice that the order in the `plugins.json` dictates which will fill the slot.
