### PR TITLE
[next] Added trust proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ the variables in a `.env` file in the root of the project in a simple
 - `WEBSOCKET_KEEP_ALIVE_TIMEOUT` - A duration in a parsable format (e.g. `30 seconds`
   , `1 minute`) that should be used to send keep alive messages through the
   websocket to keep the socket alive (Default `30 seconds`)
+- `TRUST_PROXY` - When provided, it configures the "trust proxy" settings for Express (See https://expressjs.com/en/guide/behind-proxies.html)
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "5.0.0-beta.5",
+  "version": "5.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "5.0.0-beta.6",
+  "version": "5.0.0-beta.7",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/src/core/server/app/index.ts
+++ b/src/core/server/app/index.ts
@@ -104,9 +104,12 @@ export const listenAndServe = (
 function configureApplication(options: AppOptions) {
   const { parent } = options;
 
-  // Trust the first proxy in front of us, this will enable us to trust the fact
-  // that SSL was terminated correctly.
-  parent.set("trust proxy", 1);
+  // Trust the proxy in front of us, this will enable us to trust the fact that
+  // SSL was terminated correctly.
+  const trust = options.config.get("trust_proxy");
+  if (trust) {
+    parent.set("trust proxy", trust);
+  }
 
   // Setup the view config.
   setupViews(options);

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -59,6 +59,14 @@ const config = convict({
     default: "en-US",
     env: "LOCALE",
   },
+  trust_proxy: {
+    doc:
+      'When provided, it configures the "trust proxy" settings for Express (See https://expressjs.com/en/guide/behind-proxies.html)',
+    format: String,
+    default: "",
+    env: "TRUST_PROXY",
+    arg: "trustProxy",
+  },
   enable_graphiql: {
     doc: "When true, this will enable the GraphiQL interface at /graphiql",
     format: Boolean,


### PR DESCRIPTION
## What does this PR do?

Allows the `trust proxy` configuration on express to be configurable (see https://expressjs.com/en/guide/behind-proxies.html).