### PR TITLE
Allow to throw error when change username

### DIFF
--- a/client/coral-framework/hocs/withSetUsername.js
+++ b/client/coral-framework/hocs/withSetUsername.js
@@ -48,8 +48,9 @@ const withSetUsername = hoistStatics(WrappedComponent => {
         throw new Error('User not logged in');
       }
 
+      await this.props.setUsername(this.props.currentUserId, username);
+
       try {
-        await this.props.setUsername(this.props.currentUserId, username);
         this.props.updateUsername(username);
         this.props.updateStatus({ username: { status: 'SET' } });
         this.setState({ success: true, loading: false, error: null });


### PR DESCRIPTION
## What does this PR do?
Show right feedback message when happens an error changing the username.

## How do I test this PR?

- Login
- Go to My Profile
- Click on Edit Profile
- Change your username to one that already exists and see the error message
- Change your username to a new one and see the success message


