### PR TITLE
Remove unnecessary Talk branding

### DIFF
--- a/views/admin.njk
+++ b/views/admin.njk
@@ -2,6 +2,9 @@
 
 {% block title %}Talk Admin{% endblock %}
 
+{# Favicon Configuration #}
+{% include "partials/favicon.njk" %}
+
 {% block css %}
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
 <link href="https://code.getmdl.io/1.2.1/material.min.css" rel="stylesheet">

--- a/views/login.njk
+++ b/views/login.njk
@@ -1,6 +1,6 @@
 {% extends "templates/base.njk" %}
 
-{% block title %}Talk - Login{% endblock %}
+{% block title %}Login{% endblock %}
 
 {% block css %}
 <link href="{{ resolve('coral-login/bundle.css')}}" rel="stylesheet">

--- a/views/templates/base.njk
+++ b/views/templates/base.njk
@@ -6,9 +6,6 @@
     <meta name="viewport" content="width=device-width, user-scalable=no">
     {% block meta %}{% endblock %}
 
-    {# Favicon Configuration #}
-    {% include "partials/favicon.njk" %}
-
     {# CSP and security headers #}
     {% block security %}{% endblock %}
 


### PR DESCRIPTION
## What does this PR do?
- Replaces "Talk - Login" with just "Login"
- Removes favicon from all views except the Admin
