### PR TITLE
new env variable (TALK_FORCE_LANG) can be set in order to force a language

### DIFF
--- a/client/coral-framework/services/i18n.js
+++ b/client/coral-framework/services/i18n.js
@@ -59,12 +59,14 @@ export const supportedLocales = Object.keys(translations);
 let LOCALE;
 let TIMEAGO_INSTANCE;
 
+const preferedLanguage = process.env.TALK_FORCE_LANG ? process.env.TALK_FORCE_LANG : navigator.languages;
+
 // detectLanguage will try to get the locale from storage if available,
 // otherwise will try to get it from the navigator, otherwise, it will fallback
 // to the default language.
 const detectLanguage = () =>
   first(
-    negotiateLanguages(navigator.languages, supportedLocales, {
+    negotiateLanguages(preferedLanguage, supportedLocales, {
       defaultLocale,
       strategy: 'lookup',
     })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -169,6 +169,7 @@ const config = {
       TALK_REPLY_COMMENTS_LOAD_DEPTH: '3',
       TALK_DEFAULT_STREAM_TAB: 'all',
       TALK_DEFAULT_LANG: 'en',
+      TALK_FORCE_LANG: `${JSON.stringify(process.env.TALK_FORCE_LANG)}`,
     }),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
 


### PR DESCRIPTION
## What does this PR do?
In order to avoid auto-detecting the language from the navigator's language, a new variable (TALK_FORCE_LANG) can be set in the .env file with the value of the language you want talk to be loaded in all cases.
A similar pull request #1552 was made by @larrylizhao , but he proposed to change the behavior of the TALK_DEFAULT_LANG variable. In this new request the TALK_DEFAULT_LANG variable works as intended.
If TALK_FORCE_LANG is not set then the navigator's language will be used.

## How do I test this PR?
- add TALK_FORCE_LANG equal to the language you want to force ( ex. TALK_FORCE_LANG=es ) to the .env file
- yarn build
- run talk and check if the language is the one forced despite the value of the navigator's language.