### PR TITLE
Revert CSS from #1990

### DIFF
--- a/client/coral-embed-stream/style/default.css
+++ b/client/coral-embed-stream/style/default.css
@@ -112,11 +112,6 @@ body {
   position: relative;
 }
 
-.talk-stream-comment {
-  display: flex;
-  flex-direction: row;
-}
-
 /* Comment styles */
 .comment {
   margin-bottom: 10px;


### PR DESCRIPTION
CSS changes here impact comment threading when avatar is not in use: https://github.com/coralproject/talk/pull/1990

Reverting these until changes are addressed.