### PR TITLE
Static ClassName for Featured Comments Tooltip

### DIFF
--- a/plugins/talk-plugin-featured-comments/client/components/Tooltip.js
+++ b/plugins/talk-plugin-featured-comments/client/components/Tooltip.js
@@ -5,7 +5,13 @@ import { t } from 'plugin-api/beta/client/services';
 import { Icon } from 'plugin-api/beta/client/components/ui';
 
 export default ({ className = '' }) => (
-  <div className={cn(styles.tooltip, className)}>
+  <div
+    className={cn(
+      styles.tooltip,
+      className,
+      'talk-plugin-featured-comments-tooltip'
+    )}
+  >
     <Icon name="info_outline" className={styles.icon} />
     <h3 className={styles.headline}>
       {t('talk-plugin-featured-comments.featured_comments')}:


### PR DESCRIPTION
## What does this PR do?
- Add static className to featured comments tooltip
