### PR TITLE
Keep Question Box visible after stream is closed #1939

### DIFF
--- a/client/coral-embed-stream/src/tabs/stream/components/Stream.js
+++ b/client/coral-embed-stream/src/tabs/stream/components/Stream.js
@@ -305,6 +305,14 @@ class Stream extends React.Component {
             ) : (
               <Markdown content={asset.settings.disableCommentingMessage} />
             )}
+            {questionBoxEnable && (
+              <QuestionBox
+                content={asset.settings.questionBoxContent}
+                icon={asset.settings.questionBoxIcon}
+              >
+                <Slot fill="streamQuestionArea" passthrough={slotPassthrough} />
+              </QuestionBox>
+            )}
           </div>
         )}
 

--- a/client/coral-embed-stream/src/tabs/stream/components/Stream.js
+++ b/client/coral-embed-stream/src/tabs/stream/components/Stream.js
@@ -206,15 +206,30 @@ class Stream extends React.Component {
     );
   }
 
+  renderQuestionBox() {
+    const {
+      root,
+      asset,
+      asset: {
+        settings: { questionBoxEnable, questionBoxContent, questionBoxIcon },
+      },
+    } = this.props;
+    const slotPassthrough = { root, asset };
+    if (questionBoxEnable) {
+      return (
+        <QuestionBox content={questionBoxContent} icon={questionBoxIcon}>
+          <Slot fill="streamQuestionArea" passthrough={slotPassthrough} />
+        </QuestionBox>
+      );
+    }
+  }
+
   render() {
     const {
       root,
       appendItemArray,
       asset,
-      asset: {
-        comment: highlightedComment,
-        settings: { questionBoxEnable },
-      },
+      asset: { comment: highlightedComment },
       postComment,
       notify,
       updateItem,
@@ -260,14 +275,7 @@ class Stream extends React.Component {
               content={asset.settings.infoBoxContent}
               enable={asset.settings.infoBoxEnable}
             />
-            {questionBoxEnable && (
-              <QuestionBox
-                content={asset.settings.questionBoxContent}
-                icon={asset.settings.questionBoxIcon}
-              >
-                <Slot fill="streamQuestionArea" passthrough={slotPassthrough} />
-              </QuestionBox>
-            )}
+            {this.renderQuestionBox()}
             {!banned &&
               temporarilySuspended && (
                 <RestrictedMessageBox>
@@ -305,14 +313,7 @@ class Stream extends React.Component {
             ) : (
               <Markdown content={asset.settings.disableCommentingMessage} />
             )}
-            {questionBoxEnable && (
-              <QuestionBox
-                content={asset.settings.questionBoxContent}
-                icon={asset.settings.questionBoxIcon}
-              >
-                <Slot fill="streamQuestionArea" passthrough={slotPassthrough} />
-              </QuestionBox>
-            )}
+            {this.renderQuestionBox()}
           </div>
         )}
 


### PR DESCRIPTION
## What does this PR do?

Addresses issue #1939 - Keeps the Question Box visible at the top of a comment stream after the stream is closed.