### PR TITLE
Fixed code markup for action name.

### DIFF
--- a/docs/source/api/client.md
+++ b/docs/source/api/client.md
@@ -22,7 +22,7 @@ Feel free to check all the utilities here:  `talk/plugin-api`.
 
 #### Stream
 * `setSort`
-* `showSignInDialog``
+* `showSignInDialog`
 
 ### Import 
 ```


### PR DESCRIPTION
## What does this PR do?
- The action `showSignInDialog` is accidentally wrapped in two single quotes instead of one which leads to a wrong rendered display.

## How do I test this PR?
- Not necessary