### PR TITLE
[next] Static URI Path Support

### DIFF
--- a/src/core/build/createWebpackConfig.ts
+++ b/src/core/build/createWebpackConfig.ts
@@ -499,6 +499,11 @@ export default function createWebpackConfig(
               exclude: [/\.(js|ts|tsx)$/, /\.html$/, /\.json$/],
               loader: require.resolve("file-loader"),
               options: {
+                // Because the resources loaded via CSS can sometimes be loaded
+                // directly from a CSS file, this will ensure that they are
+                // relative to those referencing files.
+                publicPath: (loaderPublicPath: string) =>
+                  "../../" + loaderPublicPath,
                 name: isProduction
                   ? "assets/media/[name].[hash:8].[ext]"
                   : "assets/media/[name].[ext]",

--- a/src/core/server/app/helpers/entrypoints.ts
+++ b/src/core/server/app/helpers/entrypoints.ts
@@ -70,11 +70,7 @@ export default class Entrypoints {
 
             // Check to see if the asset is a match.
             if (asset.src === src) {
-              entrypoint[extension].push({
-                integrity: asset.integrity,
-                // Prefix all the sources with a `/`.
-                src: "/" + asset.src,
-              });
+              entrypoint[extension].push(asset);
               break;
             }
           }

--- a/src/core/server/app/router/index.ts
+++ b/src/core/server/app/router/index.ts
@@ -31,7 +31,9 @@ export function createRouter(app: AppOptions, options: RouterOptions) {
 
   if (!options.disableClientRoutes) {
     mountClientRoutes(router, {
-      staticURI: app.config.get("static_uri"),
+      // When mounting client routes, we need to provide a staticURI even when
+      // not provided to the default current domain relative "/".
+      staticURI: app.config.get("static_uri") || "/",
       tenantCache: app.tenantCache,
     });
   } else {

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -4,6 +4,7 @@ import { parseConnectionString } from "mongodb-core";
 import os from "os";
 
 import { LOCALES } from "coral-common/helpers/i18n/locales";
+import { ensureEndSlash } from "coral-common/utils";
 
 import { InternalError } from "./errors";
 
@@ -32,7 +33,7 @@ convict.addFormat({
   },
 });
 
-// Add a custom format for the optional-url.
+// Add a custom format for the optional-url that includes a trailing slash.
 convict.addFormat({
   name: "optional-url",
   validate: (url: string) => {
@@ -40,10 +41,8 @@ convict.addFormat({
       Joi.assert(url, Joi.string().uri());
     }
   },
-  // Ensure that there is no ending slash.
-  coerce: (url: string) => {
-    return url.replace(/\/$/, "");
-  },
+  // Ensure that there is an ending slash.
+  coerce: (url: string) => (url ? ensureEndSlash(url) : url),
 });
 
 const config = convict({


### PR DESCRIPTION
## What does this PR do?

Fixes a bug related to static URI support when the path component is defined.

This provides an alternative implementation to https://github.com/coralproject/talk/pull/2371 which does not embed the fonts into the CSS files.

## How do I test this PR?

### Setup

1. Build all the static assets: `npm run build`
2. Install `http-server` with: `npm install http-server -g`

### Without Static URI

This is the default state of the application, ensure that `STATIC_URI` is not set.

1. Run the server with `npm run start`
2. Visit the site at http://localhost:3000/admin and see all the icons loading
3. Stop the server


### With Static URI and path

This is to simulate when you need to specify a custom path for the static URI.

1. Start the HTTP server with: `http-server -p 8000 --cors`
2. Set the environment variable `STATIC_URI=http://localhost:8000/dist/static` in your `.env` file
3. Run the server with `npm run start`
4. Visit the site at http://localhost:3000/admin and see all the icons loading
5. Stop the server

### With Static URI and no path

This is to simulate when you need to specify a static URI without a path.

1. Change to the static directory: `cd dist/static`
2. Start the HTTP server with: `http-server -p 8000 --cors`
2. Set the environment variable `STATIC_URI=http://localhost:8000` in your `.env` file
3. Run the server with `npm run start`
4. Visit the site at http://localhost:3000/admin and see all the icons loading
5. Stop the server

