### PR TITLE
[CORL 490] Don't show logout link for sso

### DIFF
--- a/src/core/client/stream/common/UserBox/UserBoxContainer.spec.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.spec.tsx
@@ -25,6 +25,13 @@ it("renders fully", () => {
     settings: {
       auth: {
         integrations: {
+          sso: {
+            enabled: false,
+            allowRegistration: true,
+            targetFilter: {
+              stream: false,
+            },
+          },
           facebook: {
             enabled: true,
             allowRegistration: true,
@@ -87,6 +94,13 @@ it("renders without logout button", () => {
     settings: {
       auth: {
         integrations: {
+          sso: {
+            enabled: false,
+            allowRegistration: true,
+            targetFilter: {
+              stream: false,
+            },
+          },
           facebook: {
             enabled: true,
             allowRegistration: true,
@@ -149,6 +163,13 @@ it("renders sso only", () => {
     settings: {
       auth: {
         integrations: {
+          sso: {
+            enabled: false,
+            allowRegistration: true,
+            targetFilter: {
+              stream: false,
+            },
+          },
           facebook: {
             enabled: false,
             allowRegistration: true,
@@ -211,6 +232,13 @@ it("renders sso only without logout button", () => {
     settings: {
       auth: {
         integrations: {
+          sso: {
+            enabled: false,
+            allowRegistration: true,
+            targetFilter: {
+              stream: false,
+            },
+          },
           facebook: {
             enabled: false,
             allowRegistration: true,
@@ -273,6 +301,13 @@ it("renders without register button", () => {
     settings: {
       auth: {
         integrations: {
+          sso: {
+            enabled: false,
+            allowRegistration: true,
+            targetFilter: {
+              stream: false,
+            },
+          },
           facebook: {
             enabled: true,
             allowRegistration: false,

--- a/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
@@ -49,7 +49,7 @@ export class UserBoxContainer extends Component<Props> {
       this.props.settings.auth,
       "stream"
     );
-    return integrations.length === 1  && integrations[0] === "sso";
+    return integrations.length === 1 && integrations[0] === "sso";
   }
 
   private get supportsLogout() {

--- a/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
@@ -44,18 +44,17 @@ export class UserBoxContainer extends Component<Props> {
   private handleRegister = () => this.props.showAuthPopup({ view: "SIGN_UP" });
   private handleSignOut = () => this.props.signOut();
 
-  private get authTypeSupportsLogout() {
-    return (
-      this.props.viewer &&
-      this.props.viewer.profiles.find(
-        profile => profile.__typename === "LocalProfile"
-      )
+  private get authTypePreventsLogout() {
+    const integrations = getAuthenticationIntegrations(
+      this.props.settings.auth,
+      "stream"
     );
+    return integrations.includes("sso") && !integrations.includes("local");
   }
 
   private get supportsLogout() {
     return Boolean(
-      this.authTypeSupportsLogout &&
+      !this.authTypePreventsLogout &&
         (!this.props.local.accessToken ||
           (this.props.local.accessTokenJTI !== null &&
             this.props.local.accessTokenExp !== null))

--- a/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxContainer.tsx
@@ -49,7 +49,7 @@ export class UserBoxContainer extends Component<Props> {
       this.props.settings.auth,
       "stream"
     );
-    return integrations.includes("sso") && !integrations.includes("local");
+    return integrations.length === 1  && integrations[0] === "sso";
   }
 
   private get supportsLogout() {


### PR DESCRIPTION
## What does this PR do?
Literally enforces the rule "When Coral auth is disabled and SSO is enabled for stream, don't show logout" but I'm not 100% sure that's what it should be doing. 

## How do I test this PR?
- enable sso for tenant
- disable local login for tenant
- sign in with sso
- you should not see "Not you? Sign out" link on comments tab