### PR TITLE
Fix save icon

### DIFF
--- a/plugins/talk-plugin-local-auth/client/components/Profile.css
+++ b/plugins/talk-plugin-local-auth/client/components/Profile.css
@@ -29,6 +29,7 @@
 
 .actions {
   flex-grow: 0;
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## What does this PR do?
- https://www.pivotaltracker.com/story/show/157364180

## How do I test this PR?

- Save icon of the Edit Profile dialog should be on the same line as the label