### PR TITLE
[CORL-394] Pre-Mod Link feature wouldn't capture suspect and other flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "5.0.0-beta.1",
+  "version": "5.0.0-beta.2",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/src/core/server/services/comments/pipeline/phases/index.ts
+++ b/src/core/server/services/comments/pipeline/phases/index.ts
@@ -22,11 +22,11 @@ export const moderationPhases: IntermediateModerationPhase[] = [
   commentingDisabled,
   linkify,
   purify,
-  detectLinks,
   wordList,
   staff,
   karma,
   spam,
   toxic,
+  detectLinks,
   preModerate,
 ];


### PR DESCRIPTION
## What does this PR do?
- Move premod links moderation phase further down to allow capturing suspect, toxic and other flags.

## How do I test this PR?

- Turn on Pre-Mod Link in Stream Settings
- E.g. Write a comment with a suspect word and a link
- In moderation both flags should appear