### PR TITLE
Fix logout action when no local authentication provider

### DIFF
--- a/src/core/server/app/handlers/api/auth/local/index.ts
+++ b/src/core/server/app/handlers/api/auth/local/index.ts
@@ -1,10 +1,9 @@
 import { AppOptions } from "coral-server/app";
 import { handleLogout } from "coral-server/app/middleware/passport";
-import { IntegrationDisabled } from "coral-server/errors";
 import { RequestHandler } from "coral-server/types/express";
 
-export * from "./signup";
 export * from "./forgot";
+export * from "./signup";
 
 export type LogoutOptions = Pick<AppOptions, "redis">;
 
@@ -12,14 +11,6 @@ export const logoutHandler = ({
   redis,
 }: LogoutOptions): RequestHandler => async (req, res, next) => {
   try {
-    // Tenant is guaranteed at this point.
-    const tenant = req.coral!.tenant!;
-
-    // Check to ensure that the local integration has been enabled.
-    if (!tenant.auth.integrations.local.enabled) {
-      throw new IntegrationDisabled("local");
-    }
-
     // Get the user on the request.
     const user = req.user;
     if (!user) {


### PR DESCRIPTION
## What does this PR do?
Is there any reason to check if `auth.integrations.local.enabled` is true for logout user? With this behavior, if we disable local integration and enable some other, the user will not be able to logout.

## How do I test this PR?
Remove local auth integration verification for logout.