### PR TITLE
Fixed double encoding

### DIFF
--- a/views/auth-callback.njk
+++ b/views/auth-callback.njk
@@ -4,7 +4,7 @@
     {% include "partials/data.njk" %}
   </head>
   <body>
-    <script type="application/json" id="auth">{{ encodeJSONForHTML(auth) }}</script>
+    <script type="application/json" id="auth">{{ encodeJSONForHTML(auth) | safe }}</script>
     <script type="text/javascript" src="{{ resolve('coral-auth-callback/bundle.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
## What does this PR do?

Previously, nunjucks encoded the html entities, as did our encoding function. This resolves that by marking the string safe in nunjucks, and instead using our serializer.

## How do I test this PR?

Login with facebook/google, see it work.
