### PR TITLE
Workspace + Plugin Regression

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -18,5 +18,6 @@ ONBUILD COPY . /usr/src/app
 # clear out the development dependencies again. After this we of course need to
 # clear out the yarn cache, this saves quite a lot of size.
 ONBUILD RUN cli plugins reconcile && \
+            yarn && \
             yarn build && \
             yarn cache clean


### PR DESCRIPTION
## What does this PR do?

When a plugin is loaded via the `*-onbuild` tag, external dependencies are not installed because we had migrated to yarn workspaces.

This was resolved by adding a `yarn` command to the onbuild stage.