### PR TITLE
User drawer details tweaks

### DIFF
--- a/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerQuery.css
+++ b/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerQuery.css
@@ -111,5 +111,6 @@ hr {
   border-width: 1px;
   border-radius: 2px;
 
-  padding-left: var(--spacing-1);
+  padding-left: var(--spacing-2);
+  padding-right: var(--spacing-1);
 }

--- a/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerQuery.tsx
+++ b/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerQuery.tsx
@@ -99,7 +99,7 @@ const UserHistoryDrawerQuery: FunctionComponent<Props> = ({
                   id="moderate-user-drawer-email"
                   attrs={{ title: true }}
                 >
-                  <Icon size="sm" className={styles.icon}>
+                  <Icon size="sm" className={styles.icon} title="Email address">
                     mail_outline
                   </Icon>
                 </Localized>
@@ -121,7 +121,11 @@ const UserHistoryDrawerQuery: FunctionComponent<Props> = ({
                   id="moderate-user-drawer-created-at"
                   attrs={{ title: true }}
                 >
-                  <Icon size="sm" className={styles.icon}>
+                  <Icon
+                    size="sm"
+                    className={styles.icon}
+                    title="Account creation date"
+                  >
                     date_range
                   </Icon>
                 </Localized>
@@ -138,7 +142,7 @@ const UserHistoryDrawerQuery: FunctionComponent<Props> = ({
                   id="moderate-user-drawer-member-id"
                   attrs={{ title: true }}
                 >
-                  <Icon size="sm" className={styles.icon}>
+                  <Icon size="sm" className={styles.icon} title="Member ID">
                     people_outline
                   </Icon>
                 </Localized>

--- a/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerQuery.tsx
+++ b/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerQuery.tsx
@@ -95,9 +95,14 @@ const UserHistoryDrawerQuery: FunctionComponent<Props> = ({
             </div>
             <div className={styles.userDetails}>
               <Flex alignItems="center" className={styles.userDetail}>
-                <Icon size="sm" className={styles.icon}>
-                  mail_outline
-                </Icon>
+                <Localized
+                  id="moderate-user-drawer-email"
+                  attrs={{ title: true }}
+                >
+                  <Icon size="sm" className={styles.icon}>
+                    mail_outline
+                  </Icon>
+                </Localized>
                 <Typography
                   variant="bodyCopy"
                   container="span"
@@ -112,9 +117,14 @@ const UserHistoryDrawerQuery: FunctionComponent<Props> = ({
                 />
               </Flex>
               <Flex alignItems="center" className={styles.userDetail}>
-                <Icon size="sm" className={styles.icon}>
-                  date_range
-                </Icon>
+                <Localized
+                  id="moderate-user-drawer-created-at"
+                  attrs={{ title: true }}
+                >
+                  <Icon size="sm" className={styles.icon}>
+                    date_range
+                  </Icon>
+                </Localized>
                 <Typography variant="bodyCopy" container="span">
                   {new Date(user.createdAt).toLocaleDateString("en-us", {
                     month: "long",
@@ -124,9 +134,14 @@ const UserHistoryDrawerQuery: FunctionComponent<Props> = ({
                 </Typography>
               </Flex>
               <Flex alignItems="center" className={styles.userDetail}>
-                <Icon size="sm" className={styles.icon}>
-                  people_outline
-                </Icon>
+                <Localized
+                  id="moderate-user-drawer-member-id"
+                  attrs={{ title: true }}
+                >
+                  <Icon size="sm" className={styles.icon}>
+                    people_outline
+                  </Icon>
+                </Localized>
                 <Typography
                   variant="bodyCopy"
                   container="span"

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -428,6 +428,12 @@ moderate-searchBar-seeAllResults = See all results
 
 ### Moderate User History Drawer
 
+moderate-user-drawer-email =
+  .title = Email address
+moderate-user-drawer-created-at =
+  .title = Account creation date
+moderate-user-drawer-member-id =
+  .title = Member ID
 moderate-user-drawer-tab-all-comments = All Comments
 moderate-user-drawer-tab-rejected-comments = Rejected
 moderate-user-drawer-load-more = Load More


### PR DESCRIPTION
## What does this PR do?

Tweaks the details area of the user drawer for two items:

- Increase left/right padding on the status dropdown/popover control
- Adds alternative text/tooltips to the user details icons so that users can identify what these detail items are if they are confused by the icon

## How do I test this PR?

- Select a username in moderate queue or in community area
- See described changes above in the user drawer's top details area
