### PR TITLE
External User Fix

### DIFF
--- a/services/users.js
+++ b/services/users.js
@@ -98,8 +98,12 @@ async function upsertUser(
   // Save the user in the database.
   await user.save();
 
-  // Emit that the user was created.
-  ctx.pubsub.publish('userCreated', user);
+  if (ctx) {
+    // Emit that the user was created if the context is set.
+    ctx.pubsub.publish('userCreated', user);
+  }
+
+  return user;
 }
 
 // Users is the interface for the application to interact with the

--- a/services/users.js
+++ b/services/users.js
@@ -68,6 +68,8 @@ async function upsertUser(
     },
   });
   if (user) {
+    user.wasUpserted = false;
+    user.$ignore('wasUpserted');
     return user;
   }
 
@@ -102,6 +104,10 @@ async function upsertUser(
     // Emit that the user was created if the context is set.
     ctx.pubsub.publish('userCreated', user);
   }
+
+  // Indicate that the user was upserted.
+  user.wasUpserted = true;
+  user.$ignore('wasUpserted');
 
   return user;
 }

--- a/test/server/services/users.js
+++ b/test/server/services/users.js
@@ -363,6 +363,58 @@ describe('services.UsersService', () => {
     });
   });
 
+  describe('#upsertExternalUser', () => {
+    it('should return a user when the desired user is found', async () => {
+      const ctx = Context.forSystem();
+      let user = await UsersService.upsertExternalUser(
+        ctx,
+        'an-id',
+        'a-provider',
+        'a-display-name'
+      );
+
+      expect(user).to.be.defined;
+      expect(user.wasUpserted).to.be.true;
+
+      user = await UsersService.upsertExternalUser(
+        ctx,
+        'an-id',
+        'a-provider',
+        'a-display-name'
+      );
+
+      expect(user).to.be.defined;
+      expect(user.wasUpserted).to.be.false;
+    });
+
+    it('should return a user when the desired user is not found', async () => {
+      const ctx = Context.forSystem();
+      let user = await UsersService.upsertExternalUser(
+        ctx,
+        'an-id',
+        'a-provider',
+        'a-display-name'
+      );
+
+      expect(user).to.be.defined;
+      expect(user.wasUpserted).to.be.true;
+      expect(user).to.have.property('metadata');
+      expect(user.metadata).to.have.property('displayName', 'a-display-name');
+    });
+
+    it('should work if the context passed is null', async () => {
+      let user = await UsersService.upsertExternalUser(
+        null,
+        'an-id',
+        'a-provider',
+        'a-display-name'
+      );
+
+      expect(user).to.be.defined;
+      expect(user.wasUpserted).to.be.true;
+    });
+  });
+
   describe('#isValidUsername', () => {
     it('should not allow non-alphanumeric characters in usernames', () => {
       return UsersService.isValidUsername('hi🖕')


### PR DESCRIPTION
## What does this PR do?

Returns the user when the user was not initially found, and optionally publishes to the graph context if it was non null.