### PR TITLE
Break headline on featured comments plugin

### DIFF
--- a/plugins/talk-plugin-featured-comments/client/components/Tooltip.css
+++ b/plugins/talk-plugin-featured-comments/client/components/Tooltip.css
@@ -38,13 +38,15 @@
   color: #484747;
   display: inline-block;
   margin: 0;
-  padding: 0;
+  padding: 0 16px 0 0;
   font-size: 1.02em;
   margin-left: 6px;
   letter-spacing: 0.2px;
   vertical-align: middle;
   margin-bottom: 2px;
   line-height: 22px;
+  box-sizing: border-box;
+  white-space: pre-wrap;  
 }
 
 .icon {


### PR DESCRIPTION
## What does this PR do?
If a headline is too long, we need to break it to fit the tooltip content box. e.g. German version of Talk.

![linebreak2](https://user-images.githubusercontent.com/2144796/59846558-7de7d680-9360-11e9-9c2d-83ca62251b61.png)

## How do I test this PR?

- Set Talk language to German
- Feature a comment
- Check the tooltip headline
