### PR TITLE
Break word on long description

### DIFF
--- a/client/coral-admin/src/routes/Community/components/FlaggedUser.css
+++ b/client/coral-admin/src/routes/Community/components/FlaggedUser.css
@@ -78,9 +78,10 @@
 }
 
 .flaggedByReason {
-  font-size: 1tpx;
+  font-size: 14px;
   margin: 0px;
   line-height: 1.4;
+  word-break: break-word;
 }
 
 


### PR DESCRIPTION
-Also fix font size

## What does this PR do?
Fix username report descriptions not wrapping and then hiding APPROVE button

![image](https://user-images.githubusercontent.com/7562285/52357610-70aafa80-2a04-11e9-98d3-9f7e805f0866.png)


## How do I test this PR?

- Report username with long non breaking string
- See text wraps
