### PR TITLE
Adapt files.exclude

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,11 +9,9 @@
     "**/.hg": true,
     "**/CVS": true,
     "**/.DS_Store": true,
-    "node_modules": true,
-    "dist": true,
-    ".vscode": true,
-    "package-lock.json": true
+    ".vs": true
   },
+  "tslint.exclude": "**/node_modules/**",
   "tslint.autoFixOnSave": true,
   "tslint.jsEnable": true,
   "typescript.tsdk": "node_modules/typescript/lib"


### PR DESCRIPTION
## What does this PR do?
- Show `node_modules`, `dist`, ` .vscode`, `package-lock.json` in VSCode
- Hide `.vs`
- Exclude `node_modules` from linting and formatting