### PR TITLE
[CORL-592] fix styling on radio inputs for long labels

### DIFF
--- a/src/core/client/ui/components/RadioButton/RadioButton.css
+++ b/src/core/client/ui/components/RadioButton/RadioButton.css
@@ -10,7 +10,6 @@
 .label {
   composes: bodyCopy from "coral-ui/shared/typography.css";
   display: inline-flex;
-  align-items: center;
   position: relative;
   cursor: pointer;
   user-select: none;
@@ -31,6 +30,8 @@
   border: 1px solid var(--palette-text-primary);
   border-radius: 50%;
   box-sizing: border-box;
+  margin-top: 5px;
+  flex-shrink: 0;
 }
 
 /* Box focus */
@@ -64,7 +65,7 @@
   border-radius: 50%;
   position: absolute;
   left: 3px;
-  top: 6px;
+  top: 8px;
   width: 8px;
   height: 8px;
   box-sizing: border-box;


### PR DESCRIPTION
## What does this PR do?
Fixes bug where longer labels would squish radio buttons. Also updated styles so that if a label is multiple lines, the radio button is aligned to the top instead of the centre

![image](https://user-images.githubusercontent.com/1789029/64531840-56106b00-d2de-11e9-9d35-1ea39ddbc0ad.png)


## How do I test this PR?
Click "report" in comment stream, edit stream.ftl or use dev tools to make text long enough to break line