### PR TITLE
Base64 Secret Encoding

### DIFF
--- a/docs/source/02-02-advanced-configuration.md
+++ b/docs/source/02-02-advanced-configuration.md
@@ -246,6 +246,21 @@ Refer to the documentation for [TALK_JWT_ALG](#talk-jwt-alg) for other signing
 methods and other forms of the `TALK_JWT_SECRET`. If you are interested in using
 multiple keys, then refer to [TALK_JWT_SECRETS](#talk-jwt-secrets).
 
+You can also encode your secret as a base64 string (if you are using a symmetric
+algorithm) as long as you prefix it with `base64:`. For example:
+
+```plain
+TALK_JWT_SECRET={"secret": "base64:dGVzdA=="}
+```
+
+Would be the same as:
+
+```plain
+TALK_JWT_SECRET={"secret": "test"}
+```
+
+As `dGVzdA==` is just `test` encoded using base64.
+
 ## TALK_JWT_SECRETS
 
 Used when specifying multiple secrets used for key rotations. This is a JSON
@@ -271,7 +286,6 @@ Note that the secret is stored in a JSON object, keyed by `secret`. This is only
 needed when specifying in the multiple secrets for `TALK_JWT_SECRETS`, but may
 be used to specify the single [TALK_JWT_SECRET](#talk-jwt-secret).
 
-
 When the value of [TALK_JWT_ALG](#talk-jwt-alg) is **not** a `HS*` value, then
 the value of the `TALK_JWT_SECRETS` should take the form:
 
@@ -281,7 +295,6 @@ TALK_JWT_SECRETS=[{"kid": "1", "private": "<my private key>", "public": "<my pub
 
 Refer to the documentation on the [TALK_JWT_ALG](#talk-jwt-alg) for more
 information on what to store in these parameters.
-
 
 ## TALK_JWT_SIGNING_COOKIE_NAME
 

--- a/services/jwt.js
+++ b/services/jwt.js
@@ -122,7 +122,7 @@ function SharedSecret({ kid = undefined, secret = null }, algorithm) {
 
   // If the secret is base64 encoded, then decode it!
   if (secret.startsWith('base64:')) {
-    secret = Buffer.from(secret.substring(6), 'base64').toString();
+    secret = Buffer.from(secret.substring(7), 'base64').toString();
   }
 
   return new Secret({

--- a/services/jwt.js
+++ b/services/jwt.js
@@ -120,6 +120,11 @@ function SharedSecret({ kid = undefined, secret = null }, algorithm) {
     throw new Error('Secret cannot have a zero length');
   }
 
+  // If the secret is base64 encoded, then decode it!
+  if (secret.startsWith('base64:')) {
+    secret = Buffer.from(secret.substring(6), 'base64').toString();
+  }
+
   return new Secret({
     kid,
     signingKey: secret,


### PR DESCRIPTION
## What does this PR do?

Added base64 encoding option for symmetric secrets.

## How do I test this PR?

1. Set `TALK_JWT_SECRET=base64:dGVzdA==` as your secret.
2. Start the server, try and login and do a few actions.
3. Stop the server.
4. Change the `TALK_JWT_SECRET` to `test` as `TALK_JWT_SECRET=test`
5. Start the server, and try to do a few more actions, notice that the old token still works!

This is because the token that was issued before, is actually signed with the same secret, the first time however, encoded in base64!