### PR TITLE
[CORL-543] Persisted Query Fix

### DIFF
--- a/src/core/server/app/index.ts
+++ b/src/core/server/app/index.ts
@@ -13,12 +13,12 @@ import { HTMLErrorHandler } from "coral-server/app/middleware/error";
 import { notFoundMiddleware } from "coral-server/app/middleware/notFound";
 import { createPassport } from "coral-server/app/middleware/passport";
 import { Config } from "coral-server/config";
-import { PersistedQueryCache } from "coral-server/models/queries";
 import { MailerQueue } from "coral-server/queue/tasks/mailer";
 import { ScraperQueue } from "coral-server/queue/tasks/scraper";
 import { I18n } from "coral-server/services/i18n";
 import { JWTSigningConfig } from "coral-server/services/jwt";
 import { Metrics } from "coral-server/services/metrics";
+import { PersistedQueryCache } from "coral-server/services/queries";
 import { AugmentedRedis } from "coral-server/services/redis";
 import TenantCache from "coral-server/services/tenant/cache";
 

--- a/src/core/server/graph/tenant/persisted/loader.ts
+++ b/src/core/server/graph/tenant/persisted/loader.ts
@@ -6,9 +6,14 @@ import { version } from "coral-common/version";
 import { getOperationMetadata } from "coral-server/graph/common/extensions/helpers";
 import { PersistedQuery } from "coral-server/models/queries";
 
-export function loadPersistedQueries() {
-  // Load the files in the persisted queries folder.
+export function loadPersistedQueries(): PersistedQuery[] {
+  // Check to see if we have a persisted queries folder.
   const dir = path.join(__dirname, "__generated__");
+  if (!fs.pathExistsSync(dir)) {
+    return [];
+  }
+
+  // Load the files in the persisted queries folder.
   const files = fs.readdirSync(dir);
 
   // Load each of the persisted queries.

--- a/src/core/server/graph/tenant/persisted/loader.ts
+++ b/src/core/server/graph/tenant/persisted/loader.ts
@@ -4,12 +4,17 @@ import path from "path";
 
 import { version } from "coral-common/version";
 import { getOperationMetadata } from "coral-server/graph/common/extensions/helpers";
+import logger from "coral-server/logger";
 import { PersistedQuery } from "coral-server/models/queries";
 
 export function loadPersistedQueries(): PersistedQuery[] {
   // Check to see if we have a persisted queries folder.
   const dir = path.join(__dirname, "__generated__");
   if (!fs.pathExistsSync(dir)) {
+    logger.warn(
+      { dir },
+      "persisted queries not loaded, dir not found; did you run `npm run generate-persist`?"
+    );
     return [];
   }
 
@@ -56,6 +61,8 @@ export function loadPersistedQueries(): PersistedQuery[] {
       });
     }
   }
+
+  logger.info({ queries: queries.length }, "loaded persisted queries");
 
   return queries;
 }

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -267,14 +267,6 @@ class Server {
     // Prime the queries in the database.
     await persistedQueryCache.prime();
 
-    logger.info(
-      { queries: persistedQueryCache.size },
-      "loaded persisted queries"
-    );
-    if (persistedQueryCache.size === 0) {
-      logger.warn("no persisted queries loaded, did you run `npm run build`?");
-    }
-
     const options: AppOptions = {
       parent,
       pubsub: this.pubsub,

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -19,13 +19,13 @@ import { createPubSubClient } from "coral-server/graph/common/subscriptions/pubs
 import getTenantSchema from "coral-server/graph/tenant/schema";
 import { createSubscriptionServer } from "coral-server/graph/tenant/subscriptions/server";
 import logger from "coral-server/logger";
-import { PersistedQueryCache } from "coral-server/models/queries";
 import { createQueue, TaskQueue } from "coral-server/queue";
 import { I18n } from "coral-server/services/i18n";
 import { createJWTSigningConfig } from "coral-server/services/jwt";
 import { createMetrics } from "coral-server/services/metrics";
 import { createMongoDB } from "coral-server/services/mongodb";
 import { ensureIndexes } from "coral-server/services/mongodb/indexes";
+import { PersistedQueryCache } from "coral-server/services/queries";
 import {
   AugmentedRedis,
   createAugmentedRedisClient,

--- a/src/core/server/models/queries/index.ts
+++ b/src/core/server/models/queries/index.ts
@@ -1,2 +1,1 @@
-export * from "./cache";
 export * from "./queries";

--- a/src/core/server/models/queries/queries.ts
+++ b/src/core/server/models/queries/queries.ts
@@ -1,10 +1,11 @@
 import { Db } from "mongodb";
 
-import { createIndexFactory } from "../helpers/indexing";
+import {
+  createCollection,
+  createIndexFactory,
+} from "coral-server/models/helpers";
 
-function collection(mongo: Db) {
-  return mongo.collection<Readonly<PersistedQuery>>("queries");
-}
+const collection = createCollection<Readonly<PersistedQuery>>("queries");
 
 export interface PersistedQuery {
   id: string;

--- a/src/core/server/services/queries/cache.ts
+++ b/src/core/server/services/queries/cache.ts
@@ -4,8 +4,11 @@ import { Db } from "mongodb";
 
 import { loadPersistedQueries } from "coral-server/graph/tenant/persisted";
 import logger from "coral-server/logger";
-
-import { getQueries, PersistedQuery, primeQueries } from "./queries";
+import {
+  getQueries,
+  PersistedQuery,
+  primeQueries,
+} from "coral-server/models/queries/queries";
 
 interface PersistedQueryCacheOptions {
   mongo: Db;

--- a/src/core/server/services/queries/index.ts
+++ b/src/core/server/services/queries/index.ts
@@ -1,0 +1,1 @@
+export * from "./cache";


### PR DESCRIPTION
## What does this PR do?

Handles case where the `src/core/server/graph/tenant/persisted/__generated__` folder is not generated, which occurs in development.

## How do I test this PR?

```sh
rm -rf src/core/server/graph/tenant/persisted/__generated__
npm run start:development
```

Notice no error! Also notice the nice warning in the logs mentioning that no persisted queries were loaded.