### PR TITLE
[next] Add redis_options config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 # job_environment will setup the environment for any job being executed.
 job_environment: &job_environment
   NODE_ENV: test
+  WEBPACK_MAX_CORES: 2
+  NODE_OPTIONS: --max-old-space-size=4096
 
 # job_defaults applies all the defaults for each job.
 job_defaults: &job_defaults

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ the variables in a `.env` file in the root of the project in a simple
   (Default `mongodb://127.0.0.1:27017/coral`)
 - `REDIS_URI` - The Redis database URI to connect to.
   (Default `redis://127.0.0.1:6379`)
+- `REDIS_OPTIONS` - A JSON string with optional configuration options to be used
+  when connecting to Redis as specified in the [ioredis](https://github.com/luin/ioredis/blob/1dac50a63753c2afc969315cfe38faf0edc50bc5/API.md#new_Redis_new) documentation.
+  (Default: `{}`)
 - `SIGNING_SECRET` - The shared secret to use to sign JSON Web Tokens (JWT) with
   the selected signing algorithm. 🚨 **Don't forget to set this variable!** 🚨
   (Default: `keyboard cat`)

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -131,7 +131,7 @@ const config = convict({
     format: Object,
     default: {},
     env: "REDIS_OPTIONS",
-    arg: "redis-options",
+    arg: "redisOptions",
   },
   signing_secret: {
     doc:

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -126,6 +126,13 @@ const config = convict({
     arg: "redis",
     sensitive: true,
   },
+  redis_options: {
+    doc: "The Redis options to connect to Redis Server.",
+    format: Object,
+    default: {},
+    env: "REDIS_OPTIONS",
+    arg: "redis-options",
+  },
   signing_secret: {
     doc:
       "The shared secret to use to sign JSON Web Tokens (JWT) with the selected signing algorithm.",

--- a/src/core/server/services/redis/index.ts
+++ b/src/core/server/services/redis/index.ts
@@ -1,9 +1,9 @@
+import RedisClient, { Pipeline, Redis } from "ioredis";
+
 import { Omit } from "coral-common/types";
 import { Config } from "coral-server/config";
 import { InternalError } from "coral-server/errors";
 import logger from "coral-server/logger";
-import RedisClient, { Pipeline, Redis } from "ioredis";
-import { merge } from "lodash";
 
 export interface AugmentedRedisCommands {
   mhincrby(key: string, ...args: any[]): Promise<void>;
@@ -42,16 +42,14 @@ export function createRedisClient(
   lazyConnect: boolean = false
 ): Redis {
   try {
-    const redis = new RedisClient(
-      config.get("redis"),
-      merge(
-        {},
-        {
-          lazyConnect,
-        },
-        config.get("redis_options")
-      )
-    );
+    const options = config.get("redis_options") || {};
+
+    const redis = new RedisClient(config.get("redis"), {
+      // Merge in the custom options.
+      ...options,
+      // Enforce the lazyConnect option as provided by the function invocation.
+      lazyConnect,
+    });
 
     // Configure the redis client with the handlers for logging
     attachHandlers(redis);

--- a/src/core/server/services/redis/index.ts
+++ b/src/core/server/services/redis/index.ts
@@ -1,9 +1,9 @@
-import RedisClient, { Pipeline, Redis } from "ioredis";
-
 import { Omit } from "coral-common/types";
 import { Config } from "coral-server/config";
 import { InternalError } from "coral-server/errors";
 import logger from "coral-server/logger";
+import RedisClient, { Pipeline, Redis } from "ioredis";
+import { merge } from "lodash";
 
 export interface AugmentedRedisCommands {
   mhincrby(key: string, ...args: any[]): Promise<void>;
@@ -42,9 +42,16 @@ export function createRedisClient(
   lazyConnect: boolean = false
 ): Redis {
   try {
-    const redis = new RedisClient(config.get("redis"), {
-      lazyConnect,
-    });
+    const redis = new RedisClient(
+      config.get("redis"),
+      merge(
+        {},
+        {
+          lazyConnect,
+        },
+        config.get("redis_options")
+      )
+    );
 
     // Configure the redis client with the handlers for logging
     attachHandlers(redis);


### PR DESCRIPTION
This PR add Redis Option configuration support.

With it you can configure: keepAlive, connectTimeout, tls, redis sentinel, and others.