### PR TITLE
Translation key typo

### DIFF
--- a/client/coral-admin/src/components/AdminLogin.js
+++ b/client/coral-admin/src/components/AdminLogin.js
@@ -73,7 +73,7 @@ class AdminLogin extends React.Component {
               this.setState({ requestPassword: true });
             }}
           >
-            {t('login.request_passowrd')}
+            {t('login.request_password')}
           </a>
         </p>
         {loginMaxExceeded && (

--- a/client/coral-admin/src/components/SignIn.js
+++ b/client/coral-admin/src/components/SignIn.js
@@ -79,7 +79,7 @@ class SignIn extends React.Component {
               className={styles.forgotPasswordLink}
               onClick={this.handleForgotPasswordLink}
             >
-              {t('login.request_passowrd')}
+              {t('login.request_password')}
             </a>
           </p>
         </form>

--- a/locales/ar.yml
+++ b/locales/ar.yml
@@ -359,7 +359,7 @@ ar:
     sign_in_button: 'تسجيل الدخول'
     sign_in_message: 'تسجيل الدخول للتفاعل مع مجتمعك.'
     password: كلمه المرور
-    request_passowrd: 'اطلب واحدة جديده.'
+    request_password: 'اطلب واحدة جديده.'
     team_sign_in: 'تسجيل الدخول لفريق العمل'
   marketing: 'هذا يشبه الإعلان / التسويق'
   moderate_all_streams: 'Moderate comments on All Stories'

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -385,7 +385,7 @@ de:
     sign_in_message: 'Anmelden um mit der Community zu interagieren.'
     password: Passwort
     reset_password_send_button: 'Passwort erhalten'
-    request_passowrd: 'Neues anfordern.'
+    request_password: 'Neues anfordern.'
     team_sign_in: 'Team Anmeldung'
   marketing: 'Dies scheint Werbung zu sein'
   moderate_all_streams: 'Moderate comments on All Stories'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -385,7 +385,7 @@ en:
     sign_in_message: 'Sign in to interact with your community.'
     password: Password
     reset_password_send_button: 'Retrieve Password'
-    request_passowrd: 'Request a new one.'
+    request_password: 'Request a new one.'
     team_sign_in: 'Team sign in'
   marketing: 'This looks like an ad/marketing'
   moderate_all_streams: 'Moderate comments on All Stories'

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -369,7 +369,7 @@ it:
     sign_in_message: 'Accedi per interagire con la comunità.'
     password: Password
     reset_password_send_button: 'Reimposta Password'
-    request_passowrd: 'Richiedi una nuova password.'
+    request_password: 'Richiedi una nuova password.'
     team_sign_in: 'Accesso Team'
   marketing: 'Sembra si tratti di pubblicità/marketing'
   moderate_all_streams: 'Modera i commenti in Tutte le storie'

--- a/locales/nl_NL.yml
+++ b/locales/nl_NL.yml
@@ -372,7 +372,7 @@ nl_NL:
     sign_in_message: "Log in om te communiceren met je community"
     password: Wachtwoord
     reset_password_send_button: "Wachtwoord ophalen"
-    request_passowrd: "Vraag een nieuwe aan."
+    request_password: "Vraag een nieuwe aan."
     team_sign_in: "Team login"
   marketing: "Dit lijkt op een advertentie/marketing"
   moderate_all_streams: "Modereer reacties op alle artikelen"

--- a/locales/pt_BR.yml
+++ b/locales/pt_BR.yml
@@ -333,7 +333,7 @@ pt_BR:
     sign_in_message: 'Entre para interagir com a comunidade.'
     password: Senha
     reset_password_send_button: 'Recuperar Senha'
-    request_passowrd: 'Recupere-a clicando aqui.'
+    request_password: 'Recupere-a clicando aqui.'
     team_sign_in: 'Team sign in'
   marketing: 'Isso parece um anúncio/marketing'
   moderate_all_streams: 'Comentários moderados em todas as matérias'

--- a/locales/sr.yml
+++ b/locales/sr.yml
@@ -371,7 +371,7 @@ sr:
     sign_in_message: 'Prijavi se kako bi komunikacirao sa zajednicom'
     password: 'Šifra mora sadržati minimum 8 karaktera'
     reset_password_send_button: 'povrati šifru'
-    request_passowrd: 'Zahtijevaj novu šifru'
+    request_password: 'Zahtijevaj novu šifru'
     team_sign_in: 'Prijava tima'
   marketing: 'Ovo izgleda kao reklama/marketing'
   moderate_all_streams: 'Moderiraj komentare na svim pričama'


### PR DESCRIPTION
## What does this PR do?
Fix translation key `login.request_passowrd` to `login.request_password`.
