### PR TITLE
Introspection fix

### DIFF
--- a/scripts/generateIntrospectionResult.js
+++ b/scripts/generateIntrospectionResult.js
@@ -103,16 +103,25 @@ function getIntrospectionQuery(options = {}) {
   `;
 }
 
-const generateIntrospectionResult = (resultLocation, options = {}) =>
-  graphql(schema, getIntrospectionQuery(options)).then(({ data }) => {
-    // Serialize the introspection result as JSON.
-    const introspectionResult = JSON.stringify(data, null, 2);
+const generateIntrospectionResult = async (resultLocation, options = {}) => {
+  const dir = path.dirname(resultLocation);
+  try {
+    fs.accessSync(dir);
+  } catch (err) {
+    console.log(`Cannot write to ${dir}, not generating introspection.json`);
+    return;
+  }
 
-    // Write the introspection result to the filesystem.
-    fs.writeFileSync(resultLocation, introspectionResult, 'utf8');
+  const { data } = await graphql(schema, getIntrospectionQuery(options));
 
-    console.log(`Outputted result of introspectionQuery to ${resultLocation}`);
-  });
+  // Serialize the introspection result as JSON.
+  const introspectionResult = JSON.stringify(data, null, 2);
+
+  // Write the introspection result to the filesystem.
+  fs.writeFileSync(resultLocation, introspectionResult, 'utf8');
+
+  console.log(`Outputted result of introspectionQuery to ${resultLocation}`);
+};
 
 const graphIntrospectionFilename = path.resolve(
   __dirname,


### PR DESCRIPTION
## What does this PR do?

During docker builds, the docs folder is excluded from the build context. This causes errors during the introspection generation. A patch was made that checks to see if the location is writable before it attempts to write the result.

## How do I test this PR?

1. Rename the `docs` directory to `docss`
2. Run `yarn generate-introspection`
3. Notice it doesn't error out, rather, it prints a warning