### PR TITLE
Display avatar left of comments by default

### DIFF
--- a/client/coral-embed-stream/src/tabs/stream/components/Comment.css
+++ b/client/coral-embed-stream/src/tabs/stream/components/Comment.css
@@ -138,6 +138,7 @@
 }
 
 .commentAvatar {
+  margin-top: 10px;
   max-width: 60px;
 }
 

--- a/client/coral-embed-stream/style/default.css
+++ b/client/coral-embed-stream/style/default.css
@@ -112,6 +112,11 @@ body {
   position: relative;
 }
 
+.talk-stream-comment {
+  display: flex;
+  flex-direction: row;
+}
+
 /* Comment styles */
 .comment {
   margin-bottom: 10px;


### PR DESCRIPTION
## What does this PR do?

Previously avatars would be displayed on top of comments. Most comment and forum systems will by default display avatars to the left of comments/posts. The https://github.com/snorremd/talk-plugin-gravatar plugin currently renders avatars in the avatar slot which will render the avatar on top of the comments. This change modified the comment container to be displayed as a flex container with row direction. It also adds 10px top margin to the avatar slot which corresponds with the comment header.

I made this pull request because I could not find a way to make the avatar float left from inside the avatar slot. Users of https://github.com/snorremd/talk-plugin-gravatar would have to add a custom style sheet to the talk configuration to accomplish this behaviour. I think presenting the avatar on the left side of the comment makes more sense as default.

If there is a way to achieve this behaviour without modifying Talk's css or configuring the styling with an external css file, please feel free to close this pull request. I opted to not set a `margin-right` on the avatar as avatar plugins can add padding themselves.

## How do I test this PR?

- Set up development environment of talk
- Add `{"talk-plugin-gravatar": "^0.1.3"}` to `plugins.default.json` server and client
- Post some comments
- See that avatars are rendered on the left side of comments.
