### PR TITLE
Center sign in popovers over the browser window so they are easily visible

### DIFF
--- a/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
@@ -122,21 +122,11 @@ export class UserBoxContainer extends Component<Props> {
       return null;
     }
 
-    const winLeft =
-      window.screenLeft !== undefined ? window.screenLeft : window.screenX;
-    const winTop =
-      window.screenTop !== undefined ? window.screenTop : window.screenY;
-
-    const popupWidth = 350;
-    const popupLeft = winLeft + window.outerWidth / 2 - popupWidth / 2;
-    const popupTop = winTop + 100;
-
     return (
       <>
         <Popup
           href={this.authUrl}
           title="Coral Auth"
-          features={`menubar=0,resizable=0,width=350,height=450,top=${popupTop},left=${popupLeft}}`}
           open={open}
           focus={focus}
           onFocus={this.handleFocus}

--- a/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
@@ -122,12 +122,21 @@ export class UserBoxContainer extends Component<Props> {
       return null;
     }
 
+    const winLeft =
+      window.screenLeft !== undefined ? window.screenLeft : window.screenX;
+    const winTop =
+      window.screenTop !== undefined ? window.screenTop : window.screenY;
+
+    const popupWidth = 350;
+    const popupLeft = winLeft + window.outerWidth / 2 - popupWidth / 2;
+    const popupTop = winTop + 100;
+
     return (
       <>
         <Popup
           href={this.authUrl}
           title="Coral Auth"
-          features="menubar=0,resizable=0,width=350,height=450,top=100,left=500"
+          features={`menubar=0,resizable=0,width=350,height=450,top=${popupTop},left=${popupLeft}}`}
           open={open}
           focus={focus}
           onFocus={this.handleFocus}

--- a/src/core/client/stream/common/UserBox/__snapshots__/UserBoxContainer.spec.tsx.snap
+++ b/src/core/client/stream/common/UserBox/__snapshots__/UserBoxContainer.spec.tsx.snap
@@ -3,7 +3,6 @@
 exports[`renders fully 1`] = `
 <React.Fragment>
   <Popup
-    features="menubar=0,resizable=0,width=350,height=450,top=100,left=500"
     focus={false}
     href="/embed/auth?view=SIGN_IN"
     onBlur={[Function]}
@@ -27,7 +26,6 @@ exports[`renders sso only without logout button 1`] = `null`;
 exports[`renders without logout button 1`] = `
 <React.Fragment>
   <Popup
-    features="menubar=0,resizable=0,width=350,height=450,top=100,left=500"
     focus={false}
     href="/embed/auth?view=SIGN_IN"
     onBlur={[Function]}
@@ -47,7 +45,6 @@ exports[`renders without logout button 1`] = `
 exports[`renders without register button 1`] = `
 <React.Fragment>
   <Popup
-    features="menubar=0,resizable=0,width=350,height=450,top=100,left=500"
     focus={false}
     href="/embed/auth?view=SIGN_IN"
     onBlur={[Function]}

--- a/src/core/client/stream/tabs/Profile/Settings/ChangePasswordContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Settings/ChangePasswordContainer.tsx
@@ -53,7 +53,6 @@ const ChangePasswordContainer: FunctionComponent<Props> = ({
       <Popup
         href={`${urls.embed.auth}?view=${view}`}
         title="Coral Auth"
-        features="menubar=0,resizable=0,width=350,height=450,top=100,left=500"
         open={open}
         focus={focus}
         onFocus={onFocus}

--- a/src/core/client/ui/components/Popup/Popup.ts
+++ b/src/core/client/ui/components/Popup/Popup.ts
@@ -1,5 +1,13 @@
 import { Component } from "react";
 
+interface WindowFeatures {
+  resizable: number;
+  menuBar: number;
+  width: number;
+  height: number;
+  centered: boolean;
+}
+
 interface PopupProps {
   open?: boolean;
   focus?: boolean;
@@ -9,7 +17,7 @@ interface PopupProps {
   onUnload?: (e: Event) => void;
   onClose?: () => void;
   href: string;
-  features?: string;
+  features?: Partial<WindowFeatures>;
   title?: string;
 }
 
@@ -26,8 +34,45 @@ export default class Popup extends Component<PopupProps> {
     }
   }
 
-  private openWindow(props = this.props) {
-    this.ref = window.open(props.href, props.title, props.features);
+  public static defaultFeatures: WindowFeatures = {
+    resizable: 0,
+    menuBar: 0,
+    width: 350,
+    height: 450,
+    centered: true,
+  };
+
+  private openWindow({ features = {}, href, title } = this.props) {
+    const opts: WindowFeatures = {
+      ...Popup.defaultFeatures,
+      ...features,
+    };
+
+    const winLeft =
+      window.screenLeft !== undefined ? window.screenLeft : window.screenX;
+    const winTop =
+      window.screenTop !== undefined ? window.screenTop : window.screenY;
+
+    const left = opts.centered
+      ? winLeft + window.outerWidth / 2 - opts.width / 2
+      : 0;
+    const top = opts.centered ? winTop + 100 : 0;
+
+    const pairs = Object.keys(opts).map(key => {
+      const v: any = opts;
+      return { key, value: v[key] };
+    });
+
+    let combinedFeatures = "";
+    pairs.forEach(p => {
+      if (p.key === "centered" && p.value) {
+        combinedFeatures += `left=${left},top=${top}`;
+      } else {
+        combinedFeatures += `${p.key}=${p.value},`;
+      }
+    });
+
+    this.ref = window.open(href, title, combinedFeatures);
 
     this.attemptSetCallbacks();
 

--- a/src/core/client/ui/components/Popup/Popup.ts
+++ b/src/core/client/ui/components/Popup/Popup.ts
@@ -2,7 +2,7 @@ import { Component } from "react";
 
 interface WindowFeatures {
   resizable: number;
-  menuBar: number;
+  menubar: number;
   width: number;
   height: number;
   centered: boolean;
@@ -36,7 +36,7 @@ export default class Popup extends Component<PopupProps> {
 
   public static defaultFeatures: WindowFeatures = {
     resizable: 0,
-    menuBar: 0,
+    menubar: 0,
     width: 350,
     height: 450,
     centered: true,


### PR DESCRIPTION
## What does this PR do?

Calculates the popover positioning relative to the browser window so it appears centered nicely over the window when spawned.

## How do I test this PR?

- Go to stream
- Select to sign in or register
- Notice popover is perfectly centered over the browser window horizontally, and just slightly down vertically
