### PR TITLE
When comment reply is flattened, prefill comment with @<parent username>.

### DIFF
--- a/client/coral-embed-stream/src/tabs/stream/components/Comment.js
+++ b/client/coral-embed-stream/src/tabs/stream/components/Comment.js
@@ -373,6 +373,9 @@ export default class Comment extends React.Component {
       charCountEnable,
       root,
     } = this.props;
+
+    const reachedMaxThreadingLevel = depth >= THREADING_LEVEL;
+
     return (
       <ReplyBox
         root={root}
@@ -381,7 +384,10 @@ export default class Comment extends React.Component {
         charCountEnable={charCountEnable}
         maxCharCount={maxCharCount}
         setActiveReplyBox={setActiveReplyBox}
-        parentId={depth < THREADING_LEVEL ? comment.id : parentId}
+        parentId={reachedMaxThreadingLevel ? parentId : comment.id}
+        parentAuthorName={
+          reachedMaxThreadingLevel ? comment.user.username : undefined
+        }
         notify={notify}
         postComment={postComment}
         currentUser={currentUser}

--- a/client/coral-embed-stream/src/tabs/stream/components/ReplyBox.js
+++ b/client/coral-embed-stream/src/tabs/stream/components/ReplyBox.js
@@ -24,6 +24,7 @@ class ReplyBox extends React.Component {
       currentUser,
       notify,
       parentId,
+      parentAuthorName,
       commentPostedHandler,
       maxCharCount,
       charCountEnable,
@@ -39,6 +40,7 @@ class ReplyBox extends React.Component {
           charCountEnable={charCountEnable}
           commentPostedHandler={commentPostedHandler}
           parentId={parentId}
+          parentAuthorName={parentAuthorName}
           onCancel={this.cancelReply}
           notify={notify}
           currentUser={currentUser}

--- a/client/coral-embed-stream/src/tabs/stream/containers/CommentBox.js
+++ b/client/coral-embed-stream/src/tabs/stream/containers/CommentBox.js
@@ -23,7 +23,7 @@ const showOldTagsWarningOnce = once(() => {
   }
 });
 
-const initialInput = { body: '', tags: [] };
+const initialInput = { tags: [] };
 
 /**
  * Container for posting a new Comment
@@ -32,9 +32,13 @@ class CommentBox extends React.Component {
   constructor(props) {
     super(props);
 
+    const body = this.props.parentAuthorName
+      ? '@' + this.props.parentAuthorName + '\n'
+      : '';
+
     this.state = {
       loadingState: '',
-      input: initialInput,
+      input: Object.assign(initialInput, { body: body }),
     };
   }
 


### PR DESCRIPTION
## What does this PR do?

When the max threading level is hit, prefill replies with "@<parent username>" so users know which commenter the reply was meant for.

This is a potential improvement for https://github.com/coralproject/talk/issues/1250

What do you all think? Is this a reasonable solution to the problem? Or should we hardcode the "actual parent" information in some way? Or should this new behavior be controlled by a config option? Should this go through the roadmap or something? I just wanted to throw this PR up here to get your thoughts. :)

## How do I test this PR?

- Set TALK_THREADING_LEVEL to a low number, or leave it blank to use the default value of 3.
- Run the server.
- Post some replies to yourself to create a deeply-nested thread.
- Note that once the max threading level is hit, your posts will begin to be pre-filled with @<your username>.
- Note that if you reply to a different user, the posts are correctly pre-filled with @<their username>.
