### PR TITLE
Search - Display Name

### DIFF
--- a/graph/loaders/users.js
+++ b/graph/loaders/users.js
@@ -110,6 +110,13 @@ const getUsersByQuery = async (
               },
             },
           },
+
+          // Search by the displayName metadata field.
+          {
+            'metadata.displayName': {
+              $regex,
+            },
+          },
         ],
       });
     }

--- a/models/schema/user.js
+++ b/models/schema/user.js
@@ -235,6 +235,15 @@ User.index({
   created_at: -1,
 });
 
+User.index(
+  {
+    'metadata.displayName': 1,
+  },
+  {
+    sparse: true,
+  }
+);
+
 // This query is executed often, to count the number of flagged accounts with
 // usernames.
 User.index({


### PR DESCRIPTION
## What does this PR do?

Added support for `metadata.displayName` for searches.

## Motivation

This PR serves to rectify the behavior around using a custom display name for the username (if it does not conform to our rules for that). This serves as a way to allow searches against the custom field if it is provided.

## How do I test this PR?

1. Create a user.
2. In the database, update their user to add the `displayName` property:

```js
db.users.update({id: <userID>}, {$set:{"metadata.displayName": "search-display-name"}});
```

3. Search the people tab for "search-disp" and see the specified user!