### PR TITLE
[CORL-409] Prevent users from ignoring staff members

### DIFF
--- a/src/core/client/admin/test/fixtures.ts
+++ b/src/core/client/admin/test/fixtures.ts
@@ -289,6 +289,7 @@ export const users = {
         username: "Markus",
         email: "markus@test.com",
         role: GQLUSER_ROLE.ADMIN,
+        ignoreable: false,
       },
     ],
     baseUser
@@ -300,6 +301,7 @@ export const users = {
         username: "Lukas",
         email: "lukas@test.com",
         role: GQLUSER_ROLE.MODERATOR,
+        ignoreable: false,
       },
     ],
     baseUser
@@ -311,6 +313,7 @@ export const users = {
         username: "Huy",
         email: "huy@test.com",
         role: GQLUSER_ROLE.STAFF,
+        ignoreable: false,
       },
     ],
     baseUser
@@ -322,18 +325,21 @@ export const users = {
         username: "Isabelle",
         email: "isabelle@test.com",
         role: GQLUSER_ROLE.COMMENTER,
+        ignoreable: true,
       },
       {
         id: "user-commenter-1",
         username: "Ngoc",
         email: "ngoc@test.com",
         role: GQLUSER_ROLE.COMMENTER,
+        ignoreable: true,
       },
       {
         id: "user-commenter-2",
         username: "Max",
         email: "max@test.com",
         role: GQLUSER_ROLE.COMMENTER,
+        ignoreable: true,
       },
     ],
     baseUser
@@ -344,6 +350,7 @@ export const users = {
       username: "Ingrid",
       email: "ingrid@test.com",
       role: GQLUSER_ROLE.COMMENTER,
+      ignoreable: true,
       status: {
         current: [GQLUSER_STATUS.BANNED],
         ban: { active: true },

--- a/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/CreateCommentReplyMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/CreateCommentReplyMutation.ts
@@ -178,6 +178,7 @@ function commit(
               id: viewer.id,
               username: viewer.username,
               createdAt: viewer.createdAt,
+              ignoreable: false,
             },
             body: input.body,
             revision: {

--- a/src/core/client/stream/tabs/Comments/Comment/UserPopover/UserPopoverOverviewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/UserPopover/UserPopoverOverviewContainer.tsx
@@ -30,7 +30,8 @@ export const UserPopoverOverviewContainer: FunctionComponent<Props> = ({
   const canIgnore =
     viewer &&
     viewer.id !== user.id &&
-    viewer.ignoredUsers.every(u => u.id !== user.id);
+    viewer.ignoredUsers.every(u => u.id !== user.id) &&
+    user.ignoreable;
   return (
     <HorizontalGutter spacing={3} className={styles.root}>
       <HorizontalGutter spacing={2}>
@@ -73,6 +74,7 @@ const enhanced = withFragmentContainer<Props>({
       id
       username
       createdAt
+      ignoreable
     }
   `,
 })(UserPopoverOverviewContainer);

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
@@ -148,6 +148,7 @@ function commit(
               id: viewer.id,
               username: viewer.username,
               createdAt: viewer.createdAt,
+              ignoreable: false,
             },
             revision: {
               id: uuidGenerator(),

--- a/src/core/client/stream/test/fixtures.ts
+++ b/src/core/client/stream/test/fixtures.ts
@@ -104,21 +104,25 @@ export const commenters = createFixtures<GQLUser>(
       id: "user-0",
       username: "Markus",
       role: GQLUSER_ROLE.COMMENTER,
+      ignoreable: true,
     },
     {
       id: "user-1",
       username: "Lukas",
       role: GQLUSER_ROLE.COMMENTER,
+      ignoreable: true,
     },
     {
       id: "user-2",
       username: "Isabelle",
       role: GQLUSER_ROLE.COMMENTER,
+      ignoreable: true,
     },
     {
       id: "user-3",
       username: "Markus",
       role: GQLUSER_ROLE.COMMENTER,
+      ignoreable: true,
     },
   ],
   baseUser
@@ -354,6 +358,7 @@ export const moderators = createFixtures<GQLUser>(
       id: "me-as-moderator",
       username: "Moderator",
       role: GQLUSER_ROLE.MODERATOR,
+      ignoreable: false,
     },
   ],
   baseUser

--- a/src/core/common/errors.ts
+++ b/src/core/common/errors.ts
@@ -232,6 +232,13 @@ export enum ERROR_CODES {
   USER_BANNED = "USER_BANNED",
 
   /**
+   * USER_CANNOT_BE_IGNORED is returned when the user attempts to ignore
+   * a user that is not allowed to be ignored. This is usually because the
+   * user is staff member.
+   */
+  USER_CANNOT_BE_IGNORED = "USER_CANNOT_BE_IGNORED",
+
+  /**
    * INTEGRATION_DISABLED is returned when an operation is attempted against an
    * integration that has been disabled.
    */

--- a/src/core/server/errors/index.ts
+++ b/src/core/server/errors/index.ts
@@ -573,6 +573,15 @@ export class UserSuspended extends CoralError {
   }
 }
 
+export class UserCannotBeIgnoredError extends CoralError {
+  constructor(userID: string) {
+    super({
+      code: ERROR_CODES.USER_CANNOT_BE_IGNORED,
+      context: { pub: { userID } },
+    });
+  }
+}
+
 export class PasswordResetTokenExpired extends CoralError {
   constructor(reason: string, cause?: Error) {
     super({

--- a/src/core/server/errors/translations.ts
+++ b/src/core/server/errors/translations.ts
@@ -27,6 +27,7 @@ export const ERROR_TRANSLATIONS: Record<ERROR_CODES, string> = {
   TOKEN_NOT_FOUND: "error-tokenNotFound",
   USER_NOT_ENTITLED: "error-userNotEntitled",
   USER_NOT_FOUND: "error-userNotFound",
+  USER_CANNOT_BE_IGNORED: "error-userCannotBeIgnored",
   USERNAME_ALREADY_SET: "error-usernameAlreadySet",
   USERNAME_CONTAINS_INVALID_CHARACTERS:
     "error-usernameContainsInvalidCharacters",

--- a/src/core/server/graph/tenant/resolvers/User.ts
+++ b/src/core/server/graph/tenant/resolvers/User.ts
@@ -6,6 +6,7 @@ import {
   GQLUserTypeResolver,
 } from "coral-server/graph/tenant/schema/__generated__/types";
 import * as user from "coral-server/models/user";
+import { STAFF_ROLES } from "coral-server/models/user/constants";
 
 import { UserStatusInput } from "./UserStatus";
 import { getRequestedFields } from "./util";
@@ -41,4 +42,5 @@ export const User: GQLUserTypeResolver<user.User> = {
   }),
   ignoredUsers: ({ ignoredUsers }, input, ctx, info) =>
     maybeLoadOnlyIgnoredUserID(ctx, info, ignoredUsers),
+  ignoreable: ({ role }) => !STAFF_ROLES.includes(role),
 };

--- a/src/core/server/graph/tenant/resolvers/User.ts
+++ b/src/core/server/graph/tenant/resolvers/User.ts
@@ -6,7 +6,7 @@ import {
   GQLUserTypeResolver,
 } from "coral-server/graph/tenant/schema/__generated__/types";
 import * as user from "coral-server/models/user";
-import { STAFF_ROLES } from "coral-server/models/user/constants";
+import { roleIsStaff } from "coral-server/models/user/helpers";
 
 import { UserStatusInput } from "./UserStatus";
 import { getRequestedFields } from "./util";
@@ -42,5 +42,5 @@ export const User: GQLUserTypeResolver<user.User> = {
   }),
   ignoredUsers: ({ ignoredUsers }, input, ctx, info) =>
     maybeLoadOnlyIgnoredUserID(ctx, info, ignoredUsers),
-  ignoreable: ({ role }) => !STAFF_ROLES.includes(role),
+  ignoreable: ({ role }) => !roleIsStaff(role),
 };

--- a/src/core/server/graph/tenant/schema/schema.graphql
+++ b/src/core/server/graph/tenant/schema/schema.graphql
@@ -1457,6 +1457,13 @@ type User {
     )
 
   """
+  ignoreable is a computed property based on the
+  user's role. Typically, users with elevated privileges
+  aren't allowed to be ignored.
+  """
+  ignoreable: Boolean!
+
+  """
   comments are the comments written by the User.
   """
   comments(

--- a/src/core/server/models/user/constants.ts
+++ b/src/core/server/models/user/constants.ts
@@ -1,0 +1,7 @@
+import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
+
+export const STAFF_ROLES = [
+  GQLUSER_ROLE.ADMIN,
+  GQLUSER_ROLE.MODERATOR,
+  GQLUSER_ROLE.STAFF,
+];

--- a/src/core/server/models/user/helpers.ts
+++ b/src/core/server/models/user/helpers.ts
@@ -1,11 +1,16 @@
+import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
 import { STAFF_ROLES } from "coral-server/models/user/constants";
 
 import { User } from ".";
 
-export function userIsStaff(user: User) {
-  if (STAFF_ROLES.includes(user.role)) {
+export function roleIsStaff(role: GQLUSER_ROLE) {
+  if (STAFF_ROLES.includes(role)) {
     return true;
   }
 
   return false;
+}
+
+export function userIsStaff(user: User) {
+  return roleIsStaff(user.role);
 }

--- a/src/core/server/models/user/helpers.ts
+++ b/src/core/server/models/user/helpers.ts
@@ -1,0 +1,17 @@
+import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
+
+import { User } from ".";
+
+export async function userIsStaff(user: User) {
+  const staffRoles = [
+    GQLUSER_ROLE.ADMIN,
+    GQLUSER_ROLE.MODERATOR,
+    GQLUSER_ROLE.STAFF,
+  ];
+
+  if (staffRoles.includes(user.role)) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/core/server/models/user/helpers.ts
+++ b/src/core/server/models/user/helpers.ts
@@ -2,7 +2,7 @@ import { STAFF_ROLES } from "coral-server/models/user/constants";
 
 import { User } from ".";
 
-export async function userIsStaff(user: User) {
+export function userIsStaff(user: User) {
   if (STAFF_ROLES.includes(user.role)) {
     return true;
   }

--- a/src/core/server/models/user/helpers.ts
+++ b/src/core/server/models/user/helpers.ts
@@ -1,15 +1,9 @@
-import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
+import { STAFF_ROLES } from "coral-server/models/user/constants";
 
 import { User } from ".";
 
 export async function userIsStaff(user: User) {
-  const staffRoles = [
-    GQLUSER_ROLE.ADMIN,
-    GQLUSER_ROLE.MODERATOR,
-    GQLUSER_ROLE.STAFF,
-  ];
-
-  if (staffRoles.includes(user.role)) {
+  if (STAFF_ROLES.includes(user.role)) {
     return true;
   }
 

--- a/src/core/server/models/user/index.ts
+++ b/src/core/server/models/user/index.ts
@@ -26,16 +26,16 @@ import {
 import { getLocalProfile, hasLocalProfile } from "coral-server/helpers/users";
 import logger from "coral-server/logger";
 import {
+  Connection,
+  ConnectionInput,
+  resolveConnection,
+} from "coral-server/models/helpers/connection";
+import {
   createConnectionOrderVariants,
   createIndexFactory,
 } from "coral-server/models/helpers/indexing";
 import Query from "coral-server/models/helpers/query";
 import { TenantResource } from "coral-server/models/tenant";
-import {
-  Connection,
-  ConnectionInput,
-  resolveConnection,
-} from "./helpers/connection";
 
 function collection(mongo: Db) {
   return mongo.collection<Readonly<User>>("users");

--- a/src/core/server/services/users/index.ts
+++ b/src/core/server/services/users/index.ts
@@ -9,6 +9,7 @@ import {
   TokenNotFoundError,
   UserAlreadyBannedError,
   UserAlreadySuspendedError,
+  UserCannotBeIgnoredError,
   UsernameAlreadySetError,
   UserNotFoundError,
 } from "coral-server/errors";
@@ -39,6 +40,7 @@ import {
   updateUserUsername,
   User,
 } from "coral-server/models/user";
+import { userIsStaff } from "coral-server/models/user/helpers";
 import { MailerQueue } from "coral-server/queue/tasks/mailer";
 import { JWTSigningConfig, signPATString } from "coral-server/services/jwt";
 
@@ -583,6 +585,11 @@ export async function ignore(
   const targetUser = await retrieveUser(mongo, tenant.id, userID);
   if (!targetUser) {
     throw new UserNotFoundError(userID);
+  }
+
+  const userToBeIgnoredIsStaff = await userIsStaff(targetUser);
+  if (userToBeIgnoredIsStaff) {
+    throw new UserCannotBeIgnoredError(userID);
   }
 
   // TODO: extract function

--- a/src/core/server/services/users/index.ts
+++ b/src/core/server/services/users/index.ts
@@ -587,7 +587,7 @@ export async function ignore(
     throw new UserNotFoundError(userID);
   }
 
-  const userToBeIgnoredIsStaff = await userIsStaff(targetUser);
+  const userToBeIgnoredIsStaff = userIsStaff(targetUser);
   if (userToBeIgnoredIsStaff) {
     throw new UserCannotBeIgnoredError(userID);
   }


### PR DESCRIPTION
## What does this PR do?

This removes the ignore button on staff member's overlay popup.
This also validates ignore requests in the backing API to prevent users from ignoring staff members.

## How do I test this PR?

Front-End:
- Create a user with a staff role (Admin, Mod, or Staff).
- Comment on something in any test discussion.
- Create a regular user that is not a staff role.
- View the previous discussion comment, click on the staff user's name.
- The ignore button should not be visible on the staff user's overlay popup/card.

Back-end:
- Request an ignore for a user that is a staff member
- Should return a `USER_CANNOT_BE_IGNORED`
