### PR TITLE
[next] Remove skew tolerance while parsing/checking expired token.

### DIFF
--- a/src/core/client/framework/lib/jwt.ts
+++ b/src/core/client/framework/lib/jwt.ts
@@ -24,7 +24,7 @@ export function parseJWT(token: string, skewTolerance = 300): JWT {
     header,
     payload,
     get expired() {
-      return Date.now() / 1000 - skewTolerance >= payload.exp;
+      return Date.now() / 1000 + skewTolerance >= payload.exp;
     },
   };
 }


### PR DESCRIPTION
This PR removes skew tolerance while checking expired token.

The side effect of the skewTolerance set to 300 is a blank screen when refresh the admin page with the token expired.

With this PR, the login page is immediately called when token expires.