### PR TITLE
Email Confirmation Required for Notifications

### DIFF
--- a/client/coral-ui/components/Checkbox.css
+++ b/client/coral-ui/components/Checkbox.css
@@ -50,6 +50,11 @@
   color: #00a291;
 }
 
+.input:disabled + .checkbox:before {
+  color: #e5e5e5;
+  cursor: default;
+}
+
 .input:focus + .checkbox:before {
   color: #00a291;
 }

--- a/client/coral-ui/components/Spinner.js
+++ b/client/coral-ui/components/Spinner.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styles from './Spinner.css';
+import cn from 'classnames';
 
-const Spinner = () => (
-  <div className={styles.container}>
+const Spinner = ({ className }) => (
+  <div className={cn(styles.container, className)}>
     <svg
       className={styles.spinner}
       width="40px"
@@ -22,5 +24,9 @@ const Spinner = () => (
     </svg>
   </div>
 );
+
+Spinner.propTypes = {
+  className: PropTypes.string,
+};
 
 export default Spinner;

--- a/config.js
+++ b/config.js
@@ -48,6 +48,14 @@ const CONFIG = {
   // request all of the records. Otherwise, minimum limits of 0 are enforced.
   ALLOW_NO_LIMIT_QUERIES: process.env.TALK_ALLOW_NO_LIMIT_QUERIES === 'TRUE',
 
+  // TODO: document this config.
+  // LOGGING_LEVEL specifies the logging level used by the bunyan logger.
+  LOGGING_LEVEL: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'].includes(
+    process.env.TALK_LOGGING_LEVEL
+  )
+    ? process.env.TALK_LOGGING_LEVEL
+    : 'info',
+
   //------------------------------------------------------------------------------
   // JWT based configuration
   //------------------------------------------------------------------------------

--- a/config.js
+++ b/config.js
@@ -48,7 +48,6 @@ const CONFIG = {
   // request all of the records. Otherwise, minimum limits of 0 are enforced.
   ALLOW_NO_LIMIT_QUERIES: process.env.TALK_ALLOW_NO_LIMIT_QUERIES === 'TRUE',
 
-  // TODO: document this config.
   // LOGGING_LEVEL specifies the logging level used by the bunyan logger.
   LOGGING_LEVEL: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'].includes(
     process.env.TALK_LOGGING_LEVEL

--- a/docs/_docs/02-02-advanced-configuration.md
+++ b/docs/_docs/02-02-advanced-configuration.md
@@ -563,3 +563,14 @@ This is a **Build Variable** and must be consumed during build. If using the
 image you can specify it with `--build-arg TALK_REPLY_COMMENTS_LOAD_DEPTH=3`.
 
 Specifies the initial replies to load for a comment. (Default `3`)
+
+## TALK_LOGGING_LEVEL
+
+Sets the logging level for the context logger (from [Bunyan](https://github.com/trentm/node-bunyan)) that will be phased in to replace most existing `debug()` calls. Supports the following values:
+
+- `fatal`
+- `error`
+- `warn`
+- `info`
+- `debug`
+- `trace`

--- a/docs/_docs/04-03-additional-plugins.md
+++ b/docs/_docs/04-03-additional-plugins.md
@@ -142,6 +142,10 @@ anything. You need to enable one of the `talk-plugin-notifications-category-*` p
 ```
 {:.no-copy}
 
+Configuration:
+
+- `DISABLE_REQUIRE_EMAIL_VERIFICATIONS` - When `TRUE`, it will disable the verification email check before sending notifications for those emails. **Note that organizations implementing a custom authentication system _must_ disable this feature, as they don't use our integrated auth**. (Default `FALSE`).
+
 ### talk-plugin-notifications-category-reply
 {:.param}
 
@@ -157,3 +161,11 @@ Source: [plugins/talk-plugin-notifications-category-featured](https://github.com
 
 When a comment is featured (via the `talk-plugin-featured-comments` plugin), the
 user will receive a notification email.
+
+### talk-plugin-notifications-category-staff
+{:.param}
+
+Source: [plugins/talk-plugin-notifications-category-staff](https://github.com/coralproject/talk/tree/master/plugins/talk-plugin-notifications-category-staff){:target="_blank"}
+
+Replies made to each user by a staff member will trigger an email to be sent
+with the notification details if enabled.

--- a/graph/mutators/comment.js
+++ b/graph/mutators/comment.js
@@ -12,12 +12,9 @@ const {
   ADD_COMMENT_TAG,
   EDIT_COMMENT,
 } = require('../../perms/constants');
-const debug = require('debug')('talk:graph:mutators:comment');
 
-const resolveTagsForComment = async (
-  { user, loaders: { Tags } },
-  { asset_id, tags = [] }
-) => {
+const resolveTagsForComment = async (ctx, { asset_id, tags = [] }) => {
+  const { user, loaders: { Tags } } = ctx;
   const item_type = 'COMMENTS';
 
   // Handle Tags
@@ -46,6 +43,7 @@ const resolveTagsForComment = async (
 
   // Add the staff tag for comments created as a staff member.
   if (user.can(ADD_COMMENT_TAG)) {
+    ctx.log.info({ author_id: user.id }, 'Added staff tag to comment');
     tags.push(
       TagsService.newTagLink(user, {
         name: 'STAFF',
@@ -61,7 +59,7 @@ const resolveTagsForComment = async (
  * adjustKarma will adjust the affected user's karma depending on the moderators
  * action.
  */
-const adjustKarma = (Comments, id, status) => async () => {
+const adjustKarma = (ctx, Comments, id, status) => async () => {
   try {
     // Use the dataloader to get the comment that was just moderated and
     // get the flag user's id's so we can adjust their karma too.
@@ -86,17 +84,27 @@ const adjustKarma = (Comments, id, status) => async () => {
       }),
     ]);
 
-    debug(`Comment[${id}] by User[${comment.author_id}] was Status[${status}]`);
+    ctx.log.info(
+      {
+        state: {
+          comment_id: id,
+          author_id: comment.author_id,
+          status: status,
+        },
+      },
+      'Processing karma modification'
+    );
 
     switch (status) {
       case 'REJECTED':
         // Reduce the user's karma.
-        debug(`CommentUser[${comment.author_id}] had their karma reduced`);
+        ctx.log.info('Comment author had their karma reduced');
 
         // Decrease the flag user's karma, the moderator disagreed with this
         // action.
-        debug(
-          `FlaggingUser[${flagUserIDs.join(', ')}] had their karma increased`
+        ctx.log.info(
+          { flagUserIDs },
+          'Flagging users had their karma increased'
         );
         await Promise.all([
           KarmaService.modifyUser(comment.author_id, -1, 'comment'),
@@ -107,13 +115,11 @@ const adjustKarma = (Comments, id, status) => async () => {
 
       case 'ACCEPTED':
         // Increase the user's karma.
-        debug(`CommentUser[${comment.author_id}] had their karma increased`);
+        ctx.log.info('Comment author had their karma increased');
 
         // Increase the flag user's karma, the moderator agreed with this
         // action.
-        debug(
-          `FlaggingUser[${flagUserIDs.join(', ')}] had their karma reduced`
-        );
+        ctx.log.info({ flagUserIDs }, `Flagging users had their karma reduced`);
         await Promise.all([
           KarmaService.modifyUser(comment.author_id, 1, 'comment'),
           KarmaService.modifyUser(flagUserIDs, -1, 'flag', true),
@@ -140,7 +146,7 @@ const adjustKarma = (Comments, id, status) => async () => {
  * @return {Promise}              resolves to the created comment
  */
 const createComment = async (
-  context,
+  ctx,
   {
     tags = [],
     body,
@@ -150,10 +156,10 @@ const createComment = async (
     metadata = {},
   }
 ) => {
-  const { user, loaders: { Comments }, pubsub } = context;
+  const { user, loaders: { Comments }, pubsub } = ctx;
 
   // Resolve the tags for the comment.
-  tags = await resolveTagsForComment(context, { asset_id, tags });
+  tags = await resolveTagsForComment(ctx, { asset_id, tags });
 
   let comment = await CommentsService.publicCreate({
     body,
@@ -164,6 +170,11 @@ const createComment = async (
     author_id: user.id,
     metadata,
   });
+
+  ctx.log.info(
+    { comment_id: comment.id, comment_status: status },
+    'Created comment'
+  );
 
   // If the loaders are present, clear the caches for these values because we
   // just added a new comment, hence the counts should be updated. We should
@@ -228,12 +239,14 @@ const createActions = async (item_id, actions = []) =>
 
 /**
  * Sets the status of a comment
- * @param  {Object} context graphql context
+ * @param  {Object} ctx graphql context
  * @param {String} comment     comment in graphql context
  * @param {String} id          identifier of the comment  (uuid)
  * @param {String} status      the new status of the comment
  */
-const setStatus = async ({ user, loaders: { Comments } }, { id, status }) => {
+const setStatus = async (ctx, { id, status }) => {
+  const { user, loaders: { Comments } } = ctx;
+
   let comment = await CommentsService.pushStatus(
     id,
     status,
@@ -253,7 +266,7 @@ const setStatus = async ({ user, loaders: { Comments } }, { id, status }) => {
 
   // postSetCommentStatus will use the arguments from the mutation and
   // adjust the affected user's karma in the next tick.
-  process.nextTick(adjustKarma(Comments, id, status));
+  process.nextTick(adjustKarma(ctx, Comments, id, status));
 
   return comment;
 };
@@ -292,7 +305,7 @@ const edit = async (ctx, { id, asset_id, edit: { body } }) => {
   return comment;
 };
 
-module.exports = context => {
+module.exports = ctx => {
   let mutators = {
     Comment: {
       create: () => Promise.reject(errors.ErrNotAuthorized),
@@ -301,16 +314,16 @@ module.exports = context => {
     },
   };
 
-  if (context.user && context.user.can(CREATE_COMMENT)) {
-    mutators.Comment.create = comment => createPublicComment(context, comment);
+  if (ctx.user && ctx.user.can(CREATE_COMMENT)) {
+    mutators.Comment.create = comment => createPublicComment(ctx, comment);
   }
 
-  if (context.user && context.user.can(SET_COMMENT_STATUS)) {
-    mutators.Comment.setStatus = action => setStatus(context, action);
+  if (ctx.user && ctx.user.can(SET_COMMENT_STATUS)) {
+    mutators.Comment.setStatus = action => setStatus(ctx, action);
   }
 
-  if (context.user && context.user.can(EDIT_COMMENT)) {
-    mutators.Comment.edit = action => edit(context, action);
+  if (ctx.user && ctx.user.can(EDIT_COMMENT)) {
+    mutators.Comment.edit = action => edit(ctx, action);
   }
 
   return mutators;

--- a/graph/resolvers/index.js
+++ b/graph/resolvers/index.js
@@ -15,6 +15,7 @@ const DontAgreeActionSummary = require('./dont_agree_action_summary');
 const FlagAction = require('./flag_action');
 const FlagActionSummary = require('./flag_action_summary');
 const GenericUserError = require('./generic_user_error');
+const LocalUserProfile = require('./local_user_profile');
 const RootMutation = require('./root_mutation');
 const RootQuery = require('./root_query');
 const Settings = require('./settings');
@@ -24,8 +25,9 @@ const Tag = require('./tag');
 const TagLink = require('./tag_link');
 const User = require('./user');
 const UserError = require('./user_error');
-const UserState = require('./user_state');
 const UsernameStatusHistory = require('./username_status_history');
+const UserProfile = require('./user_profile');
+const UserState = require('./user_state');
 const ValidationUserError = require('./validation_user_error');
 
 const plugins = require('../../services/plugins');
@@ -46,6 +48,7 @@ let resolvers = {
   FlagAction,
   FlagActionSummary,
   GenericUserError,
+  LocalUserProfile,
   RootMutation,
   RootQuery,
   Settings,
@@ -55,8 +58,9 @@ let resolvers = {
   TagLink,
   User,
   UserError,
-  UserState,
   UsernameStatusHistory,
+  UserProfile,
+  UserState,
   ValidationUserError,
 };
 

--- a/graph/resolvers/local_user_profile.js
+++ b/graph/resolvers/local_user_profile.js
@@ -1,0 +1,7 @@
+const { property } = require('lodash');
+
+const LocalUserProfile = {
+  confirmedAt: property('metadata.confirmed_at'),
+};
+
+module.exports = LocalUserProfile;

--- a/graph/resolvers/user_profile.js
+++ b/graph/resolvers/user_profile.js
@@ -1,0 +1,12 @@
+const UserProfile = {
+  __resolveType({ provider }) {
+    switch (provider) {
+      case 'local':
+        return 'LocalUserProfile';
+      default:
+        return undefined;
+    }
+  },
+};
+
+module.exports = UserProfile;

--- a/graph/typeDefs.graphql
+++ b/graph/typeDefs.graphql
@@ -62,12 +62,37 @@ type Token {
   jwt: String
 }
 
-type UserProfile {
+interface UserProfile {
   # The id is an identifier for the user profile (email, facebook id, etc)
   id: String!
 
   # name of the provider attached to the authentication mode
   provider: String!
+}
+
+# DefaultUserProfile is a fallback if the type of UserProfile can't be
+# determined (like if it was from a plugin that was removed).
+type DefaultUserProfile implements UserProfile {
+  # The id is an identifier for the user profile (email, facebook id, etc)
+  id: String!
+
+  # name of the provider attached to the authentication mode
+  provider: String!
+}
+
+# LocalUserProfile is for a User who has an authentication profile linked to
+# their email address.
+type LocalUserProfile implements UserProfile {
+  # id is the User's email address.
+  id: String!
+
+  # name of the provider attached to the authentication mode, in this case,
+  # 'local'.
+  provider: String!
+
+  # confirmedAt is the Date that the user had their email address confirmed,
+  # which is null if it has not been verified.
+  confirmedAt: Date
 }
 
 # USER_STATUS_USERNAME is the different states that a username can be in.

--- a/plugins/talk-plugin-auth/client/login/containers/ResendEmailConfirmation.js
+++ b/plugins/talk-plugin-auth/client/login/containers/ResendEmailConfirmation.js
@@ -41,7 +41,7 @@ ResendEmailConfirmatonContainer.propTypes = {
   success: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
   resendEmailConfirmation: PropTypes.func.isRequired,
-  errorMessage: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string,
   setView: PropTypes.func.isRequired,
   email: PropTypes.string.isRequired,
 };

--- a/plugins/talk-plugin-notifications-category-featured/client/containers/Toggle.js
+++ b/plugins/talk-plugin-notifications-category-featured/client/containers/Toggle.js
@@ -36,7 +36,11 @@ class ToggleContainer extends React.Component {
 
   render() {
     return (
-      <Toggle checked={this.getOnFeaturedSetting()} onChange={this.toggle}>
+      <Toggle
+        checked={this.getOnFeaturedSetting()}
+        onChange={this.toggle}
+        disabled={this.props.disabled}
+      >
         {t('talk-plugin-notifications-category-featured.toggle_description')}
       </Toggle>
     );
@@ -50,6 +54,7 @@ ToggleContainer.propTypes = {
   indicateOff: PropTypes.func.isRequired,
   setTurnOffInputFragment: PropTypes.func.isRequired,
   updateNotificationSettings: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
 };
 
 const enhance = compose(

--- a/plugins/talk-plugin-notifications-category-featured/index.js
+++ b/plugins/talk-plugin-notifications-category-featured/index.js
@@ -1,20 +1,16 @@
-const { graphql } = require('graphql');
 const { get } = require('lodash');
 const path = require('path');
 
 const handle = async (ctx, { comment }) => {
-  const { connectors: { graph: { schema } } } = ctx;
-
   // Check to see if this is a reply to an existing comment.
   const commentID = get(comment, 'id', null);
   if (commentID === null) {
-    ctx.log.debug('could not get comment id');
+    ctx.log.info('could not get comment id');
     return;
   }
 
   // Execute the graph request.
-  const reply = await graphql(
-    schema,
+  const reply = await ctx.graphql(
     `
       query GetAuthorUserMetadata($comment_id: ID!) {
         comment(id: $comment_id) {
@@ -28,8 +24,6 @@ const handle = async (ctx, { comment }) => {
         }
       }
     `,
-    {},
-    ctx,
     { comment_id: commentID }
   );
   if (reply.errors) {
@@ -49,7 +43,7 @@ const handle = async (ctx, { comment }) => {
 
   const userID = get(reply, 'data.comment.user.id', null);
   if (!userID) {
-    ctx.log.debug('could not get comment user id');
+    ctx.log.info('could not get comment user id');
     return;
   }
 
@@ -59,10 +53,7 @@ const handle = async (ctx, { comment }) => {
 };
 
 const hydrate = async (ctx, category, context) => {
-  const { connectors: { graph: { schema } } } = ctx;
-
-  const reply = await graphql(
-    schema,
+  const reply = await ctx.graphql(
     `
       query GetNotificationData($context: ID!) {
         comment(id: $context) {
@@ -74,8 +65,6 @@ const hydrate = async (ctx, category, context) => {
         }
       }
     `,
-    {},
-    ctx,
     { context }
   );
   if (reply.errors) {

--- a/plugins/talk-plugin-notifications-category-reply/client/containers/Toggle.js
+++ b/plugins/talk-plugin-notifications-category-reply/client/containers/Toggle.js
@@ -36,7 +36,11 @@ class ToggleContainer extends React.Component {
 
   render() {
     return (
-      <Toggle checked={this.getOnReplySetting()} onChange={this.toggle}>
+      <Toggle
+        checked={this.getOnReplySetting()}
+        onChange={this.toggle}
+        disabled={this.props.disabled}
+      >
         {t('talk-plugin-notifications-category-reply.toggle_description')}
       </Toggle>
     );
@@ -50,6 +54,7 @@ ToggleContainer.propTypes = {
   indicateOff: PropTypes.func.isRequired,
   setTurnOffInputFragment: PropTypes.func.isRequired,
   updateNotificationSettings: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
 };
 
 const enhance = compose(

--- a/plugins/talk-plugin-notifications-category-staff/client/containers/Toggle.js
+++ b/plugins/talk-plugin-notifications-category-staff/client/containers/Toggle.js
@@ -36,7 +36,11 @@ class ToggleContainer extends React.Component {
 
   render() {
     return (
-      <Toggle checked={this.getOnReplySetting()} onChange={this.toggle}>
+      <Toggle
+        checked={this.getOnReplySetting()}
+        onChange={this.toggle}
+        disabled={this.props.disabled}
+      >
         {t('talk-plugin-notifications-category-staff.toggle_description')}
       </Toggle>
     );
@@ -50,6 +54,7 @@ ToggleContainer.propTypes = {
   indicateOff: PropTypes.func.isRequired,
   setTurnOffInputFragment: PropTypes.func.isRequired,
   updateNotificationSettings: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
 };
 
 const enhance = compose(

--- a/plugins/talk-plugin-notifications-category-staff/index.js
+++ b/plugins/talk-plugin-notifications-category-staff/index.js
@@ -1,14 +1,11 @@
-const { graphql } = require('graphql');
 const { get } = require('lodash');
 const path = require('path');
 
 const handle = async (ctx, comment) => {
-  const { connectors: { graph: { schema } } } = ctx;
-
   // Check to see if this is a reply to an existing comment.
   const parentID = get(comment, 'parent_id', null);
   if (parentID === null) {
-    ctx.log.debug('could not get parent comment id');
+    ctx.log.info('could not get parent comment id');
     return;
   }
 
@@ -19,8 +16,7 @@ const handle = async (ctx, comment) => {
   }
 
   // Execute the graph request.
-  const reply = await graphql(
-    schema,
+  const reply = await ctx.graphql(
     `
       query GetAuthorUserMetadata($comment_id: ID!, $author_id: ID!) {
         author: user(id: $author_id) {
@@ -37,8 +33,6 @@ const handle = async (ctx, comment) => {
         }
       }
     `,
-    {},
-    ctx,
     { comment_id: parentID, author_id: authorID }
   );
   if (reply.errors) {
@@ -53,27 +47,27 @@ const handle = async (ctx, comment) => {
     false
   );
   if (!enabled) {
-    ctx.log.debug('onStaffReply is false, will not send the notification');
+    ctx.log.info('onStaffReply is false, will not send the notification');
     return;
   }
 
   const userID = get(reply, 'data.comment.user.id', null);
   if (!userID) {
-    ctx.log.debug('could not get parent comment user id');
+    ctx.log.info('could not get parent comment user id');
     return;
   }
 
   // Check to see if this is yourself replying to yourself, if that's the case
   // don't send a notification.
   if (userID === authorID) {
-    ctx.log.debug('user id of parent comment is the same as the new comment');
+    ctx.log.info('user id of parent comment is the same as the new comment');
     return;
   }
 
   // Check to see that this comment was indeed from a staff member.
   const role = get(reply, 'data.author.role');
   if (!['ADMIN', 'MODERATOR', 'STAFF'].includes(role)) {
-    ctx.log.debug({ role }, 'reply author is not a staff member');
+    ctx.log.info({ role }, 'reply author is not a staff member');
     return;
   }
 
@@ -83,10 +77,7 @@ const handle = async (ctx, comment) => {
 };
 
 const hydrate = async (ctx, category, context) => {
-  const { connectors: { graph: { schema } } } = ctx;
-
-  const reply = await graphql(
-    schema,
+  const reply = await ctx.graphql(
     `
       query GetNotificationData($context: ID!) {
         comment(id: $context) {
@@ -104,8 +95,6 @@ const hydrate = async (ctx, category, context) => {
         }
       }
     `,
-    {},
-    ctx,
     { context }
   );
   if (reply.errors) {

--- a/plugins/talk-plugin-notifications/client/components/Banner.css
+++ b/plugins/talk-plugin-notifications/client/components/Banner.css
@@ -1,0 +1,42 @@
+.root {
+  display: flex;
+  border: 1px solid #a8afb3;
+  border-radius: 2px;
+  margin: 16px 0;
+
+  p:first-of-type {
+    margin-top: 0;
+  }
+  p:last-child {
+    margin-bottom: 0;
+  }
+}
+.leftColumn {
+  width: 32px;
+  background-color: #787d80;
+  text-align: center;
+  padding-top: 6px;
+  font-size: 18px;
+  flex-shrink: 0;
+
+  &.error {
+    background-color: #fa6265;
+  }
+  &.success {
+    background-color: #00cd7e;
+  }
+}
+.icon {
+  color: white;
+}
+.rightColumn {
+  padding: 8px 12px 10px 12px;
+  font-size: 14px;
+}
+.title {
+  font-size: 14px;
+  margin: 0;
+  margin-bottom: 4px;
+}
+
+

--- a/plugins/talk-plugin-notifications/client/components/Banner.js
+++ b/plugins/talk-plugin-notifications/client/components/Banner.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import styles from './Banner.css';
+import { Icon } from 'coral-ui';
+import PropTypes from 'prop-types';
+import cn from 'classnames';
+
+function getIcon(icon, error, success) {
+  if (icon) {
+    return icon;
+  }
+  if (error) {
+    return 'warning';
+  }
+  if (success) {
+    return 'done';
+  }
+  return 'info';
+}
+
+const Banner = ({ title, icon, error, success, children }) => (
+  <section className={styles.root}>
+    <div
+      className={cn(styles.leftColumn, {
+        [styles.error]: error,
+        [styles.success]: success,
+      })}
+    >
+      <Icon name={getIcon(icon, error, success)} className={styles.icon} />
+    </div>
+    <div className={styles.rightColumn}>
+      <h1 className={styles.title}>{title}</h1>
+      {children}
+    </div>
+  </section>
+);
+
+Banner.propTypes = {
+  title: PropTypes.string,
+  icon: PropTypes.string,
+  children: PropTypes.node,
+  error: PropTypes.bool,
+  success: PropTypes.bool,
+};
+
+Banner.defaultProps = {
+  title: 'Title',
+  children: 'Lorem Ipsum Dolot Sit Ahmet',
+};
+
+export default Banner;

--- a/plugins/talk-plugin-notifications/client/components/EmailVerificationBanner.css
+++ b/plugins/talk-plugin-notifications/client/components/EmailVerificationBanner.css
@@ -1,0 +1,11 @@
+.spinner {
+  display: inline-block;
+}
+
+.link {
+  display: inline-block;
+  cursor: pointer;
+  margin: 2px;
+  color: #2099d6;
+  border-bottom: 1px solid #2099d6;
+}

--- a/plugins/talk-plugin-notifications/client/components/EmailVerificationBanner.js
+++ b/plugins/talk-plugin-notifications/client/components/EmailVerificationBanner.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import Banner from './Banner';
+import PropTypes from 'prop-types';
+import { Spinner } from 'plugin-api/beta/client/components/ui';
+import { t } from 'plugin-api/beta/client/services';
+import styles from './EmailVerificationBanner.css';
+
+const EmailVerificationBannerInfo = ({ onResendEmailVerification }) => (
+  <Banner icon="email" title={t('talk-plugin-notifications.banner_info.title')}>
+    <p>
+      {t('talk-plugin-notifications.banner_info.text')}
+      <a
+        className={styles.link}
+        onClick={() => {
+          onResendEmailVerification();
+          return false;
+        }}
+      >
+        {t('talk-plugin-notifications.banner_info.verify_now')}
+      </a>
+    </p>
+  </Banner>
+);
+
+const EmailVerificationBannerLoading = () => (
+  <Banner icon="email" title={t('talk-plugin-notifications.banner_info.title')}>
+    <Spinner className={styles.spinner} />
+  </Banner>
+);
+
+const EmailVerificationBannerError = ({ errorMessage }) => (
+  <Banner title={t('talk-plugin-notifications.banner_error.title')} error>
+    <p>{t('talk-plugin-notifications.banner_error.text')}</p>
+    <p>{errorMessage}</p>
+  </Banner>
+);
+
+const EmailVerificationBannerSuccess = ({ email }) => (
+  <Banner title={t('talk-plugin-notifications.banner_success.title')} success>
+    <p>{t('talk-plugin-notifications.banner_success.text', email)}</p>
+  </Banner>
+);
+
+const EmailVerificationBanner = ({
+  onResendEmailVerification,
+  email,
+  success,
+  loading,
+  errorMessage,
+}) => (
+  <div>
+    {success && <EmailVerificationBannerSuccess email={email} />}
+    {errorMessage && (
+      <EmailVerificationBannerError errorMessage={errorMessage} />
+    )}
+    {loading && <EmailVerificationBannerLoading />}
+    {!success &&
+      !errorMessage &&
+      !loading && (
+        <EmailVerificationBannerInfo
+          onResendEmailVerification={onResendEmailVerification}
+        />
+      )}
+  </div>
+);
+
+EmailVerificationBanner.propTypes = {
+  onResendEmailVerification: PropTypes.func.isRequired,
+  success: PropTypes.bool.isRequired,
+  errorMessage: PropTypes.string,
+  loading: PropTypes.bool.isRequired,
+  email: PropTypes.string.isRequired,
+};
+
+export default EmailVerificationBanner;

--- a/plugins/talk-plugin-notifications/client/components/Settings.css
+++ b/plugins/talk-plugin-notifications/client/components/Settings.css
@@ -1,5 +1,6 @@
 .root {
   margin-bottom: 20px;
+  width: 380px;
 }
 
 .innerSettings {
@@ -24,4 +25,8 @@
 
 .notifcationSettingsSlot {
   margin-bottom: 3px;
+}
+
+.disabled {
+  color: #e5e5e5;
 }

--- a/plugins/talk-plugin-notifications/client/components/Settings.js
+++ b/plugins/talk-plugin-notifications/client/components/Settings.js
@@ -5,6 +5,8 @@ import { Slot } from 'plugin-api/beta/client/components';
 import { t } from 'plugin-api/beta/client/services';
 import styles from './Settings.css';
 import { BareButton } from 'plugin-api/beta/client/components/ui';
+import EmailVerificationBanner from '../containers/EmailVerificationBanner';
+import cn from 'classnames';
 
 class Settings extends React.Component {
   childFactory = el => {
@@ -23,13 +25,20 @@ class Settings extends React.Component {
       updateNotificationSettings,
       turnOffAll,
       turnOffButtonDisabled,
+      needEmailVerification,
+      email,
     } = this.props;
 
     return (
       <IfSlotIsNotEmpty slot="notificationSettings" queryData={{ root }}>
         <div className={styles.root}>
           <h3>{t('talk-plugin-notifications.settings_title')}</h3>
-          <h4 className={styles.subtitle}>
+          {needEmailVerification && <EmailVerificationBanner email={email} />}
+          <h4
+            className={cn(styles.subtitle, {
+              [styles.disabled]: needEmailVerification,
+            })}
+          >
             {t('talk-plugin-notifications.settings_subtitle')}
           </h4>
           <div className={styles.innerSettings}>
@@ -40,6 +49,7 @@ class Settings extends React.Component {
               childFactory={this.childFactory}
               setTurnOffInputFragment={setTurnOffInputFragment}
               updateNotificationSettings={updateNotificationSettings}
+              disabled={needEmailVerification}
             />
             <BareButton
               className={styles.turnOffButton}
@@ -63,6 +73,8 @@ Settings.propTypes = {
   updateNotificationSettings: PropTypes.func.isRequired,
   turnOffAll: PropTypes.func.isRequired,
   turnOffButtonDisabled: PropTypes.bool.isRequired,
+  needEmailVerification: PropTypes.bool.isRequired,
+  email: PropTypes.string,
 };
 
 export default Settings;

--- a/plugins/talk-plugin-notifications/client/components/Toggle.css
+++ b/plugins/talk-plugin-notifications/client/components/Toggle.css
@@ -1,6 +1,6 @@
 .title {
   display: inline-block;
-  width: 270px;
+  width: 100%;
   cursor: pointer;
   user-select: none;
 
@@ -16,6 +16,5 @@
 }
 
 .checkBox {
-  width: 100%;
   text-align: right;
 }

--- a/plugins/talk-plugin-notifications/client/components/Toggle.css
+++ b/plugins/talk-plugin-notifications/client/components/Toggle.css
@@ -3,4 +3,19 @@
   width: 270px;
   cursor: pointer;
   user-select: none;
+
+  &.disabled {
+    color: #e5e5e5;
+    cursor: default;
+  }
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+}
+
+.checkBox {
+  width: 100%;
+  text-align: right;
 }

--- a/plugins/talk-plugin-notifications/client/components/Toggle.js
+++ b/plugins/talk-plugin-notifications/client/components/Toggle.js
@@ -3,24 +3,36 @@ import PropTypes from 'prop-types';
 import { Checkbox } from 'plugin-api/beta/client/components/ui';
 import styles from './Toggle.css';
 import uuid from 'uuid/v4';
+import cn from 'classnames';
 
 class Toggle extends React.Component {
   id = uuid();
 
   render() {
-    const { checked, onChange, children } = this.props;
+    const { checked, onChange, children, disabled } = this.props;
     return (
       <div className={styles.toggle}>
-        <label htmlFor={this.id} className={styles.title}>
+        <label
+          htmlFor={this.id}
+          className={cn(styles.title, { [styles.disabled]: disabled })}
+        >
           {children}
         </label>
-        <Checkbox checked={checked} onChange={onChange} id={this.id} />
+        <div className={styles.checkBox}>
+          <Checkbox
+            checked={checked}
+            onChange={onChange}
+            id={this.id}
+            disabled={disabled}
+          />
+        </div>
       </div>
     );
   }
 }
 
 Toggle.propTypes = {
+  disabled: PropTypes.bool,
   checked: PropTypes.bool,
   onChange: PropTypes.func,
   children: PropTypes.node,

--- a/plugins/talk-plugin-notifications/client/containers/EmailVerificationBanner.js
+++ b/plugins/talk-plugin-notifications/client/containers/EmailVerificationBanner.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withResendEmailConfirmation } from 'plugin-api/beta/client/hocs';
+import { compose } from 'recompose';
+import EmailVerificationBanner from '../components/EmailVerificationBanner';
+
+class EmailVerificationBannerContainer extends Component {
+  handleResendEmailVerification = () => {
+    this.props.resendEmailConfirmation(this.props.email);
+  };
+
+  render() {
+    return (
+      <EmailVerificationBanner
+        onResendEmailVerification={this.handleResendEmailVerification}
+        errorMessage={this.props.errorMessage}
+        success={this.props.success}
+        loading={this.props.loading}
+        email={this.props.email}
+      />
+    );
+  }
+}
+
+EmailVerificationBannerContainer.propTypes = {
+  success: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
+  resendEmailConfirmation: PropTypes.func.isRequired,
+  errorMessage: PropTypes.string,
+  email: PropTypes.string.isRequired,
+};
+
+export default compose(withResendEmailConfirmation)(
+  EmailVerificationBannerContainer
+);

--- a/plugins/talk-plugin-notifications/client/containers/Settings.js
+++ b/plugins/talk-plugin-notifications/client/containers/Settings.js
@@ -31,6 +31,12 @@ class SettingsContainer extends React.Component {
     this.props.updateNotificationSettings(this.state.turnOffInput);
   };
 
+  getNeedEmailVerification() {
+    return !this.props.root.me.profiles.some(
+      profile => profile.provider === 'local' && profile.confirmedAt
+    );
+  }
+
   render() {
     return (
       <Settings
@@ -42,6 +48,8 @@ class SettingsContainer extends React.Component {
         updateNotificationSettings={this.props.updateNotificationSettings}
         turnOffAll={this.turnOffAll}
         turnOffButtonDisabled={this.state.hasNotifications.length === 0}
+        needEmailVerification={this.getNeedEmailVerification()}
+        email={this.props.root.me.email}
       />
     );
   }
@@ -60,6 +68,7 @@ const enhance = compose(
         __typename
         ${getSlotFragmentSpreads(slots, 'root')}
         me {
+          email
           profiles {
             provider
             ... on LocalUserProfile {

--- a/plugins/talk-plugin-notifications/client/containers/Settings.js
+++ b/plugins/talk-plugin-notifications/client/containers/Settings.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { compose, gql } from 'react-apollo';
 import Settings from '../components/Settings';
-import { withFragments } from 'plugin-api/beta/client/hocs';
+import { withFragments, excludeIf } from 'plugin-api/beta/client/hocs';
 import { getSlotFragmentSpreads } from 'plugin-api/beta/client/utils';
 import { withUpdateNotificationSettings } from '../mutations';
 
@@ -59,9 +59,21 @@ const enhance = compose(
       fragment TalkNotifications_Settings_root on RootQuery {
         __typename
         ${getSlotFragmentSpreads(slots, 'root')}
+        me {
+          profiles {
+            provider
+            ... on LocalUserProfile {
+              confirmedAt
+            }
+          }
+        }
       }
     `,
   }),
+  excludeIf(
+    props =>
+      !props.root.me.profiles.some(profile => profile.provider === 'local')
+  ),
   withUpdateNotificationSettings
 );
 

--- a/plugins/talk-plugin-notifications/client/containers/Settings.js
+++ b/plugins/talk-plugin-notifications/client/containers/Settings.js
@@ -15,13 +15,15 @@ class SettingsContainer extends React.Component {
   };
 
   indicateOn = plugin =>
-    this.setState({
-      hasNotifications: this.state.hasNotifications.concat(plugin),
-    });
+    this.setState(state => ({
+      hasNotifications: state.hasNotifications.concat(plugin),
+    }));
+
   indicateOff = plugin =>
-    this.setState({
-      hasNotifications: this.state.hasNotifications.filter(i => i !== plugin),
-    });
+    this.setState(state => ({
+      hasNotifications: state.hasNotifications.filter(i => i !== plugin),
+    }));
+
   setTurnOffInputFragment = fragment =>
     this.setState(state => ({
       turnOffInput: { ...state.turnOffInput, ...fragment },

--- a/plugins/talk-plugin-notifications/client/translations.yml
+++ b/plugins/talk-plugin-notifications/client/translations.yml
@@ -12,4 +12,4 @@ en:
       text: An email has been sent to {0} containing a verification link.
     banner_error:
       title: Error
-      text: There have been an error sending your verification email. Please try again later.
+      text: There has been an error sending your verification email. Please try again later.

--- a/plugins/talk-plugin-notifications/client/translations.yml
+++ b/plugins/talk-plugin-notifications/client/translations.yml
@@ -3,3 +3,13 @@ en:
     settings_title: Notifications
     settings_subtitle: Receive notifications when
     turn_off_all: I do not want to receive notifications
+    banner_info:
+      title: Email Verification Required
+      text: To receive email notifications you must have a verified email address.
+      verify_now: Verify your email now
+    banner_success:
+      title: Email Verification Sent
+      text: An email has been sent to {0} containing a verification link.
+    banner_error:
+      title: Error
+      text: There have been an error sending your verification email. Please try again later.

--- a/plugins/talk-plugin-notifications/server/config.js
+++ b/plugins/talk-plugin-notifications/server/config.js
@@ -1,3 +1,8 @@
 module.exports = {
   UNSUBSCRIBE_SUBJECT: 'nunsub',
+
+  // TODO: replace this with a config option in the plugin config when we get there..
+  DISABLE_REQUIRE_EMAIL_VERIFICATIONS:
+    process.env.TALK_DISABLE_REQUIRE_EMAIL_VERIFICATIONS_NOTIFICATIONS ===
+    'TRUE',
 };

--- a/plugins/talk-plugin-notifications/server/resolvers.js
+++ b/plugins/talk-plugin-notifications/server/resolvers.js
@@ -1,4 +1,5 @@
 const { get } = require('lodash');
+const { DISABLE_REQUIRE_EMAIL_VERIFICATIONS } = require('./config');
 
 module.exports = {
   User: {
@@ -15,5 +16,9 @@ module.exports = {
     async updateNotificationSettings(obj, { input }, { mutators: { User } }) {
       await User.updateNotificationSettings(input);
     },
+  },
+  Settings: {
+    notificationsRequireConfirmation: () =>
+      Boolean(!DISABLE_REQUIRE_EMAIL_VERIFICATIONS),
   },
 };

--- a/plugins/talk-plugin-notifications/server/typeDefs.graphql
+++ b/plugins/talk-plugin-notifications/server/typeDefs.graphql
@@ -7,7 +7,7 @@ type User {
 
 type Settings {
     # notificationsRequireConfirmation when true indicates that User's must have
-    # their email address confirmed/verified before they can recieve
+    # their email address confirmed/verified before they can receive
     # notifications.
     notificationsRequireConfirmation: Boolean
 }

--- a/plugins/talk-plugin-notifications/server/typeDefs.graphql
+++ b/plugins/talk-plugin-notifications/server/typeDefs.graphql
@@ -5,6 +5,13 @@ type User {
     notificationSettings: NotificationSettings
 }
 
+type Settings {
+    # notificationsRequireConfirmation when true indicates that User's must have
+    # their email address confirmed/verified before they can recieve
+    # notifications.
+    notificationsRequireConfirmation: Boolean
+}
+
 type UpdateNotificationSettingsResponse implements Response {
   # An array of errors relating to the mutation that occurred.
   errors: [UserError!]

--- a/services/logging.js
+++ b/services/logging.js
@@ -1,6 +1,7 @@
 const { version } = require('../package.json');
 const Logger = require('bunyan');
 const uuid = require('uuid/v1');
+const { LOGGING_LEVEL } = require('../config');
 
 // Create the logging instance that all logger's are branched from.
 function createLogger(name, id = uuid()) {
@@ -9,6 +10,7 @@ function createLogger(name, id = uuid()) {
     name,
     id,
     version,
+    level: LOGGING_LEVEL,
     serializers: { req: Logger.stdSerializers.req },
   });
 }


### PR DESCRIPTION
## What does this PR do?

- Filtering for confirmed emails ✉️ 
- Fixes to logger to expose logger controls 🖊 
- Refactored GraphQL calls in other notification plugins 📈 
- Require Email Verification on the Front End

## How do I test this PR?

#### Case 1: 
1. Create a new user (without confirming their email address).
2. See notifications cannot be enabled
3. Resend Email Confirmation
4. Confirm and activate notifications

#### Case 2:
1. Login with facebook.
2. See notifications cannot be enabled (not available)