### PR TITLE
[CORL-456] add empty state for comment history

### DIFF
--- a/src/core/client/stream/tabs/Profile/CommentHistory/CommentHistory.css
+++ b/src/core/client/stream/tabs/Profile/CommentHistory/CommentHistory.css
@@ -1,0 +1,7 @@
+.emptyHistoryIcon {
+  margin: 0 0 var(--spacing-3) 0;
+}
+
+.emptyHistory {
+  padding: var(--spacing-2) 0 0 0 !important;
+}

--- a/src/core/client/stream/tabs/Profile/CommentHistory/CommentHistory.tsx
+++ b/src/core/client/stream/tabs/Profile/CommentHistory/CommentHistory.tsx
@@ -10,9 +10,9 @@ import {
   Typography,
 } from "coral-ui/components";
 
-import styles from "./CommentHistory.css";
-
 import HistoryCommentContainer from "./HistoryCommentContainer";
+
+import styles from "./CommentHistory.css";
 
 interface CommentHistoryProps {
   story: PropTypesOf<typeof HistoryCommentContainer>["story"];
@@ -41,12 +41,12 @@ const CommentHistory: FunctionComponent<CommentHistoryProps> = props => {
           <div className={styles.emptyHistoryIcon}>
             <Icon size="xl">chat_bubble_outline</Icon>
           </div>
-          <Localized id="Profile-commentHistory-empty">
+          <Localized id="profile-commentHistory-empty">
             <Typography gutterBottom variant="heading2">
               You have not written any comments
             </Typography>
           </Localized>
-          <Localized id="Profile-commentHistory-empty-subheading">
+          <Localized id="profile-commentHistory-empty-subheading">
             <Typography>A history of your comments will appear here</Typography>
           </Localized>
         </Flex>

--- a/src/core/client/stream/tabs/Profile/CommentHistory/CommentHistory.tsx
+++ b/src/core/client/stream/tabs/Profile/CommentHistory/CommentHistory.tsx
@@ -2,7 +2,15 @@ import { Localized } from "fluent-react/compat";
 import React, { FunctionComponent } from "react";
 
 import { PropTypesOf } from "coral-framework/types";
-import { Button, HorizontalGutter, Typography } from "coral-ui/components";
+import {
+  Button,
+  Flex,
+  HorizontalGutter,
+  Icon,
+  Typography,
+} from "coral-ui/components";
+
+import styles from "./CommentHistory.css";
 
 import HistoryCommentContainer from "./HistoryCommentContainer";
 
@@ -19,9 +27,30 @@ interface CommentHistoryProps {
 const CommentHistory: FunctionComponent<CommentHistoryProps> = props => {
   return (
     <HorizontalGutter size="double" data-testid="profile-commentHistory">
-      <Localized id="profile-historyComment-commentHistory">
-        <Typography variant="heading3">Comment History</Typography>
-      </Localized>
+      {props.comments.length > 0 && (
+        <Localized id="profile-historyComment-commentHistory">
+          <Typography variant="heading3">Comment History</Typography>
+        </Localized>
+      )}
+      {props.comments.length < 1 && (
+        <Flex
+          direction="column"
+          alignItems="center"
+          className={styles.emptyHistory}
+        >
+          <div className={styles.emptyHistoryIcon}>
+            <Icon size="xl">chat_bubble_outline</Icon>
+          </div>
+          <Localized id="Profile-commentHistory-empty">
+            <Typography gutterBottom variant="heading2">
+              You have not written any comments
+            </Typography>
+          </Localized>
+          <Localized id="Profile-commentHistory-empty-subheading">
+            <Typography>A history of your comments will appear here</Typography>
+          </Localized>
+        </Flex>
+      )}
       {props.comments.map(comment => (
         <HistoryCommentContainer
           key={comment.id}

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -155,7 +155,7 @@ profile-profileQuery-errorLoadingProfile = Error loading profile
 profile-profileQuery-storyNotFound = Story not found
 profile-commentHistory-loadMore = Load More
 profile-commentHistory-empty = You have not written any comments
-Profile-commentHistory-empty-subheading = A history of your comments will appear here
+profile-commentHistory-empty-subheading = A history of your comments will appear here
 
 ### Settings
 profile-settings-ignoredCommenters = Ignored Commenters

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -154,6 +154,8 @@ profile-historyComment-story = Story: {$title}
 profile-profileQuery-errorLoadingProfile = Error loading profile
 profile-profileQuery-storyNotFound = Story not found
 profile-commentHistory-loadMore = Load More
+profile-commentHistory-empty = You have not written any comments
+Profile-commentHistory-empty-subheading = A history of your comments will appear here
 
 ### Settings
 profile-settings-ignoredCommenters = Ignored Commenters


### PR DESCRIPTION
## What does this PR do?
- adds an empty state to "my profile" comment history if user has no comments

## How do I test this PR?
- log in as user with no comments, click on "my profile" tab in stream

Used a material design icon, pending discussion about bringing in fontawesome icons 
<img width="678" alt="Screen Shot 2019-07-30 at 10 38 56 AM" src="https://user-images.githubusercontent.com/1789029/62139599-a3e58c80-b2b7-11e9-8f5a-9cb92bf0cce9.png">

