### PR TITLE
[CORL-531] Ensure user drawer status drop down is padded properly

### DIFF
--- a/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerContainer.css
+++ b/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerContainer.css
@@ -91,5 +91,7 @@ hr {
   border-width: 1px;
   border-radius: var(--round-corners);
   padding-left: var(--spacing-2);
-  padding-right: var(--spacing-1);
+  padding-right: var(--spacing-2);
+
+  min-height: 21px;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the padding when you select yourself from the community area and the user status popover selection looks weird.

JIRA issue: https://vmproduct.atlassian.net/browse/CORL-531

Fixes some padding caused by the drop down caret being disable when you select yourself.

## How do I test this PR?

- Login as moderator
- Go to community area
- Select currently logged in user name in community table
- See your user status popover control looks normal

Alternate flow:
- Also check on other users to see that their user status drop downs are fine too