### PR TITLE
Fix IE11 issues in Admin

### DIFF
--- a/client/coral-admin/src/index.js
+++ b/client/coral-admin/src/index.js
@@ -14,6 +14,11 @@ import { hideShortcutsNote } from './actions/moderation';
 
 smoothscroll.polyfill();
 
+if (!NodeList.prototype.forEach) {
+  // Polyfill IE11 missing forEach in NodeList.
+  NodeList.prototype.forEach = Array.prototype.forEach;
+}
+
 function init({ store, localStorage }) {
   const shouldHide = localStorage.getItem('coral:shortcutsNote') === 'hide';
   if (shouldHide) {

--- a/client/coral-admin/src/routes/Moderation/components/Comment.css
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.css
@@ -68,7 +68,12 @@
   margin-top: 0px;
   flex: 1;
   color: black;
-  max-width: 500px;
+  /*
+    IE11 fix – Next line was supposed to be:
+    max-width: 500px;
+  */
+  padding-right: 20px;
+  /** IE11 fix end **/
   font-weight: 300;
   font-size: 16px;
   overflow-wrap: break-word;


### PR DESCRIPTION
## What does this PR do?
- Fixes https://github.com/coralproject/talk/issues/2037
- https://www.pivotaltracker.com/story/show/161655050
- Fixes a rendering bug where the approve / reject buttons would disappear in IE11..

## How do I test this PR?

- Use IE11
- Enable `talk-plugin-rich-text`
- Post a comment
- Go to moderation and moderate a comment
- Above step should work without errors
