### PR TITLE
Body Count

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -343,6 +343,20 @@ class ErrCommentTooShort extends TalkError {
   }
 }
 
+// ErrCommentTooLong is returned when the comment is too long.
+class ErrCommentTooLong extends TalkError {
+  constructor(length, allowed) {
+    super(
+      'Comment was too long',
+      {
+        translation_key: 'COMMENT_TOO_LONG',
+        status: 400,
+      },
+      { length, allowed }
+    );
+  }
+}
+
 // ErrAssetURLAlreadyExists is returned when a rename operation is requested
 // but an asset already exists with the new url.
 class ErrAssetURLAlreadyExists extends TalkError {
@@ -413,13 +427,15 @@ module.exports = {
   ErrAssetURLAlreadyExists,
   ErrAuthentication,
   ErrCannotIgnoreStaff,
-  ErrCommentTooShort,
   ErrCommentingDisabled,
+  ErrCommentTooLong,
+  ErrCommentTooShort,
   ErrContainsProfanity,
   ErrEditWindowHasEnded,
   ErrEmailAlreadyVerified,
   ErrEmailTaken,
   ErrEmailVerificationToken,
+  ErrHTTPNotFound,
   ErrInstallLock,
   ErrInvalidAssetURL,
   ErrLoginAttemptMaximumExceeded,
@@ -441,5 +457,4 @@ module.exports = {
   ErrSpecialChars,
   ErrUsernameTaken,
   ExtendableError,
-  ErrHTTPNotFound,
 };

--- a/locales/ar.yml
+++ b/locales/ar.yml
@@ -225,6 +225,7 @@ ar:
     CANNOT_IGNORE_STAFF: 'لا يمكن تجاهل الموظفين.'
     COMMENT_PARENT_NOT_VISIBLE: 'التعليق الذي ترد عليه تمت إزالته أو غير موجود.'
     COMMENT_TOO_SHORT: 'يجب أن تكون التعليقات أكثر من حرف واحد، يرجى مراجعة تعليقك وإعادة المحاولة.'
+    COMMENT_TOO_LONG: 'يتجاوز النص الحد الأقصى للطول المسموح'
     COMMENTING_CLOSED: 'تم إغلاق فاعلية التعليق'
     COMMENTING_DISABLED: 'التعليق معطّل حاليًا على هذا الموقع'
     confirm_password: 'كلمات المرور غير متطابقة. يرجى التحقق مرة أخرى'
@@ -281,7 +282,6 @@ ar:
     reasons:
       comment:
         banned_word: 'كلمة محظورة'
-        body_count: 'يتجاوز النص الحد الأقصى للطول المسموح'
         comment_noagree: أعارض
         comment_offensive: مسيء
         comment_other: آخر

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -197,6 +197,7 @@ da:
     CANNOT_IGNORE_STAFF: 'Kan ikke ignorere personale.'
     COMMENT_PARENT_NOT_VISIBLE: 'Den kommentar, du svarer på er blevet fjernet eller eksisterer ikke.'
     COMMENT_TOO_SHORT: 'Din kommentar skal indeholde noget'
+    COMMENT_TOO_LONG: 'Body overstiger max længde'
     COMMENTING_CLOSED: 'Kommentering er allerede lukket'
     confirm_password: 'Kodeordene matcher ikke. Tjek venligst igen.'
     EDIT_USERNAME_NOT_AUTHORIZED: 'Du har ikke tilladelse til at opdatere dit brugernavn.'
@@ -238,7 +239,6 @@ da:
     reasons:
       comment:
         banned_word: 'Forbudt ord'
-        body_count: 'Body overstiger max længde'
         comment_noagree: Uenig
         comment_offensive: Offensiv
         comment_other: Andre

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -224,6 +224,7 @@ de:
     CANNOT_IGNORE_STAFF: 'Mitarbeiter können nicht ignoriert werden.'
     COMMENT_PARENT_NOT_VISIBLE: 'Der Kommentar, auf den Sie antworten möchten, wurde entfernt oder existiert nicht.'
     COMMENT_TOO_SHORT: 'Kommentare sollten mehr als ein Zeichen enthalten, bitte überprüfen Sie Ihren Kommentar und probieren Sie es erneut.'
+    COMMENT_TOO_LONG: 'Text überschreitet Zeichenlimit'
     COMMENTING_CLOSED: 'Kommentarbereich ist bereits geschlossen'
     COMMENTING_DISABLED: 'Die Kommentarfunktion ist derzeit abgeschaltet'
     confirm_password: 'Passwörter nicht identisch. Bitte erneut überprüfen'
@@ -273,7 +274,6 @@ de:
     reasons:
       comment:
         banned_word: 'Unzulässiges Wort'
-        body_count: 'Text überschreitet Zeichenlimit'
         comment_noagree: 'Andere Meinung'
         comment_offensive: Unangemessen
         comment_other: Anderes

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -229,6 +229,7 @@ en:
     CANNOT_IGNORE_STAFF: 'Cannot ignore Staff members.'
     COMMENT_PARENT_NOT_VISIBLE: 'The comment that you''re replying to has been removed or doesn''t exist.'
     COMMENT_TOO_SHORT: 'Comments should be more than one character, please revise your comment and try again.'
+    COMMENT_TOO_LONG: 'Body exceeds max length'
     COMMENTING_CLOSED: 'Commenting is already closed'
     COMMENTING_DISABLED: 'Commenting is currently disabled on this site'
     confirm_password: 'Passwords don''t match. Please check again'
@@ -286,7 +287,6 @@ en:
     reasons:
       comment:
         banned_word: 'Banned Word'
-        body_count: 'Body exceeds max length'
         comment_noagree: Disagree
         comment_offensive: Offensive
         comment_other: Other

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -215,6 +215,7 @@ es:
     CANNOT_IGNORE_STAFF: 'No puede ignorar a miembros del Staff.'
     COMMENT_PARENT_NOT_VISIBLE: 'El comentario a la que estás contestando ha sido eliminado o no existe.'
     COMMENT_TOO_SHORT: 'Tu comentario debe tener algo escrito'
+    COMMENT_TOO_LONG: 'El texto exede el límite permitido'
     COMMENTING_CLOSED: 'Los comentarios ya estan cerrados'
     confirm_password: 'Las contraseñas no coinciden. Inténtelo nuevamente'
     EDIT_USERNAME_NOT_AUTHORIZED: 'No tiene permiso para editar el nombre de usuario.'
@@ -260,7 +261,6 @@ es:
     reasons:
       comment:
         banned_word: 'Palabra prohibida'
-        body_count: 'El texto exede el límite permitido'
         comment_noagree: 'No está de acuerdo'
         comment_offensive: 'Es ofensivo'
         comment_other: 'Otra razón'

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -215,7 +215,7 @@ es:
     CANNOT_IGNORE_STAFF: 'No puede ignorar a miembros del Staff.'
     COMMENT_PARENT_NOT_VISIBLE: 'El comentario a la que estás contestando ha sido eliminado o no existe.'
     COMMENT_TOO_SHORT: 'Tu comentario debe tener algo escrito'
-    COMMENT_TOO_LONG: 'El texto exede el límite permitido'
+    COMMENT_TOO_LONG: 'El texto excede el límite permitido'
     COMMENTING_CLOSED: 'Los comentarios ya estan cerrados'
     confirm_password: 'Las contraseñas no coinciden. Inténtelo nuevamente'
     EDIT_USERNAME_NOT_AUTHORIZED: 'No tiene permiso para editar el nombre de usuario.'

--- a/locales/fi_FI.yml
+++ b/locales/fi_FI.yml
@@ -197,6 +197,7 @@ fi_FI:
     CANNOT_IGNORE_STAFF: 'Työntekijöitä ei voi jättää huomioimatta'
     COMMENT_PARENT_NOT_VISIBLE: 'Kommenttia, johon yrität vastata, ei enää ole.'
     COMMENT_TOO_SHORT: 'Kommentin tulee olla vähintään kaksi merkkiä pitkä. Tarkista kirjoittamasi teksti.'
+    COMMENT_TOO_LONG: Liian pitkä viesti'
     COMMENTING_CLOSED: 'Kommentointi on suljettu'
     confirm_password: 'Salasanat eivät täsmää. Tarkista, ole hyvä.'
     EDIT_USERNAME_NOT_AUTHORIZED: 'Sinulla ei ole oikeutta päivittää tai muokata käyttäjänimeä.'
@@ -240,7 +241,6 @@ fi_FI:
     reasons:
       comment:
         banned_word: 'Kielletty sana'
-        body_count: 'Liian pitkä viesti'
         comment_noagree: 'Olen eri mieltä'
         comment_offensive: Loukkaava
         comment_other: Muu

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -191,6 +191,7 @@ fr:
     CANNOT_IGNORE_STAFF: 'Ne peut pas ignorer les membres de l''équipe.'
     COMMENT_PARENT_NOT_VISIBLE: 'Le commentaire auquel vous répondez a été supprimé ou n’existe plus.'
     COMMENT_TOO_SHORT: 'Votre commentaire doit contenir quelque chose'
+    COMMENT_TOO_LONG: 'Le texte dépasse la longueur maximale'
     COMMENTING_CLOSED: 'Les commentaires sont déjà fermés'
     confirm_password: 'Les mots de passe ne correspondent pas. Vérifiez à nouveau'
     EDIT_USERNAME_NOT_AUTHORIZED: 'Vous n''avez pas la permission de mettre à jour votre nom d''utilisateur.'
@@ -235,7 +236,6 @@ fr:
     reasons:
       comment:
         banned_word: 'Mot banni'
-        body_count: 'Le texte dépasse la longueur maximale'
         comment_noagree: 'Pas d’accord'
         comment_offensive: Offensive
         comment_other: Autre

--- a/locales/nl_NL.yml
+++ b/locales/nl_NL.yml
@@ -197,6 +197,7 @@ nl_NL:
     CANNOT_IGNORE_STAFF: 'Kan geen Staff-leden negeren.'
     COMMENT_PARENT_NOT_VISIBLE: 'De reactie waarop je probeert te reageren bestaat niet of is inmiddels verwijderd.'
     COMMENT_TOO_SHORT: 'Reacties moeten meer dan één teken hebben. Herzie je reactie en probeer opnieuw.'
+    COMMENT_TOO_LONG: 'Tekst is te lang'
     COMMENTING_CLOSED: 'Reageren is al afgesloten.'
     confirm_password: 'Wachtwoorden komen niet overeen. Controleer opnieuw.'
     EDIT_USERNAME_NOT_AUTHORIZED: 'Je bent niet gemachtigd om je gebruikersnaam te wijzigen.'
@@ -239,7 +240,6 @@ nl_NL:
     reasons:
       comment:
         banned_word: 'Geblokeerd woord'
-        body_count: 'Tekst is te lang'
         comment_noagree: 'Niet eens'
         comment_offensive: Aanstootgevend
         comment_other: Anders

--- a/services/moderation/phases/commentLength.js
+++ b/services/moderation/phases/commentLength.js
@@ -1,4 +1,4 @@
-const { ErrCommentTooShort } = require('../../../errors');
+const { ErrCommentTooShort, ErrCommentTooLong } = require('../../../errors');
 
 // This phase checks to see if the comment is long enough.
 module.exports = (
@@ -17,19 +17,6 @@ module.exports = (
 
   // Reject if the comment is too long
   if (charCountEnable && comment.body.length > charCount) {
-    // Add the flag related to Trust to the comment.
-    return {
-      status: 'REJECTED',
-      actions: [
-        {
-          action_type: 'FLAG',
-          user_id: null,
-          group_id: 'BODY_COUNT',
-          metadata: {
-            count: comment.body.length,
-          },
-        },
-      ],
-    };
+    throw new ErrCommentTooLong(comment.body.length, charCount);
   }
 };


### PR DESCRIPTION
## What does this PR do?

Adjusts the behavior when a comment exceeds the maximum length, preventing it from being committed at all.

## How do I test this PR?

1. In the admin (/admin/configure/stream), ensure that the `Limit Comment Length` is unchecked, and saved.
2. In another browser, open the stream (/dev), and login as another user.
3. Back in the admin browser/tab, check the box for comment length, setting it to `5`
4. In the user tab, submit the comment `123456`, and see the error on the stream page indicating the comment length was exceeded.
5. In the admin tab, notice that the comment does not appear int he moderation screen.