### PR TITLE
Update default plugins and docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,7 @@
-# Mozilla Community Participation Guidelines
+# Vox Media Code of Conduct
 
-## Version 2.3 - Updated May 16, 2017
+## Introduction
 
-The heart of Mozilla is people. We put people first and do our best to recognize, appreciate and respect the diversity of our global contributors. The Mozilla Project welcomes contributions from everyone who shares our goals and wants to contribute in a healthy and constructive manner within our community. As such, we have adopted this code of conduct and require all those who participate to agree and adhere to these Community Participation Guidelines in order to help us create a safe and positive community experience for all.
-https://www.mozilla.org/en-US/about/governance/policies/participation/
+This code of conduct governs the environment of the Vox Product team. We created it not because we anticipate bad behavior, but because we believe that articulating our values and obligations to one another reinforces the already exceptional level of respect among the team and because having a code provides us with clear avenues to correct our culture should it ever stray from that course. We make this code public in the hopes of contributing to the ongoing conversation about inclusion in the tech, design, and media communities and encourage other teams to fork it and make it their own. To our team, we commit to enforce and evolve this code as our team grows.
+
+Read the rest here: http://code-of-conduct.voxmedia.com/

--- a/docs/source/plugin/talk-plugin-notifications-category-moderation-actions.md
+++ b/docs/source/plugin/talk-plugin-notifications-category-moderation-actions.md
@@ -1,9 +1,9 @@
 ---
-title: talk-plugin-notifications-category-moderator-actions
-permalink: /plugin/talk-plugin-notifications-category-moderator-actions//
+title: talk-plugin-notifications-category-moderation-actions
+permalink: /plugin/talk-plugin-notifications-category-moderation-actions/
 layout: plugin
 plugin:
-    name: talk-plugin-notifications-moderator-actions
+    name: talk-plugin-notifications-moderation-actions
     depends:
         - name: talk-plugin-notifications
     provides:

--- a/docs/source/plugin/talk-plugin-notifications-category-moderation-actions.md
+++ b/docs/source/plugin/talk-plugin-notifications-category-moderation-actions.md
@@ -1,0 +1,17 @@
+---
+title: talk-plugin-notifications-category-moderator-actions
+permalink: /plugin/talk-plugin-notifications-category-moderator-actions//
+layout: plugin
+plugin:
+    name: talk-plugin-notifications-moderator-actions
+    depends:
+        - name: talk-plugin-notifications
+    provides:
+        - Server
+        - Client
+---
+
+When a comment that is initially withheld from publication and is then approved or rejected, the user will receive a notification email.
+
+Configuration:
+`TALK_MODERATION_NOTIFICATION_TYPES`. This plugin requires values to be set. Available options: `APPROVED`, `REJECTED` as a single string (comma separated).

--- a/docs/source/plugin/talk-plugin-notifications-category-moderation-actions.md
+++ b/docs/source/plugin/talk-plugin-notifications-category-moderation-actions.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-notifications-category-moderation-actions/
 layout: plugin
 plugin:
     name: talk-plugin-notifications-moderation-actions
+    default: true
     depends:
         - name: talk-plugin-notifications
     provides:

--- a/plugins.default.json
+++ b/plugins.default.json
@@ -1,26 +1,44 @@
 {
   "server": [
-    "talk-plugin-featured-comments",
+    "talk-plugin-auth",
     "talk-plugin-local-auth",
+    "talk-plugin-featured-comments",
+    "talk-plugin-respect",
+    "talk-plugin-rich-text",
     "talk-plugin-profile-data",
-    "talk-plugin-respect"
+    "talk-plugin-notifications",
+    "talk-plugin-notifications-category-featured",
+    "talk-plugin-notifications-category-moderation-actions",
+    "talk-plugin-notifications-category-reply",
+    "talk-plugin-notifications-category-staff",
+    "talk-plugin-notifications-digest-hourly",
+    "talk-plugin-notifications-digest-daily"
   ],
   "client": [
     "talk-plugin-auth",
+    "talk-plugin-local-auth",
     "talk-plugin-author-menu",
     "talk-plugin-featured-comments",
     "talk-plugin-flag-details",
-    "talk-plugin-ignore-user",
-    "talk-plugin-local-auth",
     "talk-plugin-member-since",
     "talk-plugin-moderation-actions",
     "talk-plugin-permalink",
-    "talk-plugin-profile-data",
     "talk-plugin-respect",
+    "talk-plugin-rich-text",
+    "talk-plugin-like",
+    "talk-plugin-viewing-options",
     "talk-plugin-sort-most-replied",
     "talk-plugin-sort-most-respected",
     "talk-plugin-sort-newest",
     "talk-plugin-sort-oldest",
-    "talk-plugin-viewing-options"
+    "talk-plugin-profile-data",
+    "talk-plugin-notifications",
+    "talk-plugin-notifications-category-featured",
+    "talk-plugin-notifications-category-moderation-actions",
+    "talk-plugin-notifications-category-reply",
+    "talk-plugin-notifications-category-staff",
+    "talk-plugin-notifications-digest-hourly",
+    "talk-plugin-notifications-digest-daily",
+    "talk-plugin-ignore-user"
   ]
 }

--- a/plugins.default.json
+++ b/plugins.default.json
@@ -1,6 +1,5 @@
 {
   "server": [
-    "talk-plugin-auth",
     "talk-plugin-local-auth",
     "talk-plugin-featured-comments",
     "talk-plugin-respect",
@@ -25,7 +24,6 @@
     "talk-plugin-permalink",
     "talk-plugin-respect",
     "talk-plugin-rich-text",
-    "talk-plugin-like",
     "talk-plugin-viewing-options",
     "talk-plugin-sort-most-replied",
     "talk-plugin-sort-most-respected",

--- a/plugins/talk-plugin-comment-content/README.md
+++ b/plugins/talk-plugin-comment-content/README.md
@@ -4,7 +4,6 @@ permalink: /plugin/talk-plugin-comment-content/
 layout: plugin
 plugin:
     name: talk-plugin-comment-content
-    default: true
     provides:
         - Client
 ---

--- a/plugins/talk-plugin-featured-comments/README.md
+++ b/plugins/talk-plugin-featured-comments/README.md
@@ -14,7 +14,7 @@ Enables the ability for Moderators to feature and un-feature comments via the
 Stream and the Admin. Featured comments show in a first-place tab on the Stream
 if there are any featured comments on that story.
 
-When paired with the [talk-plugin-moderator-actions](/talk/plugin/talk-plugin-moderator-actions)
+When paired with the [talk-plugin-moderation-actions](/talk/plugin/talk-plugin-moderation-actions)
 plugin, moderators will have the option of featuring comments from the comment
 stream.
 

--- a/plugins/talk-plugin-moderation-actions/README.md
+++ b/plugins/talk-plugin-moderation-actions/README.md
@@ -1,9 +1,9 @@
 ---
-title: talk-plugin-moderator-actions
-permalink: /plugin/talk-plugin-moderator-actions/
+title: talk-plugin-moderation-actions
+permalink: /plugin/talk-plugin-moderation-actions/
 layout: plugin
 plugin:
-    name: talk-plugin-moderator-actions
+    name: talk-plugin-moderation-actions
     default: true
     provides:
         - Client

--- a/plugins/talk-plugin-notifications-category-featured/README.md
+++ b/plugins/talk-plugin-notifications-category-featured/README.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-notifications-category-featured/
 layout: plugin
 plugin:
     name: talk-plugin-notifications-category-featured
+    default: true
     depends:
         - name: talk-plugin-notifications
         - name: talk-plugin-featured-comments

--- a/plugins/talk-plugin-notifications-category-moderation-actions/README.md
+++ b/plugins/talk-plugin-notifications-category-moderation-actions/README.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-notifications-moderation-actions/
 layout: plugin
 plugin:
     name: talk-plugin-notifications-moderation-actions
+    default: true
     depends:
         - name: talk-plugin-notifications
     provides:

--- a/plugins/talk-plugin-notifications-category-reply/README.md
+++ b/plugins/talk-plugin-notifications-category-reply/README.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-notifications-category-reply/
 layout: plugin
 plugin:
     name: talk-plugin-notifications-category-reply
+    default: true
     depends:
         - name: talk-plugin-notifications
     provides:

--- a/plugins/talk-plugin-notifications-category-staff/README.md
+++ b/plugins/talk-plugin-notifications-category-staff/README.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-notifications-category-staff/
 layout: plugin
 plugin:
     name: talk-plugin-notifications-category-staff
+    default: true
     depends:
         - name: talk-plugin-notifications
     provides:

--- a/plugins/talk-plugin-notifications-digest-daily/README.md
+++ b/plugins/talk-plugin-notifications-digest-daily/README.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-notifications-digest-daily/
 layout: plugin
 plugin:
     name: talk-plugin-notifications-digest-daily
+    default: true
     depends:
         - name: talk-plugin-notifications
     provides:

--- a/plugins/talk-plugin-notifications-digest-hourly/README.md
+++ b/plugins/talk-plugin-notifications-digest-hourly/README.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-notifications-digest-hourly/
 layout: plugin
 plugin:
     name: talk-plugin-notifications-digest-hourly
+    default: true
     depends:
         - name: talk-plugin-notifications
     provides:

--- a/plugins/talk-plugin-notifications/README.md
+++ b/plugins/talk-plugin-notifications/README.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-notifications/
 layout: plugin
 plugin:
     name: talk-plugin-notifications
+    default: true
     provides:
         - Server
         - Client

--- a/plugins/talk-plugin-offtopic/README.md
+++ b/plugins/talk-plugin-offtopic/README.md
@@ -4,7 +4,6 @@ permalink: /plugin/talk-plugin-offtopic/
 layout: plugin
 plugin:
     name: talk-plugin-offtopic
-    default: true
     provides:
         - Server
         - Client

--- a/plugins/talk-plugin-rich-text/README.md
+++ b/plugins/talk-plugin-rich-text/README.md
@@ -4,6 +4,7 @@ permalink: /plugin/talk-plugin-rich-text/
 layout: plugin
 plugin:
     name: talk-plugin-rich-text
+    default: true
     provides:
         - Client
         - Server

--- a/test/e2e/page_objects/embedStream.js
+++ b/test/e2e/page_objects/embedStream.js
@@ -97,7 +97,7 @@ module.exports = {
       elements: {
         logoutButton: '.talk-stream-userbox-logout',
         signInButton: '#coralSignInButton',
-        commentBoxTextarea: '.talk-plugin-commentbox-textarea',
+        commentBoxTextarea: '.talk-plugin-rich-text-content',
         commentBoxPostButton: '.talk-plugin-commentbox-button',
         firstComment: '.talk-stream-comment.talk-stream-comment-level-0',
         firstCommentContent:

--- a/test/server/graph/mutations/createComment.js
+++ b/test/server/graph/mutations/createComment.js
@@ -16,7 +16,7 @@ describe('graph.mutations.createComment', () => {
   beforeEach(() => SettingsService.init());
 
   const query = `
-    mutation CreateComment($input: CreateCommentInput = {asset_id: 123, body: "Here's my comment!"}) {
+    mutation CreateComment($input: CreateCommentInput = {asset_id: 123, body: "Here's my comment!", richTextBody: "Here's my comment!"}) {
       createComment(input: $input) {
         comment {
           id
@@ -293,6 +293,7 @@ describe('graph.mutations.createComment', () => {
             input: {
               asset_id: '123',
               body,
+              richTextBody: 'This is such a nice comment!',
             },
           });
 

--- a/test/server/graph/mutations/editComment.js
+++ b/test/server/graph/mutations/editComment.js
@@ -39,10 +39,12 @@ describe('graph.mutations.editComment', () => {
   it('a user can edit their own comment', async () => {
     const context = new Context({ user });
     const testStartedAt = new Date();
+    const body = `hello there! ${String(Math.random()).slice(2)}`;
     const comment = await CommentsService.publicCreate({
       asset_id: asset.id,
       author_id: user.id,
-      body: `hello there! ${String(Math.random()).slice(2)}`,
+      body,
+      richTextBody: body,
     });
 
     // body_history should be there
@@ -58,6 +60,7 @@ describe('graph.mutations.editComment', () => {
       asset_id: asset.id,
       edit: {
         body: newBody,
+        richTextBody: newBody,
       },
     });
     if (response.errors && response.errors.length) {
@@ -86,10 +89,12 @@ describe('graph.mutations.editComment', () => {
   });
 
   it("A user can't edit their comment outside of the edit comment time window", async () => {
+    const body = `hello there! ${String(Math.random()).slice(2)}`;
     const comment = await CommentsService.publicCreate({
       asset_id: asset.id,
       author_id: user.id,
-      body: `hello there! ${String(Math.random()).slice(2)}`,
+      body,
+      richTextBody: body,
     });
 
     const now = new Date();
@@ -103,6 +108,7 @@ describe('graph.mutations.editComment', () => {
       asset_id: asset.id,
       edit: {
         body: newBody,
+        richTextBody: newBody,
       },
     });
     if (response.errors && response.errors.length > 0) {
@@ -120,10 +126,12 @@ describe('graph.mutations.editComment', () => {
   });
 
   it("A user can't edit someone else's comment", async () => {
+    const body = `hello there! ${String(Math.random()).slice(2)}`;
     const comment = await CommentsService.publicCreate({
       asset_id: asset.id,
       author_id: user.id,
-      body: `hello there! ${String(Math.random()).slice(2)}`,
+      body,
+      richTextBody: body,
     });
 
     const ctx = Context.forSystem();
@@ -140,6 +148,7 @@ describe('graph.mutations.editComment', () => {
       asset_id: asset.id,
       edit: {
         body: newBody,
+        richTextBody: newBody,
       },
     });
     expect(response.errors).to.be.empty;
@@ -162,6 +171,7 @@ describe('graph.mutations.editComment', () => {
       asset_id: asset.id,
       edit: {
         body: newBody,
+        richTextBody: newBody,
       },
     });
     if (response.errors && response.errors.length > 0) {
@@ -182,10 +192,12 @@ describe('graph.mutations.editComment', () => {
       },
       beforeEdit: {
         body: 'I was offensive and thus REJECTED',
+        richTextBody: 'I was offensive and thus REJECTED',
         status: 'REJECTED',
       },
       edit: {
         body: 'I have been edited to be less offensive',
+        richTextBody: 'I have been edited to be less offensive',
       },
       error: true,
     },
@@ -200,10 +212,12 @@ describe('graph.mutations.editComment', () => {
       },
       beforeEdit: {
         body: "I'm a perfectly acceptable comment",
+        richTextBody: "I'm a perfectly acceptable comment",
         status: 'ACCEPTED',
       },
       edit: {
         body: `I have been sneakily edited to add a banned word: ${bannedWord}`,
+        richTextBody: `I have been sneakily edited to add a banned word: ${bannedWord}`,
       },
       afterEdit: {
         status: 'REJECTED',
@@ -220,10 +234,12 @@ describe('graph.mutations.editComment', () => {
       },
       beforeEdit: {
         body: `I'm a rejected comment with bad word ${bannedWord}`,
+        richTextBody: `I'm a rejected comment with bad word ${bannedWord}`,
         status: 'REJECTED',
       },
       edit: {
         body: 'I have been edited to remove the bad word',
+        richTextBody: 'I have been edited to remove the bad word',
       },
       error: true,
     },
@@ -236,10 +252,13 @@ describe('graph.mutations.editComment', () => {
       },
       beforeEdit: {
         body: "I'm a perfectly acceptable comment",
+        richTextBody: "I'm a perfectly acceptable comment",
         status: 'ACCEPTED',
       },
       edit: {
         body: 'I have been edited to add a link: https://coralproject.net/',
+        richTextBody:
+          'I have been edited to add a link: https://coralproject.net/',
       },
       afterEdit: {
         status: 'SYSTEM_WITHHELD',
@@ -266,6 +285,7 @@ describe('graph.mutations.editComment', () => {
         asset_id: asset.id,
         edit: {
           body: newBody,
+          richTextBody: newBody,
         },
       });
 


### PR DESCRIPTION
## What does this PR do?
- Adds docs for `talk-plugin-notifications-category-moderation-actions`
- Updates `plugins.default.json` to reflect our recommended plugins
- Fixes typo in docs creating a broken link
