### PR TITLE
do not show admin drawer unless user has access

### DIFF
--- a/client/coral-admin/src/components/Drawer.js
+++ b/client/coral-admin/src/components/Drawer.js
@@ -7,9 +7,9 @@ import t from 'coral-framework/services/i18n';
 import { can } from 'coral-framework/services/perms';
 import cn from 'classnames';
 
-const CoralDrawer = ({ handleLogout, currentUser }) => (
-  <Drawer className={cn('talk-admin-drawer-nav', styles.drawer)}>
-    {currentUser && can(currentUser, 'ACCESS_ADMIN') ? (
+const CoralDrawer = ({ handleLogout, currentUser }) =>
+  currentUser && can(currentUser, 'ACCESS_ADMIN') ? (
+    <Drawer className={cn('talk-admin-drawer-nav', styles.drawer)}>
       <div>
         <Navigation className={styles.nav}>
           {can(currentUser, 'MODERATE_COMMENTS') && (
@@ -48,9 +48,8 @@ const CoralDrawer = ({ handleLogout, currentUser }) => (
           <span>{`v${process.env.VERSION}`}</span>
         </Navigation>
       </div>
-    ) : null}
-  </Drawer>
-);
+    </Drawer>
+  ) : null;
 
 CoralDrawer.propTypes = {
   handleLogout: PropTypes.func.isRequired,

--- a/test/e2e/page_objects/admin.js
+++ b/test/e2e/page_objects/admin.js
@@ -30,6 +30,10 @@ module.exports = {
           .waitForElementVisible('@signOutButton')
           .click('@signOutButton');
       },
+      login(user) {
+        this.expect.section('@login').to.be.visible;
+        return this.section.login.login(user);
+      },
       navigateAndLogin(user) {
         this.navigate().expect.section('@login').to.be.visible;
         return this.section.login.login(user);

--- a/test/e2e/specs/02_admin.js
+++ b/test/e2e/specs/02_admin.js
@@ -20,13 +20,18 @@ module.exports = {
     client.end();
   },
 
+  'Admin goes to login': client => {
+    const adminPage = client.page.admin();
+    adminPage.navigate().expect.element('drawerButton').to.not.be.present;
+  },
+
   'Admin logs in': client => {
     const adminPage = client.page.admin();
     const {
       testData: { admin },
     } = client.globals;
 
-    adminPage.navigateAndLogin(admin);
+    adminPage.login(admin);
   },
 
   'Admin goes to Stories': client => {


### PR DESCRIPTION
Fixes https://github.com/coralproject/talk/issues/1791

## What does this PR do?
It does not render the admin drawer menu unless the user is logged in and has access. This prevents a blank menu from being visible.

## How do I test this PR?

The end-to-end tests have been updated to check for this change.
