### PR TITLE
Set versions to 4.5.0 instead of latest

### DIFF
--- a/docs/source/01-01-talk-quickstart.md
+++ b/docs/source/01-01-talk-quickstart.md
@@ -48,7 +48,7 @@ be used to setup Talk:
 version: '2'
 services:
   talk:
-    image: coralproject/talk:latest
+    image: coralproject/talk:4.5.0
     restart: always
     ports:
       - "3000:3000"

--- a/docs/source/01-02-installation-from-docker.md
+++ b/docs/source/01-02-installation-from-docker.md
@@ -43,7 +43,7 @@ be used to setup Talk:
 version: '2'
 services:
   talk:
-    image: coralproject/talk:latest
+    image: coralproject/talk:4.5.0
     restart: always
     ports:
       - "3000:3000"
@@ -121,7 +121,7 @@ base installation with additional custom plugins. Images can be created with the
 most basic of `Dockerfile`'s:
 
 ```docker
-FROM coralproject/talk:latest-onbuild
+FROM coralproject/talk:4.5.0-onbuild
 ```
 
 And running the following to build the docker image:
@@ -153,7 +153,7 @@ your containerized infrastructure. The versioning of our Docker tags as well
 lets you do something like:
 
 ```docker
-FROM coralproject/talk:4.0-onbuild
+FROM coralproject/talk:4.5.0-onbuild
 ```
 
-Which would pin your image to `4.0` release's.
+Which would pin your image to `4.5.0` release's.

--- a/docs/source/plugins/overview.md
+++ b/docs/source/plugins/overview.md
@@ -109,7 +109,7 @@ If you deploy using Docker, you can extend from the `*-onbuild` image, an
 example `Dockerfile` for your project could be:
 
 ```Dockerfile
-FROM coralproject/talk:latest-onbuild
+FROM coralproject/talk:4.5.0-onbuild
 ```
 
 Where the directory for your instance would contain a `plugins.json` file


### PR DESCRIPTION
## What does this PR do?

Let's have our docs say 4.5.0 instead of latest so people who copy code don't accidentally pull a non-stable version of Talk.