### PR TITLE
[CORL-427] AddEmailAddressDialog should appear at the top

### DIFF
--- a/plugins/talk-plugin-local-auth/client/containers/AddEmailAddressDialog.css
+++ b/plugins/talk-plugin-local-auth/client/containers/AddEmailAddressDialog.css
@@ -1,0 +1,6 @@
+.dialog {
+  border: none;
+  box-shadow: 0 9px 46px 8px rgba(0, 0, 0, 0.14), 0 11px 15px -7px rgba(0, 0, 0, 0.12), 0 24px 38px 3px rgba(0, 0, 0, 0.2);
+  width: 400px;
+  top: 10px;
+}

--- a/plugins/talk-plugin-local-auth/client/containers/AddEmailAddressDialog.js
+++ b/plugins/talk-plugin-local-auth/client/containers/AddEmailAddressDialog.js
@@ -17,6 +17,8 @@ import {
   EmailAddressAdded,
 } from '../components/AddEmailAddress';
 
+import styles from './AddEmailAddressDialog.css';
+
 class AddEmailAddressDialog extends React.Component {
   state = {
     step: 0,
@@ -72,7 +74,11 @@ class AddEmailAddressDialog extends React.Component {
     } = this.props;
 
     return (
-      <Dialog open={true} id="talk-plugin-local-auth-email-dialog">
+      <Dialog
+        open={true}
+        id="talk-plugin-local-auth-email-dialog"
+        className={styles.dialog}
+      >
         {step === 0 && <AddEmailForm onSubmit={this.handleSubmit} />}
         {step === 1 &&
           !requireEmailConfirmation && (


### PR DESCRIPTION
## What does this PR do?
- `AddEmailAddressDialog` now appears at the top

## How do I test this PR?
- Create a new account with a social login
- Set your username
- See the add email address dialog appear at the top