### PR TITLE
Added missing German translations.

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -3,6 +3,13 @@ de:
     sort_comments: 'Kommentare sortieren'
     view_options: Ansichtsoptionen
   already_flagged_username: 'Sie haben diesen Nutzernamen schon markiert.'
+  alwayspremoddialog:
+    are_you_sure: 'Sind sie sicher, dass sie immer vormoderieren wollen für {0}?'
+    always_premod_user: 'Nutzer immer vormoderieren?'
+    cancel: Abbrechen
+    note: 'Hinweis: {0}'
+    note_always_premod_user: 'Kommentare dieses Nutzers werden niemals automatisch freigegeben sondern erscheinen immer in der Liste für Vormoderation.'
+    yes_always_premod_user: 'Nutzer vormoderieren'
   bandialog:
     are_you_sure: 'Sind Sie sich sicher, dass Sie {0} sperren möchten?'
     ban_user: 'Nutzer sperren?'
@@ -28,6 +35,9 @@ de:
     flagged: markiert
     undo_reject: 'Rückgängig machen'
     view_context: 'Kontext ansehen'
+    edit_history: 'Verlauf anpassen'
+    show_edit_history: 'Zeige Verlaufshistorie'
+    hide_edit_history: 'Verstecke Verlaufshistorie'
   comment_box:
     cancel: Abbrechen
     characters_remaining: 'verbleibende Zeichen'
@@ -48,9 +58,10 @@ de:
   comment_post_notif_premod: 'Vielen Dank für Ihren Kommentar. Unsere Moderatoren werden ihn in Kürze bearbeiten.'
   comment_singular: Kommentar
   common:
-    copied: 'Kopiert'
-    notsupported: 'Nicht unterstützt'
+    contains_link: 'Enthält einen Link'
     copy: Kopieren
+    copied: 'Kopiert'
+    notsupported: 'Nicht unterstützt'   
     error: 'Ein Problem ist aufgetreten.'
     reaction: 'Reaktion'
     reactions: 'Reaktionen'
@@ -62,6 +73,8 @@ de:
     active: Aktiv
     admin: Administrator
     ads_marketing: 'Dies scheint Werbung zu sein'
+    all: 'Alle'
+    always_premod: 'Vormoderiert'
     are_you_sure: 'Sind Sie sich sicher, dass Sie {0} sperren möchten?'
     ban_user: 'Nutzer sperren?'
     banned: Gesperrt
@@ -69,6 +82,8 @@ de:
     cancel: Abbrechen
     commenter: Kommentator
     dont_like_username: 'Unsympathischer Nutzername'
+    filter_users: 'Nutzer filtern'
+    filter_role: Rolle
     flaggedaccounts: 'Gemeldete Nutzernamen'
     flags: Markierungen
     impersonating: 'Identität unklar'
@@ -85,6 +100,7 @@ de:
     spam_ads: Spam/Werbung
     staff: Mitarbeiter
     status: Status
+    suspended: 'Vorübergehend gesperrt'
     username_and_email: 'Nutzername und E-Mail'
     yes_ban_user: 'Ja, Nutzer sperren'
   configure:
@@ -111,6 +127,8 @@ de:
     copy_and_paste: 'Kopieren Sie diesen Code in Ihr CMS, um die Kommentarfunktion an entsprechender Stelle anzuzeigen.'
     custom_css_url: 'Benutzerdefinierte CSS-URL'
     custom_css_url_desc: 'URL eines CSS-Stylesheets zum Überschreiben des Standard-Designs'
+    custom_admin_css_url: 'Benutzerdefinierte CSS URL für Admin Panel'
+    custom_admin_css_url_desc: 'URL eines CSS-Stylesheets zum Überschreiben des Standart-Designs für das Admin Panel.'
     days: Tage
     description: 'Ändern Sie die Einstellungen für den Kommentarbereich dieses Artikels.'
     disable_commenting_desc: 'Verfassen Sie eine Nachricht, die angezeigt wird, solange das Kommentieren deaktiviert ist.'
@@ -147,6 +165,9 @@ de:
     organization_info_copy_2: 'Wir empfehlen, einee generische E-Mail-Adresse (z.B. community@yournewsroom.com) für diesen Zweck einzurichten. Die kann über die Zeit gleich bleiben, und gibt nach außen keine Namen preis, die von Nutzern im Fall von Konflikten für persönliche Angriffe missbraucht werden könnten.'
     organization_information: 'Über die Organisation'
     organization_name: 'Name der Organisation'
+    suspect_or_forbidden_words_placeholder: 'Wort oder Phrase'
+    product_guide_link: 'Produkt Guide'
+    report_bug_or_feedback: 'Feedback'
     require_email_verification: 'E-Mail-Bestätigung erforderlich'
     require_email_verification_text: 'Neue Nutzer müssen ihre E-Mail-Adresse bestätigen.'
     save: Speichern
@@ -165,6 +186,7 @@ de:
     suspect_word_title: 'Liste verdächtiger Wörter'
     tech_settings: 'Technische Einstellungen'
     title: 'Kommentarbereich konfigurieren'
+    view_last_version: 'Letzte Version'
     weeks: Wochen
     wordlist: 'Gesperrte Wörter'
   confirm_email:
@@ -222,6 +244,7 @@ de:
     copied: 'Kopiert'
   error:
     ALREADY_EXISTS: 'Ressource existiert bereits'
+    AUTHENTICATION: 'Bei der Anmeldung ist ein Fehler aufgetreten.'
     CANNOT_IGNORE_STAFF: 'Mitarbeiter können nicht ignoriert werden.'
     COMMENT_PARENT_NOT_VISIBLE: 'Der Kommentar, auf den Sie antworten möchten, wurde entfernt oder existiert nicht.'
     COMMENT_TOO_SHORT: 'Kommentare sollten mehr als ein Zeichen enthalten, bitte überprüfen Sie Ihren Kommentar und probieren Sie es erneut.'
@@ -250,6 +273,7 @@ de:
     organization_contact_email: 'E-Mail-Adresse der Organisation ist ungültig.'
     organization_name: 'Namen von Organisationen dürfen nur Buchstaben und Zahlen enthalten.'
     password: 'Passwort muss mindestens 8 Zeichen enthalten'
+    PAGE_NOT_AVAILABLE_ROLE: 'Der Zugriff auf diese Seite ist eingeschränkt. Bitte wenden Sie sich an den Administrator.'
     PASSWORD_INCORRECT: 'Ihr bestehendes Passwort wurde falsch eingegeben'
     PASSWORD_LENGTH: 'Passwort ist zu kurz'
     PASSWORD_REQUIRED: 'Passwort ist erforderlich'
@@ -265,6 +289,13 @@ de:
     USERNAME_REQUIRED: 'Nutzername muss angegeben werden'
   flag_comment: 'Kommentar melden'
   flag_reason: 'Grund der Meldung (optional)'
+  flag_reasons:
+    username:
+      impersonating: 'Gibt sich für jemand anderen aus'
+      nolike: 'Ich mag diesen Nutzernamen nicht'
+      offensive: 'Dieser Nutzername ist unangemessen'
+      other: Sonstiges
+      spam: 'Dies scheint Werbung zu sein'
   flag_username: 'Nutzername melden'
   flagged_usernames:
     notify_approved: '{0} hat Nutzername {1} freigegeben'
@@ -281,6 +312,7 @@ de:
         comment_spam: Spam
         links: Link
         suspect_word: 'Verdächtiges Wort'
+        trust: Karma
       user:
         username_impersonating: 'Identität unklar'
         username_nolike: Unerwünscht
@@ -300,6 +332,7 @@ de:
     comments: Kommentare
     configure_stream: Konfigurieren
     content_not_available: 'Dieser Inhalt ist nicht verfügbar'
+    edit: Ändern
     edit_name:
       button: Senden
       error: 'Nutzernamen dürfen nur Buchstaben, Zahlen und _ enthalten'
@@ -343,16 +376,30 @@ de:
       title: 'Zugelassene Domains'
   like: 'Gefällt mir'
   loading_results: 'Lädt Ergebnisse'
+  login:
+    email_address: 'E-Mail-Adresse'
+    forgot_password: 'Passwort vergessen?'
+    go_back: 'Zurück'
+    sign_in: 'Anmelden'
+    sign_in_button: 'Anmelden'
+    sign_in_message: 'Anmelden um mit der Community zu interagieren.'
+    password: Passwort
+    reset_password_send_button: 'Passwort erhalten'
+    request_passowrd: 'Neues anfordern.'
+    team_sign_in: 'Team Anmeldung'
   marketing: 'Dies scheint Werbung zu sein'
+  moderate_all_streams: 'Moderate comments on All Stories'
   moderate_this_stream: 'Diesen Kommentarbereich moderieren'
   modqueue:
     account: Konto-Markierungen
     actions: Aktionen
     all: Alle
     all_streams: 'Alle Kommentarbereiche'
+    always_premod_user_actions: 'Nutzer immer vormoderieren'
     approve: Freigeben
     approved: Freigegeben
     ban_user: Sperren
+    ban_user_actions: 'Nutzer sperren'
     billion: Mrd
     close: Schließen
     empty_queue: 'Keine weiteren Kommentare zu moderieren! Arbeite nicht zu viel, gönn’ dir eine Pause!'
@@ -387,6 +434,7 @@ de:
     show_shortcuts: 'Tastaturkürzel anzeigen'
     singleview: Zen-Modus
     sort: Sortieren
+    suspend: 'Nutzer vorübergehend sperren'
     system_withheld: 'System Withheld'
     thismenu: 'Dieses Menü öffnen'
     thousand: T
@@ -424,6 +472,13 @@ de:
     username: Nutzername
     write_message: 'Nachricht schreiben'
     yes_suspend: 'Ja, vorübergehend sperren'
+  reject_username_dialog:
+    cancel: Abbrechen
+    description: 'Sagen Sie uns warun der Name nicht Ok ist?'
+    message: 'Grund für die Meldung (optional)'
+    reason: Begründung
+    reject_username: 'Nutzernamen ablehnen'
+    title: 'Nutzernamen ablehnen'
   reply: Antworten
   report: Melden
   report_notif: 'Vielen Dank für Ihre Meldung. Unsere Moderatoren wurden informiert und werden sich in Kürze darum kümmern.'
@@ -452,11 +507,14 @@ de:
     closed: Geschlossen
     empty_result: 'Ihre Suche war ohne Ergebnisse. Versuchen Sie, Ihre Anfrage weiter zu fassen.'
     filter_streams: 'Kommentarbereiche filtern'
+    most_recent_stories: 'Neueste Artikel'
     newest: Neueste
+    no_results: 'Keine Ergebnisse'
     oldest: Älteste
     open: Offen
     pubdate: Veröffentlichungsdatum
     search: Suchen
+    search_results: Suchergebnisse
     sort_by: 'Sortieren nach'
     status: Status
     stream_status: Status
@@ -484,24 +542,41 @@ de:
     username_flags: 'Markierungen für diesen Nutzernamen'
   user_detail:
     all: Alle
+    always_premod: 'Nutzer immer vormoderieren'
+    always_premoded: 'Vormoderiert'
     ban: 'Nutzer sperren'
+    banned: Gesperrt
     email: E-Mail
+    id: ID
+    karma: Karma
+    karma_docs_link: 'https://docs.coralproject.net/talk/trust/#user-karma-score'
+    learn_more: 'Mehr erfahren'
     member_since: 'Mitglied seit'
     reject_rate: Ablehn-Rate
+    reject_username: 'Nutzernamen ablehnen'
     rejected: Abgelehnte
+    remove_always_premod: 'Vormoderation entfernen'
     remove_ban: 'Sperre aufheben'
     remove_suspension: 'Vorübergehende Sperrung aufheben'
     suspend: 'Nutzer vorübergehend sperren'
+    suspended: 'Vorübergehend gesperrt'
     total_comments: 'Anzahl Kommentare'
+    unreliable: Unzuverlässig
     user_history: Konto-Verlauf
+    user_karma_score: 'Nutzer Karma Wert'
+    username: Username
+    username_needs_approval: 'Nutzername muss akzetiert werden'
+    username_rejected: 'Nutzername abgelehnt'
   user_history:
     action: Aktion
+    always_premod_removed: 'Vormoderation entfernen'
     ban_removed: 'Sperrung aufgehoben'
     date: Datum
     suspended: 'Vorübergehend gesperrt, {0}'
     suspension_removed: 'Vorübergehende Sperrung aufgehoben'
     system: System
     taken_by: Durch
+    user_always_premoded: 'Nutzer vormoderiert'
     user_banned: 'Nutzer gesperrt'
     username_status: 'Nutzername {0}'
   user_impersonating: 'Gibt sich für jemand anderen aus'

--- a/plugins/talk-plugin-local-auth/translations.yml
+++ b/plugins/talk-plugin-local-auth/translations.yml
@@ -344,7 +344,7 @@ de:
       change_username_attempt: "Der Nutzername kann zur Zeit nicht aktualisiert werden. Änderungen sind nur nach jeweils 14 Tagen möglich."
     change_email:
       confirm_email_change: "Änderung der E-Mail-Adresse bestätigen"
-      description: "Sie versuchen, Ihre E-Mail-Adresse ändern: die neue E-Mail-Adresse wird zum Login sowie für Benachrichtigungen bzgl. Ihres Benutzerkontos verwendet."
+      description: "Sie versuchen Ihre E-Mail-Adresse zu ändern: die neue E-Mail-Adresse wird zum Login sowie für Benachrichtigungen bzgl. Ihres Benutzerkontos verwendet."
       old_email: "Alte E-Mail-Adresse"
       new_email: "Neue E-Mail-Adresse"
       enter_password: "Passwort"


### PR DESCRIPTION
## What does this PR do?
Add missing locale keys and translate it to German.

## How do I test this PR?

- Set `TALK_WHITELISTED_LANGUAGES=de` on env
- Check Talk instance and see that It's in German now (e.g. always premoderate feature)
