### PR TITLE
Watcher --only

### DIFF
--- a/scripts/watcher/bin/watcher.ts
+++ b/scripts/watcher/bin/watcher.ts
@@ -4,16 +4,24 @@ import program from "commander";
 import path from "path";
 import watch from "../";
 
+function list(val: string) {
+  return val.split(",");
+}
+
 program
   .version("0.1.0")
   .usage("<configFile>")
+  .option("-o, --only <watcher>", "only run the specified watcher", list)
   .arguments("<configFile>")
   .description("Run watchers defined in <configFile>")
-  .action(configFile => {
+  .action((configFile, cmd) => {
+    const { only = [] } = cmd;
+
     let config: any = require(path.resolve(configFile));
     if (config.__esModule) {
       config = config.default;
     }
-    watch(config);
+
+    watch(config, { only });
   })
   .parse(process.argv);

--- a/scripts/watcher/types.ts
+++ b/scripts/watcher/types.ts
@@ -17,6 +17,10 @@ export interface Executor {
   execute(filePath: string): void;
 }
 
+export interface Options {
+  only?: string[];
+}
+
 export interface Config {
   rootDir?: string;
   backend?: Watcher;


### PR DESCRIPTION
## What does this PR do?

Adds a new `--only` flag that allows only the specified list of comma separated watchers to run.

## Examples

```bash
# to only run the server
npm run watch -- --only runServer

# to only run the server and css
npm run watch -- --only runServer,compileCSSTypes
```