### PR TITLE
JWT_Audience is listed twice in the docs under required keys

### DIFF
--- a/docs/source/integrating/authentication.md
+++ b/docs/source/integrating/authentication.md
@@ -74,7 +74,6 @@ example issuer and Talk must match:
 |------|----------------------|
 |`JWT_ISSUER`|`JWT_ISSUER`|
 |`JWT_AUDIENCE`|`JWT_AUDIENCE`|
-|`JWT_AUDIENCE`|`JWT_AUDIENCE`|
 |`SECRET`|`JWT_SECRET`*|
 
 \* Note that secrets is a pretty complex topic, refer to the


### PR DESCRIPTION
## What does this PR do?
Removes duplicate mention of `JWT_Audience` env variable.
## How do I test this PR?
Preview markdown.