### PR TITLE
[CORL-454] fix dismiss button being cut off in pre-mod notice

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentInReviewMessage.css
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentInReviewMessage.css
@@ -1,3 +1,7 @@
 .flex {
   width: 100%;
 }
+
+.buttonWrapper {
+  padding-left: var(--spacing-2);
+}

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentInReviewMessage.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentInReviewMessage.tsx
@@ -20,11 +20,17 @@ const PostCommentInReview: FunctionComponent<
             Your comment has been submitted and will be reviewed by a moderator
           </div>
         </Localized>
-        <Localized id="comments-submitStatus-dismiss">
-          <Button onClick={props.onDismiss} variant="underlined" color="light">
-            Dismiss
-          </Button>
-        </Localized>
+        <div className={styles.buttonWrapper}>
+          <Localized id="comments-submitStatus-dismiss">
+            <Button
+              onClick={props.onDismiss}
+              variant="underlined"
+              color="light"
+            >
+              Dismiss
+            </Button>
+          </Localized>
+        </div>
       </Flex>
     </Message>
   );


### PR DESCRIPTION
## What does this PR do?
- fixes https://vmproduct.atlassian.net/jira/software/projects/CORL/boards/91?selectedIssue=CORL-454

issue where the "dismiss" button was getting cut off on small screens. This is because the ButtonReset styles include `overflow: hidden`, I'd be interested in knowing the reasoning behind that reset. Solution was just to wrap the button in an additional div, which fixed the clipping, then added some padding to make it easier to read. 

## How do I test this PR?
- turn on pre-mod
- set screen width to < 600px
- submit a comment

<img width="337" alt="Screen Shot 2019-07-30 at 11 04 36 AM" src="https://user-images.githubusercontent.com/1789029/62141353-6e8e6e00-b2ba-11e9-9437-962bf0cc21c0.png">
