### PR TITLE
[next] Integrate typescript-snapshots-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10226,11 +10226,8 @@
       "resolved": "https://registry.npmjs.org/fluent-intl-polyfill/-/fluent-intl-polyfill-0.1.0.tgz",
       "integrity": "sha1-ETOUSrJHeINHOZVZaIPg05z4hc8=",
       "dev": true,
-      "dependencies": {
-        "intl-pluralrules": {
-          "version": "github:projectfluent/IntlPluralRules#94cb0fa1c23ad943bc5aafef43cea132fa51d68b",
-          "from": "github:projectfluent/IntlPluralRules#94cb0fa1c23ad943bc5aafef43cea132fa51d68b"
-        }
+      "requires": {
+        "intl-pluralrules": "github:projectfluent/IntlPluralRules#94cb0fa1c23ad943bc5aafef43cea132fa51d68b"
       }
     },
     "fluent-langneg": {
@@ -12672,6 +12669,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "intl-pluralrules": {
+      "version": "github:projectfluent/IntlPluralRules#94cb0fa1c23ad943bc5aafef43cea132fa51d68b",
+      "from": "github:projectfluent/IntlPluralRules#module",
       "dev": true
     },
     "invariant": {
@@ -24532,6 +24534,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
       "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "dev": true
+    },
+    "typescript-snapshots-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typescript-snapshots-plugin/-/typescript-snapshots-plugin-1.2.0.tgz",
+      "integrity": "sha1-4rp5y0C3Vc4tUp6h5fYlMyd5T5g=",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "typeface-manuale": "0.0.54",
     "typeface-source-sans-pro": "0.0.54",
     "typescript": "^3.0.3",
+    "typescript-snapshots-plugin": "^1.2.0",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "webpack": "4.12.0",
     "webpack-cli": "^3.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,12 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "noErrorTruncation": true,
-    "lib": ["dom", "es6", "esnext.asynciterable"]
+    "lib": ["dom", "es6", "esnext.asynciterable"],
+    "plugins": [
+      {
+        "name": "typescript-snapshots-plugin"
+      }
+    ]
   },
   "include": [
     "./src/**/.*.js",


### PR DESCRIPTION
## What does this PR do?
- Integrate https://github.com/asvetliakov/typescript-snapshots-plugin a successor of the VSCode extension https://github.com/asvetliakov/snapshot-tools
- Fixes issue where naming a snapshot like `expect(testRenderer.toJSON()).toMatchSnapshot("custom name");` would not be found by `snapshot-tools`.

## How do I test this PR?

- Hover over `toMatchSnapshot`