### PR TITLE
Update the slack config name in the docs

### DIFF
--- a/plugins/talk-plugin-slack-notifications/README.md
+++ b/plugins/talk-plugin-slack-notifications/README.md
@@ -11,7 +11,7 @@ plugin:
 Enables all new comments that are written to be posted to a Slack channel as
 well. Configure an
 [Incoming Webhook](https://api.slack.com/incoming-webhooks)
-app and provide that url in the form of the `SLACK_WEBHOOK_URL`
+app and provide that url in the form of the `TALK_SLACK_WEBHOOK_URL`
 detailed below.
 
 *Warning: On high volume sites, this means every single comment will flow into
@@ -20,5 +20,5 @@ recipe to further customize the behavior*.
 
 Configuration:
 
-- `SLACK_WEBHOOK_URL` (**required**) - The webhook url that will be
+- `TALK_SLACK_WEBHOOK_URL` (**required**) - The webhook url that will be
   used to post new comments to.


### PR DESCRIPTION
## What does this PR do?
Replaces `SLACK_WEBHOOK_URL` with `TALK_SLACK_WEBHOOK_URL` in the slack notification plugin documentation

## How do I test this PR?

- I checked the README
