### PR TITLE
[next] Compile schema when watching client

### DIFF
--- a/config/watcher.ts
+++ b/config/watcher.ts
@@ -77,6 +77,7 @@ const config: Config = {
       "compileCSSTypes",
       "compileRelayStream",
       "compileRelayAuth",
+      "compileSchema",
     ],
     docz: ["runDocz", "compileCSSTypes"],
     compile: [


### PR DESCRIPTION
## What does this PR do?
- Compile schema on default watch because it's required 

