### PR TITLE
[next] Don't use css capitalize

### DIFF
--- a/src/core/client/auth/test/__snapshots__/navigation.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/navigation.spec.tsx.snap
@@ -140,7 +140,7 @@ exports[`navigates to sign in form 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -282,7 +282,7 @@ exports[`navigates to sign up form 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -397,7 +397,7 @@ exports[`renders sign in form 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"

--- a/src/core/client/auth/test/__snapshots__/signIn.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/signIn.spec.tsx.snap
@@ -95,7 +95,7 @@ exports[`accepts correct password 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -223,7 +223,7 @@ exports[`accepts valid email 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -364,7 +364,7 @@ exports[`checks for invalid email 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -479,7 +479,7 @@ exports[`renders sign in form 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -620,7 +620,7 @@ exports[`shows error when submitting empty form 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -735,7 +735,7 @@ exports[`shows server error 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -855,7 +855,7 @@ exports[`shows server error 2`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -970,7 +970,7 @@ exports[`submits form successfully 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -1085,7 +1085,7 @@ exports[`submits form successfully 2`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign in and join the conversation
+        Sign in to Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"

--- a/src/core/client/auth/test/__snapshots__/signUp.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/signUp.spec.tsx.snap
@@ -148,7 +148,7 @@ exports[`accepts correct password 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -342,7 +342,7 @@ exports[`accepts correct password confirmation 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -523,7 +523,7 @@ exports[`accepts valid email 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -704,7 +704,7 @@ exports[`accepts valid username 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -898,7 +898,7 @@ exports[`checks for invalid characters in username 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -1092,7 +1092,7 @@ exports[`checks for invalid email 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -1286,7 +1286,7 @@ exports[`checks for too long username 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -1480,7 +1480,7 @@ exports[`checks for too short password 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -1674,7 +1674,7 @@ exports[`checks for too short username 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -1868,7 +1868,7 @@ exports[`checks for wrong password confirmation 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -2010,7 +2010,7 @@ exports[`renders sign up form 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -2204,7 +2204,7 @@ exports[`shows error when submitting empty form 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -2346,7 +2346,7 @@ exports[`shows server error 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -2493,7 +2493,7 @@ exports[`shows server error 2`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -2635,7 +2635,7 @@ exports[`submits form successfully 1`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"
@@ -2777,7 +2777,7 @@ exports[`submits form successfully 2`] = `
         onTouchEnd={[Function]}
         type="submit"
       >
-        Sign up and join the conversation
+        Sign up and Join the Conversation
       </button>
       <div
         className="Flex-root Flex-flex Flex-justifyCenter"

--- a/src/core/client/stream/test/comments/__snapshots__/loadMore.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/__snapshots__/loadMore.spec.tsx.snap
@@ -135,7 +135,7 @@ exports[`loads more comments 1`] = `
           onTouchEnd={[Function]}
           type="submit"
         >
-          Sign in and join the conversation
+          Sign in and Join the Conversation
         </button>
       </div>
     </div>
@@ -480,7 +480,7 @@ exports[`renders comment stream 1`] = `
           onTouchEnd={[Function]}
           type="submit"
         >
-          Sign in and join the conversation
+          Sign in and Join the Conversation
         </button>
       </div>
     </div>
@@ -634,7 +634,7 @@ exports[`renders comment stream 1`] = `
         onTouchEnd={[Function]}
         type="button"
       >
-        Load more
+        Load More
       </button>
     </div>
   </div>

--- a/src/core/client/stream/test/comments/__snapshots__/permalinkView.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/__snapshots__/permalinkView.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders permalink view 1`] = `
       target="_parent"
       type="button"
     >
-      Show all comments
+      Show All Comments
     </a>
     <div
       className="Indent-root"
@@ -223,7 +223,7 @@ exports[`show all comments 1`] = `
           onTouchEnd={[Function]}
           type="submit"
         >
-          Sign in and join the conversation
+          Sign in and Join the Conversation
         </button>
       </div>
     </div>

--- a/src/core/client/stream/test/comments/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders permalink view with unknown comment 1`] = `
       target="_parent"
       type="button"
     >
-      Show all comments
+      Show All Comments
     </a>
     <p
       className="Typography-root Typography-bodyCopy Typography-colorTextPrimary"
@@ -167,7 +167,7 @@ exports[`show all comments 1`] = `
           onTouchEnd={[Function]}
           type="submit"
         >
-          Sign in and join the conversation
+          Sign in and Join the Conversation
         </button>
       </div>
     </div>

--- a/src/core/client/stream/test/comments/__snapshots__/renderReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/__snapshots__/renderReplies.spec.tsx.snap
@@ -135,7 +135,7 @@ exports[`renders comment stream 1`] = `
           onTouchEnd={[Function]}
           type="submit"
         >
-          Sign in and join the conversation
+          Sign in and Join the Conversation
         </button>
       </div>
     </div>

--- a/src/core/client/stream/test/comments/__snapshots__/renderStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/__snapshots__/renderStream.spec.tsx.snap
@@ -135,7 +135,7 @@ exports[`renders comment stream 1`] = `
           onTouchEnd={[Function]}
           type="submit"
         >
-          Sign in and join the conversation
+          Sign in and Join the Conversation
         </button>
       </div>
     </div>

--- a/src/core/client/stream/test/comments/__snapshots__/showAllReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/__snapshots__/showAllReplies.spec.tsx.snap
@@ -135,7 +135,7 @@ exports[`renders comment stream 1`] = `
           onTouchEnd={[Function]}
           type="submit"
         >
-          Sign in and join the conversation
+          Sign in and Join the Conversation
         </button>
       </div>
     </div>
@@ -292,7 +292,7 @@ exports[`renders comment stream 1`] = `
               onTouchEnd={[Function]}
               type="button"
             >
-              Show all
+              Show All
             </button>
           </div>
         </div>
@@ -437,7 +437,7 @@ exports[`show all replies 1`] = `
           onTouchEnd={[Function]}
           type="submit"
         >
-          Sign in and join the conversation
+          Sign in and Join the Conversation
         </button>
       </div>
     </div>

--- a/src/core/client/ui/components/BaseButton/BaseButton.css
+++ b/src/core/client/ui/components/BaseButton/BaseButton.css
@@ -1,6 +1,5 @@
 .root {
   composes: buttonReset from "talk-ui/shared/buttonReset.css";
-  text-transform: capitalize;
 }
 
 .keyboardFocus {

--- a/src/locales/en-US/auth.ftl
+++ b/src/locales/en-US/auth.ftl
@@ -4,7 +4,7 @@
 
 signIn-signInToJoinHeader = Sign in to join the conversation
 
-signIn-signInAndJoinButton = Sign in and join the conversation
+signIn-signInAndJoinButton = Sign in to Join the Conversation
 
 signIn-emailAddressLabel = Email Address
 signIn-emailAddressTextField =
@@ -22,7 +22,7 @@ signIn-noAccountSignUp = Don't have an account? <button>Sign Up</button>
 
 signUp-signUpToJoinHeader = Sign up to join the conversation
 
-signUp-signUpAndJoinButton = Sign up and join the conversation
+signUp-signUpAndJoinButton = Sign up and Join the Conversation
 
 signUp-emailAddressLabel = Email Address
 signUp-emailAddressTextField =

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -17,13 +17,13 @@ general-userBoxAuthenticated-notYou =
 comments-streamQuery-assetNotFound = Asset not found
 
 comments-postCommentForm-submit = Submit
-comments-stream-loadMore = Load more
-comments-replyList-showAll = Show all
+comments-stream-loadMore = Load More
+comments-replyList-showAll = Show All
 
 comments-permalinkButton-share = Share
 comments-permalinkPopover-copy = Copy
 comments-permalinkPopover-copied = Copied
-comments-permalinkView-showAllComments = Show all comments
+comments-permalinkView-showAllComments = Show All Comments
 comments-permalinkView-commentNotFound = Comment not found
 
 comments-rte-bold =
@@ -37,7 +37,7 @@ comments-rte-blockquote =
 
 comments-poweredBy = Powered by <logo>{ -brand-name }</logo>
 
-comments-postCommentFormFake-signInAndJoin = Sign in and join the conversation
+comments-postCommentFormFake-signInAndJoin = Sign in and Join the Conversation
 
 comments-postCommentForm-rteLabel = Post a comment
 


### PR DESCRIPTION
## What does this PR do?
- https://www.pivotaltracker.com/story/show/160100255
- Manually capitalize titles which is more accurate than using `text-transform: capitalize;`

## How do I test this PR?
- Buttons should have manually capitalized titles :-)
