### PR TITLE
Specify Subject Prefix config

### DIFF
--- a/plugins/talk-plugin-notifications/README.md
+++ b/plugins/talk-plugin-notifications/README.md
@@ -17,6 +17,7 @@ Configuration:
 
 - `TALK_DISABLE_REQUIRE_EMAIL_VERIFICATIONS_NOTIFICATIONS` - When `TRUE`, it will disable the verification email check before sending notifications for those emails. **Note that organizations implementing a custom authentication system _must_ disable this feature, as they don't use our integrated auth**. (Default `FALSE`).
 - `TALK_CLIENT_FORCE_NOTIFICATION_SETTINGS` - When `TRUE`, the settings pane for notifications will show always, even if the user does not have a `local` profile. (Default `FALSE`).
+- `TALK_EMAIL_SUBJECT_PREFIX` - The prefix for the subject of emails sent. An email with the specified subject of 'Your latest comment activity' would then be sent as '[Talk] Your latest comment activity'. (Default `[Talk]`)
 
 You can enable other notification options by adding more
 `talk-plugin-notification-*` plugins!


### PR DESCRIPTION
## What does this PR do?
Simply specifies in the notification plugin docs where the email subject prefix is set.

## How do I test this PR?
This PR only affects documentation.