### PR TITLE
Use Markdown for the "asset is closed" message.

### DIFF
--- a/client/coral-admin/src/routes/Configure/components/StreamSettings.js
+++ b/client/coral-admin/src/routes/Configure/components/StreamSettings.js
@@ -3,7 +3,7 @@ import { SelectField, Option } from 'react-mdl-selectfield';
 import t from 'coral-framework/services/i18n';
 import styles from './StreamSettings.css';
 import { Textfield } from 'react-mdl';
-import { Icon, TextArea } from 'coral-ui';
+import { Icon } from 'coral-ui';
 import PropTypes from 'prop-types';
 import Slot from 'coral-framework/components/Slot';
 import MarkdownEditor from 'coral-framework/components/MarkdownEditor';
@@ -66,8 +66,8 @@ class StreamSettings extends React.Component {
     this.props.updatePending({ updater });
   };
 
-  updateClosedMessage = event => {
-    const updater = { closedMessage: { $set: event.target.value } };
+  updateClosedMessage = value => {
+    const updater = { closedMessage: { $set: value } };
     this.props.updatePending({ updater });
   };
 
@@ -178,7 +178,7 @@ class StreamSettings extends React.Component {
         >
           <p>{t('configure.closed_comments_desc')}</p>
           <div>
-            <TextArea
+            <MarkdownEditor
               className={styles.descriptionBox}
               onChange={this.updateClosedMessage}
               value={settings.closedMessage}

--- a/client/coral-embed-stream/src/tabs/stream/components/Stream.js
+++ b/client/coral-embed-stream/src/tabs/stream/components/Stream.js
@@ -4,11 +4,11 @@ import StreamError from './StreamError';
 import Comment from '../containers/Comment';
 import BannedAccount from '../../../components/BannedAccount';
 import ChangeUsername from '../containers/ChangeUsername';
-import Markdown from 'coral-framework/components/Markdown';
 import Slot from 'coral-framework/components/Slot';
 import InfoBox from './InfoBox';
 import { can } from 'coral-framework/services/perms';
 import ModerationLink from './ModerationLink';
+import Markdown from 'coral-framework/components/Markdown';
 import RestrictedMessageBox from 'coral-framework/components/RestrictedMessageBox';
 import t, { timeago } from 'coral-framework/services/i18n';
 import CommentBox from '../containers/CommentBox';
@@ -298,7 +298,7 @@ class Stream extends React.Component {
         ) : (
           <div>
             {asset.isClosed ? (
-              <p>{asset.settings.closedMessage}</p>
+              <Markdown content={asset.settings.closedMessage} />
             ) : (
               <Markdown content={asset.settings.disableCommentingMessage} />
             )}


### PR DESCRIPTION
## What does this PR do?

Makes the last remaining TextArea in the stream settings also a Markdown, and adapts the rendering on the stream. Now all long text inputs on that settings page are Markdowns (stream intro, asset closed , comments deactivated).
