### PR TITLE
Toxic Comments Plugin logging

### DIFF
--- a/plugins/talk-plugin-toxic-comments/package.json
+++ b/plugins/talk-plugin-toxic-comments/package.json
@@ -7,6 +7,7 @@
   "author": "The Coral Project Team <coral@mozillafoundation.org>",
   "license": "Apache-2.0",
   "dependencies": {
+    "debug": "^4.0.1",
     "ms": "^2.0.0"
   }
 }

--- a/plugins/talk-plugin-toxic-comments/server/hooks.js
+++ b/plugins/talk-plugin-toxic-comments/server/hooks.js
@@ -1,5 +1,6 @@
 const { getScores, isToxic } = require('./perspective');
 const { ErrToxic } = require('./errors');
+const debug = require('debug')('talk:plugin:toxic-comments');
 
 function handlePositiveToxic(input) {
   input.status = 'SYSTEM_WITHHELD';
@@ -20,7 +21,7 @@ async function getScore(body) {
     scores = await getScores(body);
   } catch (err) {
     // Warn and let mutation pass.
-    console.trace(err); // TODO: log/handle this differently?
+    debug('Error sending to API: %o', err);
     return;
   }
 

--- a/plugins/talk-plugin-toxic-comments/server/perspective.js
+++ b/plugins/talk-plugin-toxic-comments/server/perspective.js
@@ -28,7 +28,6 @@ async function getScores(text) {
         comment: {
           text,
         },
-
         // TODO: support other languages.
         languages: ['en'],
         doNotStore: DO_NOT_STORE,
@@ -39,28 +38,30 @@ async function getScores(text) {
       }),
     }
   );
+
   const data = await response.json();
 
   // If we get an error, just say it's not a toxic comment.
-  let retData = {
-    TOXICITY: {
-      summaryScore: 0.0,
-    },
-    SEVERE_TOXICITY: {
-      summaryScore: 0.0,
-    },
-  };
-
   if (data.error) {
     debug('Recieved Error when submitting: %o', data.error);
-  } else {
-    retData.TOXICITY.summaryScore =
-      data.attributeScores.TOXICITY.summaryScore.value;
-    retData.SEVERE_TOXICITY.summaryScore =
-      data.attributeScores.SEVERE_TOXICITY.summaryScore.value;
+    return {
+      TOXICITY: {
+        summaryScore: 0.0,
+      },
+      SEVERE_TOXICITY: {
+        summaryScore: 0.0,
+      },
+    };
   }
 
-  return retData;
+  return {
+    TOXICITY: {
+      summaryScore: data.attributeScores.TOXICITY.summaryScore.value,
+    },
+    SEVERE_TOXICITY: {
+      summaryScore: data.attributeScores.SEVERE_TOXICITY.summaryScore.value,
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

This adds debug logging to the toxic-comments plugin. This was particularly useful for us to see what data Talk was actually sending to Google, as well as erroring cleanly when we gave a fake API key.

## How do I test this PR?

Add the toxic-comments plugin and then set your env vars to `TALK_PERSPECTIVE_API_KEY="FAKEKEYTOREPLACE"`
