### PR TITLE
Update Github Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,34 @@
-### Expected behavior
+<!--
 
-### Actual behavior
+  Thank you for filing an issue on Coral Talk!
 
-### Steps to reproduce behavior
+  Please fill out the questions below so we can take action on your issue as soon as we can.
+
+  If you're filing a feature request, you do not need to follow the outline below. Instead please include "Feature Idea" in your issue title and explain a specific example in which that feature would be useful.
+  
+-->
+
+#### Do you want to request a **feature** or report a **bug**?
+
+
+#### Intended outcome:
+<!--
+What you were trying to accomplish when the bug occurred?
+-->
+
+#### Actual outcome:
+<!--
+What happened instead?
+
+Please provide as much detail as possible, including a screenshot or copy-paste of any related error messages, logs, or other output that might be related. Places to look for information include your browser console, server console, and network logs. The more information you can give the better.
+-->
+
+#### How to reproduce the issue:
+<!--
+Instructions for how the issue can be reproduced by someone from our team or by a contributor. Be as specific as possible, and only mention what is necessary to reproduce the bug. If possible, try to isolate the exact circumstances in which the bug occurs and avoid speculation over what the cause might be.
+-->
+
+#### Version and environment
+<!--
+List what version of Talk you're using, as well as any other relevant environment information, such as operating system or browser
+-->


### PR DESCRIPTION
## What does this PR do?

Updates the Github issue template to prompt for more information from those filing issues. It also gives different instructions for those filing bugs versus suggesting features.

