### PR TITLE
support translation in permalink share button

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -48,6 +48,8 @@ de:
   comment_post_notif_premod: 'Vielen Dank für Ihren Kommentar. Unsere Moderatoren werden ihn in Kürze bearbeiten.'
   comment_singular: Kommentar
   common:
+    copied: 'Kopiert'
+    notsupported: 'Nicht unterstützt'
     copy: Kopieren
     error: 'Ein Problem ist aufgetreten.'
     reaction: 'Reaktion'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -49,6 +49,8 @@ en:
   comment_singular: Comment
   common:
     copy: Copy
+    copied: 'Copied'
+    notsupported: 'Not supported'
     error: 'An error has occurred.'
     reaction: reaction
     reactions: reactions

--- a/plugins/talk-plugin-permalink/client/components/PermalinkButton.js
+++ b/plugins/talk-plugin-permalink/client/components/PermalinkButton.js
@@ -105,9 +105,9 @@ export default class PermalinkButton extends React.Component {
                 },
               ])}
             >
-              {!copyFailure && !copySuccessful && 'Copy'}
-              {copySuccessful && 'Copied'}
-              {copyFailure && 'Not supported'}
+              {!copyFailure && !copySuccessful && t('common.copy') }
+              {copySuccessful && t('common.copied') }
+              {copyFailure && t('common.notsupported') }
             </Button>
           </div>
         </div>

--- a/plugins/talk-plugin-permalink/client/components/PermalinkButton.js
+++ b/plugins/talk-plugin-permalink/client/components/PermalinkButton.js
@@ -105,9 +105,9 @@ export default class PermalinkButton extends React.Component {
                 },
               ])}
             >
-              {!copyFailure && !copySuccessful && t('common.copy') }
-              {copySuccessful && t('common.copied') }
-              {copyFailure && t('common.notsupported') }
+              {!copyFailure && !copySuccessful && t('common.copy')}
+              {copySuccessful && t('common.copied')}
+              {copyFailure && t('common.notsupported')}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Thx for the great project ❤️  we are in the integration phase to use it on austrian's greatest news publisher website, and stumbled upon some "minor" issue.

let me know if you'd need any further changes, i cannot add translations for all the other languages. but i guess it will fallback anyway to the english version, right?


## What does this PR do?
adds translation calls for the share button.
should fix https://github.com/coralproject/talk/issues/1802

## How do I test this PR?

- click on the "share" button on a comment/reply

