### PR TITLE
Use scheduledDeletionDelayHours variable on hoc

### DIFF
--- a/plugins/talk-plugin-profile-data/client/hocs/index.js
+++ b/plugins/talk-plugin-profile-data/client/hocs/index.js
@@ -3,6 +3,8 @@ import { gql } from 'react-apollo';
 import moment from 'moment';
 import update from 'immutability-helper';
 
+import { scheduledDeletionDelayHours } from '../../config';
+
 export const withRequestDownloadLink = withMutation(
   gql`
     mutation DownloadCommentHistory {
@@ -48,7 +50,7 @@ export const withRequestAccountDeletion = withMutation(
             });
 
             const scheduledDeletionDate = moment()
-              .add(24, 'hours')
+              .add(scheduledDeletionDelayHours, 'hours')
               .toDate();
 
             const data = update(prev, {


### PR DESCRIPTION
## What does this PR do?
Introduce use of scheduledDeletionDelayHours on scheduling deletion date

## How do I test this PR?

- change scheduledDeletionDelayHours on `config.js`
- login
- request delete account
- check if the new schedule value is right
