### PR TITLE
[CORL-506] Added closedAt to createStory mutation

### DIFF
--- a/src/core/server/graph/tenant/schema/schema.graphql
+++ b/src/core/server/graph/tenant/schema/schema.graphql
@@ -3479,6 +3479,13 @@ input CreateStory {
   be scraped, but can be provided here.
   """
   metadata: StoryMetadataInput
+
+  """
+  closedAt when provided specifies the date that the given story will be closed
+  at. If not provided, the story close will use the settings to determine the
+  automatic close date.
+  """
+  closedAt: Time
 }
 
 input CreateStoryInput {

--- a/src/core/server/models/story/index.ts
+++ b/src/core/server/models/story/index.ts
@@ -222,7 +222,9 @@ export async function findOrCreateStory(
   return upsertStory(mongo, tenantID, { url }, now);
 }
 
-export type CreateStoryInput = Partial<Pick<Story, "metadata" | "scrapedAt">>;
+export type CreateStoryInput = Partial<
+  Pick<Story, "metadata" | "scrapedAt" | "closedAt">
+>;
 
 export async function createStory(
   mongo: Db,

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -163,7 +163,7 @@ export async function create(
   tenant: Tenant,
   storyID: string,
   storyURL: string,
-  { metadata }: CreateStory,
+  { metadata, closedAt }: CreateStory,
   now = new Date()
 ) {
   // Ensure that the given URL is allowed.
@@ -175,7 +175,7 @@ export async function create(
   }
 
   // Construct the input payload.
-  const input: CreateStoryInput = { metadata };
+  const input: CreateStoryInput = { metadata, closedAt };
   if (metadata) {
     input.scrapedAt = now;
   }


### PR DESCRIPTION
## What does this PR do?

Adds a new optional `closedAt` field to the `createStory` mutation. This you to create a story that is already closed, or closed in the future in a single GraphQL call.