### PR TITLE
Fix Clearing RTE Edit Content Bug

### DIFF
--- a/plugins/talk-plugin-rich-text/client/components/Editor.js
+++ b/plugins/talk-plugin-rich-text/client/components/Editor.js
@@ -22,7 +22,7 @@ class Editor extends React.Component {
   };
 
   getHTML(props = this.props) {
-    if (props.input.richTextBody) {
+    if (props.input.richTextBody !== undefined) {
       return props.input.richTextBody;
     }
     return (


### PR DESCRIPTION
## What does this PR do?
- Fixes https://github.com/coralproject/talk/issues/2256

## How do I test this PR?

- Use Chrome
- Edit a comment
- Erase comment content using multiples of `backspace`. The RTE should be empty as it is supposed to.