### PR TITLE
Don't crash on email address lookup failure

### DIFF
--- a/jobs/mailer.js
+++ b/jobs/mailer.js
@@ -111,7 +111,12 @@ const processJob = transport => async ({ id, data }, done) => {
   const { message } = data;
 
   // Get the email address from the job data.
-  message.to = await getEmailAddress(data);
+  try {
+    message.to = await getEmailAddress(data);
+  } catch (err) {
+    logger.error({ err }, 'Failed to get user email address to send mail');
+    return done(err);
+  }
 
   const log = logger.child({ jobID: id });
   log.info('Starting to send mail');


### PR DESCRIPTION
## What does this PR do?

If for whatever reason an email job gets queued for a user with no
email, an exception is thrown on the `getEmailAddress()` step. This
exception is never handled and therefore the app crashes, which is
non-ideal. Handle it and log instead, as per other errors in this function.

This state is fairly easy to get into if your plugins are configured such
that users can register with SSO and aren't required to set a username
and password. In my case, the actual culprit was the profile-data plugin,
which will attempt to send email without checking (and might be worth
fixing separately), but at any rate core shouldn't be crashing as a result
of plugin behaviour.

## How do I test this PR?

Cause an email to be sent to a user with no email. For example, enable
the plugins google-auth and profile-data but not local-auth, create an
account via Google SSO, and then attempt to delete the account.
Observe whether the app crashes in the mailer job handling.