### PR TITLE
fix minor ui/css bug in moderation/comment component caused by long links

### DIFF
--- a/client/coral-admin/src/routes/Moderation/components/Comment.css
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.css
@@ -62,6 +62,7 @@
   font-weight: 300;
   margin-bottom: 8px;
   overflow-wrap: break-word;
+  word-break:break-word;
 }
 
 .body {


### PR DESCRIPTION
Hi, 

Edit: this is related to issue #2129 

## What does this PR do?

We're experiencing an minor css bug in the moderation/comment component (noticed in versions 4.6.7 - 4.6.10). Long links aren't wrapped/broken which causes an overflow (see below). I figured the fastest way to fix this would be a quick PR 😄 

Example Screenshots:

before: 
![image](https://user-images.githubusercontent.com/4024755/50051305-cb645c00-010f-11e9-8854-096e8bb0293b.png)

after:
![image](https://user-images.githubusercontent.com/4024755/50051311-e0d98600-010f-11e9-93e5-630c1d5648e1.png)


## How do I test this PR?

- run talk in dev mode
- navigate to /dev
- create a comment containing a long link without dashes
- navigate to /admin/moderate and search for the comment
- the line should be wrapped/broken now, buttons should be still visible
