### PR TITLE
[CORL-455] prevent zooming on filter select

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/SortMenu.css
+++ b/src/core/client/stream/tabs/Comments/Stream/SortMenu.css
@@ -1,7 +1,7 @@
 .mobileSelect {
-  font-size: 0;
   padding: 11px;
   width: 0px;
+  line-height: 0;
 }
 .mobileAfterWrapper {
   right: 5px;


### PR DESCRIPTION
## What does this PR do?
Fixes [bug where tapping the filter button on the comments stream would zoom the display on iOS](https://vmproduct.atlassian.net/jira/software/projects/CORL/boards/91?selectedIssue=CORL-455). 

I'm 90% sure this will work but unable to test on device (yet). The zooming happens because the font-size was set to 0, and any font-size under 16 on a form input triggers the zoom on iOS. I've set line-height to 0 for the same effect. 
