### PR TITLE
Clarify that Reliable commenter is also not yet in use

### DIFF
--- a/docs/source/02-02-advanced-configuration.md
+++ b/docs/source/02-02-advanced-configuration.md
@@ -499,8 +499,9 @@ Could be read as:
   pre-moderated once in order to post freely again. If they instead get rejected
   again, then they must have two of their comments approved in order to get
   added back to the queue.
-- At the moment of writing, behavior is not attached to the flagging
-  reliability, but it is recorded.
+- At the moment of writing, behavior is not attached to reliable commenters
+  as well as the flagging reliability and unreliability. Regardless, 
+  all of these scores are recorded for future implementation.
 
 ## TALK_DISABLE_IGNORE_FLAGS_AGAINST_STAFF
 


### PR DESCRIPTION
## What does this PR do?
Clarifies that reliable commenter threshold are not yet in use - as per https://docs.coralproject.net/talk/trust/