### PR TITLE
[CORL-512] Turn off bidi characters in favor of <bidi> tags

### DIFF
--- a/src/core/client/framework/lib/i18n/generateBundles.ts
+++ b/src/core/client/framework/lib/i18n/generateBundles.ts
@@ -44,7 +44,10 @@ export default async function generateBundles(
   const promises = [];
 
   for (const locale of locales) {
-    const bundle = new FluentBundle(locale, { functions });
+    // `useIsolating: false` will remove bidi characters.
+    // https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
+    // We should be able to use `<bdi>` tags instead to support rtl languages.
+    const bundle = new FluentBundle(locale, { functions, useIsolating: false });
     if (locale in data.bundled) {
       bundle.addMessages(data.bundled[locale]);
       promises.push(decorateWarnMissing(bundle));

--- a/src/core/client/framework/testHelpers/createFluentBundle.ts
+++ b/src/core/client/framework/testHelpers/createFluentBundle.ts
@@ -38,9 +38,9 @@ function createFluentBundle(
   target: string,
   pathToLocale: string
 ): FluentBundle {
-  // `useIsolating: false` will remove bidi characterse.
-  // See https://github.com/projectfluent/fluent.js/commit/41e5445d2e399f090306c5b9a084bcce5111bbd3
-  // And https://www.w3.org/International/questions/qa-bidi-unicode-controls
+  // `useIsolating: false` will remove bidi characters.
+  // https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
+  // We should be able to use `<bdi>` tags instead to support rtl languages.
   const bundle = new FluentBundle("en-US", { functions, useIsolating: false });
   const files = fs.readdirSync(pathToLocale);
   const prefixes = commonPrefixes.concat(target);

--- a/src/core/server/services/i18n/index.ts
+++ b/src/core/server/services/i18n/index.ts
@@ -49,7 +49,11 @@ export class I18n {
 
         // Now we have a language code.
         const bundle: FluentBundle =
-          this.bundles[locale] || new FluentBundle(locale);
+          // `useIsolating: false` will remove bidi characters.
+          // https://github.com/projectfluent/fluent.js/wiki/Unicode-Isolation
+          // We should be able to use `<bdi>` tags instead to support rtl languages.
+          this.bundles[locale] ||
+          new FluentBundle(locale, { useIsolating: false });
 
         // Load all the translations in the folder.
         const files = await fs.readdir(path.join(localesFolder, folder));


### PR DESCRIPTION
Removes bidi characters that renders weird artefacts in Outlook and older versions of Edge. Isolation can be achieved using `<bidi>` tags instead.

# How to test
- Open in edge 16, there should be no bidi character artefacts like
![image](https://user-images.githubusercontent.com/14221600/64707954-026c7000-d4de-11e9-863f-65a7af54dab4.png )
