### PR TITLE
Fix for Load More on Community page

### DIFF
--- a/client/coral-admin/src/routes/Community/containers/People.js
+++ b/client/coral-admin/src/routes/Community/containers/People.js
@@ -140,8 +140,11 @@ const LOAD_MORE_QUERY = gql`
     $limit: Int
     $cursor: Cursor
     $value: String
+    $state: UserStateInput
   ) {
-    users(query: { value: $value, limit: $limit, cursor: $cursor }) {
+    users(
+      query: { value: $value, limit: $limit, cursor: $cursor, state: $state }
+    ) {
       hasNextPage
       endCursor
       nodes {


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/coralproject/talk/issues/2143

## How do I test this PR?
- create a bunch of users
- set a bunch of them to admins (but leave a few non-admins so we can make sure load more works)
- set filter to admin
- click load more
- should only load non admins
- see the cat meow

![Peek 2019-04-03 03-02](https://user-images.githubusercontent.com/11047577/55432444-1ae66f00-55bd-11e9-9a88-61cb4413b6f6.gif)
