### PR TITLE
Visible validation errors in the username change box

### DIFF
--- a/plugins/talk-plugin-local-auth/client/components/Profile.js
+++ b/plugins/talk-plugin-local-auth/client/components/Profile.js
@@ -232,6 +232,7 @@ class Profile extends React.Component {
                   validationType="username"
                   disabled={!usernameCanBeUpdated}
                   columnDisplay
+                  errorMsg={this.state.errors.newUsername}
                 >
                   <div className={styles.bottomText}>
                     <span>


### PR DESCRIPTION
Fixes: #1924 

## What does this PR do?
Added error message to profile tab in embedded comments for when disallowed characters are added while changing the username.

![formvalidation](https://user-images.githubusercontent.com/13480136/47268479-51be5080-d55a-11e8-8b31-d15856438190.png)

## How do I test this PR?
- log in to the embedded comments section
- open the profile tab
- click edit profile
- try to add special characters to the username box
