### PR TITLE
Fix add email dialog cutoff

### DIFF
--- a/plugins/talk-plugin-local-auth/client/containers/AddEmailAddressDialog.js
+++ b/plugins/talk-plugin-local-auth/client/containers/AddEmailAddressDialog.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
 
 import PropTypes from 'prop-types';
 import { compose, gql } from 'react-apollo';
@@ -25,12 +24,14 @@ class AddEmailAddressDialog extends React.Component {
 
   componentDidMount() {
     this.props.startAttach();
-    document.body.style.minHeight =
-      `${document.getElementById('talk-plugin-local-auth-email-dialog').clientHeight}px`
+    document.body.style.minHeight = `${
+      document.getElementById('talk-plugin-local-auth-email-dialog')
+        .clientHeight
+    }px`;
   }
 
   componentWillUnmount() {
-    document.body.style.removeProperty("min-height");
+    document.body.style.removeProperty('min-height');
   }
 
   handleDone = () => {

--- a/plugins/talk-plugin-local-auth/client/containers/AddEmailAddressDialog.js
+++ b/plugins/talk-plugin-local-auth/client/containers/AddEmailAddressDialog.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { findDOMNode } from 'react-dom';
+
 import PropTypes from 'prop-types';
 import { compose, gql } from 'react-apollo';
 import { bindActionCreators } from 'redux';
@@ -23,6 +25,12 @@ class AddEmailAddressDialog extends React.Component {
 
   componentDidMount() {
     this.props.startAttach();
+    document.body.style.minHeight =
+      `${document.getElementById('talk-plugin-local-auth-email-dialog').clientHeight}px`
+  }
+
+  componentWillUnmount() {
+    document.body.style.removeProperty("min-height");
   }
 
   handleDone = () => {
@@ -63,7 +71,7 @@ class AddEmailAddressDialog extends React.Component {
     } = this.props;
 
     return (
-      <Dialog open={true}>
+      <Dialog open={true} id="talk-plugin-local-auth-email-dialog">
         {step === 0 && <AddEmailForm onSubmit={this.handleSubmit} />}
         {step === 1 &&
           !requireEmailConfirmation && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3319,13 +3319,6 @@ debug@2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.1:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
-  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
-  dependencies:
-    ms "^2.1.1"
-
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"


### PR DESCRIPTION
## What does this PR do?
- Fixes https://www.pivotaltracker.com/story/show/161737173

## How do I test this PR?

- Enable facebook login
- Goto an empty asset / story
- Create account with facebook
- See add email dialog is fully visible
