### PR TITLE
lint js files, cleanup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn.lock
 coverage
 
 .idea/
+.vs
 .docz
 *.swp
 *.DS_STORE

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     ".vscode": true,
     "package-lock.json": true
   },
-  "tslint.autoFixOnSave": true
+  "tslint.autoFixOnSave": true,
+  "tslint.jsEnable": true
 }

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -3,29 +3,26 @@ const paths = require("./paths");
 module.exports = {
   rootDir: "../",
   roots: ["<rootDir>/src", "<rootDir>/scripts"],
-  collectCoverageFrom: [
-    "src/**/*.{js,jsx,mjs,ts,tsx}"
-  ],
+  collectCoverageFrom: ["src/**/*.{js,jsx,mjs,ts,tsx}"],
   coveragePathIgnorePatterns: ["/node_modules/"],
-  setupFiles: [
-    "<rootDir>/config/polyfills.js"
-  ],
+  setupFiles: ["<rootDir>/config/polyfills.js"],
   testMatch: [
     "**/__tests__/**/*.{js,jsx,mjs,ts,tsx}",
-    "**/*.(spec|test).{js,jsx,mjs,ts,tsx}"
+    "**/*.(spec|test).{js,jsx,mjs,ts,tsx}",
   ],
   testEnvironment: "node",
   testURL: "http://localhost",
   transform: {
     "^.+\\.(js|jsx|mjs|ts|tsx)$": "<rootDir>/node_modules/ts-jest",
     "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
-    "^(?!.*\\.(js|jsx|mjs|css|json|ftl)$)": "<rootDir>/config/jest/fileTransform.js"
+    "^(?!.*\\.(js|jsx|mjs|css|json|ftl)$)":
+      "<rootDir>/config/jest/fileTransform.js",
   },
   transformIgnorePatterns: [
-    "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|ts|tsx)$"
+    "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|ts|tsx)$",
   ],
   moduleNameMapper: {
-    "^react-native$": "react-native-web"
+    "^react-native$": "react-native-web",
   },
   moduleFileExtensions: [
     "web.js",
@@ -36,6 +33,6 @@ module.exports = {
     "node",
     "mjs",
     "ts",
-    "tsx"
+    "tsx",
   ],
-}
+};

--- a/config/jest/cssTransform.js
+++ b/config/jest/cssTransform.js
@@ -1,14 +1,14 @@
-'use strict';
+"use strict";
 
 // This is a custom Jest transformer turning style imports into empty objects.
 // http://facebook.github.io/jest/docs/en/webpack.html
 
 module.exports = {
   process() {
-    return 'module.exports = {};';
+    return "module.exports = {};";
   },
   getCacheKey() {
     // The output is always the same.
-    return 'cssTransform';
+    return "cssTransform";
   },
 };

--- a/config/jest/fileTransform.js
+++ b/config/jest/fileTransform.js
@@ -1,6 +1,6 @@
-'use strict';
+"use strict";
 
-const path = require('path');
+const path = require("path");
 
 // This is a custom Jest transformer turning file imports into filenames.
 // http://facebook.github.io/jest/docs/en/webpack.html

--- a/config/postcss.config.js
+++ b/config/postcss.config.js
@@ -5,28 +5,31 @@ const kebabCase = require("lodash/kebabCase");
 const mapKeys = require("lodash/mapKeys");
 const flat = require("flat");
 const flexbugsFixes = require("postcss-flexbugs-fixes");
-const paths = require('./paths');
+const paths = require("./paths");
 
 delete require.cache[paths.appThemeVariables];
 const variables = require(paths.appThemeVariables);
-const flatKebabVariables = mapKeys(flat(variables, {delimiter: "-"}), (_, k) => kebabCase(k));
+const flatKebabVariables = mapKeys(
+  flat(variables, { delimiter: "-" }),
+  (_, k) => kebabCase(k)
+);
 
 module.exports = {
   // Necessary for external CSS imports to work
   // https://github.com/facebookincubator/create-react-app/issues/2677
-  ident: 'postcss',
+  ident: "postcss",
   plugins: [
     precss({ variables: flatKebabVariables }),
     fontMagician(),
     flexbugsFixes,
     autoprefixer({
       browsers: [
-        '>1%',
-        'last 4 versions',
-        'Firefox ESR',
-        'not ie < 9', // React doesn't support IE8 anyway
+        ">1%",
+        "last 4 versions",
+        "Firefox ESR",
+        "not ie < 9", // React doesn't support IE8 anyway
       ],
-      flexbox: 'no-2009',
+      flexbox: "no-2009",
     }),
   ],
 };

--- a/doczrc.js
+++ b/doczrc.js
@@ -37,7 +37,9 @@ export default {
         },
       ],
     });
-    config.resolve.plugins = [new TsconfigPathsPlugin({ extensions, configFile: paths.appTsconfig })];
+    config.resolve.plugins = [
+      new TsconfigPathsPlugin({ extensions, configFile: paths.appTsconfig }),
+    ];
     // fs.writeFileSync(path.resolve(__dirname, "tmp"), stringify(config, null, 2));
     return config;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8255,12 +8255,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8275,17 +8277,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8402,7 +8407,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8414,6 +8420,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8428,6 +8435,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8435,12 +8443,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8459,6 +8469,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8539,7 +8550,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8551,6 +8563,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8672,6 +8685,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "compile:css-types": "tcm src/core/client/",
     "compile:relay-stream": "relay-compiler --src ./src/core/client/stream --schema ./src/core/server/graph/tenant/schema/schema.graphql --language typescript --artifactDirectory ./src/core/client/stream/__generated__ --no-watchman",
     "start:development": "NODE_ENV=development ts-node -r tsconfig-paths/register src/index.ts",
-    "lint-fix": "tslint --fix --project ./tsconfig.json && tslint --fix --project ./src/core/client/tsconfig.json",
+    "lint-fix": "npm run lint:server -- --fix && npm run lint:client -- --fix && npm run lint:scripts -- --fix",
     "lint": "npm-run-all --parallel lint:*",
     "lint:server": "tslint --project ./tsconfig.json",
     "lint:client": "tslint --project ./src/core/client/tsconfig.json",
+    "lint:scripts": "tslint config/**/*.js scripts/**/*.js",
     "docz:watch": "docz dev"
   },
   "author": "",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -22,7 +22,6 @@ const fs = require("fs-extra");
 const webpack = require("webpack");
 const config = require("../config/webpack.config.prod");
 const paths = require("../config/paths");
-const checkRequiredFiles = require("react-dev-utils/checkRequiredFiles");
 const formatWebpackMessages = require("react-dev-utils/formatWebpackMessages");
 const printHostingInstructions = require("react-dev-utils/printHostingInstructions");
 const FileSizeReporter = require("react-dev-utils/FileSizeReporter");
@@ -39,14 +38,11 @@ const WARN_AFTER_CHUNK_GZIP_SIZE = 1024 * 1024;
 // Treat warnings as errors when we are in CI
 // TODO: This is currently turned off until we have
 // an optimized build.
-const treatWarningsAsErrors = false && process.env.CI &&
+const treatWarningsAsErrors =
+  false &&
+  process.env.CI &&
   (typeof process.env.CI !== "string" ||
     process.env.CI.toLowerCase() !== "false");
-
-// Warn and crash if required files are missing
-if (!checkRequiredFiles([paths.appStreamHtml, paths.appStreamIndex])) {
-  process.exit(1);
-}
 
 // First, read the current file sizes in build directory.
 // This lets us display how much they changed later.
@@ -117,10 +113,7 @@ function build(previousFileSizes) {
         }
         return reject(new Error(messages.errors.join("\n\n")));
       }
-      if (
-        treatWarningsAsErrors &&
-        messages.warnings.length
-      ) {
+      if (treatWarningsAsErrors && messages.warnings.length) {
         console.log(
           chalk.yellow(
             "\nTreating warnings as errors because process.env.CI = true.\n" +

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -20,25 +20,15 @@ const fs = require("fs");
 const chalk = require("chalk");
 const webpack = require("webpack");
 const WebpackDevServer = require("webpack-dev-server");
-const clearConsole = require("react-dev-utils/clearConsole");
-const checkRequiredFiles = require("react-dev-utils/checkRequiredFiles");
 const {
   choosePort,
   createCompiler,
   prepareProxy,
   prepareUrls,
 } = require("react-dev-utils/WebpackDevServerUtils");
-const openBrowser = require("react-dev-utils/openBrowser");
 const paths = require("../config/paths");
 const config = require("../config/webpack.config.dev");
 const createDevServerConfig = require("../config/webpackDevServer.config");
-
-const isInteractive = process.stdout.isTTY;
-
-// Warn and crash if required files are missing
-if (!checkRequiredFiles([paths.appStreamHtml, paths.appStreamIndex])) {
-  process.exit(1);
-}
 
 const PORT = parseInt(process.env.DEV_SERVER_PORT, 10) || 8080;
 const HOST = process.env.HOST || "0.0.0.0";
@@ -85,11 +75,7 @@ choosePort(HOST, PORT)
       if (err) {
         return console.log(err);
       }
-      if (isInteractive) {
-        clearConsole();
-      }
       console.log(chalk.cyan("Starting the development server...\n"));
-      openBrowser(urls.localUrlForBrowser);
     });
 
     ["SIGINT", "SIGTERM"].forEach(function(sig) {

--- a/src/core/client/.babelrc.js
+++ b/src/core/client/.babelrc.js
@@ -1,14 +1,12 @@
 module.exports = {
   presets: [
     ["@babel/env", { targets: "last 2 versions, ie 11", modules: false }],
-    "@babel/react"
+    "@babel/react",
   ],
-  plugins: [
-    "@babel/syntax-dynamic-import",
-  ],
+  plugins: ["@babel/syntax-dynamic-import"],
   env: {
-    "production": {
-      "plugins": [],
+    production: {
+      plugins: [],
     },
   },
-}
+};

--- a/src/core/client/tsconfig.json
+++ b/src/core/client/tsconfig.json
@@ -6,7 +6,13 @@
     "jsx": "preserve",
     "noEmit": true,
     "strictNullChecks": true,
-    "lib": ["dom", "es7", "scripthost", "es2015", "esnext.asynciterable"],
+    "lib": [
+      "dom",
+      "es7",
+      "scripthost",
+      "es2015",
+      "esnext.asynciterable"
+    ],
     "baseUrl": "./",
     "paths": {
       "talk-admin/*": [

--- a/src/core/client/tslint.json
+++ b/src/core/client/tslint.json
@@ -5,10 +5,16 @@
   ],
   "rules": {
     "jsx-no-multiline-js": false,
-    "jsx-boolean-value": [true, "never"]
+    "jsx-boolean-value": [
+      true,
+      "never"
+    ]
   },
   "jsRules": {
     "jsx-no-multiline-js": false,
-    "jsx-boolean-value": [true, "never"]
+    "jsx-boolean-value": [
+      true,
+      "never"
+    ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,11 @@
     "outDir": "dist",
     // See https://github.com/prismagraphql/graphql-request/issues/26 for why we
     // have to include "dom" here.
-    "lib": ["es6", "esnext.asynciterable", "dom"],
+    "lib": [
+      "es6",
+      "esnext.asynciterable",
+      "dom"
+    ],
     "baseUrl": "./",
     "paths": {
       "talk-server/*": [

--- a/tslint.json
+++ b/tslint.json
@@ -7,11 +7,18 @@
   "rules": {
     "prettier": true,
     "object-literal-sort-keys": false,
-    "interface-name": [true, "never-prefix"],
+    "interface-name": [
+      true,
+      "never-prefix"
+    ],
     "no-switch-case-fall-through": true,
     "member-ordering": false,
-    "variable-name": [true,
-      "ban-keywords", "check-format", "allow-leading-underscore", "allow-pascal-case"
+    "variable-name": [
+      true,
+      "ban-keywords",
+      "check-format",
+      "allow-leading-underscore",
+      "allow-pascal-case"
     ]
   },
   "jsRules": {
@@ -19,8 +26,17 @@
     "object-literal-sort-keys": false,
     "no-switch-case-fall-through": true,
     "member-ordering": false,
-    "variable-name": [true,
-      "ban-keywords", "check-format", "allow-leading-underscore", "allow-pascal-case"
+    "variable-name": [
+      true,
+      "ban-keywords",
+      "check-format",
+      "allow-leading-underscore",
+      "allow-pascal-case"
+    ]
+  },
+  "linterOptions": {
+    "exclude": [
+      "**/node_modules/**/*"
     ]
   }
 }


### PR DESCRIPTION
## What does this PR do?
- Lint and fix js files
- Setup VSCode to lint and fix js files using tslint
- Ignore `node_modules` in `tslint`
- Don't open browser in `start.js`
- Remove checks for required files in `start.js` and `build.js`.

