### PR TITLE
Staff Reply Notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ plugins/*
 !plugins/talk-plugin-moderation-actions
 !plugins/talk-plugin-notifications
 !plugins/talk-plugin-notifications-category-reply
+!plugins/talk-plugin-notifications-category-staff
 !plugins/talk-plugin-offtopic
 !plugins/talk-plugin-permalink
 !plugins/talk-plugin-profile-settings

--- a/plugins/talk-plugin-notifications-category-reply/translations.yml
+++ b/plugins/talk-plugin-notifications-category-reply/translations.yml
@@ -2,5 +2,5 @@ en:
   talk-plugin-notifications:
     categories:
       reply:
-        subject: "Some has replied to your comment on [{0}]"
+        subject: "Someone has replied to your comment on {0}"
         body: "{0}\n{1} replied to your comment: {2}"

--- a/plugins/talk-plugin-notifications-category-staff/client/.eslintrc.json
+++ b/plugins/talk-plugin-notifications-category-staff/client/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@coralproject/eslint-config-talk/client"
+}

--- a/plugins/talk-plugin-notifications-category-staff/client/containers/Toggle.js
+++ b/plugins/talk-plugin-notifications-category-staff/client/containers/Toggle.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { compose, gql } from 'react-apollo';
+import Toggle from 'talk-plugin-notifications/client/components/Toggle';
+import { t } from 'plugin-api/beta/client/services';
+import { withFragments } from 'plugin-api/beta/client/hocs';
+
+class ToggleContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    props.setTurnOffInputFragment({ onStaffReply: false });
+
+    if (this.getOnReplySetting()) {
+      props.indicateOn();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const prevSetting = this.getOnReplySetting(this.props);
+    const nextSetting = this.getOnReplySetting(nextProps);
+    if (prevSetting && !nextSetting) {
+      nextProps.indicateOff();
+    } else if (!prevSetting && nextSetting) {
+      nextProps.indicateOn();
+    }
+  }
+
+  getOnReplySetting = (props = this.props) =>
+    props.root.me.notificationSettings.onStaffReply;
+
+  toggle = () => {
+    this.props.updateNotificationSettings({
+      onStaffReply: !this.getOnReplySetting(),
+    });
+  };
+
+  render() {
+    return (
+      <Toggle checked={this.getOnReplySetting()} onChange={this.toggle}>
+        {t('talk-plugin-notifications-category-staff.toggle_description')}
+      </Toggle>
+    );
+  }
+}
+
+ToggleContainer.propTypes = {
+  data: PropTypes.object,
+  root: PropTypes.object,
+  indicateOn: PropTypes.func.isRequired,
+  indicateOff: PropTypes.func.isRequired,
+  setTurnOffInputFragment: PropTypes.func.isRequired,
+  updateNotificationSettings: PropTypes.func.isRequired,
+};
+
+const enhance = compose(
+  withFragments({
+    root: gql`
+      fragment TalkNotificationsCategoryStaffReply_User_Fragment on RootQuery {
+        me {
+          notificationSettings {
+            onStaffReply
+          }
+        }
+      }
+    `,
+  })
+);
+
+export default enhance(ToggleContainer);

--- a/plugins/talk-plugin-notifications-category-staff/client/graphql.js
+++ b/plugins/talk-plugin-notifications-category-staff/client/graphql.js
@@ -1,0 +1,33 @@
+import { gql } from 'react-apollo';
+
+export default {
+  mutations: {
+    UpdateNotificationSettings: ({
+      variables: { input },
+      state: { auth: { user: { id } } },
+    }) => ({
+      update: proxy => {
+        if (input.onStaffReply === undefined) {
+          return;
+        }
+
+        const fragment = gql`
+          fragment TalkNotificationsCategoryStaffReply_User_Fragment on User {
+            notificationSettings {
+              onStaffReply
+            }
+          }
+        `;
+        const fragmentId = `User_${id}`;
+        const data = {
+          __typename: 'User',
+          notificationSettings: {
+            __typename: 'NotificationSettings',
+            onStaffReply: input.onStaffReply,
+          },
+        };
+        proxy.writeFragment({ fragment, id: fragmentId, data });
+      },
+    }),
+  },
+};

--- a/plugins/talk-plugin-notifications-category-staff/client/index.js
+++ b/plugins/talk-plugin-notifications-category-staff/client/index.js
@@ -1,0 +1,11 @@
+import Toggle from './containers/Toggle';
+import translations from './translations.yml';
+import graphql from './graphql';
+
+export default {
+  slots: {
+    notificationSettings: [Toggle],
+  },
+  translations,
+  ...graphql,
+};

--- a/plugins/talk-plugin-notifications-category-staff/client/translations.yml
+++ b/plugins/talk-plugin-notifications-category-staff/client/translations.yml
@@ -1,0 +1,3 @@
+en:
+  talk-plugin-notifications-category-staff:
+    toggle_description: A staff member replies to my comment

--- a/plugins/talk-plugin-notifications-category-staff/index.js
+++ b/plugins/talk-plugin-notifications-category-staff/index.js
@@ -1,0 +1,151 @@
+const { graphql } = require('graphql');
+const { get } = require('lodash');
+const path = require('path');
+
+const handle = async (ctx, comment) => {
+  const { connectors: { graph: { schema } } } = ctx;
+
+  // Check to see if this is a reply to an existing comment.
+  const parentID = get(comment, 'parent_id', null);
+  if (parentID === null) {
+    ctx.log.debug('could not get parent comment id');
+    return;
+  }
+
+  const authorID = get(comment, 'author_id', null);
+  if (authorID === null) {
+    ctx.log.error('could not get author id');
+    return;
+  }
+
+  // Execute the graph request.
+  const reply = await graphql(
+    schema,
+    `
+      query GetAuthorUserMetadata($comment_id: ID!, $author_id: ID!) {
+        author: user(id: $author_id) {
+          role
+        }
+        comment(id: $comment_id) {
+          id
+          user {
+            id
+            notificationSettings {
+              onStaffReply
+            }
+          }
+        }
+      }
+    `,
+    {},
+    ctx,
+    { comment_id: parentID, author_id: authorID }
+  );
+  if (reply.errors) {
+    ctx.log.error({ err: reply.errors }, 'could not query for author metadata');
+    return;
+  }
+
+  // Check if the user has notifications enabled.
+  const enabled = get(
+    reply,
+    'data.comment.user.notificationSettings.onStaffReply',
+    false
+  );
+  if (!enabled) {
+    ctx.log.debug('onStaffReply is false, will not send the notification');
+    return;
+  }
+
+  const userID = get(reply, 'data.comment.user.id', null);
+  if (!userID) {
+    ctx.log.debug('could not get parent comment user id');
+    return;
+  }
+
+  // Check to see if this is yourself replying to yourself, if that's the case
+  // don't send a notification.
+  if (userID === authorID) {
+    ctx.log.debug('user id of parent comment is the same as the new comment');
+    return;
+  }
+
+  // Check to see that this comment was indeed from a staff member.
+  const role = get(reply, 'data.author.role');
+  if (!['ADMIN', 'MODERATOR', 'STAFF'].includes(role)) {
+    ctx.log.debug({ role }, 'reply author is not a staff member');
+    return;
+  }
+
+  // The user does have notifications for replied comments enabled, queue the
+  // notification to be sent.
+  return { userID, date: comment.created_at, context: comment.id };
+};
+
+const hydrate = async (ctx, category, context) => {
+  const { connectors: { graph: { schema } } } = ctx;
+
+  const reply = await graphql(
+    schema,
+    `
+      query GetNotificationData($context: ID!) {
+        comment(id: $context) {
+          id
+          asset {
+            title
+            url
+          }
+          user {
+            username
+          }
+        }
+        settings {
+          organizationName
+        }
+      }
+    `,
+    {},
+    ctx,
+    { context }
+  );
+  if (reply.errors) {
+    throw reply.errors;
+  }
+
+  const comment = get(reply, 'data.comment');
+  const headline = get(comment, 'asset.title', null);
+  const replier = get(comment, 'user.username', null);
+  const assetURL = get(comment, 'asset.url', null);
+  const permalink = `${assetURL}?commentId=${comment.id}`;
+  const organizationName = get(reply, 'data.settings.organizationName', null);
+
+  return [headline, replier, organizationName, permalink];
+};
+
+const handler = {
+  handle,
+  category: 'staff',
+  event: 'commentAdded',
+  hydrate,
+  supersedesCategories: ['reply'],
+};
+
+module.exports = {
+  typeDefs: `
+    type NotificationSettings {
+      onStaffReply: Boolean!
+    }
+
+    input NotificationSettingsInput {
+      onStaffReply: Boolean
+    }
+  `,
+  resolvers: {
+    NotificationSettings: {
+      // onStaffReply returns false by default if not specified.
+      onStaffReply: settings => get(settings, 'onStaffReply', false),
+    },
+  },
+  translations: path.join(__dirname, 'translations.yml'),
+  notifications: [handler],
+};

--- a/plugins/talk-plugin-notifications-category-staff/translations.yml
+++ b/plugins/talk-plugin-notifications-category-staff/translations.yml
@@ -1,0 +1,6 @@
+en:
+  talk-plugin-notifications:
+    categories:
+      staff:
+        subject: "Someone at {0} has replied to your comment"
+        body: "{0}\n{1} works for {2} and has replied to your comment: {3}"


### PR DESCRIPTION
## What does this PR do?

Adds a notification type for when a staff member replies to your comment, you can get a notification!

## How do I test this PR?

1. Enable the plugin (server + client)
2. Have your settings enabled for "A staff member replies to my comment"
3. Post a comment.
4. Using a **different** staff account, reply to the comment.
5. Check your email!

This option will supersede the "All replies" notification option, so if both are enabled, and a staff member replies, you will only get the staff reply notification.

_Note: This uses the new `  notifications.supersedesCategories` plugin hook which defines which notifications this type of notification will supersede for this particular event. The category supersede filter **will not work across different events**._