### PR TITLE
[next] Websocket Keep Alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,9 +385,9 @@ the variables in a `.env` file in the root of the project in a simple
 - `CLUSTER_METRICS_PORT` - If `CONCURRENCY` is more than `1`, the metrics are provided at this port under `/cluster_metrics`. (Default `3001`)
 - `DISABLE_LIVE_UPDATES` - When `true`, disables subscriptions for the comment
   stream for all stories across all tenants (Default `false`)
-- `WEBSOCKET_KEEP_ALIVE_TIMEOUT` - A duration in a parsable format (e.g. `300ms`
-  , `10s`, `1m`) that should be used to send keep alive messages through the
-  websocket to keep the socket alive (Default `30s`)
+- `WEBSOCKET_KEEP_ALIVE_TIMEOUT` - A duration in a parsable format (e.g. `30 seconds`
+  , `1 minute`) that should be used to send keep alive messages through the
+  websocket to keep the socket alive (Default `30 seconds`)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,9 @@ the variables in a `.env` file in the root of the project in a simple
 - `CLUSTER_METRICS_PORT` - If `CONCURRENCY` is more than `1`, the metrics are provided at this port under `/cluster_metrics`. (Default `3001`)
 - `DISABLE_LIVE_UPDATES` - When `true`, disables subscriptions for the comment
   stream for all stories across all tenants (Default `false`)
+- `WEBSOCKET_KEEP_ALIVE_TIMEOUT` - A duration in a parsable format (e.g. `300ms`
+  , `10s`, `1m`) that should be used to send keep alive messages through the
+  websocket to keep the socket alive (Default `30s`)
 
 ## License
 

--- a/src/core/client/framework/lib/network/createManagedSubscriptionClient.ts
+++ b/src/core/client/framework/lib/network/createManagedSubscriptionClient.ts
@@ -89,6 +89,7 @@ export default function createManagedSubscriptionClient(
       if (!subscriptionClient) {
         subscriptionClient = new SubscriptionClient(url, {
           reconnect: true,
+          timeout: 60000,
           connectionCallback: err => {
             if (err) {
               // If an error is thrown as a result of live updates being

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -173,6 +173,14 @@ const config = convict({
     env: "STATIC_URI",
     arg: "staticUri",
   },
+  websocket_keep_alive_timeout: {
+    doc:
+      "The keepalive timeout (in ms) that should be used to send keep alive messages through the websocket to keep the socket alive",
+    format: "duration",
+    default: "30s",
+    env: "WEBSOCKET_KEEP_ALIVE_TIMEOUT",
+    arg: "websocketKeepAliveTimeout",
+  },
   disable_tenant_caching: {
     doc:
       "Disables the tenant caching, all tenants will be loaded from MongoDB each time it's needed",

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -177,7 +177,7 @@ const config = convict({
     doc:
       "The keepalive timeout (in ms) that should be used to send keep alive messages through the websocket to keep the socket alive",
     format: "duration",
-    default: "30s",
+    default: "30 seconds",
     env: "WEBSOCKET_KEEP_ALIVE_TIMEOUT",
     arg: "websocketKeepAliveTimeout",
   },

--- a/src/core/server/graph/tenant/subscriptions/server.ts
+++ b/src/core/server/graph/tenant/subscriptions/server.ts
@@ -223,6 +223,13 @@ export function createSubscriptionServer(
   schema: GraphQLSchema,
   options: Options
 ) {
+  const keepAlive = options.config.get("websocket_keep_alive_timeout");
+  if (typeof keepAlive !== "number") {
+    throw new Error(
+      "expected the websocket_keep_alive_timeout configuration to be a number"
+    );
+  }
+
   return SubscriptionServer.create(
     {
       schema,
@@ -230,6 +237,7 @@ export function createSubscriptionServer(
       subscribe,
       onConnect: onConnect(options),
       onOperation: onOperation(options),
+      keepAlive,
     },
     {
       server,

--- a/src/core/server/graph/tenant/subscriptions/server.ts
+++ b/src/core/server/graph/tenant/subscriptions/server.ts
@@ -224,9 +224,9 @@ export function createSubscriptionServer(
   options: Options
 ) {
   const keepAlive = options.config.get("websocket_keep_alive_timeout");
-  if (typeof keepAlive !== "number") {
+  if (typeof keepAlive !== "number" || keepAlive <= 0) {
     throw new Error(
-      "expected the websocket_keep_alive_timeout configuration to be a number"
+      "expected the websocket_keep_alive_timeout configuration to be a positive number"
     );
   }
 


### PR DESCRIPTION
## What does this PR do?

Adds a new `WEBSOCKET_KEEP_ALIVE_TIMEOUT` variable for adjusting the keep alive message timeout to be sent across the websocket connection to prevent it from closing.