### PR TITLE
fix: rename devToolsExtension

### DIFF
--- a/client/coral-framework/services/store.js
+++ b/client/coral-framework/services/store.js
@@ -14,9 +14,9 @@ import {
 export function createStore(reducers, middlewares = []) {
   const enhancers = [applyMiddleware(...middlewares)];
 
-  if (window.devToolsExtension) {
+  if (window.__REDUX_DEVTOOLS_EXTENSION__) {
     // we can't have the last argument of compose() be undefined
-    enhancers.push(window.devToolsExtension());
+    enhancers.push(window.__REDUX_DEVTOOLS_EXTENSION__());
   }
 
   return reduxCreateStore(combineReducers(reducers), {}, compose(...enhancers));


### PR DESCRIPTION
## What does this PR do?

> Note that starting from v2.7, window.devToolsExtension was renamed to window.__REDUX_DEVTOOLS_EXTENSION__ / window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__.

## How do I test this PR?

- click a button
- view the cat
- see the cat meow
