### PR TITLE
Case sensitive displayName Issue

### DIFF
--- a/graph/loaders/users.js
+++ b/graph/loaders/users.js
@@ -84,10 +84,10 @@ const getUsersByQuery = async (
 
     if (value.length > 0) {
       // Lowercase the search term and escape any regex characters.
-      value = escapeRegExp(value).toLowerCase();
+      value = escapeRegExp(value);
 
-      // Compile the prefix search regex.
-      const $regex = new RegExp(`^${value}`);
+      const lowercasedRegex = new RegExp(`^${value.toLowerCase()}`);
+      const notLowercasedRegex = new RegExp(`^${value}`);
 
       // Merge in the regex params.
       query.merge({
@@ -95,7 +95,7 @@ const getUsersByQuery = async (
           // Search by a prefix match on the username.
           {
             lowercaseUsername: {
-              $regex,
+              $regex: lowercasedRegex,
             },
           },
 
@@ -104,7 +104,7 @@ const getUsersByQuery = async (
             profiles: {
               $elemMatch: {
                 id: {
-                  $regex,
+                  $regex: lowercasedRegex,
                 },
                 provider: 'local',
               },
@@ -114,7 +114,7 @@ const getUsersByQuery = async (
           // Search by the displayName metadata field.
           {
             'metadata.displayName': {
-              $regex,
+              $regex: notLowercasedRegex,
             },
           },
         ],


### PR DESCRIPTION
## What does this PR do?

When searching for users, we can store the username in a few places (depending on the user case):

- `username`: local usernames are set here
- `lowercaseUsername`: lowercased versions of the local usernames are stored here
- `metadata.displayName`: external auth integration usernames are stored here

See the issue? It turns out that if a user had a `metadata.displayName` that contained an uppercase character, you could never lookup that specific user, because the prefix search being conducted (in order to use the index and make it quick!) always lowercased the regex pattern.

This PR makes the search on the people page case sensitive for the `metadata.displayName` field, but keeps the case insensitive search for the `lowercaseUsername` field.

## How do I test this PR?

1. Create a user in the database, note their `username`.
2. Execute the following query: ```db.users.update({username: "<USERNAME FROM STEP 1>"}, {$set: {"metadata.displayName": "**Test"}});```
3. Visit: https://talk-stg.coralproject.net/admin/community/people and search for `**T` and notice that the user shows up!
4. Search for `**t` and notice that the user does *not* show up.