### PR TITLE
Notification Settings Pane Controls

### DIFF
--- a/middleware/staticTemplate.js
+++ b/middleware/staticTemplate.js
@@ -13,6 +13,25 @@ const {
 
 const { RECAPTCHA_PUBLIC, WEBSOCKET_LIVE_URI } = require('../config');
 
+// Grab TALK_CLIENT_* environment variables.
+const TALK_CLIENT = /^TALK_CLIENT_/i;
+
+// TALK_CLIENT_ENV is all the environment keys that are loaded at runtime.
+const TALK_CLIENT_ENV = Object.keys(process.env)
+  .filter(key => TALK_CLIENT.test(key))
+  .reduce(
+    (env, key) => {
+      env[key] = process.env[key];
+      return env;
+    },
+    {
+      TALK_RECAPTCHA_PUBLIC: RECAPTCHA_PUBLIC,
+      LIVE_URI: WEBSOCKET_LIVE_URI,
+      STATIC_URL,
+      STATIC_ORIGIN,
+    }
+  );
+
 // TEMPLATE_LOCALS stores the static data that is provided as a `text/json` on
 // to the client from the template.
 const TEMPLATE_LOCALS = {
@@ -20,12 +39,8 @@ const TEMPLATE_LOCALS = {
   BASE_PATH,
   MOUNT_PATH,
   STATIC_URL,
-  data: {
-    TALK_RECAPTCHA_PUBLIC: RECAPTCHA_PUBLIC,
-    LIVE_URI: WEBSOCKET_LIVE_URI,
-    STATIC_URL,
-    STATIC_ORIGIN,
-  },
+  TALK_CLIENT_ENV,
+  data: TALK_CLIENT_ENV,
 };
 
 // attachStaticLocals will attach the locals to the response only.

--- a/plugin-api/beta/client/selectors/index.js
+++ b/plugin-api/beta/client/selectors/index.js
@@ -1,1 +1,2 @@
 export const pluginsConfigSelector = state => state.config.plugins_config;
+export const staticConfigSelector = state => state.config.static;

--- a/plugins/talk-plugin-notifications/README.md
+++ b/plugins/talk-plugin-notifications/README.md
@@ -16,6 +16,7 @@ anything. You need to enable one of the `talk-plugin-notifications-category-*` p
 Configuration:
 
 - `DISABLE_REQUIRE_EMAIL_VERIFICATIONS` - When `TRUE`, it will disable the verification email check before sending notifications for those emails. **Note that organizations implementing a custom authentication system _must_ disable this feature, as they don't use our integrated auth**. (Default `FALSE`).
+- `TALK_CLIENT_FORCE_NOTIFICATION_SETTINGS` - When `TRUE`, the settings pane for notifications will show always, even if the user does not have a `local` profile. (Default `FALSE`).
 
 You can enable other notification options by adding more
 `talk-plugin-notification-*` plugins!


### PR DESCRIPTION
## What does this PR do?

Introduced the `TALK_CLIENT_FORCE_NOTIFICATION_SETTINGS` configuration variable:

When `TRUE`, the settings pane for notifications will show always, even if the user does not have a `local` profile. (Default `FALSE`).

## How do I test this PR?

This requires the following plugins to be enabled to test:

- talk-plugin-notifications
- talk-plugin-notifications-category-reply

Test with the following steps:

1. Create a user with Facebook/Google/Other auth
2. Go to notification settings under My Profile -> Settings
3. See no notification settings
4. Set `TALK_CLIENT_FORCE_NOTIFICATION_SETTINGS=TRUE`, and restart the server
5. Go to notification settings under My Profile -> Settings
6. See notification settings!
