### PR TITLE
Patch fix for white screen issue when viewing moderation queues

### DIFF
--- a/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
@@ -71,26 +71,29 @@ const Queue: FunctionComponent<Props> = ({
         </Flex>
       )}
       <TransitionGroup component={null} appear={false} enter={false} exit>
-        {comments.map(c => (
-          <CSSTransition
-            key={c.id}
-            timeout={400}
-            classNames={{
-              exit: styles.exitTransition,
-              exitActive: styles.exitTransitionActive,
-              exitDone: styles.exitTransitionDone,
-            }}
-          >
-            <ModerateCardContainer
-              settings={settings}
-              viewer={viewer}
-              comment={c}
-              danglingLogic={danglingLogic}
-              showStoryInfo={Boolean(allStories)}
-              onUsernameClicked={onShowUserDrawer}
-            />
-          </CSSTransition>
-        ))}
+        {comments
+          // FIXME (Nick/Wyatt): Investigate why comments are coming back null
+          .filter(c => Boolean(c))
+          .map(c => (
+            <CSSTransition
+              key={c.id}
+              timeout={400}
+              classNames={{
+                exit: styles.exitTransition,
+                exitActive: styles.exitTransitionActive,
+                exitDone: styles.exitTransitionDone,
+              }}
+            >
+              <ModerateCardContainer
+                settings={settings}
+                viewer={viewer}
+                comment={c}
+                danglingLogic={danglingLogic}
+                showStoryInfo={Boolean(allStories)}
+                onUsernameClicked={onShowUserDrawer}
+              />
+            </CSSTransition>
+          ))}
       </TransitionGroup>
       {hasMore && (
         <Flex justifyContent="center">


### PR DESCRIPTION
## What does this PR do?

Filter null comments coming into moderation queues to prevent white s…creening

Wyatt and I are not sure why comments are coming back null, but this should
keep the moderation area from blanking out when it errors handling nulled out
comments crashing the queue.

FIXME tag added with Wyatt/Nick as this is only a patching fix and does
not resolve the underlying issue.

## How do I test this PR?

- Make comments
- ???
- See them in appear in moderation queues without errors

Still not 100% sure of the source of this white screening issue or how the null comments are appearing in the moderation area.
