### PR TITLE
[next] Persist oidc meta fields from given attribute list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,9 @@ the variables in a `.env` file in the root of the project in a simple
 - `WEBSOCKET_KEEP_ALIVE_TIMEOUT` - A duration in a parsable format (e.g. `30 seconds`
   , `1 minute`) that should be used to send keep alive messages through the
   websocket to keep the socket alive (Default `30 seconds`)
+- `OIDC_META_FIELDS` - A comma-separated list with field names for OIDC attribute that should be persisted in the user profile document.
+  Those fields represent additional attributes in JWT that are not present in OIDC specification (e.g. Unique id for oidc provider).
+  (Default `null`)
 
 ## License
 

--- a/src/core/server/app/middleware/passport/strategies/oidc/index.ts
+++ b/src/core/server/app/middleware/passport/strategies/oidc/index.ts
@@ -159,6 +159,16 @@ export async function findOrCreateOIDCUser(
     audience: aud,
   };
 
+  const oidcMetaFields = process.env.OIDC_META_FIELDS;
+
+  if (oidcMetaFields) {
+    profile.meta = {};
+
+    oidcMetaFields.split(",").forEach(field => {
+      Object.assign(profile.meta, { [field]: Object(token)[field] });
+    });
+  }
+
   // Try to lookup user given their id provided in the `sub` claim.
   let user = await retrieveUserWithProfile(mongo, tenant.id, profile);
   if (!user) {

--- a/src/core/server/models/user/user.ts
+++ b/src/core/server/models/user/user.ts
@@ -61,6 +61,7 @@ export interface OIDCProfile {
   id: string;
   issuer: string;
   audience: string;
+  meta?: object;
 }
 
 export interface SSOProfile {


### PR DESCRIPTION
This PR suggests to add some way to persist data from oidc response in the user profile.

Specific fields can be sent in the oidc response, for example: unique id (in the oidc provider), full name etc.

These fields, specified by an environment variable, will be saved in the user profile, in a field called `meta` as an object.

This implementation could be useful for another providers too, because of this, I used an environment variable specific to OIDC integration.