### PR TITLE
[CORL-439] Allow admins to configure GDPR features

### DIFF
--- a/src/core/client/admin/routes/Configure/OnOffField.tsx
+++ b/src/core/client/admin/routes/Configure/OnOffField.tsx
@@ -15,6 +15,7 @@ interface Props {
   offLabel?: React.ReactNode;
   format?: ((value: any, name: string) => any) | null;
   parse?: ((value: any, name: string) => any) | null;
+  className?: string;
 }
 
 const OnOffField: FunctionComponent<Props> = ({
@@ -25,8 +26,9 @@ const OnOffField: FunctionComponent<Props> = ({
   invert = false,
   parse = parseStringBool,
   format,
+  className,
 }) => (
-  <div>
+  <div className={className}>
     <Field
       name={name}
       type="radio"

--- a/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfig.css
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfig.css
@@ -1,0 +1,8 @@
+.radioButtons {
+  display: flex;
+  padding-left: var(--spacing-4);
+  align-items: flex-start;
+  & > *:not(:last-child) {
+    margin-right: var(--spacing-5);
+  }
+}

--- a/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfig.tsx
@@ -1,6 +1,5 @@
 import { Localized } from "fluent-react/compat";
 import React, { FunctionComponent } from "react";
-import { Field } from "react-final-form";
 
 import {
   FieldSet,
@@ -8,95 +7,137 @@ import {
   FormField,
   HorizontalGutter,
   InputLabel,
-  Option,
-  SelectField,
-  TextField,
   Typography,
 } from "coral-ui/components";
 import OnOffField from "../../OnOffField";
 
 import Header from "../../Header";
 
+import styles from "./AccountFeaturesConfig.css";
+
 interface Props {
   disabled?: boolean;
 }
 
 const AccountFeaturesConfig: FunctionComponent<Props> = ({ disabled }) => (
-  <HorizontalGutter size="oneAndAHalf" container={<FieldSet />}>
-    <Localized id="configure-account-features-title">
-      <Header container="legend">Commenter account mangement features</Header>
-    </Localized>
-    <Localized id="configure-account-features-explanation" strong={<strong />}>
-      <Typography variant="detail">
-        You can enable and disable certain features for your commenters to use
-        within their Profile. These features also assist towards GDPR
-        compliance.
-      </Typography>
-    </Localized>
-    <HorizontalGutter size="double">
-      <FormField container="fieldset">
+  <div>
+    <HorizontalGutter size="oneAndAHalf">
+      <Localized id="configure-account-features-title">
+        <Header container="legend">Commenter account mangement features</Header>
+      </Localized>
+      <Localized
+        id="configure-account-features-explanation"
+        strong={<strong />}
+      >
+        <Typography variant="bodyCopy">
+          You can enable and disable certain features for your commenters to use
+          within their Profile. These features also assist towards GDPR
+          compliance.
+        </Typography>
+      </Localized>
+      <HorizontalGutter container={<FieldSet />}>
         <Localized id="configure-account-features-change-usernames">
-          <InputLabel container="legend">Change their usernames</InputLabel>
+          <Typography variant="heading4">Allow users to:</Typography>
         </Localized>
-        <OnOffField
-          name="accountFeatures.changeUsername"
-          disabled={disabled || false}
-          onLabel={
-            <Localized id="configure-account-features-yes">
-              <span>Yes</span>
-            </Localized>
-          }
-          offLabel={
-            <Localized id="configure-account-features-no">
-              <span>No</span>
-            </Localized>
-          }
-        />
-      </FormField>
+        <FormField container="fieldset">
+          <Flex justifyContent="space-between">
+            <HorizontalGutter size="half">
+              <Localized id="configure-account-features-change-usernames">
+                <InputLabel container="legend">
+                  Change their usernames
+                </InputLabel>
+              </Localized>
+              <Localized id="configure-account-features-change-usernames-details">
+                <Typography>
+                  Usernames can be changed once every 14 days.
+                </Typography>
+              </Localized>
+            </HorizontalGutter>
+            <OnOffField
+              name="accountFeatures.changeUsername"
+              disabled={disabled || false}
+              className={styles.radioButtons}
+              onLabel={
+                <Localized id="configure-account-features-yes">
+                  <span>Yes</span>
+                </Localized>
+              }
+              offLabel={
+                <Localized id="configure-account-features-no">
+                  <span>No</span>
+                </Localized>
+              }
+            />
+          </Flex>
+        </FormField>
+      </HorizontalGutter>
+      <HorizontalGutter size="double">
+        <FormField container="fieldset">
+          <Flex justifyContent="space-between">
+            <HorizontalGutter size="half">
+              <Localized id="configure-account-features-download-comments">
+                <InputLabel container="legend">
+                  Download their comments
+                </InputLabel>
+              </Localized>
+              <Localized id="configure-account-features-download-comments-details">
+                <Typography>
+                  Commenters can download a csv of their comment history.
+                </Typography>
+              </Localized>
+            </HorizontalGutter>
+            <OnOffField
+              name="accountFeatures.downloadComments"
+              disabled={disabled || false}
+              className={styles.radioButtons}
+              onLabel={
+                <Localized id="configure-account-features-yes">
+                  <span>Yes</span>
+                </Localized>
+              }
+              offLabel={
+                <Localized id="configure-account-features-no">
+                  <span>No</span>
+                </Localized>
+              }
+            />
+          </Flex>
+        </FormField>
+      </HorizontalGutter>
+      <HorizontalGutter size="double">
+        <FormField container="fieldset">
+          <Flex justifyContent="space-between">
+            <HorizontalGutter size="half">
+              <Localized id="configure-account-features-delete-account">
+                <InputLabel container="legend">Delete their account</InputLabel>
+              </Localized>
+              <Localized id="configure-account-features-delete-account-details">
+                <Typography>
+                  Removes all of their comment data, username, and email address
+                  from the site and the database.
+                </Typography>
+              </Localized>
+            </HorizontalGutter>
+            <OnOffField
+              name="accountFeatures.deleteAccount"
+              disabled={disabled || false}
+              className={styles.radioButtons}
+              onLabel={
+                <Localized id="configure-account-features-yes">
+                  <span>Yes</span>
+                </Localized>
+              }
+              offLabel={
+                <Localized id="configure-account-features-no">
+                  <span>No</span>
+                </Localized>
+              }
+            />
+          </Flex>
+        </FormField>
+      </HorizontalGutter>
     </HorizontalGutter>
-    <HorizontalGutter size="double">
-      <FormField container="fieldset">
-        <Localized id="configure-account-features-download-comments">
-          <InputLabel container="legend">Download their comments</InputLabel>
-        </Localized>
-        <OnOffField
-          name="accountFeatures.downloadComments"
-          disabled={disabled || false}
-          onLabel={
-            <Localized id="configure-account-features-yes">
-              <span>Yes</span>
-            </Localized>
-          }
-          offLabel={
-            <Localized id="configure-account-features-no">
-              <span>No</span>
-            </Localized>
-          }
-        />
-      </FormField>
-    </HorizontalGutter>
-    <HorizontalGutter size="double">
-      <FormField container="fieldset">
-        <Localized id="configure-account-features-download-comments">
-          <InputLabel container="legend">Delete their account</InputLabel>
-        </Localized>
-        <OnOffField
-          name="accountFeatures.deleteAccount"
-          disabled={disabled || false}
-          onLabel={
-            <Localized id="configure-account-features-yes">
-              <span>Yes</span>
-            </Localized>
-          }
-          offLabel={
-            <Localized id="configure-account-features-no">
-              <span>No</span>
-            </Localized>
-          }
-        />
-      </FormField>
-    </HorizontalGutter>
-  </HorizontalGutter>
+  </div>
 );
 
 export default AccountFeaturesConfig;

--- a/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfig.tsx
@@ -1,0 +1,102 @@
+import { Localized } from "fluent-react/compat";
+import React, { FunctionComponent } from "react";
+import { Field } from "react-final-form";
+
+import {
+  FieldSet,
+  Flex,
+  FormField,
+  HorizontalGutter,
+  InputLabel,
+  Option,
+  SelectField,
+  TextField,
+  Typography,
+} from "coral-ui/components";
+import OnOffField from "../../OnOffField";
+
+import Header from "../../Header";
+
+interface Props {
+  disabled?: boolean;
+}
+
+const AccountFeaturesConfig: FunctionComponent<Props> = ({ disabled }) => (
+  <HorizontalGutter size="oneAndAHalf" container={<FieldSet />}>
+    <Localized id="configure-account-features-title">
+      <Header container="legend">Commenter account mangement features</Header>
+    </Localized>
+    <Localized id="configure-account-features-explanation" strong={<strong />}>
+      <Typography variant="detail">
+        You can enable and disable certain features for your commenters to use
+        within their Profile. These features also assist towards GDPR
+        compliance.
+      </Typography>
+    </Localized>
+    <HorizontalGutter size="double">
+      <FormField container="fieldset">
+        <Localized id="configure-account-features-change-usernames">
+          <InputLabel container="legend">Change their usernames</InputLabel>
+        </Localized>
+        <OnOffField
+          name="accountFeatures.changeUsername"
+          disabled={disabled || false}
+          onLabel={
+            <Localized id="configure-account-features-yes">
+              <span>Yes</span>
+            </Localized>
+          }
+          offLabel={
+            <Localized id="configure-account-features-no">
+              <span>No</span>
+            </Localized>
+          }
+        />
+      </FormField>
+    </HorizontalGutter>
+    <HorizontalGutter size="double">
+      <FormField container="fieldset">
+        <Localized id="configure-account-features-download-comments">
+          <InputLabel container="legend">Download their comments</InputLabel>
+        </Localized>
+        <OnOffField
+          name="accountFeatures.downloadComments"
+          disabled={disabled || false}
+          onLabel={
+            <Localized id="configure-account-features-yes">
+              <span>Yes</span>
+            </Localized>
+          }
+          offLabel={
+            <Localized id="configure-account-features-no">
+              <span>No</span>
+            </Localized>
+          }
+        />
+      </FormField>
+    </HorizontalGutter>
+    <HorizontalGutter size="double">
+      <FormField container="fieldset">
+        <Localized id="configure-account-features-download-comments">
+          <InputLabel container="legend">Delete their account</InputLabel>
+        </Localized>
+        <OnOffField
+          name="accountFeatures.deleteAccount"
+          disabled={disabled || false}
+          onLabel={
+            <Localized id="configure-account-features-yes">
+              <span>Yes</span>
+            </Localized>
+          }
+          offLabel={
+            <Localized id="configure-account-features-no">
+              <span>No</span>
+            </Localized>
+          }
+        />
+      </FormField>
+    </HorizontalGutter>
+  </HorizontalGutter>
+);
+
+export default AccountFeaturesConfig;

--- a/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfig.tsx
@@ -25,10 +25,7 @@ const AccountFeaturesConfig: FunctionComponent<Props> = ({ disabled }) => (
       <Localized id="configure-account-features-title">
         <Header container="legend">Commenter account mangement features</Header>
       </Localized>
-      <Localized
-        id="configure-account-features-explanation"
-        strong={<strong />}
-      >
+      <Localized id="configure-account-features-explanation">
         <Typography variant="bodyCopy">
           You can enable and disable certain features for your commenters to use
           within their Profile. These features also assist towards GDPR
@@ -36,7 +33,7 @@ const AccountFeaturesConfig: FunctionComponent<Props> = ({ disabled }) => (
         </Typography>
       </Localized>
       <HorizontalGutter container={<FieldSet />}>
-        <Localized id="configure-account-features-change-usernames">
+        <Localized id="configure-account-features-allow">
           <Typography variant="heading4">Allow users to:</Typography>
         </Localized>
         <FormField container="fieldset">

--- a/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfigContainer.tsx
@@ -1,5 +1,3 @@
-import { pureMerge } from "coral-common/utils";
-import { FormApi } from "final-form";
 import React from "react";
 import { graphql } from "react-relay";
 

--- a/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AccountFeaturesConfigContainer.tsx
@@ -1,0 +1,46 @@
+import { pureMerge } from "coral-common/utils";
+import { FormApi } from "final-form";
+import React from "react";
+import { graphql } from "react-relay";
+
+import { AccountFeaturesConfigContainer_settings as SettingsData } from "coral-admin/__generated__/AccountFeaturesConfigContainer_settings.graphql";
+import { DeepNullable, DeepPartial } from "coral-common/types";
+import { withFragmentContainer } from "coral-framework/lib/relay";
+
+import { GQLSettings } from "coral-framework/schema";
+import AccountFeaturesConfig from "./AccountFeaturesConfig";
+
+export type FormProps = DeepNullable<Pick<GQLSettings, "accountFeatures">>;
+export type OnInitValuesFct = (values: DeepPartial<FormProps>) => void;
+
+interface Props {
+  settings: SettingsData;
+  onInitValues: (values: SettingsData) => void;
+  disabled?: boolean;
+}
+
+class AccountFeaturesConfigContainer extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+    props.onInitValues(props.settings);
+  }
+
+  public render() {
+    const { disabled } = this.props;
+    return <AccountFeaturesConfig disabled={disabled} />;
+  }
+}
+
+const enhanced = withFragmentContainer<Props>({
+  settings: graphql`
+    fragment AccountFeaturesConfigContainer_settings on Settings {
+      accountFeatures {
+        changeUsername
+        deleteAccount
+        downloadComments
+      }
+    }
+  `,
+})(AccountFeaturesConfigContainer);
+
+export default enhanced;

--- a/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigContainer.tsx
@@ -18,6 +18,7 @@ import {
 import { getMessage } from "coral-framework/lib/i18n";
 import { withFragmentContainer } from "coral-framework/lib/relay";
 import { GQLSettings } from "coral-framework/schema";
+import { HorizontalGutter } from "coral-ui/components";
 
 import AccountFeaturesConfigContainer from "./AccountFeaturesConfigContainer";
 import AuthConfig from "./AuthConfig";
@@ -101,7 +102,7 @@ class AuthConfigContainer extends React.Component<Props> {
 
   public render() {
     return (
-      <div>
+      <HorizontalGutter size="double">
         <AccountFeaturesConfigContainer
           onInitValues={this.handleOnInitValues}
           settings={this.props.settings}
@@ -112,7 +113,7 @@ class AuthConfigContainer extends React.Component<Props> {
           auth={this.props.auth}
           onInitValues={this.handleOnInitValues}
         />
-      </div>
+      </HorizontalGutter>
     );
   }
 }

--- a/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigContainer.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { graphql } from "react-relay";
 
 import { AuthConfigContainer_auth as AuthData } from "coral-admin/__generated__/AuthConfigContainer_auth.graphql";
+import { AuthConfigContainer_settings as SettingsData } from "coral-admin/__generated__/AuthConfigContainer_settings.graphql";
 import { DeepNullable, DeepPartial } from "coral-common/types";
 import { pureMerge } from "coral-common/utils";
 import { CoralContext, withContext } from "coral-framework/lib/bootstrap";
@@ -18,9 +19,12 @@ import { getMessage } from "coral-framework/lib/i18n";
 import { withFragmentContainer } from "coral-framework/lib/relay";
 import { GQLSettings } from "coral-framework/schema";
 
+import AccountFeaturesConfigContainer from "./AccountFeaturesConfigContainer";
 import AuthConfig from "./AuthConfig";
 
-export type FormProps = DeepNullable<Pick<GQLSettings, "auth">>;
+export type FormProps = DeepNullable<
+  Pick<GQLSettings, "auth" | "accountFeatures">
+>;
 export type OnInitValuesFct = (values: DeepPartial<FormProps>) => void;
 
 interface Props {
@@ -29,6 +33,7 @@ interface Props {
   submitting?: boolean;
   addSubmitHook: AddSubmitHook<FormProps>;
   auth: AuthData;
+  settings: SettingsData;
 }
 
 class AuthConfigContainer extends React.Component<Props> {
@@ -96,16 +101,28 @@ class AuthConfigContainer extends React.Component<Props> {
 
   public render() {
     return (
-      <AuthConfig
-        disabled={this.props.submitting}
-        auth={this.props.auth}
-        onInitValues={this.handleOnInitValues}
-      />
+      <div>
+        <AccountFeaturesConfigContainer
+          onInitValues={this.handleOnInitValues}
+          settings={this.props.settings}
+          disabled={this.props.submitting}
+        />
+        <AuthConfig
+          disabled={this.props.submitting}
+          auth={this.props.auth}
+          onInitValues={this.handleOnInitValues}
+        />
+      </div>
     );
   }
 }
 
 const enhanced = withFragmentContainer<Props>({
+  settings: graphql`
+    fragment AuthConfigContainer_settings on Settings {
+      ...AccountFeaturesConfigContainer_settings
+    }
+  `,
   auth: graphql`
     fragment AuthConfigContainer_auth on Auth {
       ...FacebookConfigContainer_auth

--- a/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigRoute.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigRoute.tsx
@@ -6,6 +6,7 @@ import { AuthConfigRouteContainerQueryResponse } from "coral-admin/__generated__
 import { withRouteConfig } from "coral-framework/lib/router";
 import { Delay, Spinner } from "coral-ui/components";
 
+import AccountFeaturesConfigContainer from "./AccountFeaturesConfigContainer";
 import AuthConfigContainer from "./AuthConfigContainer";
 
 interface Props {
@@ -24,11 +25,14 @@ class AuthConfigRoute extends React.Component<Props> {
       );
     }
     return (
-      <AuthConfigContainer
-        auth={this.props.data.settings.auth}
-        form={this.props.form}
-        submitting={this.props.submitting}
-      />
+      <div>
+        <AuthConfigContainer
+          settings={this.props.data.settings}
+          auth={this.props.data.settings.auth}
+          form={this.props.form}
+          submitting={this.props.submitting}
+        />
+      </div>
     );
   }
 }
@@ -37,6 +41,7 @@ const enhanced = withRouteConfig<Props>({
   query: graphql`
     query AuthConfigRouteContainerQuery {
       settings {
+        ...AuthConfigContainer_settings
         auth {
           ...AuthConfigContainer_auth
         }

--- a/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigRoute.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigRoute.tsx
@@ -6,7 +6,6 @@ import { AuthConfigRouteContainerQueryResponse } from "coral-admin/__generated__
 import { withRouteConfig } from "coral-framework/lib/router";
 import { Delay, Spinner } from "coral-ui/components";
 
-import AccountFeaturesConfigContainer from "./AccountFeaturesConfigContainer";
 import AuthConfigContainer from "./AuthConfigContainer";
 
 interface Props {
@@ -25,14 +24,12 @@ class AuthConfigRoute extends React.Component<Props> {
       );
     }
     return (
-      <div>
-        <AuthConfigContainer
-          settings={this.props.data.settings}
-          auth={this.props.data.settings.auth}
-          form={this.props.form}
-          submitting={this.props.submitting}
-        />
-      </div>
+      <AuthConfigContainer
+        settings={this.props.data.settings}
+        auth={this.props.data.settings.auth}
+        form={this.props.form}
+        submitting={this.props.submitting}
+      />
     );
   }
 }

--- a/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
@@ -2068,12 +2068,14 @@ exports[`renders configure auth 1`] = `
               <legend
                 className="Box-root Typography-root Typography-heading1 Typography-colorTextPrimary Header-root"
               >
-                Missing translation "configure-account-features-title"
+                Commenter account mangement features
               </legend>
               <p
                 className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
               >
-                Missing translation "configure-account-features-explanation"
+                You can enable and disable certain features for your commenters to use
+within their Profile. These features also assist towards GDPR
+compliance.
               </p>
               <fieldset
                 className="FieldSet-root Box-root HorizontalGutter-root HorizontalGutter-full"
@@ -2081,7 +2083,7 @@ exports[`renders configure auth 1`] = `
                 <h1
                   className="Box-root Typography-root Typography-heading4 Typography-colorTextPrimary"
                 >
-                  Missing translation "configure-account-features-change-usernames"
+                  Allow users to:
                 </h1>
                 <fieldset
                   className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
@@ -2095,12 +2097,12 @@ exports[`renders configure auth 1`] = `
                       <legend
                         className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
                       >
-                        Missing translation "configure-account-features-change-usernames"
+                        Change their usernames
                       </legend>
                       <p
                         className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
                       >
-                        Missing translation "configure-account-features-change-usernames-details"
+                        Usernames can be changed once every 14 days.
                       </p>
                     </div>
                     <div
@@ -2126,7 +2128,7 @@ exports[`renders configure auth 1`] = `
                           htmlFor="accountFeatures.changeUsername-true"
                         >
                           <span>
-                            Missing translation "configure-account-features-yes"
+                            Yes
                           </span>
                         </label>
                       </div>
@@ -2150,7 +2152,7 @@ exports[`renders configure auth 1`] = `
                           htmlFor="accountFeatures.changeUsername-false"
                         >
                           <span>
-                            Missing translation "configure-account-features-no"
+                            No
                           </span>
                         </label>
                       </div>
@@ -2173,12 +2175,12 @@ exports[`renders configure auth 1`] = `
                       <legend
                         className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
                       >
-                        Missing translation "configure-account-features-download-comments"
+                        Download their comments
                       </legend>
                       <p
                         className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
                       >
-                        Missing translation "configure-account-features-download-comments-details"
+                        Commenters can download a csv of their comment history.
                       </p>
                     </div>
                     <div
@@ -2204,7 +2206,7 @@ exports[`renders configure auth 1`] = `
                           htmlFor="accountFeatures.downloadComments-true"
                         >
                           <span>
-                            Missing translation "configure-account-features-yes"
+                            Yes
                           </span>
                         </label>
                       </div>
@@ -2228,7 +2230,7 @@ exports[`renders configure auth 1`] = `
                           htmlFor="accountFeatures.downloadComments-false"
                         >
                           <span>
-                            Missing translation "configure-account-features-no"
+                            No
                           </span>
                         </label>
                       </div>
@@ -2251,12 +2253,12 @@ exports[`renders configure auth 1`] = `
                       <legend
                         className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
                       >
-                        Missing translation "configure-account-features-delete-account"
+                        Delete their account
                       </legend>
                       <p
                         className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
                       >
-                        Missing translation "configure-account-features-delete-account-details"
+                        Removes all of their comment data, username, and email address from the site and the database.
                       </p>
                     </div>
                     <div
@@ -2282,7 +2284,7 @@ exports[`renders configure auth 1`] = `
                           htmlFor="accountFeatures.deleteAccount-true"
                         >
                           <span>
-                            Missing translation "configure-account-features-yes"
+                            Yes
                           </span>
                         </label>
                       </div>
@@ -2306,7 +2308,7 @@ exports[`renders configure auth 1`] = `
                           htmlFor="accountFeatures.deleteAccount-false"
                         >
                           <span>
-                            Missing translation "configure-account-features-no"
+                            No
                           </span>
                         </label>
                       </div>

--- a/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
@@ -2060,147 +2060,286 @@ exports[`renders configure auth 1`] = `
       >
         <div
           className="Box-root HorizontalGutter-root HorizontalGutter-double"
-          data-testid="configure-authContainer"
         >
-          <div
-            className="Box-root HorizontalGutter-root HorizontalGutter-double"
-          >
-            <h1
-              className="Box-root Typography-root Typography-heading1 Typography-colorTextPrimary Header-root"
-            >
-              Authentication Integrations
-            </h1>
+          <div>
             <div
-              className="ConfigBox-root"
+              className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
             >
-              <div
-                className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
+              <legend
+                className="Box-root Typography-root Typography-heading1 Typography-colorTextPrimary Header-root"
               >
-                <div>
-                  <span>
-                    Login with Email Authentication
-                  </span>
-                </div>
-                <div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <div
-                      className="CheckBox-root"
-                    >
-                      <input
-                        checked={true}
-                        className="CheckBox-input"
-                        disabled={false}
-                        id="auth.integrations.local.enabled"
-                        name="auth.integrations.local.enabled"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value={true}
-                      />
-                      <label
-                        className="CheckBox-label CheckBox-labelLight"
-                        htmlFor="auth.integrations.local.enabled"
-                      >
-                        <span
-                          className="CheckBox-labelSpan"
-                        >
-                          Enabled
-                        </span>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ConfigBox-content"
+                Missing translation "configure-account-features-title"
+              </legend>
+              <p
+                className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
               >
-                <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-double"
+                Missing translation "configure-account-features-explanation"
+              </p>
+              <fieldset
+                className="FieldSet-root Box-root HorizontalGutter-root HorizontalGutter-full"
+              >
+                <h1
+                  className="Box-root Typography-root Typography-heading4 Typography-colorTextPrimary"
+                >
+                  Missing translation "configure-account-features-change-usernames"
+                </h1>
+                <fieldset
+                  className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                 >
                   <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    className="Box-root Flex-root Flex-flex Flex-justifySpaceBetween"
                   >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      <span>
-                        Use Email Authentication login on
-                      </span>
-                    </label>
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
+                      className="Box-root HorizontalGutter-root HorizontalGutter-half"
+                    >
+                      <legend
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Missing translation "configure-account-features-change-usernames"
+                      </legend>
+                      <p
+                        className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+                      >
+                        Missing translation "configure-account-features-change-usernames-details"
+                      </p>
+                    </div>
+                    <div
+                      className="AccountFeaturesConfig-radioButtons"
                     >
                       <div
-                        className="CheckBox-root"
+                        className="Box-root Flex-root RadioButton-root Flex-flex Flex-alignCenter"
                       >
                         <input
                           checked={true}
-                          className="CheckBox-input"
+                          className="RadioButton-input"
                           disabled={false}
-                          id="auth.integrations.local.targetFilter.admin"
-                          name="auth.integrations.local.targetFilter.admin"
+                          id="accountFeatures.changeUsername-true"
+                          name="accountFeatures.changeUsername"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
-                          type="checkbox"
+                          type="radio"
                           value={true}
                         />
                         <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.local.targetFilter.admin"
+                          className="RadioButton-label"
+                          htmlFor="accountFeatures.changeUsername-true"
                         >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Coral Admin
+                          <span>
+                            Missing translation "configure-account-features-yes"
                           </span>
                         </label>
                       </div>
                       <div
-                        className="CheckBox-root"
+                        className="Box-root Flex-root RadioButton-root Flex-flex Flex-alignCenter"
                       >
                         <input
-                          checked={true}
-                          className="CheckBox-input"
+                          checked={false}
+                          className="RadioButton-input"
                           disabled={false}
-                          id="auth.integrations.local.targetFilter.stream"
-                          name="auth.integrations.local.targetFilter.stream"
+                          id="accountFeatures.changeUsername-false"
+                          name="accountFeatures.changeUsername"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
+                          type="radio"
+                          value={false}
                         />
                         <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.local.targetFilter.stream"
+                          className="RadioButton-label"
+                          htmlFor="accountFeatures.changeUsername-false"
                         >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Comment Stream
+                          <span>
+                            Missing translation "configure-account-features-no"
                           </span>
                         </label>
                       </div>
                     </div>
                   </div>
+                </fieldset>
+              </fieldset>
+              <div
+                className="Box-root HorizontalGutter-root HorizontalGutter-double"
+              >
+                <fieldset
+                  className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                >
                   <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    className="Box-root Flex-root Flex-flex Flex-justifySpaceBetween"
                   >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                    <div
+                      className="Box-root HorizontalGutter-root HorizontalGutter-half"
                     >
-                      Registration
-                    </label>
-                    <p
-                      className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
+                      <legend
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Missing translation "configure-account-features-download-comments"
+                      </legend>
+                      <p
+                        className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+                      >
+                        Missing translation "configure-account-features-download-comments-details"
+                      </p>
+                    </div>
+                    <div
+                      className="AccountFeaturesConfig-radioButtons"
                     >
-                      Allow users that have not signed up before with this authentication
-integration to register for a new account.
-                    </p>
+                      <div
+                        className="Box-root Flex-root RadioButton-root Flex-flex Flex-alignCenter"
+                      >
+                        <input
+                          checked={true}
+                          className="RadioButton-input"
+                          disabled={false}
+                          id="accountFeatures.downloadComments-true"
+                          name="accountFeatures.downloadComments"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="radio"
+                          value={true}
+                        />
+                        <label
+                          className="RadioButton-label"
+                          htmlFor="accountFeatures.downloadComments-true"
+                        >
+                          <span>
+                            Missing translation "configure-account-features-yes"
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="Box-root Flex-root RadioButton-root Flex-flex Flex-alignCenter"
+                      >
+                        <input
+                          checked={false}
+                          className="RadioButton-input"
+                          disabled={false}
+                          id="accountFeatures.downloadComments-false"
+                          name="accountFeatures.downloadComments"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="radio"
+                          value={false}
+                        />
+                        <label
+                          className="RadioButton-label"
+                          htmlFor="accountFeatures.downloadComments-false"
+                        >
+                          <span>
+                            Missing translation "configure-account-features-no"
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+              <div
+                className="Box-root HorizontalGutter-root HorizontalGutter-double"
+              >
+                <fieldset
+                  className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                >
+                  <div
+                    className="Box-root Flex-root Flex-flex Flex-justifySpaceBetween"
+                  >
+                    <div
+                      className="Box-root HorizontalGutter-root HorizontalGutter-half"
+                    >
+                      <legend
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Missing translation "configure-account-features-delete-account"
+                      </legend>
+                      <p
+                        className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+                      >
+                        Missing translation "configure-account-features-delete-account-details"
+                      </p>
+                    </div>
+                    <div
+                      className="AccountFeaturesConfig-radioButtons"
+                    >
+                      <div
+                        className="Box-root Flex-root RadioButton-root Flex-flex Flex-alignCenter"
+                      >
+                        <input
+                          checked={true}
+                          className="RadioButton-input"
+                          disabled={false}
+                          id="accountFeatures.deleteAccount-true"
+                          name="accountFeatures.deleteAccount"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="radio"
+                          value={true}
+                        />
+                        <label
+                          className="RadioButton-label"
+                          htmlFor="accountFeatures.deleteAccount-true"
+                        >
+                          <span>
+                            Missing translation "configure-account-features-yes"
+                          </span>
+                        </label>
+                      </div>
+                      <div
+                        className="Box-root Flex-root RadioButton-root Flex-flex Flex-alignCenter"
+                      >
+                        <input
+                          checked={false}
+                          className="RadioButton-input"
+                          disabled={false}
+                          id="accountFeatures.deleteAccount-false"
+                          name="accountFeatures.deleteAccount"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="radio"
+                          value={false}
+                        />
+                        <label
+                          className="RadioButton-label"
+                          htmlFor="accountFeatures.deleteAccount-false"
+                        >
+                          <span>
+                            Missing translation "configure-account-features-no"
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+          <div
+            className="Box-root HorizontalGutter-root HorizontalGutter-double"
+            data-testid="configure-authContainer"
+          >
+            <div
+              className="Box-root HorizontalGutter-root HorizontalGutter-double"
+            >
+              <h1
+                className="Box-root Typography-root Typography-heading1 Typography-colorTextPrimary Header-root"
+              >
+                Authentication Integrations
+              </h1>
+              <div
+                className="ConfigBox-root"
+              >
+                <div
+                  className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
+                >
+                  <div>
+                    <span>
+                      Login with Email Authentication
+                    </span>
+                  </div>
+                  <div>
                     <div
                       className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
@@ -2211,8 +2350,8 @@ integration to register for a new account.
                           checked={true}
                           className="CheckBox-input"
                           disabled={false}
-                          id="auth.integrations.local.allowRegistration"
-                          name="auth.integrations.local.allowRegistration"
+                          id="auth.integrations.local.enabled"
+                          name="auth.integrations.local.enabled"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -2220,464 +2359,153 @@ integration to register for a new account.
                           value={true}
                         />
                         <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.local.allowRegistration"
+                          className="CheckBox-label CheckBox-labelLight"
+                          htmlFor="auth.integrations.local.enabled"
                         >
                           <span
                             className="CheckBox-labelSpan"
                           >
-                            Allow Registration
+                            Enabled
                           </span>
                         </label>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-            <div
-              className="ConfigBox-root"
-              data-testid="configure-auth-oidc-container"
-            >
-              <div
-                className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
-              >
-                <div>
-                  <span>
-                    Login with OpenID Connect
-                  </span>
-                </div>
-                <div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <div
-                      className="CheckBox-root"
-                    >
-                      <input
-                        checked={false}
-                        className="CheckBox-input"
-                        disabled={false}
-                        id="auth.integrations.oidc.enabled"
-                        name="auth.integrations.oidc.enabled"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value={false}
-                      />
-                      <label
-                        className="CheckBox-label CheckBox-labelLight"
-                        htmlFor="auth.integrations.oidc.enabled"
-                      >
-                        <span
-                          className="CheckBox-labelSpan"
-                        >
-                          Enabled
-                        </span>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ConfigBox-content"
-              >
                 <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-double"
+                  className="ConfigBox-content"
                 >
-                  <p
-                    className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
-                  >
-                    To learn more: 
-                    <a
-                      className="TextLink-root"
-                      href="https://openid.net/connect/"
-                      target="_blank"
-                    >
-                      https://openid.net/connect/
-                      <span
-                        aria-hidden="true"
-                        className="Icon-root Icon-xs TextLink-icon"
-                      >
-                        open_in_new
-                      </span>
-                    </a>
-                  </p>
-                  <hr
-                    className="HorizontalRule-root"
-                  />
                   <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    className="Box-root HorizontalGutter-root HorizontalGutter-double"
                   >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Redirect URI
-                    </label>
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
-                      <div
-                        className="TextField-root"
-                      >
-                        <input
-                          className="TextField-input TextField-colorRegular"
-                          name="redirectURI"
-                          placeholder=""
-                          readOnly={true}
-                          type="text"
-                          value="http://localhost/oidc/callback"
-                        />
-                      </div>
-                      <button
-                        className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled"
-                        data-color="primary"
-                        data-variant="filled"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
                       >
                         <span>
-                          Copy
+                          Use Email Authentication login on
                         </span>
-                      </button>
-                    </div>
-                  </div>
-                  <hr
-                    className="HorizontalRule-root"
-                  />
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Provider Name
-                    </label>
-                    <p
-                      className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
-                    >
-                      The provider of the OpenID Connect integration. This will be used when the name of the provider
-needs to be displayed, e.g. “Log in with &lt;Facebook&gt;”.
-                    </p>
-                    <div
-                      className="TextField-root"
-                    >
-                      <input
-                        autoCapitalize="off"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        className="TextField-input TextField-colorRegular"
-                        disabled={true}
-                        name="auth.integrations.oidc.name"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        spellCheck={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Client ID
-                    </label>
-                    <div
-                      className="TextField-root"
-                    >
-                      <input
-                        autoCapitalize="off"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        className="TextField-input TextField-colorRegular"
-                        disabled={true}
-                        name="auth.integrations.oidc.clientID"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        spellCheck={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Client Secret
-                    </label>
-                    <div
-                      className="PasswordField-root"
-                    >
+                      </label>
                       <div
-                        className="PasswordField-wrapper"
+                        className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
                       >
-                        <input
-                          autoCapitalize="off"
-                          autoComplete="off"
-                          autoCorrect="off"
-                          className="PasswordField-colorRegular PasswordField-input"
-                          disabled={true}
-                          name="auth.integrations.oidc.clientSecret"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          placeholder=""
-                          spellCheck={false}
-                          type="password"
-                          value=""
-                        />
                         <div
-                          className="PasswordField-icon"
-                          onClick={[Function]}
-                          role="button"
-                          tabIndex={0}
-                          title="Hide Client Secret"
+                          className="CheckBox-root"
                         >
-                          <span
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm"
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={false}
+                            id="auth.integrations.local.targetFilter.admin"
+                            name="auth.integrations.local.targetFilter.admin"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.local.targetFilter.admin"
                           >
-                            visibility
-                          </span>
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Coral Admin
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={false}
+                            id="auth.integrations.local.targetFilter.stream"
+                            name="auth.integrations.local.targetFilter.stream"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.local.targetFilter.stream"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Comment Stream
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Registration
+                      </label>
+                      <p
+                        className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
+                      >
+                        Allow users that have not signed up before with this authentication
+integration to register for a new account.
+                      </p>
+                      <div
+                        className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={false}
+                            id="auth.integrations.local.allowRegistration"
+                            name="auth.integrations.local.allowRegistration"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.local.allowRegistration"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Allow Registration
+                            </span>
+                          </label>
                         </div>
                       </div>
                     </div>
                   </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Issuer
-                    </label>
-                    <p
-                      className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
-                    >
-                      After entering your Issuer information, click the Discover button to have Coral complete
-the remaining fields. You may also enter the information manually.
-                    </p>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
-                    >
-                      <div
-                        className="TextField-root"
-                      >
-                        <input
-                          autoCapitalize="off"
-                          autoComplete="off"
-                          autoCorrect="off"
-                          className="TextField-input TextField-colorRegular"
-                          disabled={true}
-                          name="auth.integrations.oidc.issuer"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          placeholder=""
-                          spellCheck={false}
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                      <button
-                        className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled Button-disabled"
-                        data-color="primary"
-                        data-variant="filled"
-                        disabled={true}
-                        id="configure-auth-oidc-discover"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        Discover
-                      </button>
-                    </div>
+                </div>
+              </div>
+              <div
+                className="ConfigBox-root"
+                data-testid="configure-auth-oidc-container"
+              >
+                <div
+                  className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
+                >
+                  <div>
+                    <span>
+                      Login with OpenID Connect
+                    </span>
                   </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Authorization URL
-                    </label>
-                    <div
-                      className="TextField-root"
-                    >
-                      <input
-                        autoCapitalize="off"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        className="TextField-input TextField-colorRegular"
-                        disabled={true}
-                        name="auth.integrations.oidc.authorizationURL"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        spellCheck={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Token URL
-                    </label>
-                    <div
-                      className="TextField-root"
-                    >
-                      <input
-                        autoCapitalize="off"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        className="TextField-input TextField-colorRegular"
-                        disabled={true}
-                        name="auth.integrations.oidc.tokenURL"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        spellCheck={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      JWKS URI
-                    </label>
-                    <div
-                      className="TextField-root"
-                    >
-                      <input
-                        autoCapitalize="off"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        className="TextField-input TextField-colorRegular"
-                        disabled={true}
-                        name="auth.integrations.oidc.jwksURI"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        spellCheck={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      <span>
-                        Use OpenID Connect login on
-                      </span>
-                    </label>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
-                    >
-                      <div
-                        className="CheckBox-root"
-                      >
-                        <input
-                          checked={true}
-                          className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.oidc.targetFilter.admin"
-                          name="auth.integrations.oidc.targetFilter.admin"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
-                        />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.oidc.targetFilter.admin"
-                        >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Coral Admin
-                          </span>
-                        </label>
-                      </div>
-                      <div
-                        className="CheckBox-root"
-                      >
-                        <input
-                          checked={true}
-                          className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.oidc.targetFilter.stream"
-                          name="auth.integrations.oidc.targetFilter.stream"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
-                        />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.oidc.targetFilter.stream"
-                        >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Comment Stream
-                          </span>
-                        </label>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Registration
-                    </label>
-                    <p
-                      className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
-                    >
-                      Allow users that have not signed up before with this authentication
-integration to register for a new account.
-                    </p>
+                  <div>
                     <div
                       className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
@@ -2687,9 +2515,9 @@ integration to register for a new account.
                         <input
                           checked={false}
                           className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.oidc.allowRegistration"
-                          name="auth.integrations.oidc.allowRegistration"
+                          disabled={false}
+                          id="auth.integrations.oidc.enabled"
+                          name="auth.integrations.oidc.enabled"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
@@ -2697,83 +2525,160 @@ integration to register for a new account.
                           value={false}
                         />
                         <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.oidc.allowRegistration"
+                          className="CheckBox-label CheckBox-labelLight"
+                          htmlFor="auth.integrations.oidc.enabled"
                         >
                           <span
                             className="CheckBox-labelSpan"
                           >
-                            Allow Registration
+                            Enabled
                           </span>
                         </label>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-            <div
-              className="ConfigBox-root"
-            >
-              <div
-                className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
-              >
-                <div>
-                  <span>
-                    Login with Single Sign On
-                  </span>
-                </div>
-                <div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <div
-                      className="CheckBox-root"
-                    >
-                      <input
-                        checked={false}
-                        className="CheckBox-input"
-                        disabled={false}
-                        id="auth.integrations.sso.enabled"
-                        name="auth.integrations.sso.enabled"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value={false}
-                      />
-                      <label
-                        className="CheckBox-label CheckBox-labelLight"
-                        htmlFor="auth.integrations.sso.enabled"
-                      >
-                        <span
-                          className="CheckBox-labelSpan"
-                        >
-                          Enabled
-                        </span>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ConfigBox-content"
-              >
                 <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-double"
+                  className="ConfigBox-content"
                 >
                   <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                    data-testid="configure-auth-sso-key"
+                    className="Box-root HorizontalGutter-root HorizontalGutter-double"
                   >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                    <p
+                      className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
                     >
-                      Key
-                    </label>
+                      To learn more: 
+                      <a
+                        className="TextLink-root"
+                        href="https://openid.net/connect/"
+                        target="_blank"
+                      >
+                        https://openid.net/connect/
+                        <span
+                          aria-hidden="true"
+                          className="Icon-root Icon-xs TextLink-icon"
+                        >
+                          open_in_new
+                        </span>
+                      </a>
+                    </p>
+                    <hr
+                      className="HorizontalRule-root"
+                    />
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Redirect URI
+                      </label>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="TextField-root"
+                        >
+                          <input
+                            className="TextField-input TextField-colorRegular"
+                            name="redirectURI"
+                            placeholder=""
+                            readOnly={true}
+                            type="text"
+                            value="http://localhost/oidc/callback"
+                          />
+                        </div>
+                        <button
+                          className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled"
+                          data-color="primary"
+                          data-variant="filled"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span>
+                            Copy
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                    <hr
+                      className="HorizontalRule-root"
+                    />
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Provider Name
+                      </label>
+                      <p
+                        className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
+                      >
+                        The provider of the OpenID Connect integration. This will be used when the name of the provider
+needs to be displayed, e.g. “Log in with &lt;Facebook&gt;”.
+                      </p>
+                      <div
+                        className="TextField-root"
+                      >
+                        <input
+                          autoCapitalize="off"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          className="TextField-input TextField-colorRegular"
+                          disabled={true}
+                          name="auth.integrations.oidc.name"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder=""
+                          spellCheck={false}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Client ID
+                      </label>
+                      <div
+                        className="TextField-root"
+                      >
+                        <input
+                          autoCapitalize="off"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          className="TextField-input TextField-colorRegular"
+                          disabled={true}
+                          name="auth.integrations.oidc.clientID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder=""
+                          spellCheck={false}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Client Secret
+                      </label>
                       <div
                         className="PasswordField-root"
                       >
@@ -2785,18 +2690,22 @@ integration to register for a new account.
                             autoComplete="off"
                             autoCorrect="off"
                             className="PasswordField-colorRegular PasswordField-input"
-                            name="key"
+                            disabled={true}
+                            name="auth.integrations.oidc.clientSecret"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
                             placeholder=""
-                            readOnly={true}
                             spellCheck={false}
                             type="password"
+                            value=""
                           />
                           <div
                             className="PasswordField-icon"
                             onClick={[Function]}
                             role="button"
                             tabIndex={0}
-                            title="Hide SSO Key"
+                            title="Hide Client Secret"
                           >
                             <span
                               aria-hidden="true"
@@ -2807,127 +2716,272 @@ integration to register for a new account.
                           </div>
                         </div>
                       </div>
-                      <button
-                        className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled Button-disabled"
-                        data-color="primary"
-                        data-variant="filled"
-                        disabled={true}
-                        id="configure-auth-sso-regenerate"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        Regenerate
-                      </button>
                     </div>
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-directionRow gutter"
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Issuer
+                      </label>
                       <p
-                        className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary SSOKeyField-keyGenerated"
+                        className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
                       >
-                        KEY GENERATED AT:
-Invalid Date
+                        After entering your Issuer information, click the Discover button to have Coral complete
+the remaining fields. You may also enter the information manually.
                       </p>
-                      <span
-                        aria-hidden="true"
-                        className="Icon-root Icon-sm SSOKeyField-warnIcon"
-                      >
-                        warning
-                      </span>
-                      <p
-                        className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary SSOKeyField-warn"
-                      >
-                        Regenerating a key will invalidate any existing user sessions,
-and all signed-in users will be signed out.
-                      </p>
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      <span>
-                        Use Single Sign On login on
-                      </span>
-                    </label>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
-                    >
                       <div
-                        className="CheckBox-root"
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="TextField-root"
+                        >
+                          <input
+                            autoCapitalize="off"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            className="TextField-input TextField-colorRegular"
+                            disabled={true}
+                            name="auth.integrations.oidc.issuer"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            spellCheck={false}
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                        <button
+                          className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled Button-disabled"
+                          data-color="primary"
+                          data-variant="filled"
+                          disabled={true}
+                          id="configure-auth-oidc-discover"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          Discover
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Authorization URL
+                      </label>
+                      <div
+                        className="TextField-root"
                       >
                         <input
-                          checked={true}
-                          className="CheckBox-input"
+                          autoCapitalize="off"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          className="TextField-input TextField-colorRegular"
                           disabled={true}
-                          id="auth.integrations.sso.targetFilter.admin"
-                          name="auth.integrations.sso.targetFilter.admin"
+                          name="auth.integrations.oidc.authorizationURL"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
+                          placeholder=""
+                          spellCheck={false}
+                          type="text"
+                          value=""
                         />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.sso.targetFilter.admin"
-                        >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Coral Admin
-                          </span>
-                        </label>
                       </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Token URL
+                      </label>
                       <div
-                        className="CheckBox-root"
+                        className="TextField-root"
                       >
                         <input
-                          checked={true}
-                          className="CheckBox-input"
+                          autoCapitalize="off"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          className="TextField-input TextField-colorRegular"
                           disabled={true}
-                          id="auth.integrations.sso.targetFilter.stream"
-                          name="auth.integrations.sso.targetFilter.stream"
+                          name="auth.integrations.oidc.tokenURL"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
+                          placeholder=""
+                          spellCheck={false}
+                          type="text"
+                          value=""
                         />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.sso.targetFilter.stream"
-                        >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Comment Stream
-                          </span>
-                        </label>
                       </div>
                     </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
-                      Registration
-                    </label>
-                    <p
-                      className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        JWKS URI
+                      </label>
+                      <div
+                        className="TextField-root"
+                      >
+                        <input
+                          autoCapitalize="off"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          className="TextField-input TextField-colorRegular"
+                          disabled={true}
+                          name="auth.integrations.oidc.jwksURI"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder=""
+                          spellCheck={false}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
-                      Allow users that have not signed up before with this authentication
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        <span>
+                          Use OpenID Connect login on
+                        </span>
+                      </label>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.oidc.targetFilter.admin"
+                            name="auth.integrations.oidc.targetFilter.admin"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.oidc.targetFilter.admin"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Coral Admin
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.oidc.targetFilter.stream"
+                            name="auth.integrations.oidc.targetFilter.stream"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.oidc.targetFilter.stream"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Comment Stream
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Registration
+                      </label>
+                      <p
+                        className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
+                      >
+                        Allow users that have not signed up before with this authentication
 integration to register for a new account.
-                    </p>
+                      </p>
+                      <div
+                        className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={false}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.oidc.allowRegistration"
+                            name="auth.integrations.oidc.allowRegistration"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={false}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.oidc.allowRegistration"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Allow Registration
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ConfigBox-root"
+              >
+                <div
+                  className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
+                >
+                  <div>
+                    <span>
+                      Login with Single Sign On
+                    </span>
+                  </div>
+                  <div>
                     <div
                       className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
@@ -2935,614 +2989,557 @@ integration to register for a new account.
                         className="CheckBox-root"
                       >
                         <input
-                          checked={true}
+                          checked={false}
                           className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.sso.allowRegistration"
-                          name="auth.integrations.sso.allowRegistration"
+                          disabled={false}
+                          id="auth.integrations.sso.enabled"
+                          name="auth.integrations.sso.enabled"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           type="checkbox"
-                          value={true}
+                          value={false}
                         />
                         <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.sso.allowRegistration"
+                          className="CheckBox-label CheckBox-labelLight"
+                          htmlFor="auth.integrations.sso.enabled"
                         >
                           <span
                             className="CheckBox-labelSpan"
                           >
-                            Allow Registration
+                            Enabled
                           </span>
                         </label>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-            <div
-              className="ConfigBox-root"
-            >
-              <div
-                className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
-              >
-                <div>
-                  <span>
-                    Login with Google
-                  </span>
-                </div>
-                <div>
+                <div
+                  className="ConfigBox-content"
+                >
                   <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    className="Box-root HorizontalGutter-root HorizontalGutter-double"
                   >
                     <div
-                      className="CheckBox-root"
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                      data-testid="configure-auth-sso-key"
                     >
-                      <input
-                        checked={false}
-                        className="CheckBox-input"
-                        disabled={false}
-                        id="auth.integrations.google.enabled"
-                        name="auth.integrations.google.enabled"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value={false}
-                      />
                       <label
-                        className="CheckBox-label CheckBox-labelLight"
-                        htmlFor="auth.integrations.google.enabled"
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
                       >
-                        <span
-                          className="CheckBox-labelSpan"
+                        Key
+                      </label>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="PasswordField-root"
                         >
-                          Enabled
+                          <div
+                            className="PasswordField-wrapper"
+                          >
+                            <input
+                              autoCapitalize="off"
+                              autoComplete="off"
+                              autoCorrect="off"
+                              className="PasswordField-colorRegular PasswordField-input"
+                              name="key"
+                              placeholder=""
+                              readOnly={true}
+                              spellCheck={false}
+                              type="password"
+                            />
+                            <div
+                              className="PasswordField-icon"
+                              onClick={[Function]}
+                              role="button"
+                              tabIndex={0}
+                              title="Hide SSO Key"
+                            >
+                              <span
+                                aria-hidden="true"
+                                className="Icon-root Icon-sm"
+                              >
+                                visibility
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <button
+                          className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled Button-disabled"
+                          data-color="primary"
+                          data-variant="filled"
+                          disabled={true}
+                          id="configure-auth-sso-regenerate"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          Regenerate
+                        </button>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-directionRow gutter"
+                      >
+                        <p
+                          className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary SSOKeyField-keyGenerated"
+                        >
+                          KEY GENERATED AT:
+Invalid Date
+                        </p>
+                        <span
+                          aria-hidden="true"
+                          className="Icon-root Icon-sm SSOKeyField-warnIcon"
+                        >
+                          warning
+                        </span>
+                        <p
+                          className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary SSOKeyField-warn"
+                        >
+                          Regenerating a key will invalidate any existing user sessions,
+and all signed-in users will be signed out.
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        <span>
+                          Use Single Sign On login on
                         </span>
                       </label>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.sso.targetFilter.admin"
+                            name="auth.integrations.sso.targetFilter.admin"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.sso.targetFilter.admin"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Coral Admin
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.sso.targetFilter.stream"
+                            name="auth.integrations.sso.targetFilter.stream"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.sso.targetFilter.stream"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Comment Stream
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Registration
+                      </label>
+                      <p
+                        className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
+                      >
+                        Allow users that have not signed up before with this authentication
+integration to register for a new account.
+                      </p>
+                      <div
+                        className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.sso.allowRegistration"
+                            name="auth.integrations.sso.allowRegistration"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.sso.allowRegistration"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Allow Registration
+                            </span>
+                          </label>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
               <div
-                className="ConfigBox-content"
+                className="ConfigBox-root"
               >
                 <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-double"
+                  className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
                 >
-                  <p
-                    className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+                  <div>
+                    <span>
+                      Login with Google
+                    </span>
+                  </div>
+                  <div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <div
+                        className="CheckBox-root"
+                      >
+                        <input
+                          checked={false}
+                          className="CheckBox-input"
+                          disabled={false}
+                          id="auth.integrations.google.enabled"
+                          name="auth.integrations.google.enabled"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          type="checkbox"
+                          value={false}
+                        />
+                        <label
+                          className="CheckBox-label CheckBox-labelLight"
+                          htmlFor="auth.integrations.google.enabled"
+                        >
+                          <span
+                            className="CheckBox-labelSpan"
+                          >
+                            Enabled
+                          </span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="ConfigBox-content"
+                >
+                  <div
+                    className="Box-root HorizontalGutter-root HorizontalGutter-double"
                   >
-                    To enable the integration with Google Authentication you need
+                    <p
+                      className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+                    >
+                      To enable the integration with Google Authentication you need
 to create and set up a web application. For more information visit:
 
-                    <a
-                      className="TextLink-root"
-                      href="https://developers.google.com/identity/protocols/OAuth2WebServer#creatingcred"
-                      target="_blank"
-                    >
-                      https://developers.google.com/identity/protocols/OAuth2WebServer#creatingcred
-                      <span
-                        aria-hidden="true"
-                        className="Icon-root Icon-xs TextLink-icon"
+                      <a
+                        className="TextLink-root"
+                        href="https://developers.google.com/identity/protocols/OAuth2WebServer#creatingcred"
+                        target="_blank"
                       >
-                        open_in_new
-                      </span>
-                    </a>
-                    .
-                  </p>
-                  <hr
-                    className="HorizontalRule-root"
-                  />
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Redirect URI
-                    </label>
+                        https://developers.google.com/identity/protocols/OAuth2WebServer#creatingcred
+                        <span
+                          aria-hidden="true"
+                          className="Icon-root Icon-xs TextLink-icon"
+                        >
+                          open_in_new
+                        </span>
+                      </a>
+                      .
+                    </p>
+                    <hr
+                      className="HorizontalRule-root"
+                    />
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Redirect URI
+                      </label>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="TextField-root"
+                        >
+                          <input
+                            className="TextField-input TextField-colorRegular"
+                            name="redirectURI"
+                            placeholder=""
+                            readOnly={true}
+                            type="text"
+                            value="http://localhost/google/callback"
+                          />
+                        </div>
+                        <button
+                          className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled"
+                          data-color="primary"
+                          data-variant="filled"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span>
+                            Copy
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                    <hr
+                      className="HorizontalRule-root"
+                    />
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Client ID
+                      </label>
                       <div
                         className="TextField-root"
-                      >
-                        <input
-                          className="TextField-input TextField-colorRegular"
-                          name="redirectURI"
-                          placeholder=""
-                          readOnly={true}
-                          type="text"
-                          value="http://localhost/google/callback"
-                        />
-                      </div>
-                      <button
-                        className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled"
-                        data-color="primary"
-                        data-variant="filled"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span>
-                          Copy
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                  <hr
-                    className="HorizontalRule-root"
-                  />
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Client ID
-                    </label>
-                    <div
-                      className="TextField-root"
-                    >
-                      <input
-                        autoCapitalize="off"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        className="TextField-input TextField-colorRegular"
-                        disabled={true}
-                        name="auth.integrations.google.clientID"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        spellCheck={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Client Secret
-                    </label>
-                    <div
-                      className="PasswordField-root"
-                    >
-                      <div
-                        className="PasswordField-wrapper"
                       >
                         <input
                           autoCapitalize="off"
                           autoComplete="off"
                           autoCorrect="off"
-                          className="PasswordField-colorRegular PasswordField-input"
+                          className="TextField-input TextField-colorRegular"
                           disabled={true}
-                          name="auth.integrations.google.clientSecret"
+                          name="auth.integrations.google.clientID"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           placeholder=""
                           spellCheck={false}
-                          type="password"
+                          type="text"
                           value=""
                         />
-                        <div
-                          className="PasswordField-icon"
-                          onClick={[Function]}
-                          role="button"
-                          tabIndex={0}
-                          title="Hide Client Secret"
-                        >
-                          <span
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm"
-                          >
-                            visibility
-                          </span>
-                        </div>
                       </div>
                     </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      <span>
-                        Use Google login on
-                      </span>
-                    </label>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
-                    >
-                      <div
-                        className="CheckBox-root"
-                      >
-                        <input
-                          checked={true}
-                          className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.google.targetFilter.admin"
-                          name="auth.integrations.google.targetFilter.admin"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
-                        />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.google.targetFilter.admin"
-                        >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Coral Admin
-                          </span>
-                        </label>
-                      </div>
-                      <div
-                        className="CheckBox-root"
-                      >
-                        <input
-                          checked={true}
-                          className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.google.targetFilter.stream"
-                          name="auth.integrations.google.targetFilter.stream"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
-                        />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.google.targetFilter.stream"
-                        >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Comment Stream
-                          </span>
-                        </label>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Registration
-                    </label>
-                    <p
-                      className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
-                    >
-                      Allow users that have not signed up before with this authentication
-integration to register for a new account.
-                    </p>
                     <div
                       className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
-                      <div
-                        className="CheckBox-root"
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
                       >
-                        <input
-                          checked={true}
-                          className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.google.allowRegistration"
-                          name="auth.integrations.google.allowRegistration"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
-                        />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.google.allowRegistration"
+                        Client Secret
+                      </label>
+                      <div
+                        className="PasswordField-root"
+                      >
+                        <div
+                          className="PasswordField-wrapper"
                         >
-                          <span
-                            className="CheckBox-labelSpan"
+                          <input
+                            autoCapitalize="off"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            className="PasswordField-colorRegular PasswordField-input"
+                            disabled={true}
+                            name="auth.integrations.google.clientSecret"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            spellCheck={false}
+                            type="password"
+                            value=""
+                          />
+                          <div
+                            className="PasswordField-icon"
+                            onClick={[Function]}
+                            role="button"
+                            tabIndex={0}
+                            title="Hide Client Secret"
                           >
-                            Allow Registration
-                          </span>
-                        </label>
+                            <span
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm"
+                            >
+                              visibility
+                            </span>
+                          </div>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="ConfigBox-root"
-              data-testid="configure-auth-facebook-container"
-            >
-              <div
-                className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
-              >
-                <div>
-                  <span>
-                    Login with Facebook
-                  </span>
-                </div>
-                <div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
                     <div
-                      className="CheckBox-root"
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
-                      <input
-                        checked={false}
-                        className="CheckBox-input"
-                        disabled={false}
-                        id="auth.integrations.facebook.enabled"
-                        name="auth.integrations.facebook.enabled"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        type="checkbox"
-                        value={false}
-                      />
                       <label
-                        className="CheckBox-label CheckBox-labelLight"
-                        htmlFor="auth.integrations.facebook.enabled"
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
                       >
-                        <span
-                          className="CheckBox-labelSpan"
-                        >
-                          Enabled
+                        <span>
+                          Use Google login on
                         </span>
                       </label>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.google.targetFilter.admin"
+                            name="auth.integrations.google.targetFilter.admin"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.google.targetFilter.admin"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Coral Admin
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.google.targetFilter.stream"
+                            name="auth.integrations.google.targetFilter.stream"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.google.targetFilter.stream"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Comment Stream
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Registration
+                      </label>
+                      <p
+                        className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
+                      >
+                        Allow users that have not signed up before with this authentication
+integration to register for a new account.
+                      </p>
+                      <div
+                        className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.google.allowRegistration"
+                            name="auth.integrations.google.allowRegistration"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.google.allowRegistration"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Allow Registration
+                            </span>
+                          </label>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
               <div
-                className="ConfigBox-content"
+                className="ConfigBox-root"
+                data-testid="configure-auth-facebook-container"
               >
                 <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-double"
+                  className="Box-root Flex-root ConfigBox-title Flex-flex Flex-justifySpaceBetween"
                 >
-                  <p
-                    className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
-                  >
-                    To enable the integration with Facebook Authentication,
-you need to create and set up a web application.
-For more information visit: 
-                    <a
-                      className="TextLink-root"
-                      href="https://developers.facebook.com/docs/facebook-login/web"
-                      target="_blank"
-                    >
-                      https://developers.facebook.com/docs/facebook-login/web
-                      <span
-                        aria-hidden="true"
-                        className="Icon-root Icon-xs TextLink-icon"
-                      >
-                        open_in_new
-                      </span>
-                    </a>
-                    .
-                  </p>
-                  <hr
-                    className="HorizontalRule-root"
-                  />
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Redirect URI
-                    </label>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
-                    >
-                      <div
-                        className="TextField-root"
-                      >
-                        <input
-                          className="TextField-input TextField-colorRegular"
-                          name="redirectURI"
-                          placeholder=""
-                          readOnly={true}
-                          type="text"
-                          value="http://localhost/facebook/callback"
-                        />
-                      </div>
-                      <button
-                        className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled"
-                        data-color="primary"
-                        data-variant="filled"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span>
-                          Copy
-                        </span>
-                      </button>
-                    </div>
+                  <div>
+                    <span>
+                      Login with Facebook
+                    </span>
                   </div>
-                  <hr
-                    className="HorizontalRule-root"
-                  />
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Client ID
-                    </label>
-                    <div
-                      className="TextField-root"
-                    >
-                      <input
-                        autoCapitalize="off"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        className="TextField-input TextField-colorRegular"
-                        disabled={true}
-                        name="auth.integrations.facebook.clientID"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        spellCheck={false}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Client Secret
-                    </label>
-                    <div
-                      className="PasswordField-root"
-                    >
-                      <div
-                        className="PasswordField-wrapper"
-                      >
-                        <input
-                          autoCapitalize="off"
-                          autoComplete="off"
-                          autoCorrect="off"
-                          className="PasswordField-colorRegular PasswordField-input"
-                          disabled={true}
-                          name="auth.integrations.facebook.clientSecret"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          placeholder=""
-                          spellCheck={false}
-                          type="password"
-                          value=""
-                        />
-                        <div
-                          className="PasswordField-icon"
-                          onClick={[Function]}
-                          role="button"
-                          tabIndex={0}
-                          title="Hide Client Secret"
-                        >
-                          <span
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm"
-                          >
-                            visibility
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      <span>
-                        Use Facebook login on
-                      </span>
-                    </label>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
-                    >
-                      <div
-                        className="CheckBox-root"
-                      >
-                        <input
-                          checked={true}
-                          className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.facebook.targetFilter.admin"
-                          name="auth.integrations.facebook.targetFilter.admin"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
-                        />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.facebook.targetFilter.admin"
-                        >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Coral Admin
-                          </span>
-                        </label>
-                      </div>
-                      <div
-                        className="CheckBox-root"
-                      >
-                        <input
-                          checked={true}
-                          className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.facebook.targetFilter.stream"
-                          name="auth.integrations.facebook.targetFilter.stream"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          type="checkbox"
-                          value={true}
-                        />
-                        <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.facebook.targetFilter.stream"
-                        >
-                          <span
-                            className="CheckBox-labelSpan"
-                          >
-                            Comment Stream
-                          </span>
-                        </label>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
-                  >
-                    <label
-                      className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
-                    >
-                      Registration
-                    </label>
-                    <p
-                      className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
-                    >
-                      Allow users that have not signed up before with this authentication
-integration to register for a new account.
-                    </p>
+                  <div>
                     <div
                       className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
                     >
@@ -3550,27 +3547,289 @@ integration to register for a new account.
                         className="CheckBox-root"
                       >
                         <input
-                          checked={true}
+                          checked={false}
                           className="CheckBox-input"
-                          disabled={true}
-                          id="auth.integrations.facebook.allowRegistration"
-                          name="auth.integrations.facebook.allowRegistration"
+                          disabled={false}
+                          id="auth.integrations.facebook.enabled"
+                          name="auth.integrations.facebook.enabled"
                           onBlur={[Function]}
                           onChange={[Function]}
                           onFocus={[Function]}
                           type="checkbox"
-                          value={true}
+                          value={false}
                         />
                         <label
-                          className="CheckBox-label"
-                          htmlFor="auth.integrations.facebook.allowRegistration"
+                          className="CheckBox-label CheckBox-labelLight"
+                          htmlFor="auth.integrations.facebook.enabled"
                         >
                           <span
                             className="CheckBox-labelSpan"
                           >
-                            Allow Registration
+                            Enabled
                           </span>
                         </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="ConfigBox-content"
+                >
+                  <div
+                    className="Box-root HorizontalGutter-root HorizontalGutter-double"
+                  >
+                    <p
+                      className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+                    >
+                      To enable the integration with Facebook Authentication,
+you need to create and set up a web application.
+For more information visit: 
+                      <a
+                        className="TextLink-root"
+                        href="https://developers.facebook.com/docs/facebook-login/web"
+                        target="_blank"
+                      >
+                        https://developers.facebook.com/docs/facebook-login/web
+                        <span
+                          aria-hidden="true"
+                          className="Icon-root Icon-xs TextLink-icon"
+                        >
+                          open_in_new
+                        </span>
+                      </a>
+                      .
+                    </p>
+                    <hr
+                      className="HorizontalRule-root"
+                    />
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Redirect URI
+                      </label>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="TextField-root"
+                        >
+                          <input
+                            className="TextField-input TextField-colorRegular"
+                            name="redirectURI"
+                            placeholder=""
+                            readOnly={true}
+                            type="text"
+                            value="http://localhost/facebook/callback"
+                          />
+                        </div>
+                        <button
+                          className="BaseButton-root Button-root Button-sizeSmall Button-colorPrimary Button-variantFilled"
+                          data-color="primary"
+                          data-variant="filled"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span>
+                            Copy
+                          </span>
+                        </button>
+                      </div>
+                    </div>
+                    <hr
+                      className="HorizontalRule-root"
+                    />
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Client ID
+                      </label>
+                      <div
+                        className="TextField-root"
+                      >
+                        <input
+                          autoCapitalize="off"
+                          autoComplete="off"
+                          autoCorrect="off"
+                          className="TextField-input TextField-colorRegular"
+                          disabled={true}
+                          name="auth.integrations.facebook.clientID"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder=""
+                          spellCheck={false}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Client Secret
+                      </label>
+                      <div
+                        className="PasswordField-root"
+                      >
+                        <div
+                          className="PasswordField-wrapper"
+                        >
+                          <input
+                            autoCapitalize="off"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            className="PasswordField-colorRegular PasswordField-input"
+                            disabled={true}
+                            name="auth.integrations.facebook.clientSecret"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            spellCheck={false}
+                            type="password"
+                            value=""
+                          />
+                          <div
+                            className="PasswordField-icon"
+                            onClick={[Function]}
+                            role="button"
+                            tabIndex={0}
+                            title="Hide Client Secret"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm"
+                            >
+                              visibility
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        <span>
+                          Use Facebook login on
+                        </span>
+                      </label>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-doubleItemGutter Flex-directionRow gutter"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.facebook.targetFilter.admin"
+                            name="auth.integrations.facebook.targetFilter.admin"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.facebook.targetFilter.admin"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Coral Admin
+                            </span>
+                          </label>
+                        </div>
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.facebook.targetFilter.stream"
+                            name="auth.integrations.facebook.targetFilter.stream"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.facebook.targetFilter.stream"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Comment Stream
+                            </span>
+                          </label>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                    >
+                      <label
+                        className="Box-root Typography-root Typography-inputLabel Typography-colorTextPrimary InputLabel-root"
+                      >
+                        Registration
+                      </label>
+                      <p
+                        className="Box-root Typography-root Typography-detail Typography-colorTextSecondary ConfigDescription-description"
+                      >
+                        Allow users that have not signed up before with this authentication
+integration to register for a new account.
+                      </p>
+                      <div
+                        className="Box-root HorizontalGutter-root FormField-root HorizontalGutter-half"
+                      >
+                        <div
+                          className="CheckBox-root"
+                        >
+                          <input
+                            checked={true}
+                            className="CheckBox-input"
+                            disabled={true}
+                            id="auth.integrations.facebook.allowRegistration"
+                            name="auth.integrations.facebook.allowRegistration"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            type="checkbox"
+                            value={true}
+                          />
+                          <label
+                            className="CheckBox-label"
+                            htmlFor="auth.integrations.facebook.allowRegistration"
+                          >
+                            <span
+                              className="CheckBox-labelSpan"
+                            >
+                              Allow Registration
+                            </span>
+                          </label>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/core/client/admin/test/fixtures.ts
+++ b/src/core/client/admin/test/fixtures.ts
@@ -141,6 +141,11 @@ export const settings = createFixture<GQLSettings>({
       },
     },
   },
+  accountFeatures: {
+    downloadComments: true,
+    changeUsername: true,
+    deleteAccount: true,
+  },
 });
 
 export const settingsWithEmptyAuth = createFixture<GQLSettings>(

--- a/src/core/client/stream/tabs/Profile/ChangeUsername/ChangeUsernameContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/ChangeUsername/ChangeUsernameContainer.tsx
@@ -168,7 +168,7 @@ const ChangeUsernameContainer: FunctionComponent<Props> = ({
       {!showEditForm && (
         <Flex alignItems="baseline">
           <Typography variant="header2">{viewer.username}</Typography>
-          {canChangeLocalAuth && (
+          {canChangeLocalAuth && settings.accountFeatures.changeUsername && (
             <Localized id="profile-changeUsername-edit">
               <Button size="small" color="primary" onClick={toggleEditForm}>
                 edit
@@ -374,6 +374,9 @@ const enhanced = withFragmentContainer<Props>({
   `,
   settings: graphql`
     fragment ChangeUsernameContainer_settings on Settings {
+      accountFeatures {
+        changeUsername
+      }
       auth {
         integrations {
           local {

--- a/src/core/client/stream/tabs/Profile/Settings/SettingsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Settings/SettingsContainer.tsx
@@ -21,7 +21,9 @@ const SettingsContainer: FunctionComponent<Props> = ({ viewer, settings }) => (
   <HorizontalGutter spacing={5} className={styles.root}>
     <IgnoreUserSettingsContainer viewer={viewer} />
     <ChangePasswordContainer settings={settings} />
-    <DownloadCommentsContainer viewer={viewer} />
+    {settings.accountFeatures.downloadComments && (
+      <DownloadCommentsContainer viewer={viewer} />
+    )}
   </HorizontalGutter>
 );
 
@@ -34,6 +36,9 @@ const enhanced = withFragmentContainer<Props>({
   `,
   settings: graphql`
     fragment SettingsContainer_settings on Settings {
+      accountFeatures {
+        downloadComments
+      }
       ...ChangePasswordContainer_settings
     }
   `,

--- a/src/core/client/stream/test/fixtures.ts
+++ b/src/core/client/stream/test/fixtures.ts
@@ -96,6 +96,11 @@ export const settings = createFixture<GQLSettings>({
   charCount: {
     enabled: false,
   },
+  accountFeatures: {
+    downloadComments: true,
+    changeUsername: true,
+    deleteAccount: true,
+  },
 });
 
 export const settingsWithoutLocalAuth = createFixture<GQLSettings>(

--- a/src/core/server/graph/tenant/schema/schema.graphql
+++ b/src/core/server/graph/tenant/schema/schema.graphql
@@ -1074,6 +1074,24 @@ type StoryConfiguration {
 }
 
 """
+CommenterAccountFeatures stores the configuration for commenter account features.
+"""
+type CommenterAccountFeatures {
+  """
+  changeUsername when true, non-sso user may change username every 14 days
+  """
+  changeUsername: Boolean!
+  """
+  downloadComments when true, user may download their comment history 
+  """
+  downloadComments: Boolean!
+  """
+  deleteAccount when true, non-sso user may permanently delete their account 
+  """
+  deleteAccount: Boolean!
+}
+
+"""
 Settings stores the global settings for a given Tenant.
 """
 type Settings {
@@ -1187,6 +1205,11 @@ type Settings {
   reaction specifies the configuration for reactions.
   """
   reaction: ReactionConfiguration!
+
+  """
+  accountFeatures stores the configuration for commenter account features.
+  """
+  accountFeatures: CommenterAccountFeatures!
 
   """
   stories stores the configuration around stories.
@@ -3087,6 +3110,24 @@ input ReactionConfigurationInput {
 }
 
 """
+CommenterAccountFeatures stores the configuration for commenter account features.
+"""
+input CommenterAccountFeaturesInput {
+  """
+  changeUsername when true, non-sso user may change username every 14 days
+  """
+  changeUsername: Boolean
+  """
+  downloadComments when true, user may download their comment history 
+  """
+  downloadComments: Boolean
+  """
+  deleteAccount when true, non-sso user may permanently delete their account 
+  """
+  deleteAccount: Boolean
+}
+
+"""
 SettingsInput is the partial type of the Settings type for performing mutations.
 """
 input SettingsInput {
@@ -3184,6 +3225,11 @@ input SettingsInput {
   reaction specifies the configuration for reactions.
   """
   reaction: ReactionConfigurationInput
+
+  """
+  accountFeatures specifies the configuration for accounts.
+  """
+  accountFeatures: CommenterAccountFeaturesInput
 }
 
 """

--- a/src/core/server/models/settings.ts
+++ b/src/core/server/models/settings.ts
@@ -50,6 +50,15 @@ export interface AuthIntegrations {
 }
 
 /**
+ * AccountFeatures are features enabled for commenter accounts
+ */
+export interface AccountFeatures {
+  changeUsername: boolean;
+  deleteAccount: boolean;
+  downloadComments: boolean;
+}
+
+/**
  * Auth is the set of configured authentication integrations.
  */
 export type Auth = Omit<GQLAuth, "integrations"> & {
@@ -112,4 +121,9 @@ export type Settings = GlobalModerationSettings &
      * disableCommenting will disable commenting site-wide.
      */
     disableCommenting: DisableCommenting;
+
+    /**
+     * AccountFeatures are features enabled for commenter accounts
+     */
+    accountFeatures: AccountFeatures;
   };

--- a/src/core/server/models/tenant.ts
+++ b/src/core/server/models/tenant.ts
@@ -192,6 +192,11 @@ export async function createTenant(
       },
       disableLazy: false,
     },
+    accountFeatures: {
+      changeUsername: false,
+      deleteAccount: false,
+      downloadComments: false,
+    },
     createdAt: now,
   };
 

--- a/src/core/server/services/users/index.ts
+++ b/src/core/server/services/users/index.ts
@@ -518,6 +518,10 @@ function enabledAuthenticationIntegrations(
  * @param user the User that we are updating
  */
 function canUpdateLocalProfile(tenant: Tenant, user: User): boolean {
+  if (!tenant.accountFeatures.changeUsername) {
+    return false;
+  }
+
   if (!hasLocalProfile(user)) {
     return false;
   }
@@ -871,6 +875,9 @@ export async function requestCommentsDownload(
   user: User,
   now: Date
 ) {
+  if (!tenant.accountFeatures.downloadComments) {
+    throw new Error("Downloading comments is not enabled");
+  }
   // Check to see if the user is allowed to download this now.
   if (
     user.lastDownloadedAt &&

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -745,3 +745,19 @@ configure-general-reactions-sort-input =
   .placehodlder = E.g. Most Respected
 configure-general-reactions-preview = Preview
 configure-general-reaction-sortMenu-sortBy = Sort by
+
+configure-account-features-title = Commenter account mangement features
+configure-account-features-explanation = 
+  You can enable and disable certain features for your commenters to use
+  within their Profile. These features also assist towards GDPR
+  compliance.
+configure-account-features-allow = Allow users to:
+configure-account-features-change-usernames = Change their usernames
+configure-account-features-change-usernames-details = Usernames can be changed once every 14 days.
+configure-account-features-yes = Yes
+configure-account-features-no = No
+configure-account-features-download-comments = Download their comments
+configure-account-features-download-comments-details = Commenters can download a csv of their comment history.
+configure-account-features-delete-account = Delete their account
+configure-account-features-delete-account-details = 
+  Removes all of their comment data, username, and email address from the site and the database.


### PR DESCRIPTION
## What does this PR do?
Adds toggles to authentication config panel allowing admins to toggle account features:
- download comments
- change username
- delete account

## Migrations

```js
db.tenants.updateMany({}, {
  $set: {
    accountFeatures: {
      changeUsername: false,
      deleteAccount: false,
      downloadComments: false
    }
  }
})
```

## How do I test this PR?

- log in as admin
- go to configure> authentication
- toggle on and off features
- go to stream
- check for "edit" button next to username and download comments section in settings