### PR TITLE
[CORL-511] fix safari user drawer display bugs

### DIFF
--- a/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerContainer.css
+++ b/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerContainer.css
@@ -1,6 +1,6 @@
 .comments {
   flex: auto;
-  overflow: hidden;
+  overflow: scroll;
 }
 
 .close {

--- a/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerContainer.tsx
+++ b/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerContainer.tsx
@@ -39,28 +39,30 @@ const UserHistoryDrawerContainer: FunctionComponent<Props> = ({
       <Button className={styles.close} onClick={onClose}>
         <Icon size="md">close</Icon>
       </Button>
-      <Flex className={styles.username} itemGutter>
-        <span>{user.username}</span>
-        <div>
-          <UserBadgesContainer user={user} />
-        </div>
-      </Flex>
-      <div className={styles.userStatus}>
-        <Flex alignItems="center" itemGutter="half">
-          <div className={styles.userStatusLabel}>
-            <Typography variant="bodyCopyBold" container="div">
-              <Flex alignItems="center" itemGutter="half">
-                <Localized id="moderate-user-drawer-status-label">
-                  Status:
-                </Localized>
-              </Flex>
-            </Typography>
+      <div>
+        <Flex className={styles.username} itemGutter>
+          <span>{user.username}</span>
+          <div>
+            <UserBadgesContainer user={user} />
           </div>
-          <div className={styles.userStatusChange}>
-            <UserStatusChangeContainer settings={settings} user={user} />
-          </div>
-          <UserStatusDetailsContainer user={user} />
         </Flex>
+        <div className={styles.userStatus}>
+          <Flex alignItems="center" itemGutter="half">
+            <div className={styles.userStatusLabel}>
+              <Typography variant="bodyCopyBold" container="div">
+                <Flex alignItems="center" itemGutter="half">
+                  <Localized id="moderate-user-drawer-status-label">
+                    Status:
+                  </Localized>
+                </Flex>
+              </Typography>
+            </div>
+            <div className={styles.userStatusChange}>
+              <UserStatusChangeContainer settings={settings} user={user} />
+            </div>
+            <UserStatusDetailsContainer user={user} />
+          </Flex>
+        </div>
       </div>
       <div>
         <Flex alignItems="center" className={styles.userDetail}>


### PR DESCRIPTION
- fixes reported bug where elements are overlapping (was caused by flex being used for layout, there wasn't enough room, placing items in the same container ensures they don't overlap
- fixes unreported bug where it was impossible to scroll the drawer on safari. Not sure why `overflow: hidden` was used and why it worked on chrome, but switching it to `scroll` doesn't seem to have broken anything and now it works on safari??