### PR TITLE
[CORL-577] Moderation Counts Bug

### DIFF
--- a/src/core/server/models/story/counts/shared.ts
+++ b/src/core/server/models/story/counts/shared.ts
@@ -106,8 +106,10 @@ export async function recalculateSharedModerationQueueQueueCounts(
   // Increment the hash key values.
   const pipeline = redis.pipeline();
 
-  // Mark the key as fresh, and update the values!
-  pipeline.mhincrby(
+  // Mark the key as fresh, and update the values! We're using `HMSET` here
+  // because this can still result in race conditions when the call is made
+  // twice.
+  pipeline.hmset(
     key,
     ...queues.reduce((acc, queue) => [...acc, queue._id, queue.total], [])
   );


### PR DESCRIPTION
## What does this PR do?

Addresses the issue where the recalculation is called multiple times resulting in a race that causes the increment operation to instead double increment the values.

## How do I test this PR?

With all your coral pages closed in your browsers:

```sh
# If you're running Redis using Docker, use the following to connect to Redis:
docker run --rm -ti --link redis:redis redis:3.2 redis-cli -h redis

# Then from the Redis console, run:
FLUSHDB
```

Then, visit the Coral admin page for moderation. Refresh a few times with comments in them. Notice the count is accurate!