### PR TITLE
IfSlotIsNotEmpty Bug

### DIFF
--- a/client/coral-framework/components/IfSlotIsNotEmpty.js
+++ b/client/coral-framework/components/IfSlotIsNotEmpty.js
@@ -7,7 +7,7 @@ class IfSlotIsNotEmpty extends React.Component {
   isSlotEmpty(props = this.props) {
     const { slotElements } = props;
     return slotElements.length === 0
-      ? false
+      ? true
       : slotElements.every(elements => elements.length === 0);
   }
 
@@ -19,6 +19,7 @@ class IfSlotIsNotEmpty extends React.Component {
 
 IfSlotIsNotEmpty.propTypes = {
   slot: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  slotElements: PropTypes.array.isRequired,
   children: PropTypes.node.isRequired,
   passthrough: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
## What does this PR do?

Fixes a bug with the `IfSlotIsNotEmpty` component.

## How do I test this PR?

1. Remove all external auth plugins.
2. Build static assets.
3. Notice that the sign in dialog has a "Or".
4. Apply this branch.
5. Rebuild static assets.
6. Notice that the sign in dialog does not have the "Or"!
