### PR TITLE
[CORL-476] add user role from SSO token

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ You will then have to generate a JWT with the following claims:
 - `user.badges` (_optional_) - array of strings to be displayed as badges beside
   username inside Coral, visible to other users and moderators. For example, to indicate
   a user's subscription status.
+- `user.role` (_optional_) - one of "COMMENTER", "STAFF", "MODERATOR", "ADMIN". Will create/update
+  Coral user with this role.
 
 An example of the claims for this token would be:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24217,7 +24217,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }

--- a/src/core/server/app/middleware/passport/strategies/verifiers/sso.spec.ts
+++ b/src/core/server/app/middleware/passport/strategies/verifiers/sso.spec.ts
@@ -6,7 +6,14 @@ import { validate } from "coral-server/app/request/body";
 
 describe("isSSOToken", () => {
   it("understands valid sso tokens", () => {
-    const token = { user: { id: "id", email: "email", username: "username" } };
+    const token = {
+      user: {
+        id: "id",
+        email: "email",
+        username: "username",
+        role: "COMMENTER",
+      },
+    };
     expect(isSSOToken(token)).toBeTruthy();
   });
 
@@ -19,6 +26,15 @@ describe("isSSOToken", () => {
     ).toBeFalsy();
     expect(
       isSSOToken({ user: { email: "email", username: "username" } } as object)
+    ).toBeFalsy();
+    expect(
+      isSSOToken({
+        user: {
+          email: "email",
+          username: "username",
+          role: "SUPERADMIN",
+        },
+      } as object)
     ).toBeFalsy();
     expect(isSSOToken({})).toBeFalsy();
   });

--- a/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
+++ b/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
@@ -133,10 +133,7 @@ export async function findOrCreateSSOUser(
       {
         id,
         username,
-        role:
-          role && Object.values(GQLUSER_ROLE).includes(role)
-            ? role
-            : GQLUSER_ROLE.COMMENTER,
+        role: role || GQLUSER_ROLE.COMMENTER,
         badges,
         email,
         profiles: [profile],
@@ -154,7 +151,7 @@ export async function findOrCreateSSOUser(
         mongo,
         tenant.id,
         user.id,
-        { email, username, badges },
+        { email, username, badges, role: role || user.role },
         lastIssuedAt
       );
     }

--- a/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
+++ b/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
@@ -38,6 +38,7 @@ export interface SSOUserProfile {
   email: string;
   username: string;
   badges?: string[];
+  role?: GQLUSER_ROLE;
 }
 
 export interface SSOToken {
@@ -60,8 +61,9 @@ export const SSOUserProfileSchema = Joi.object()
       .required(),
     username: Joi.string().required(),
     badges: Joi.array().items(Joi.string()),
+    role: Joi.string(),
   })
-  .optionalKeys(["badges"]);
+  .optionalKeys(["badges", "role"]);
 
 export const SSOTokenSchema = Joi.object()
   .keys({
@@ -92,7 +94,7 @@ export async function findOrCreateSSOUser(
   const {
     jti,
     exp,
-    user: { id, email, username, badges },
+    user: { id, email, username, badges, role },
     iat,
   } = decodedToken;
 
@@ -131,7 +133,10 @@ export async function findOrCreateSSOUser(
       {
         id,
         username,
-        role: GQLUSER_ROLE.COMMENTER,
+        role:
+          role && Object.values(GQLUSER_ROLE).includes(role)
+            ? role
+            : GQLUSER_ROLE.COMMENTER,
         badges,
         email,
         profiles: [profile],

--- a/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
+++ b/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
@@ -61,7 +61,7 @@ export const SSOUserProfileSchema = Joi.object()
       .required(),
     username: Joi.string().required(),
     badges: Joi.array().items(Joi.string()),
-    role: Joi.string(),
+    role: Joi.string().only(Object.values(GQLUSER_ROLE)),
   })
   .optionalKeys(["badges", "role"]);
 

--- a/src/core/server/models/user/helpers.ts
+++ b/src/core/server/models/user/helpers.ts
@@ -2,6 +2,7 @@ import { isEqual } from "lodash";
 
 import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
 
+import { SSOUserProfile } from "coral-server/app/middleware/passport/strategies/verifiers/sso";
 import { STAFF_ROLES } from "./constants";
 import { LocalProfile, SSOProfile, User } from "./user";
 
@@ -24,12 +25,13 @@ export function getSSOProfile(user: Pick<User, "profiles">) {
 }
 
 export function needsSSOUpdate(
-  token: Pick<User, "email" | "username" | "badges">,
-  user: Pick<User, "email" | "username" | "badges">
+  token: SSOUserProfile,
+  user: Pick<User, "email" | "username" | "badges" | "role">
 ) {
   return (
     user.email !== token.email ||
     user.username !== token.username ||
+    (token.role && user.role !== token.role) ||
     !isEqual(user.badges, token.badges)
   );
 }

--- a/src/core/server/models/user/user.ts
+++ b/src/core/server/models/user/user.ts
@@ -675,6 +675,7 @@ export interface UpdateUserInput {
   email?: string;
   username?: string;
   badges?: string[];
+  role?: GQLUSER_ROLE;
 }
 
 export async function updateUserFromSSO(
@@ -684,7 +685,7 @@ export async function updateUserFromSSO(
   update: UpdateUserInput,
   lastIssuedAt: Date
 ) {
-  // Update the user with the new password.
+  // Update the user with the new properties.
   const result = await collection(mongo).findOneAndUpdate(
     {
       tenantID,


### PR DESCRIPTION
## What does this PR do?
- Assign SSO user a role based on role passed in on sso token

## How do I test this PR?
- generate an SSO token with `role: GQLUSER_ROLE` added to user claim

PR is vs CORL-172 because I'm pretty sure they'd conflict otherwise. Will change base branch to next after 172 is merged. 

Question: can we assume role will always be passed through in uppercase or should we allow lowercase and transform?
