### PR TITLE
Static URI + Social Callback bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "A better commenting experience from Mozilla, The New York Times, and the Washington Post. https://coralproject.net",
   "main": "app.js",
   "private": true,

--- a/services/passport.js
+++ b/services/passport.js
@@ -97,6 +97,11 @@ const HandleGenerateCredentials = (req, res, next) => (err, user) => {
   res.json({ user, token });
 };
 
+const generateAuthPopupCallbackCSP = req =>
+  req.locals.STATIC_URL && req.locals.BASE_URL !== req.locals.STATIC_URL
+    ? `default-src 'self' ${req.locals.STATIC_URL};`
+    : "default-src 'self';";
+
 /**
  * Returns the response to the login attempt via a popup callback with some JS.
  */
@@ -106,7 +111,7 @@ const HandleAuthPopupCallback = (req, res, next) => (err, user) => {
   res.header('Pragma', 'no-cache');
 
   // Ensure the only scripts that can run here are those on the Talk domain.
-  res.header('Content-Security-Policy', "default-src 'self';");
+  res.header('Content-Security-Policy', generateAuthPopupCallbackCSP(req));
 
   // Attach static locals to the response locals object.
   attachStaticLocals(res.locals);


### PR DESCRIPTION
## What does this PR do?

Adds support for the [TALK_STATIC_URI](https://docs.coralproject.net/talk/advanced-configuration/#talk-static-uri) on social callbacks.