### PR TITLE
Show/hide a comment's edit history from Moderation and User Detail.

### DIFF
--- a/client/coral-admin/src/components/UserDetailComment.css
+++ b/client/coral-admin/src/components/UserDetailComment.css
@@ -139,3 +139,21 @@
     margin-right: 5px;
   }
 }
+
+.bodyHistoryToggle {
+  color: #666;
+  font-size: 12px;
+  line-height: 1px;
+  font-weight: 300;
+  text-decoration: underline;
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.editedBody {
+  margin-top: 6px;
+  font-weight: 300;
+  font-size: 16px;
+  overflow-wrap: break-word;
+}

--- a/client/coral-admin/src/components/UserDetailComment.css
+++ b/client/coral-admin/src/components/UserDetailComment.css
@@ -34,7 +34,7 @@
   color: #063b9a;
   text-decoration: none;
   font-weight: 500;
-  letter-spacing: .5px;
+  letter-spacing: 0.5px;
   margin-left: 10px;
   font-size: 13px;
   margin-left: 5px;
@@ -109,7 +109,7 @@
 }
 
 .external {
-  font-size: .7em;
+  font-size: 0.7em;
   text-decoration: none;
   color: #063b9a;
   cursor: pointer;
@@ -119,7 +119,7 @@
 
   &:hover {
     text-decoration: underline;
-    opacity: .9;
+    opacity: 0.9;
   }
 
   > i {
@@ -152,7 +152,7 @@
 }
 
 .editedCommentBody {
-  padding: 5px;
+  padding: 0 5px 5px 5px;
 }
 
 .editedComment {

--- a/client/coral-admin/src/components/UserDetailComment.css
+++ b/client/coral-admin/src/components/UserDetailComment.css
@@ -151,7 +151,11 @@
   }
 }
 
-.editedBody {
+.editedCommentBody {
+  padding: 5px;
+}
+
+.editedComment {
   margin-top: 6px;
   font-weight: 300;
   font-size: 16px;

--- a/client/coral-admin/src/components/UserDetailComment.js
+++ b/client/coral-admin/src/components/UserDetailComment.js
@@ -19,6 +19,8 @@ import TimeAgo from 'coral-framework/components/TimeAgo';
 import t from 'coral-framework/services/i18n';
 
 class UserDetailComment extends React.Component {
+  state = { showingEditHistory: false };
+
   approve = () =>
     this.props.comment.status === 'ACCEPTED'
       ? null
@@ -28,6 +30,25 @@ class UserDetailComment extends React.Component {
     this.props.comment.status === 'REJECTED'
       ? null
       : this.props.rejectComment({ commentId: this.props.comment.id });
+
+  getBodyHistory = () => {
+    const bodyHistory = [];
+    const comment = this.props.comment;
+    for (let i = 0; i < comment.body_history.length - 1; i++) {
+      bodyHistory.push(
+        <div key={i} className={styles.editedBody}>
+          <TimeAgo className={styles.created} datetime={comment.created_at} />
+          {comment.body_history[i].body}
+        </div>
+      );
+    }
+
+    return bodyHistory;
+  };
+
+  toggleEditHistory = () => {
+    this.setState({ showingEditHistory: !this.state.showingEditHistory });
+  };
 
   render() {
     const {
@@ -80,6 +101,14 @@ class UserDetailComment extends React.Component {
               <span>
                 &nbsp;<span className={styles.editedMarker}>
                   ({t('comment.edited')})
+                </span>
+                &nbsp;<span
+                  className={styles.bodyHistoryToggle}
+                  onClick={this.toggleEditHistory}
+                >
+                  {this.state.showingEditHistory
+                    ? t('comment.hide_edit_history')
+                    : t('comment.show_edit_history')}
                 </span>
               </span>
             ) : null}
@@ -142,6 +171,14 @@ class UserDetailComment extends React.Component {
             </div>
           </CommentAnimatedEdit>
         </div>
+
+        {this.state.showingEditHistory ? (
+          <div className={styles.container}>
+            {t('comment.edit_history')}
+            {this.getBodyHistory()}
+          </div>
+        ) : null}
+
         <CommentDetails root={root} comment={comment} />
       </li>
     );

--- a/client/coral-admin/src/components/UserDetailComment.js
+++ b/client/coral-admin/src/components/UserDetailComment.js
@@ -36,9 +36,13 @@ class UserDetailComment extends React.Component {
     const comment = this.props.comment;
     for (let i = 0; i < comment.body_history.length - 1; i++) {
       bodyHistory.push(
-        <div key={i} className={styles.editedBody}>
-          <TimeAgo className={styles.created} datetime={comment.created_at} />
-          {comment.body_history[i].body}
+        <div key={i} className={styles.editedComment}>
+          <div>
+            <TimeAgo className={styles.created} datetime={comment.created_at} />
+          </div>
+          <div className={styles.editedCommentBody}>
+            {comment.body_history[i].body}
+          </div>
         </div>
       );
     }

--- a/client/coral-admin/src/containers/UserDetailComment.js
+++ b/client/coral-admin/src/containers/UserDetailComment.js
@@ -42,6 +42,10 @@ export default withFragments({
       status_history {
         type
       }
+      body_history {
+        body
+        created_at
+      }
       ${getSlotFragmentSpreads(slots, 'comment')}
       ...${getDefinitionName(CommentLabels.fragments.comment)}
       ...${getDefinitionName(CommentDetails.fragments.comment)}

--- a/client/coral-admin/src/routes/Moderation/components/Comment.css
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.css
@@ -62,7 +62,7 @@
   font-weight: 300;
   margin-bottom: 8px;
   overflow-wrap: break-word;
-  word-break:break-word;
+  word-break: break-word;
 }
 
 .body {
@@ -103,7 +103,7 @@
     color: #063b9a;
     text-decoration: none;
     font-weight: 500;
-    letter-spacing: .5px;
+    letter-spacing: 0.5px;
     margin-left: 10px;
     font-size: 13px;
     margin-left: 5px;
@@ -111,14 +111,14 @@
     border-bottom: solid 1px;
     line-height: 16px;
     &:hover {
-      opacity: .9;
+      opacity: 0.9;
       cursor: pointer;
     }
   }
 }
 
 .username {
-  color: #393B44;
+  color: #393b44;
   text-decoration: none;
   cursor: pointer;
   font-weight: 600;
@@ -127,12 +127,12 @@
   margin-left: -5px;
   transition: background-color 200ms ease;
   &:hover {
-    background-color: #E0E0E0;
+    background-color: #e0e0e0;
   }
 }
 
 .external {
-  font-size: .7em;
+  font-size: 0.7em;
   text-decoration: none;
   color: #063b9a;
   cursor: pointer;
@@ -140,7 +140,7 @@
   white-space: nowrap;
   &:hover {
     text-decoration: underline;
-    opacity: .9;
+    opacity: 0.9;
   }
   i {
     font-size: 12px;
@@ -209,7 +209,7 @@
 }
 
 .editedCommentBody {
-  padding: 5px;
+  padding: 0 5px 5px 5px;
 }
 
 .editedComment {

--- a/client/coral-admin/src/routes/Moderation/components/Comment.css
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.css
@@ -196,3 +196,21 @@
 .commentContentFooter {
   flex: 1;
 }
+
+.bodyHistoryToggle {
+  color: #666;
+  font-size: 12px;
+  line-height: 1px;
+  font-weight: 300;
+  text-decoration: underline;
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.editedBody {
+  margin-top: 6px;
+  font-weight: 300;
+  font-size: 16px;
+  overflow-wrap: break-word;
+}

--- a/client/coral-admin/src/routes/Moderation/components/Comment.css
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.css
@@ -208,7 +208,11 @@
   }
 }
 
-.editedBody {
+.editedCommentBody {
+  padding: 5px;
+}
+
+.editedComment {
   margin-top: 6px;
   font-weight: 300;
   font-size: 16px;

--- a/client/coral-admin/src/routes/Moderation/components/Comment.js
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.js
@@ -52,9 +52,13 @@ class Comment extends React.Component {
     const comment = this.props.comment;
     for (let i = 0; i < comment.body_history.length - 1; i++) {
       bodyHistory.push(
-        <div key={i} className={styles.editedBody}>
-          <TimeAgo className={styles.created} datetime={comment.created_at} />
-          {comment.body_history[i].body}
+        <div key={i} className={styles.editedComment}>
+          <div>
+            <TimeAgo className={styles.created} datetime={comment.created_at} />
+          </div>
+          <div className={styles.editedCommentBody}>
+            {comment.body_history[i].body}
+          </div>
         </div>
       );
     }

--- a/client/coral-admin/src/routes/Moderation/components/Comment.js
+++ b/client/coral-admin/src/routes/Moderation/components/Comment.js
@@ -22,6 +22,8 @@ import t from 'coral-framework/services/i18n';
 class Comment extends React.Component {
   ref = null;
 
+  state = { showingEditHistory: false };
+
   handleRef = ref => (this.ref = ref);
 
   handleFocusOrClick = () => {
@@ -44,6 +46,26 @@ class Comment extends React.Component {
     this.props.comment.status === 'REJECTED'
       ? null
       : this.props.rejectComment({ commentId: this.props.comment.id });
+
+  getBodyHistory = () => {
+    const bodyHistory = [];
+    const comment = this.props.comment;
+    for (let i = 0; i < comment.body_history.length - 1; i++) {
+      bodyHistory.push(
+        <div key={i} className={styles.editedBody}>
+          <TimeAgo className={styles.created} datetime={comment.created_at} />
+          {comment.body_history[i].body}
+        </div>
+      );
+    }
+
+    return bodyHistory;
+  };
+
+  toggleEditHistory = () => {
+    this.setState({ showingEditHistory: !this.state.showingEditHistory });
+    this.props.clearHeightCache && this.props.clearHeightCache();
+  };
 
   componentDidUpdate(prev) {
     if (!prev.selected && this.props.selected) {
@@ -137,6 +159,14 @@ class Comment extends React.Component {
                   &nbsp;<span className={styles.editedMarker}>
                     ({t('comment.edited')})
                   </span>
+                  &nbsp;<span
+                    className={styles.bodyHistoryToggle}
+                    onClick={this.toggleEditHistory}
+                  >
+                    {this.state.showingEditHistory
+                      ? t('comment.hide_edit_history')
+                      : t('comment.show_edit_history')}
+                  </span>
                 </span>
               ) : null}
               <div className={styles.adminCommentInfoBar}>
@@ -201,6 +231,14 @@ class Comment extends React.Component {
             </div>
           </CommentAnimatedEdit>
         </div>
+
+        {this.state.showingEditHistory ? (
+          <div className={styles.container}>
+            {t('comment.edit_history')}
+            {this.getBodyHistory()}
+          </div>
+        ) : null}
+
         <CommentDetails
           root={root}
           comment={comment}

--- a/client/coral-admin/src/routes/Moderation/containers/Comment.js
+++ b/client/coral-admin/src/routes/Moderation/containers/Comment.js
@@ -52,6 +52,10 @@ export default withFragments({
       status_history {
         type
       }
+      body_history {
+        body
+        created_at
+      }
       hasParent
       ${getSlotFragmentSpreads(slots, 'comment')}
       ...${getDefinitionName(CommentLabels.fragments.comment)}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -35,6 +35,9 @@ en:
     flagged: flagged
     undo_reject: Undo
     view_context: 'View context'
+    edit_history: 'Edit history'
+    show_edit_history: 'Show edit history'
+    hide_edit_history: 'Hide edit history'
   comment_box:
     cancel: Cancel
     characters_remaining: 'characters remaining'

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -35,6 +35,9 @@ es:
     flagged: Reportado
     undo_reject: Deshacer
     view_context: 'Ver contexto'
+    edit_history: 'Historial de ediciones'
+    show_edit_history: 'Mostrar historial de ediciones'
+    hide_edit_history: 'Ocultar historial de ediciones'
   comment_box:
     cancel: Cancelar
     characters_remaining: 'caracteres restantes'


### PR DESCRIPTION
## What does this PR do?
Add a "toggle" in the comments cards in Moderation and User Detail to be able to see the comment's edit history.

(#1951)

## How do I test this PR?
1. Find an edited comment either in a moderation queue or user details.
2. Click on Show edit history
3. Click on Hide edit history

Moderation queue:
![2019-05-04 12 17 02](https://user-images.githubusercontent.com/8509232/57182610-b2faa100-6e66-11e9-8063-299c9eb6b178.gif)

User details:
![2019-05-04 12 17 47](https://user-images.githubusercontent.com/8509232/57182611-b2faa100-6e66-11e9-87cb-5bd1987af75f.gif)


