### PR TITLE
Username Status Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "A better commenting experience from Mozilla, The New York Times, and the Washington Post. https://coralproject.net",
   "main": "app.js",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "description": "A better commenting experience from Mozilla, The New York Times, and the Washington Post. https://coralproject.net",
   "main": "app.js",
   "private": true,

--- a/services/users.js
+++ b/services/users.js
@@ -84,9 +84,7 @@ async function upsertUser(
     status: {
       username: {
         status: usernameStatus,
-        history: {
-          status: usernameStatus,
-        },
+        history: [{ status: usernameStatus }],
       },
     },
   });


### PR DESCRIPTION
## What does this PR do?

Fixes a small bug with the username history that would have affected the views in the Admin.

## How do I test this PR?

Create a new user with the `UsersService.upsertExternalUser` method, and notice that the username status is set to `SET` and the history has a `SET` item in it.