### PR TITLE
[next] Moderation Edge

### DIFF
--- a/src/core/server/graph/tenant/resolvers/AcceptCommentPayload.ts
+++ b/src/core/server/graph/tenant/resolvers/AcceptCommentPayload.ts
@@ -1,0 +1,7 @@
+import { GQLAcceptCommentPayloadTypeResolver } from "talk-server/graph/tenant/schema/__generated__/types";
+
+import { moderationQueuesPayloadResolver } from "./ModerationQueues";
+
+export const AcceptCommentPayload: GQLAcceptCommentPayloadTypeResolver = {
+  moderationQueues: moderationQueuesPayloadResolver,
+};

--- a/src/core/server/graph/tenant/resolvers/ModerationQueues.ts
+++ b/src/core/server/graph/tenant/resolvers/ModerationQueues.ts
@@ -1,16 +1,24 @@
+import {
+  AcceptCommentPayloadToModerationQueuesResolver,
+  GQLModerationQueuesTypeResolver,
+  RejectCommentPayloadToModerationQueuesResolver,
+} from "talk-server/graph/tenant/schema/__generated__/types";
 import { CommentConnectionInput } from "talk-server/models/comment";
 import { FilterQuery } from "talk-server/models/query";
-import { CommentModerationCountsPerQueue } from "talk-server/models/story";
+import {
+  CommentModerationCountsPerQueue,
+  Story,
+} from "talk-server/models/story";
 import {
   PENDING_STATUS,
   REPORTED_STATUS,
   UNMODERATED_STATUSES,
 } from "talk-server/services/comments/moderation/counts";
 
-import { GQLModerationQueuesTypeResolver } from "../schema/__generated__/types";
+import TenantContext from "../context";
 import { ModerationQueueInput } from "./ModerationQueue";
 
-export interface ModerationQueuesInput {
+interface ModerationQueuesInput {
   connection: Partial<CommentConnectionInput>;
   counts: CommentModerationCountsPerQueue;
 }
@@ -28,6 +36,72 @@ const mergeModerationInputFilters = (
   },
   count: input.counts[selector],
 });
+
+/**
+ * storyModerationInputResolver can be used to retrieve the moderationQueue for
+ * a specific Story.
+ *
+ * @param story the story that will be used to base the comment moderation
+ *              queues on
+ */
+export const storyModerationInputResolver = (
+  story: Story
+): ModerationQueuesInput => ({
+  connection: {
+    filter: {
+      // This moderationQueues is being sourced from the Story, so require
+      // that all the comments for theses queues are also for this Story.
+      storyID: story.id,
+    },
+  },
+  counts: story.commentCounts.moderationQueue.queues,
+});
+
+/**
+ * sharedModerationInputResolver implements the resolver function style which
+ * allows it to be used in a type resolver.
+ *
+ * @param source the source of the type, not used
+ * @param args the args of the type, not used
+ * @param ctx the TenantContext that will be used to get the shared counts
+ */
+export const sharedModerationInputResolver = async (
+  source: any,
+  args: any,
+  ctx: TenantContext
+): Promise<ModerationQueuesInput> => ({
+  // We don't need to filter the connection, as this is tenant wide (tenant
+  // filtering is completed at the model layer).
+  connection: {},
+  counts: await ctx.loaders.Comments.sharedModerationQueueQueuesCounts.load(),
+});
+
+/**
+ * moderationQueuesPayloadResolver implements the resolver that can be used for
+ * moderation actions payloads.
+ *
+ * @param source the source of the payload, not used
+ * @param args the args of the payload containing potentially a Story ID
+ * @param ctx the TenantContext for which we can use to retrieve the shared data
+ */
+export const moderationQueuesPayloadResolver:
+  | AcceptCommentPayloadToModerationQueuesResolver
+  | RejectCommentPayloadToModerationQueuesResolver = async (
+  source,
+  args,
+  ctx
+): Promise<ModerationQueuesInput | null> => {
+  if (args.storyID) {
+    const story = await ctx.loaders.Stories.story.load(args.storyID);
+    if (!story) {
+      return null;
+    }
+
+    return storyModerationInputResolver(story);
+  }
+
+  return sharedModerationInputResolver(source, args, ctx);
+};
 
 export const ModerationQueues: GQLModerationQueuesTypeResolver<
   ModerationQueuesInput

--- a/src/core/server/graph/tenant/resolvers/Query.ts
+++ b/src/core/server/graph/tenant/resolvers/Query.ts
@@ -1,6 +1,6 @@
 import { GQLQueryTypeResolver } from "talk-server/graph/tenant/schema/__generated__/types";
 
-import { ModerationQueuesInput } from "./ModerationQueues";
+import { sharedModerationInputResolver } from "./ModerationQueues";
 
 export const Query: GQLQueryTypeResolver<void> = {
   story: (source, args, ctx) => ctx.loaders.Stories.findOrCreate.load(args),
@@ -13,14 +13,5 @@ export const Query: GQLQueryTypeResolver<void> = {
     ctx.loaders.Auth.discoverOIDCConfiguration.load(issuer),
   debugScrapeStoryMetadata: (source, { url }, ctx) =>
     ctx.loaders.Stories.debugScrapeMetadata.load(url),
-  moderationQueues: async (
-    source,
-    args,
-    ctx
-  ): Promise<ModerationQueuesInput> => ({
-    // We don't need to filter the connection, as this is tenant wide (tenant
-    // filtering is completed at the model layer).
-    connection: {},
-    counts: await ctx.loaders.Comments.sharedModerationQueueQueuesCounts.load(),
-  }),
+  moderationQueues: sharedModerationInputResolver,
 };

--- a/src/core/server/graph/tenant/resolvers/RejectCommentPayload.ts
+++ b/src/core/server/graph/tenant/resolvers/RejectCommentPayload.ts
@@ -1,0 +1,7 @@
+import { GQLRejectCommentPayloadTypeResolver } from "talk-server/graph/tenant/schema/__generated__/types";
+
+import { moderationQueuesPayloadResolver } from "./ModerationQueues";
+
+export const RejectCommentPayload: GQLRejectCommentPayloadTypeResolver = {
+  moderationQueues: moderationQueuesPayloadResolver,
+};

--- a/src/core/server/graph/tenant/resolvers/Story.ts
+++ b/src/core/server/graph/tenant/resolvers/Story.ts
@@ -3,7 +3,8 @@ import { DateTime } from "luxon";
 import { GQLStoryTypeResolver } from "talk-server/graph/tenant/schema/__generated__/types";
 import { decodeActionCounts } from "talk-server/models/action/comment";
 import * as story from "talk-server/models/story";
-import { ModerationQueuesInput } from "./ModerationQueues";
+
+import { storyModerationInputResolver } from "./ModerationQueues";
 
 export const Story: GQLStoryTypeResolver<story.Story> = {
   comments: (s, input, ctx) => ctx.loaders.Comments.forStory(s.id, input),
@@ -23,14 +24,5 @@ export const Story: GQLStoryTypeResolver<story.Story> = {
   },
   commentActionCounts: s => decodeActionCounts(s.commentCounts.action),
   commentCounts: s => s.commentCounts.status,
-  moderationQueues: (s): ModerationQueuesInput => ({
-    connection: {
-      filter: {
-        // This moderationQueues is being sourced from the Story, so require
-        // that all the comments for theses queues are also for this Story.
-        storyID: s.id,
-      },
-    },
-    counts: s.commentCounts.moderationQueue.queues,
-  }),
+  moderationQueues: storyModerationInputResolver,
 };

--- a/src/core/server/graph/tenant/resolvers/index.ts
+++ b/src/core/server/graph/tenant/resolvers/index.ts
@@ -3,6 +3,7 @@ import Time from "talk-server/graph/common/scalars/time";
 
 import { GQLResolver } from "talk-server/graph/tenant/schema/__generated__/types";
 
+import { AcceptCommentPayload } from "./AcceptCommentPayload";
 import { AuthIntegrations } from "./AuthIntegrations";
 import { Comment } from "./Comment";
 import { CommentCounts } from "./CommentCounts";
@@ -16,10 +17,12 @@ import { Mutation } from "./Mutation";
 import { OIDCAuthIntegration } from "./OIDCAuthIntegration";
 import { Profile } from "./Profile";
 import { Query } from "./Query";
+import { RejectCommentPayload } from "./RejectCommentPayload";
 import { Story } from "./Story";
 import { User } from "./User";
 
 const Resolvers: GQLResolver = {
+  AcceptCommentPayload,
   AuthIntegrations,
   Comment,
   CommentCounts,
@@ -34,6 +37,7 @@ const Resolvers: GQLResolver = {
   GoogleAuthIntegration,
   Profile,
   Query,
+  RejectCommentPayload,
   Time,
   Story,
   User,

--- a/src/core/server/graph/tenant/schema/schema.graphql
+++ b/src/core/server/graph/tenant/schema/schema.graphql
@@ -2868,6 +2868,13 @@ type AcceptCommentPayload {
   comment: Comment
 
   """
+  moderationQueues will return the selected moderation queues. If the `storyID`
+  is provided, it will filter the moderation queues for only comments in that
+  Story.
+  """
+  moderationQueues(storyID: ID): ModerationQueues
+
+  """
   clientMutationId is required for Relay support.
   """
   clientMutationId: String!
@@ -2899,6 +2906,13 @@ type RejectCommentPayload {
   comment is the Comment that was rejected.
   """
   comment: Comment
+
+  """
+  moderationQueues will return the selected moderation queues. If the `storyID`
+  is provided, it will filter the moderation queues for only comments in that
+  Story.
+  """
+  moderationQueues(storyID: ID): ModerationQueues
 
   """
   clientMutationId is required for Relay support.


### PR DESCRIPTION
## What does this PR do?

- Added moderation queue edge to accept/reject comment payloads
- Simplified moderationQueue returns
- Simplified resolvers

## How do I test this PR?

Attempt the following queries:

```graphql
mutation AcceptComment($commentID: ID!, $commentRevisionID: ID!) {
  acceptComment(input: {commentID: $commentID, commentRevisionID: $commentRevisionID, clientMutationId: ""}) {
    comment {
      id
      status
    }
    moderationQueues {
      unmoderated {
        count
      }
      reported {
        count
      }
    }
  }
}
```

```graphql
mutation RejectComment($commentID: ID!, $commentRevisionID: ID!) {
  rejectComment(input: {commentID: $commentID, commentRevisionID: $commentRevisionID, clientMutationId: ""}) {
    comment {
      id
      status
    }
    moderationQueues {
      unmoderated {
        count
      }
      reported {
        count
      }
    }
  }
}
```