### PR TITLE
bugfix: throw error when email already exist on changing

### DIFF
--- a/plugins/talk-plugin-local-auth/server/mutators.js
+++ b/plugins/talk-plugin-local-auth/server/mutators.js
@@ -35,24 +35,22 @@ async function updateUserEmailAddress(ctx, email, confirmPassword) {
   email = email.toLowerCase().trim();
 
   // Update the Users email address.
-  try {
-    await User.update(
-      {
-        id: user.id,
-        profiles: { $elemMatch: { provider: 'local' } },
-      },
-      {
-        $set: { 'profiles.$.id': email },
-        $unset: { 'profiles.$.metadata.confirmed_at': 1 },
-      }
-    );
-  } catch (err) {
+  await User.update(
+    {
+      id: user.id,
+      profiles: { $elemMatch: { provider: 'local' } },
+    },
+    {
+      $set: { 'profiles.$.id': email },
+      $unset: { 'profiles.$.metadata.confirmed_at': 1 },
+    }
+  ).catch(err => {
     if (err.code === 11000) {
       throw new ErrEmailTaken();
     }
 
     throw err;
-  }
+  });
 
   // Get some context for the email to be sent.
   const { organizationContactEmail } = await Settings.select(


### PR DESCRIPTION
## What does this PR do?
Fix `talk-plugin-local-auth` mutator to catch error and show in the frontend. 

## How do I test this PR?

- Login
- Go to My Profile
- Click on Edit Profile
- Change your e-mail to a already used one and see the error
- Change your e-mail to a new one and see the success message and receive email
