### PR TITLE
re-introduce comment count on tabs

### DIFF
--- a/client/coral-admin/src/routes/Moderation/components/Moderation.js
+++ b/client/coral-admin/src/routes/Moderation/components/Moderation.js
@@ -139,10 +139,9 @@ class Moderation extends Component {
       key: queue,
       name: queueConfig[queue].name,
       icon: queueConfig[queue].icon,
+      count: root[`${queue}Count`],
       indicator:
         ['premod', 'reported'].includes(queue) && root[queue].nodes.length > 0,
-      // TODO: Eventually we'll reintroduce counting
-      // count: root[`${props.queue}Count`]
     }));
 
     const slotPassthrough = {
@@ -151,7 +150,6 @@ class Moderation extends Component {
       activeTab,
       handleCommentChange,
     };
-
     return (
       <div>
         <ModerationHeader

--- a/client/coral-admin/src/routes/Moderation/components/ModerationMenu.js
+++ b/client/coral-admin/src/routes/Moderation/components/ModerationMenu.js
@@ -5,6 +5,7 @@ import styles from './ModerationMenu.css';
 import { Icon } from 'coral-ui';
 import { Link } from 'react-router';
 import cn from 'classnames';
+import CountBadge from '../../../components/CountBadge';
 
 const ModerationMenu = ({ asset = {}, items, getModPath, activeTab }) => {
   return (
@@ -34,6 +35,7 @@ const ModerationMenu = ({ asset = {}, items, getModPath, activeTab }) => {
             >
               <Icon name={queue.icon} className={styles.tabIcon} /> {queue.name}{' '}
               {queue.indicator && <Indicator />}
+              <CountBadge count={queue.count} />
             </Link>
           ))}
         </div>

--- a/client/coral-admin/src/routes/Moderation/containers/Moderation.js
+++ b/client/coral-admin/src/routes/Moderation/containers/Moderation.js
@@ -486,11 +486,7 @@ const withModQueueQuery = withQuery(
       }
     `
     )}
-    ${
-      ''
-      /*
-     TODO: eventually we'll reintroduce counting..
-     Object.keys(queueConfig).map(
+    ${Object.keys(queueConfig).map(
       queue => `
       ${queue}Count: commentCount(query: {
         excludeDeleted: true,
@@ -512,8 +508,7 @@ const withModQueueQuery = withQuery(
         asset_id: $asset_id,
       })
     `
-    )*/
-    }
+    )}
     asset(id: $asset_id) @skip(if: $allAssets) {
       id
       title


### PR DESCRIPTION
https://github.com/coralproject/talk/pull/1618 removed the count badge on the navigation tabs.

this PR will bring them back.
i tested it on our comments (a snapshot of the DB a acouple of days ago) - and it does not seem to introduce a huge perf. issue.

![bildschirmfoto 2018-09-03 um 10 25 29](https://user-images.githubusercontent.com/2891702/44976161-9834fd00-af64-11e8-90c8-d1339251e28f.png)



any ideas why it was initially removed?
we really would ❤️  to have those counters back.

