### PR TITLE
Add suggested index to comments

### DIFF
--- a/models/schema/comment.js
+++ b/models/schema/comment.js
@@ -163,6 +163,12 @@ Comment.index({
   created_at: -1,
 });
 
+Comment.index({
+  asset_id: 1,
+  parent_id: 1,
+  created_at: 1,
+});
+
 Comment.index(
   {
     'action_counts.flag': 1,


### PR DESCRIPTION
## What does this PR do?

This adds an index to the comment table based off of suggestions from MongoDB Atlas running in production on our site.

![screen shot 2018-07-09 at 11 31 40 am](https://user-images.githubusercontent.com/20201/42460640-659a855a-836c-11e8-9644-90e9d30c1985.png)

## How do I test this PR?

This index, as I understand it, should apply automatically when running talk.
