### PR TITLE
External User Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "description": "A better commenting experience from Mozilla, The New York Times, and the Washington Post. https://coralproject.net",
   "main": "app.js",
   "private": true,


### PR DESCRIPTION
## What does this PR do?

The advertised behavior of the `services/users.upsertExternalUser(ctx, id, provider, displayName)` incorrectly assigned the provider `id`. This resolves that issue by setting the user's ID to the one provided by the integration as well as falling back to the correct user lookup for when a user returns.