### PR TITLE
Username Change Fixes

### DIFF
--- a/plugins/talk-plugin-local-auth/client/components/ChangeEmailContentDialog.js
+++ b/plugins/talk-plugin-local-auth/client/components/ChangeEmailContentDialog.js
@@ -63,15 +63,15 @@ class ChangeEmailContentDialog extends React.Component {
               columnDisplay
               showSuccess={false}
             />
+            <div className={styles.bottomActions}>
+              <Button className={styles.cancel} onClick={this.props.cancel}>
+                {t('talk-plugin-local-auth.change_email.cancel')}
+              </Button>
+              <Button className={styles.confirmChanges} type="submit">
+                {t('talk-plugin-local-auth.change_email.confirm_change')}
+              </Button>
+            </div>
           </form>
-          <div className={styles.bottomActions}>
-            <Button className={styles.cancel} onClick={this.props.cancel}>
-              {t('talk-plugin-local-auth.change_email.cancel')}
-            </Button>
-            <Button className={styles.confirmChanges} type="submit">
-              {t('talk-plugin-local-auth.change_email.confirm_change')}
-            </Button>
-          </div>
         </div>
       </div>
     );

--- a/plugins/talk-plugin-local-auth/client/components/ChangeEmailContentDialog.js
+++ b/plugins/talk-plugin-local-auth/client/components/ChangeEmailContentDialog.js
@@ -16,7 +16,8 @@ class ChangeEmailContentDialog extends React.Component {
     });
   };
 
-  confirmChanges = async () => {
+  confirmChanges = async e => {
+    e.preventDefault();
     await this.props.save();
     this.props.next();
   };
@@ -44,7 +45,7 @@ class ChangeEmailContentDialog extends React.Component {
               {this.props.formData.newEmail}
             </span>
           </div>
-          <form>
+          <form onSubmit={this.confirmChanges}>
             <InputField
               id="confirmPassword"
               label={t('talk-plugin-local-auth.change_email.enter_password')}
@@ -67,10 +68,7 @@ class ChangeEmailContentDialog extends React.Component {
             <Button className={styles.cancel} onClick={this.props.cancel}>
               {t('talk-plugin-local-auth.change_email.cancel')}
             </Button>
-            <Button
-              className={styles.confirmChanges}
-              onClick={this.confirmChanges}
-            >
+            <Button className={styles.confirmChanges} type="submit">
               {t('talk-plugin-local-auth.change_email.confirm_change')}
             </Button>
           </div>

--- a/plugins/talk-plugin-local-auth/client/components/ChangeUsernameContentDialog.js
+++ b/plugins/talk-plugin-local-auth/client/components/ChangeUsernameContentDialog.js
@@ -16,7 +16,9 @@ class ChangeUsernameContentDialog extends React.Component {
     });
   };
 
-  confirmChanges = async () => {
+  confirmChanges = async e => {
+    e.preventDefault();
+
     if (this.formHasError()) {
       this.showError();
       return;
@@ -60,7 +62,7 @@ class ChangeUsernameContentDialog extends React.Component {
               {this.props.formData.newUsername}
             </span>
           </div>
-          <form>
+          <form onSubmit={this.confirmChanges}>
             <InputField
               id="confirmNewUsername"
               label="Re-enter new username"
@@ -81,18 +83,15 @@ class ChangeUsernameContentDialog extends React.Component {
                 {t('talk-plugin-local-auth.change_username.bottom_note')}
               </span>
             </InputField>
+            <div className={styles.bottomActions}>
+              <Button className={styles.cancel} onClick={this.props.cancel}>
+                {t('talk-plugin-local-auth.change_username.cancel')}
+              </Button>
+              <Button className={styles.confirmChanges} type="submit">
+                {t('talk-plugin-local-auth.change_username.confirm_changes')}
+              </Button>
+            </div>
           </form>
-          <div className={styles.bottomActions}>
-            <Button className={styles.cancel} onClick={this.props.cancel}>
-              {t('talk-plugin-local-auth.change_username.cancel')}
-            </Button>
-            <Button
-              className={styles.confirmChanges}
-              onClick={this.confirmChanges}
-            >
-              {t('talk-plugin-local-auth.change_username.confirm_changes')}
-            </Button>
-          </div>
         </div>
       </div>
     );

--- a/plugins/talk-plugin-local-auth/client/components/Profile.css
+++ b/plugins/talk-plugin-local-auth/client/components/Profile.css
@@ -7,30 +7,38 @@
   border-radius: 2px;
   box-sizing: border-box;
   justify-content: space-between;
-  
-  &.editing { 
+
+  &.editing {
     background-color: #EDEDED;
   }
 }
 
+.wrapper {
+  display: flex;
+  position: relative;
+  box-sizing: inherit;
+  justify-content: inherit;
+  flex-grow: 1;
+}
+
 .content {
   flex-grow: 1;
-} 
+}
 
 .actions {
   flex-grow: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-}                                                                       
+}
 
 .email {
   margin: 0;
 }
 
-.username {   
+.username {
   margin-bottom: 4px;
-}         
+}
 
 .button {
   border: 1px solid #787d80;
@@ -48,7 +56,7 @@
   > i {
     font-size: 17px;
   }
-    
+
   &:hover {
     background-color: #399ee2;
     color: white;
@@ -82,13 +90,13 @@
   height: 30px;
   display: inline-block;
   width: 230px;
-  display: flex;  
+  display: flex;
 
   > .detailLabelIcon {
     font-size: 1.2em;
     padding: 0 5px;
     color: #787D80;
-    line-height: 30px; 
+    line-height: 30px;
   }
 
   &.disabled {
@@ -115,7 +123,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
-} 
+}
 
 .detailItem {
   margin-bottom: 12px;

--- a/plugins/talk-plugin-local-auth/client/containers/Profile.js
+++ b/plugins/talk-plugin-local-auth/client/containers/Profile.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect, withFragments } from 'plugin-api/beta/client/hocs';
 import Profile from '../components/Profile';
 import { notify } from 'coral-framework/actions/notification';
-import { withChangeUsername } from 'plugin-api/beta/client/hocs';
+import { withSetUsername } from 'plugin-api/beta/client/hocs';
 import { withUpdateEmailAddress } from '../hocs';
 
 const mapDispatchToProps = dispatch => bindActionCreators({ notify }, dispatch);
@@ -33,7 +33,7 @@ const withData = withFragments({
 
 export default compose(
   connect(null, mapDispatchToProps),
-  withChangeUsername,
+  withSetUsername,
   withUpdateEmailAddress,
   withData
 )(Profile);

--- a/plugins/talk-plugin-local-auth/client/translations.yml
+++ b/plugins/talk-plugin-local-auth/client/translations.yml
@@ -22,19 +22,18 @@ en:
       confirm_changes: "Confirm Changes"
       username_does_not_match: "Username does not match"
       cant_be_equal: "Your new {0} must be different to your current one"
-      change_username_attempt: "Username can't be updated. Usernames can be changed every 14 days"
+      changed_username_success_msg: "Username Changed - Your username has been successfully changed. You will not be able to change your user name for 14 days."
+      change_username_attempt: "Username can't be updated. Usernames can only be changed every 14 days."
     change_email:
       confirm_email_change: "Confirm Email Address Change"
       description: "You are attempting to change your email address. Your new email address will be used for your login and to receive account notifications."
-      old_email: "Old Email Address" 
+      old_email: "Old Email Address"
       new_email: "New Email Address"
       enter_password: "Enter Password"
       incorrect_password: "Incorrect Password"
       confirm_change: "Confirm Change"
       cancel: "Cancel"
       change_email_msg: "Email Address Changed - Your email address has been successfully changed. This email address will now be used for signing in and email notifications."
-      changed_username_success_msg: "Username Changed - Your username has been successfully changed. You will not be able to change your user name for 14 days."
-      change_username_attempt: "Username can't be updated. Usernames can only be changed every 14 days."
     add_email:
       add_email_address: "Add Email Address"
       enter_email_address: "Enter Email Address:"
@@ -52,7 +51,7 @@ en:
       verify:
         title: "Verify Your Email Address"
         description:  "We’ve sent an email to {0} to verify your account. You must verify your email address so that it can be used for account change confirmations and notifications."
-      added: 
+      added:
         title: "Email Address Added"
         description: "Your email address has been added to your account."
         subtitle: "Need to change your email address?"


### PR DESCRIPTION
## What does this PR do?

- Ensures all forms are properly wrapped with a `<form>` tag and respects the `onSubmit` event.
- Changed the `changeUsername` mutation to the `setUsername` mutation to reflect username state machine flow.
- Disabled username field when the username can't be changed due to the change cooldown.

## How do I test this PR?

- Try to change your username by hitting enter every form field along the way instead of clicking save
- Try to change your username by clicking save to every form along the way