### PR TITLE
[Next] Add auto redirect when there is a single enabled auth integration

### DIFF
--- a/src/core/client/stream/common/UserBox/UserBoxContainer.spec.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.spec.tsx
@@ -28,6 +28,7 @@ it("renders fully", () => {
           facebook: {
             enabled: true,
             allowRegistration: true,
+            redirectURL: "http://localhost/facebook",
             targetFilter: {
               stream: true,
             },
@@ -35,6 +36,7 @@ it("renders fully", () => {
           google: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/google",
             targetFilter: {
               stream: true,
             },
@@ -42,6 +44,7 @@ it("renders fully", () => {
           oidc: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/oidc",
             targetFilter: {
               stream: true,
             },
@@ -87,6 +90,7 @@ it("renders without logout button", () => {
           facebook: {
             enabled: true,
             allowRegistration: true,
+            redirectURL: "http://localhost/facebook",
             targetFilter: {
               stream: true,
             },
@@ -94,6 +98,7 @@ it("renders without logout button", () => {
           google: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/google",
             targetFilter: {
               stream: true,
             },
@@ -101,6 +106,7 @@ it("renders without logout button", () => {
           oidc: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/oidc",
             targetFilter: {
               stream: true,
             },
@@ -146,6 +152,7 @@ it("renders sso only", () => {
           facebook: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/facebook",
             targetFilter: {
               stream: true,
             },
@@ -153,6 +160,7 @@ it("renders sso only", () => {
           google: {
             enabled: true,
             allowRegistration: true,
+            redirectURL: "http://localhost/google",
             targetFilter: {
               stream: false,
             },
@@ -160,6 +168,7 @@ it("renders sso only", () => {
           oidc: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/oidc",
             targetFilter: {
               stream: true,
             },
@@ -205,6 +214,7 @@ it("renders sso only without logout button", () => {
           facebook: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/facebook",
             targetFilter: {
               stream: true,
             },
@@ -212,6 +222,7 @@ it("renders sso only without logout button", () => {
           google: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/google",
             targetFilter: {
               stream: true,
             },
@@ -219,6 +230,7 @@ it("renders sso only without logout button", () => {
           oidc: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/oidc",
             targetFilter: {
               stream: true,
             },
@@ -264,6 +276,7 @@ it("renders without register button", () => {
           facebook: {
             enabled: true,
             allowRegistration: false,
+            redirectURL: "http://localhost/facebook",
             targetFilter: {
               stream: true,
             },
@@ -271,6 +284,7 @@ it("renders without register button", () => {
           google: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/google",
             targetFilter: {
               stream: false,
             },
@@ -278,6 +292,7 @@ it("renders without register button", () => {
           oidc: {
             enabled: false,
             allowRegistration: true,
+            redirectURL: "http://localhost/oidc",
             targetFilter: {
               stream: true,
             },

--- a/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
@@ -71,7 +71,7 @@ export class UserBoxContainer extends Component<Props> {
     ].some(i => i.enabled && i.targetFilter.stream);
   }
 
-  private get authUrl(): any {
+  private get authUrl(): string {
     const {
       facebook,
       google,
@@ -87,24 +87,14 @@ export class UserBoxContainer extends Component<Props> {
       return defaultAuthUrl;
     }
 
-    const onlyFacebookIntegration =
-      facebook.enabled && !google.enabled && !oidc.enabled;
-    const onlyGoogleIntegration =
-      !facebook.enabled && google.enabled && !oidc.enabled;
-    const onlyOidcIntegration =
-      !facebook.enabled && !google.enabled && oidc.enabled;
-
-    if (onlyFacebookIntegration) {
-      return facebook.redirectURL;
+    // For each of these integrations, if only one is enabled, then return the
+    // redirectURL for that one only.
+    const integrations = [facebook, google, oidc];
+    const enabled = integrations.filter(integration => integration.enabled);
+    if (enabled.length === 1 && enabled[0].redirectURL) {
+      return enabled[0].redirectURL;
     }
 
-    if (onlyGoogleIntegration) {
-      return google.redirectURL;
-    }
-
-    if (onlyOidcIntegration) {
-      return oidc.redirectURL;
-    }
     return defaultAuthUrl;
   }
 

--- a/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
@@ -72,10 +72,47 @@ export class UserBoxContainer extends Component<Props> {
     ].some(i => i.enabled && i.targetFilter.stream);
   }
 
+  private get authUrl(): any {
+    const {
+      facebook,
+      google,
+      local,
+      oidc,
+    } = this.props.settings.auth.integrations;
+
+    const defaultAuthUrl = `${urls.embed.auth}?view=${
+      this.props.local.authPopup.view
+    }`;
+
+    if (local.enabled) {
+      return defaultAuthUrl;
+    }
+
+    const onlyFacebookIntegration =
+      facebook.enabled && !google.enabled && !oidc.enabled;
+    const onlyGoogleIntegration =
+      !facebook.enabled && google.enabled && !oidc.enabled;
+    const onlyOidcIntegration =
+      !facebook.enabled && !google.enabled && oidc.enabled;
+
+    if (onlyFacebookIntegration) {
+      return facebook.redirectURL;
+    }
+
+    if (onlyGoogleIntegration) {
+      return google.redirectURL;
+    }
+
+    if (onlyOidcIntegration) {
+      return oidc.redirectURL;
+    }
+    return defaultAuthUrl;
+  }
+
   public render() {
     const {
       local: {
-        authPopup: { open, focus, view },
+        authPopup: { open, focus },
       },
       viewer,
     } = this.props;
@@ -97,7 +134,7 @@ export class UserBoxContainer extends Component<Props> {
     return (
       <>
         <Popup
-          href={`${urls.embed.auth}?view=${view}`}
+          href={this.authUrl}
           title="Coral Auth"
           features="menubar=0,resizable=0,width=350,height=450,top=100,left=500"
           open={open}
@@ -155,6 +192,7 @@ const enhanced = withSignOutMutation(
                   oidc {
                     enabled
                     allowRegistration
+                    redirectURL
                     targetFilter {
                       stream
                     }
@@ -162,6 +200,7 @@ const enhanced = withSignOutMutation(
                   google {
                     enabled
                     allowRegistration
+                    redirectURL
                     targetFilter {
                       stream
                     }
@@ -169,6 +208,7 @@ const enhanced = withSignOutMutation(
                   facebook {
                     enabled
                     allowRegistration
+                    redirectURL
                     targetFilter {
                       stream
                     }

--- a/src/core/client/stream/test/fixtures.ts
+++ b/src/core/client/stream/test/fixtures.ts
@@ -45,6 +45,7 @@ export const settings = createFixture<GQLSettings>({
       facebook: {
         enabled: false,
         allowRegistration: true,
+        redirectURL: "http://localhost/facebook",
         targetFilter: {
           stream: true,
         },
@@ -52,6 +53,7 @@ export const settings = createFixture<GQLSettings>({
       google: {
         enabled: false,
         allowRegistration: true,
+        redirectURL: "http://localhost/google",
         targetFilter: {
           stream: true,
         },
@@ -59,6 +61,7 @@ export const settings = createFixture<GQLSettings>({
       oidc: {
         enabled: false,
         allowRegistration: true,
+        redirectURL: "http://localhost/oidc",
         targetFilter: {
           stream: true,
         },

--- a/src/core/server/graph/tenant/schema/schema.graphql
+++ b/src/core/server/graph/tenant/schema/schema.graphql
@@ -430,6 +430,13 @@ type SSOAuthIntegration {
   allowRegistration: Boolean!
 
   """
+  redirectURL is the URL that the user should be redirected to in order to start
+  an authentication flow with the given integration. This field is not stored,
+  and is instead computed from the Tenant.
+  """
+  redirectURL: String
+
+  """
   targetFilter will restrict where the authentication integration should be
   displayed. If the value of targetFilter is null, then the authentication
   integration should be displayed in all targets.


### PR DESCRIPTION
## What does this PR do?
When there is only one authorization provider, the login button will open it automatically.

## How do I test this PR?
Enabling a single authentication provider, except local, (_Talk Admin -> Configure -> Authentication ->_), go to the comment stream and try logging in. The popup will already open on the selected provider page.

