### PR TITLE
[CORL-515] Show text field selection border on Firefox

### DIFF
--- a/src/core/client/ui/components/TextField/TextField.css
+++ b/src/core/client/ui/components/TextField/TextField.css
@@ -22,6 +22,10 @@
     color: var(--palette-text-secondary);
     background-color: var(--palette-grey-lightest);
   }
+  &:focus {
+    box-shadow: 0 0 3px rgba(81, 125, 207, 1);
+    border: 1px solid rgba(81, 125, 207, 1);
+  }
 }
 
 .adornment {


### PR DESCRIPTION
Shows a selection border in Firefox when a user is focused on a text field.
This mirrors the functionality in Chrome.

<img width="615" alt="image" src="https://user-images.githubusercontent.com/5751504/64629886-444bc800-d3b1-11e9-929a-702585735404.png">
