### PR TITLE
Set Akismet is_test to false

### DIFF
--- a/plugins/talk-plugin-akismet/server/hooks.js
+++ b/plugins/talk-plugin-akismet/server/hooks.js
@@ -71,7 +71,7 @@ module.exports = {
             permalink: asset.url,
             comment_type: 'comment',
             comment_content: input.body,
-            is_test: true,
+            is_test: false,
           });
 
           debug(`comment analyzed as ${spam ? 'being' : 'not being'} spam`);


### PR DESCRIPTION
## What does this PR do?

This sets akismet api calls to be normal and not test calls. From https://akismet.com/development/api/#comment-check, is_test should be false if these are real queries and not test queries.

## How do I test this PR?

 - Configure the akismet plugin with a pro account
 - Make comments on the talk instance
 - Verify comments show up in dashboard
