### PR TITLE
[next] Ancestors

### DIFF
--- a/src/core/server/graph/tenant/resolvers/Comment.ts
+++ b/src/core/server/graph/tenant/resolvers/Comment.ts
@@ -93,7 +93,6 @@ export const Comment: GQLCommentTypeResolver<comment.Comment> = {
   permalink: async ({ id, storyID }, input, ctx) => {
     const story = await ctx.loaders.Stories.story.load(storyID);
     if (!story) {
-      // TODO: better error reporting?
       throw new StoryNotFoundError(storyID);
     }
     return getURLWithCommentID(story.url, id);

--- a/src/core/server/graph/tenant/resolvers/CommentCounts.ts
+++ b/src/core/server/graph/tenant/resolvers/CommentCounts.ts
@@ -1,14 +1,14 @@
-import {
-  GQLCOMMENT_STATUS,
-  GQLCommentCountsTypeResolver,
-} from "coral-server/graph/tenant/schema/__generated__/types";
+import { GQLCommentCountsTypeResolver } from "coral-server/graph/tenant/schema/__generated__/types";
+import { VISIBLE_STATUSES } from "coral-server/models/comment/constants";
 import { CommentStatusCounts } from "coral-server/models/story";
 
 export const CommentCounts: GQLCommentCountsTypeResolver<
   CommentStatusCounts
 > = {
   totalVisible: commentCounts =>
-    commentCounts[GQLCOMMENT_STATUS.ACCEPTED] +
-    commentCounts[GQLCOMMENT_STATUS.NONE],
+    VISIBLE_STATUSES.reduce(
+      (total, status) => total + commentCounts[status],
+      0
+    ),
   statuses: commentCounts => commentCounts,
 };

--- a/src/core/server/models/comment/constants.ts
+++ b/src/core/server/models/comment/constants.ts
@@ -1,0 +1,10 @@
+import { GQLCOMMENT_STATUS } from "coral-server/graph/tenant/schema/__generated__/types";
+
+/**
+ * VISIBLE_STATUSES are the comment statuses that a Comment may have that would
+ * make it visible to readers.
+ */
+export const VISIBLE_STATUSES = [
+  GQLCOMMENT_STATUS.NONE,
+  GQLCOMMENT_STATUS.ACCEPTED,
+];

--- a/src/core/server/models/comment/helpers.ts
+++ b/src/core/server/models/comment/helpers.ts
@@ -1,0 +1,23 @@
+import { Comment } from ".";
+import { VISIBLE_STATUSES } from "./constants";
+
+/**
+ * hasAncestors will check to see if a given comment has any ancestors.
+ *
+ * @param comment the comment to check the ancestors on
+ */
+export function hasAncestors(
+  comment: Pick<Comment, "ancestorIDs" | "parentID">
+): comment is Required<Pick<Comment, "ancestorIDs" | "parentID">> {
+  return Boolean(comment.ancestorIDs.length > 0);
+}
+
+/**
+ * hasVisibleStatus will check to see if the comment has a visibility status
+ * where readers could see it.
+ *
+ * @param comment the comment to check the status on
+ */
+export function hasVisibleStatus(comment: Pick<Comment, "status">): boolean {
+  return VISIBLE_STATUSES.includes(comment.status);
+}


### PR DESCRIPTION
## What does this PR do?

Simplifies the ancestor and child ID management on the comment's.

This will requires a database migration, the following changes should be applied to existing databases:

```js
db.comments.updateMany(
  {},
  {
    $rename: {
      replyIDs: "childIDs",
      replyCount: "childCount",
      grandparentIDs: "ancestorIDs",
    },
  }
);

db.comments.find().forEach(comment => {
  if (comment.parentID) {
    if (!comment.ancestorIDs) {
      comment.ancestorIDs = [];
    }

    comment.ancestorIDs.push(comment.parentID);
    comment.ancestorIDs.reverse();

    db.comments.update(
      { id: comment.id },
      {
        $set: {
          ancestorIDs: comment.ancestorIDs,
        },
      }
    );
  } else {
    db.comments.update(
      { id: comment.id },
      {
        $set: {
          ancestorIDs: [],
        },
      }
    );
  }
});
```