### PR TITLE
[CORL-489] change routing for auth and auth/callback

### DIFF
--- a/config/webpackDevServer.config.ts
+++ b/config/webpackDevServer.config.ts
@@ -71,7 +71,7 @@ export default function({
         { from: /^\/account/, to: "/account.html" },
         { from: /^\/admin/, to: "/admin.html" },
         { from: /^\/embed\/stream/, to: "/stream.html" },
-        { from: /^\/embed\/auth/, to: "/auth.html" },
+        { from: /^\/embed\/auth$/, to: "/auth.html" },
         { from: /^\/embed\/auth\/callback/, to: "/auth-callback.html" },
         { from: /^\/install/, to: "/install.html" },
       ],

--- a/src/core/server/app/router/client.ts
+++ b/src/core/server/app/router/client.ts
@@ -122,19 +122,19 @@ export function mountClientRoutes(
     })
   );
   router.use(
-    "/embed/auth",
-    createClientTargetRouter({
-      staticURI,
-      cacheDuration: false,
-      entrypoint: entrypoints.get("auth"),
-    })
-  );
-  router.use(
     "/embed/auth/callback",
     createClientTargetRouter({
       staticURI,
       cacheDuration: false,
       entrypoint: entrypoints.get("authCallback"),
+    })
+  );
+  router.use(
+    "/embed/auth",
+    createClientTargetRouter({
+      staticURI,
+      cacheDuration: false,
+      entrypoint: entrypoints.get("auth"),
     })
   );
 


### PR DESCRIPTION
## What does this PR do?
Fixes https://vmproduct.atlassian.net/browse/CORL-489?atlOrigin=eyJpIjoiZWY1M2MyNzRhNjc0NDkxNDkxYTg4MDhjMzBlZWQ3YmEiLCJwIjoiaiJ9

This was a weird one. Turns out the route /embed/auth/callback was actually displaying the html and js for /embed/auth, because of two separate bugs in dev and in prod. 

## How do I test this PR?
- enable google or fb login
- attempt to log in to admin via google or fb