### PR TITLE
Add note explaining possible plugin conflict

### DIFF
--- a/plugins/talk-plugin-rich-text/README.md
+++ b/plugins/talk-plugin-rich-text/README.md
@@ -46,7 +46,7 @@ Settings for highlighting links. These will only apply if `higlightLinks` is set
 
 #### `dompurify`
 
-Rules to sanitize html input.  We use [DOMPurify] (https://github.com/cure53/DOMPurify) to prevent web attacks and XSS. Here is the complete list of [settings] (https://github.com/cure53/DOMPurify)
+Rules to sanitize html input.  We use [DOMPurify](https://github.com/cure53/DOMPurify) to prevent web attacks and XSS. Here is the complete list of [settings](https://github.com/cure53/DOMPurify)
 
 #### `jsdom`
 

--- a/plugins/talk-plugin-rich-text/README.md
+++ b/plugins/talk-plugin-rich-text/README.md
@@ -16,6 +16,9 @@ Enables secure rich text support server-side.
 Add `"talk-plugin-rich-text"` to the `plugins.json` in your Talk installation.
 This plugin provides a server and a client side implementation.
 
+###### Note: Possible plugin conflict
+The plugin `talk-plugin-comment-content` will prevent this plugin from rendering comments with rich text styling and is not needed if this plugin is enabled.
+
 ## Server implementation
 
 ### How does this work?
@@ -47,7 +50,7 @@ Rules to sanitize html input.  We use [DOMPurify] (https://github.com/cure53/DOM
 
 #### `jsdom`
 
-In order to run html in the server we need [jsdom](https://github.com/jsdom/jsdom). Usually you wouldn’t need to modify this settings. 
+In order to run html in the server we need [jsdom](https://github.com/jsdom/jsdom). Usually you wouldn’t need to modify this settings.
 
 ## Client implementation
 
@@ -58,10 +61,10 @@ This plugin contains 2 important components:
 - The Editor (`./components/Editor.js`)
 - The Comment Content Renderer (`./components/CommentContent.js`)
 
-The editor component utilizes the [contentEditable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content) and execCommand API. 
+The editor component utilizes the [contentEditable](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Editable_content) and execCommand API.
 
 If you check our `index.js` you will notice that we inject this editor in the
-`commentBox` slot. We do this to replace the core comment box with this one. 
+`commentBox` slot. We do this to replace the core comment box with this one.
 
 Now, in order to render the new styled comments we need a comment renderer. For
 this task we will have to replace our core comment renderer by using the


### PR DESCRIPTION
## What does this PR do?
Adds copy to docs explaining that `talk-plugin-comment-content` should not be enabled if using `talk-plugin-rich-text`.

## How do I test this PR?
This PR is specifically for documentation and does not affect functionality.