### PR TITLE
[CORL-399] Hide Non-Visible Comments

### DIFF
--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkView.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkView.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent, MouseEvent } from "react";
 import { PropTypesOf } from "coral-framework/types";
 import {
   Button,
+  CallOut,
   Flex,
   HorizontalGutter,
   Typography,
@@ -69,11 +70,13 @@ const PermalinkView: FunctionComponent<PermalinkViewProps> = ({
         )}
       </Flex>
       {!comment && (
-        <Localized id="comments-permalinkView-commentRemovedOrDoesNotExist">
-          <Typography>
-            This comment has been removed or does not exist.
-          </Typography>
-        </Localized>
+        <CallOut fullWidth>
+          <Localized id="comments-permalinkView-commentRemovedOrDoesNotExist">
+            <Typography>
+              This comment has been removed or does not exist.
+            </Typography>
+          </Localized>
+        </CallOut>
       )}
       {comment && (
         <HorizontalGutter>

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkView.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkView.tsx
@@ -69,8 +69,10 @@ const PermalinkView: FunctionComponent<PermalinkViewProps> = ({
         )}
       </Flex>
       {!comment && (
-        <Localized id="comments-permalinkView-commentNotFound">
-          <Typography>Comment not found</Typography>
+        <Localized id="comments-permalinkView-commentRemovedOrDoesNotExist">
+          <Typography>
+            This comment has been removed or does not exist.
+          </Typography>
         </Localized>
       )}
       {comment && (

--- a/src/core/client/stream/tabs/Comments/PermalinkView/__snapshots__/PermalinkView.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/__snapshots__/PermalinkView.spec.tsx.snap
@@ -48,10 +48,10 @@ exports[`renders comment not found 1`] = `
     </Localized>
   </ForwardRef(forwardRef)>
   <Localized
-    id="comments-permalinkView-commentNotFound"
+    id="comments-permalinkView-commentRemovedOrDoesNotExist"
   >
     <ForwardRef(forwardRef)>
-      Comment not found
+      This comment has been removed or does not exist.
     </ForwardRef(forwardRef)>
   </Localized>
 </ForwardRef(forwardRef)>

--- a/src/core/client/stream/tabs/Comments/PermalinkView/__snapshots__/PermalinkView.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/__snapshots__/PermalinkView.spec.tsx.snap
@@ -47,13 +47,17 @@ exports[`renders comment not found 1`] = `
       </ForwardRef(forwardRef)>
     </Localized>
   </ForwardRef(forwardRef)>
-  <Localized
-    id="comments-permalinkView-commentRemovedOrDoesNotExist"
+  <withPropsOnChange(CallOut)
+    fullWidth={true}
   >
-    <ForwardRef(forwardRef)>
-      This comment has been removed or does not exist.
-    </ForwardRef(forwardRef)>
-  </Localized>
+    <Localized
+      id="comments-permalinkView-commentRemovedOrDoesNotExist"
+    >
+      <ForwardRef(forwardRef)>
+        This comment has been removed or does not exist.
+      </ForwardRef(forwardRef)>
+    </Localized>
+  </withPropsOnChange(CallOut)>
 </ForwardRef(forwardRef)>
 `;
 

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
@@ -70,7 +70,7 @@ exports[`renders permalink view with unknown comment 1`] = `
     <p
       className="Typography-root Typography-bodyCopy Typography-colorTextPrimary"
     >
-      Comment not found
+      This comment has been removed or does not exist.
     </p>
   </div>
 </section>

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
@@ -67,11 +67,15 @@ exports[`renders permalink view with unknown comment 1`] = `
         View Full Discussion
       </a>
     </div>
-    <p
-      className="Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+    <div
+      className="CallOut-root CallOut-colorRegular CallOut-fullWidth"
     >
-      This comment has been removed or does not exist.
-    </p>
+      <p
+        className="Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+      >
+        This comment has been removed or does not exist.
+      </p>
+    </div>
   </div>
 </section>
 `;

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -32,7 +32,7 @@ comments-permalinkPopover =
   .description = A dialog showing a permalink to the comment
 comments-permalinkButton-share = Share
 comments-permalinkView-viewFullDiscussion = View Full Discussion
-comments-permalinkView-commentNotFound = Comment not found
+comments-permalinkView-commentRemovedOrDoesNotExist = This comment has been removed or does not exist.
 
 comments-rte-bold =
   .title = Bold

--- a/src/locales/pt-BR/stream.ftl
+++ b/src/locales/pt-BR/stream.ftl
@@ -32,8 +32,7 @@ comments-permalinkPopover =
   .description = Uma caixa de diálogo mostrando um link permanente para o comentário
 comments-permalinkButton-share = Compartilhar
 comments-permalinkView-viewFullDiscussion = Ver discussão completa
-comments-permalinkView-commentNotFound = Comentário não encontrado
-
+comments-permalinkView-commentRemovedOrDoesNotExist = Este comentário foi removido ou não existe.
 comments-rte-bold =
   .title = Negrito
 


### PR DESCRIPTION
## What does this PR do?

Hides non-visible comments from the permalink view from direct access.

## How do I test this PR?

- Create a comment
- Copy the share URL of that comment
- Reject that comment
- Visit the share URL of that comment, notice the comment not visible