### PR TITLE
[CORL-516] forgot password flow in admin

### DIFF
--- a/src/core/client/admin/routeConfig.tsx
+++ b/src/core/client/admin/routeConfig.tsx
@@ -16,6 +16,7 @@ import {
   OrganizationConfigRoute,
   WordListConfigRoute,
 } from "./routes/Configure/sections";
+import ForgotPasswordRoute from "./routes/ForgotPassword";
 import InviteRoute from "./routes/Invite";
 import LoginRoute from "./routes/Login";
 import ModerateRoute from "./routes/Moderate";
@@ -79,5 +80,6 @@ export default makeRouteConfig(
     </Route>
     <Route path="invite" {...InviteRoute.routeConfig} />
     <Route path="login" {...LoginRoute.routeConfig} />
+    <Route path="forgot-password" {...ForgotPasswordRoute.routeConfig} />
   </Route>
 );

--- a/src/core/client/admin/routes/ForgotPassword/CheckEmail.tsx
+++ b/src/core/client/admin/routes/ForgotPassword/CheckEmail.tsx
@@ -8,26 +8,23 @@ interface Props {
   email: string;
 }
 
-const CheckEmail: FunctionComponent<Props> = ({ email }) => {
-  const UserEmail = () => <strong>{email}</strong>;
-  return (
-    <div data-testid="forgotPassword-checkEmail-container">
-      <Main data-testid="forgotPassword-checkEmail-main">
-        <HorizontalGutter size="full">
-          <Localized
-            id="forgotPassword-checkEmail-receiveEmail"
-            email={<UserEmail />}
-          >
-            <Typography variant="bodyCopy">
-              {
-                "If there is an account associated with <email></email>, you will receive an email with a link to create a new password."
-              }
-            </Typography>
-          </Localized>
-        </HorizontalGutter>
-      </Main>
-    </div>
-  );
-};
+const CheckEmail: FunctionComponent<Props> = ({ email }) => (
+  <div data-testid="forgotPassword-checkEmail-container">
+    <Main data-testid="forgotPassword-checkEmail-main">
+      <HorizontalGutter size="full">
+        <Localized
+          id="forgotPassword-checkEmail-receiveEmail"
+          $email={email}
+          strong={<strong />}
+        >
+          <Typography variant="bodyCopy">
+            If there is an account associated with <strong>{email}</strong>, you
+            will receive an email with a link to create a new password.
+          </Typography>
+        </Localized>
+      </HorizontalGutter>
+    </Main>
+  </div>
+);
 
 export default CheckEmail;

--- a/src/core/client/admin/routes/ForgotPassword/CheckEmail.tsx
+++ b/src/core/client/admin/routes/ForgotPassword/CheckEmail.tsx
@@ -1,0 +1,33 @@
+import { Localized } from "fluent-react/compat";
+import React, { FunctionComponent } from "react";
+
+import Main from "coral-auth/components/Main";
+import { HorizontalGutter, Typography } from "coral-ui/components";
+
+interface Props {
+  email: string;
+}
+
+const CheckEmail: FunctionComponent<Props> = ({ email }) => {
+  const UserEmail = () => <strong>{email}</strong>;
+  return (
+    <div data-testid="forgotPassword-checkEmail-container">
+      <Main data-testid="forgotPassword-checkEmail-main">
+        <HorizontalGutter size="full">
+          <Localized
+            id="forgotPassword-checkEmail-receiveEmail"
+            email={<UserEmail />}
+          >
+            <Typography variant="bodyCopy">
+              {
+                "If there is an account associated with <email></email>, you will receive an email with a link to create a new password."
+              }
+            </Typography>
+          </Localized>
+        </HorizontalGutter>
+      </Main>
+    </div>
+  );
+};
+
+export default CheckEmail;

--- a/src/core/client/admin/routes/ForgotPassword/ForgotPasswordContainer.css
+++ b/src/core/client/admin/routes/ForgotPassword/ForgotPasswordContainer.css
@@ -1,0 +1,11 @@
+.container {
+  width: 350px;
+  background-color: #f5f5f5;
+  border: 1px solid var(--palette-grey-lighter);
+  margin-top: 70px;
+  box-sizing: border-box;
+}
+
+.textLink {
+  color: var(--palette-primary-main);
+}

--- a/src/core/client/admin/routes/ForgotPassword/ForgotPasswordContainer.tsx
+++ b/src/core/client/admin/routes/ForgotPassword/ForgotPasswordContainer.tsx
@@ -1,0 +1,47 @@
+import { Localized } from "fluent-react/compat";
+import { Link } from "found";
+import React, { FunctionComponent, useState } from "react";
+
+import { Bar, SubBar, Title } from "coral-auth/components/Header";
+import { Flex, Typography } from "coral-ui/components";
+import CheckEmail from "./CheckEmail";
+import ForgotPasswordForm from "./ForgotPasswordForm";
+
+import styles from "./ForgotPasswordContainer.css";
+
+const ForgotPasswordContainer: FunctionComponent = () => {
+  const [checkEmail, setCheckEmail] = useState<string | null>(null);
+  return (
+    <Flex justifyContent="center">
+      <div className={styles.container}>
+        <Bar>
+          {!checkEmail ? (
+            <Localized id="forgotPassword-forgotPasswordHeader">
+              <Title>Forgot Password?</Title>
+            </Localized>
+          ) : (
+            <Localized id="forgotPassword-checkEmailHeader">
+              <Title>Check Email</Title>
+            </Localized>
+          )}
+        </Bar>
+        <SubBar>
+          <Typography variant="bodyCopy" container={Flex}>
+            <Localized id="forgotPassword-gotBackToSignIn">
+              <Link className={styles.textLink} to="/admin/login">
+                Go back to sign in page
+              </Link>
+            </Localized>
+          </Typography>
+        </SubBar>
+        {checkEmail ? (
+          <CheckEmail email={checkEmail} />
+        ) : (
+          <ForgotPasswordForm onCheckEmail={setCheckEmail} />
+        )}
+      </div>
+    </Flex>
+  );
+};
+
+export default ForgotPasswordContainer;

--- a/src/core/client/admin/routes/ForgotPassword/ForgotPasswordForm.tsx
+++ b/src/core/client/admin/routes/ForgotPassword/ForgotPasswordForm.tsx
@@ -87,6 +87,7 @@ const ForgotPasswordForm: FunctionComponent<Props> = props => {
                           placeholder="Email Address"
                           color={colorFromMeta(meta)}
                           disabled={submitting}
+                          type="email"
                           fullWidth
                           {...input}
                         />

--- a/src/core/client/admin/routes/ForgotPassword/ForgotPasswordForm.tsx
+++ b/src/core/client/admin/routes/ForgotPassword/ForgotPasswordForm.tsx
@@ -1,0 +1,119 @@
+import { FORM_ERROR } from "final-form";
+import { Localized } from "fluent-react/compat";
+import React, { FunctionComponent, useCallback } from "react";
+import { Field, Form } from "react-final-form";
+
+import Main from "coral-auth/components/Main";
+import { InvalidRequestError } from "coral-framework/lib/errors";
+import { colorFromMeta, ValidationMessage } from "coral-framework/lib/form";
+import { useMutation } from "coral-framework/lib/relay";
+import {
+  composeValidators,
+  required,
+  validateEmail,
+} from "coral-framework/lib/validation";
+import {
+  Button,
+  CallOut,
+  FormField,
+  HorizontalGutter,
+  InputLabel,
+  TextField,
+  Typography,
+} from "coral-ui/components";
+
+import ForgotPasswordMutation from "./ForgotPasswordMutation";
+
+interface FormProps {
+  email: string;
+}
+
+interface Props {
+  onCheckEmail: (email: string) => void;
+}
+
+const ForgotPasswordForm: FunctionComponent<Props> = props => {
+  const forgotPassword = useMutation(ForgotPasswordMutation);
+  const onSubmit = useCallback(
+    async (form: FormProps) => {
+      try {
+        await forgotPassword(form);
+        props.onCheckEmail(form.email);
+      } catch (error) {
+        if (error instanceof InvalidRequestError) {
+          return error.invalidArgs;
+        }
+        return { [FORM_ERROR]: error.message };
+      }
+      return;
+    },
+    [forgotPassword]
+  );
+  return (
+    <div data-testid="admin-forgotPassword-container">
+      <Main data-testid="admin-forgotPassword-main">
+        <Form onSubmit={onSubmit}>
+          {({ handleSubmit, submitting, submitError }) => (
+            <form autoComplete="off" onSubmit={handleSubmit}>
+              <HorizontalGutter size="full">
+                <Localized id="forgotPassword-enterEmailAndGetALink">
+                  <Typography variant="bodyCopy">
+                    Enter your email address below and we will send you a link
+                    to reset your password.
+                  </Typography>
+                </Localized>
+                {submitError && (
+                  <CallOut color="error" fullWidth>
+                    {submitError}
+                  </CallOut>
+                )}
+                <Field
+                  name="email"
+                  validate={composeValidators(required, validateEmail)}
+                >
+                  {({ input, meta }) => (
+                    <FormField>
+                      <Localized id="forgotPassword-emailAddressLabel">
+                        <InputLabel htmlFor={input.name}>
+                          Email Address
+                        </InputLabel>
+                      </Localized>
+                      <Localized
+                        id="forgotPassword-emailAddressTextField"
+                        attrs={{ placeholder: true }}
+                      >
+                        <TextField
+                          id={input.name}
+                          placeholder="Email Address"
+                          color={colorFromMeta(meta)}
+                          disabled={submitting}
+                          fullWidth
+                          {...input}
+                        />
+                      </Localized>
+                      <ValidationMessage meta={meta} fullWidth />
+                    </FormField>
+                  )}
+                </Field>
+                <Localized id="forgotPassword-sendEmailButton">
+                  <Button
+                    variant="filled"
+                    color="primary"
+                    size="large"
+                    fullWidth
+                    type="submit"
+                    disabled={submitting}
+                  >
+                    Send Email
+                  </Button>
+                </Localized>
+              </HorizontalGutter>
+            </form>
+          )}
+        </Form>
+      </Main>
+    </div>
+  );
+};
+
+export default ForgotPasswordForm;

--- a/src/core/client/admin/routes/ForgotPassword/ForgotPasswordMutation.ts
+++ b/src/core/client/admin/routes/ForgotPassword/ForgotPasswordMutation.ts
@@ -1,0 +1,12 @@
+import { pick } from "lodash";
+
+import { createMutation } from "coral-framework/lib/relay";
+import { forgotPassword, ForgotPasswordInput } from "coral-framework/rest";
+
+const ForgotPasswordMutation = createMutation(
+  "forgotPassword",
+  (_, input: ForgotPasswordInput, { rest }) =>
+    forgotPassword(rest, pick(input, ["email"]))
+);
+
+export default ForgotPasswordMutation;

--- a/src/core/client/admin/routes/ForgotPassword/ForgotPasswordRoute.tsx
+++ b/src/core/client/admin/routes/ForgotPassword/ForgotPasswordRoute.tsx
@@ -1,0 +1,11 @@
+import { withRouteConfig } from "coral-framework/lib/router";
+import React from "react";
+import ForgotPasswordContainer from "./ForgotPasswordContainer";
+
+const ForgotPasswordRoute: React.FunctionComponent = () => {
+  return <ForgotPasswordContainer />;
+};
+
+const enhanced = withRouteConfig({})(ForgotPasswordRoute);
+
+export default enhanced;

--- a/src/core/client/admin/routes/ForgotPassword/index.ts
+++ b/src/core/client/admin/routes/ForgotPassword/index.ts
@@ -1,0 +1,1 @@
+export { default, default as ForgotPasswordRoute } from "./ForgotPasswordRoute";

--- a/src/core/client/admin/routes/Login/views/SignIn/SignInWithEmail.css
+++ b/src/core/client/admin/routes/Login/views/SignIn/SignInWithEmail.css
@@ -1,0 +1,4 @@
+.textLink {
+  color: var(--palette-primary-main);
+  text-decoration: underline;
+}

--- a/src/core/client/admin/routes/Login/views/SignIn/SignInWithEmail.tsx
+++ b/src/core/client/admin/routes/Login/views/SignIn/SignInWithEmail.tsx
@@ -1,4 +1,5 @@
 import { Localized } from "fluent-react/compat";
+import { Link } from "found";
 import React, { FunctionComponent } from "react";
 import { Field, Form } from "react-final-form";
 
@@ -13,12 +14,16 @@ import {
   Button,
   ButtonIcon,
   CallOut,
+  Flex,
   FormField,
   HorizontalGutter,
   InputLabel,
+  Typography,
 } from "coral-ui/components";
 
 import EmailField from "../../EmailField";
+
+import styles from "./SignInWithEmail.css";
 
 interface FormProps {
   email: string;
@@ -62,6 +67,18 @@ const SignInWithEmail: FunctionComponent<SignInWithEmailForm> = props => {
                     />
                   </Localized>
                   <ValidationMessage meta={meta} fullWidth />
+                  <Flex justifyContent="flex-end">
+                    <Typography>
+                      <Localized id="login-signIn-forgot-password">
+                        <Link
+                          className={styles.textLink}
+                          to="/admin/forgot-password"
+                        >
+                          Forgot your password?
+                        </Link>
+                      </Localized>
+                    </Typography>
+                  </Flex>
                 </FormField>
               )}
             </Field>
@@ -74,6 +91,7 @@ const SignInWithEmail: FunctionComponent<SignInWithEmailForm> = props => {
               fullWidth
             >
               <ButtonIcon size="md">email</ButtonIcon>
+
               <Localized id="login-signIn-signInWithEmail">
                 <span>Sign in with Email</span>
               </Localized>

--- a/src/core/client/admin/test/auth/__snapshots__/signInWithEmail.spec.tsx.snap
+++ b/src/core/client/admin/test/auth/__snapshots__/signInWithEmail.spec.tsx.snap
@@ -94,6 +94,21 @@ exports[`accepts correct password 1`] = `
           </div>
         </div>
       </div>
+      <div
+        className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd"
+      >
+        <p
+          className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+        >
+          <a
+            className="SignInWithEmail-textLink"
+            href="/admin/forgot-password"
+            onClick={[Function]}
+          >
+            Forgot your password?
+          </a>
+        </p>
+      </div>
     </div>
     <button
       className="BaseButton-root Button-root Button-sizeLarge Button-colorBrand Button-variantFilled Button-fullWidth"
@@ -214,6 +229,21 @@ exports[`accepts valid email 1`] = `
         <span>
           This field is required.
         </span>
+      </div>
+      <div
+        className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd"
+      >
+        <p
+          className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+        >
+          <a
+            className="SignInWithEmail-textLink"
+            href="/admin/forgot-password"
+            onClick={[Function]}
+          >
+            Forgot your password?
+          </a>
+        </p>
       </div>
     </div>
     <button
@@ -348,6 +378,21 @@ exports[`checks for invalid email 1`] = `
         <span>
           This field is required.
         </span>
+      </div>
+      <div
+        className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd"
+      >
+        <p
+          className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+        >
+          <a
+            className="SignInWithEmail-textLink"
+            href="/admin/forgot-password"
+            onClick={[Function]}
+          >
+            Forgot your password?
+          </a>
+        </p>
       </div>
     </div>
     <button
@@ -504,6 +549,21 @@ exports[`renders sign in form 1`] = `
                     </div>
                   </div>
                 </div>
+                <div
+                  className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd"
+                >
+                  <p
+                    className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+                  >
+                    <a
+                      className="SignInWithEmail-textLink"
+                      href="/admin/forgot-password"
+                      onClick={[Function]}
+                    >
+                      Forgot your password?
+                    </a>
+                  </p>
+                </div>
               </div>
               <button
                 className="BaseButton-root Button-root Button-sizeLarge Button-colorBrand Button-variantFilled Button-fullWidth"
@@ -652,6 +712,21 @@ exports[`shows error when submitting empty form 1`] = `
           This field is required.
         </span>
       </div>
+      <div
+        className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd"
+      >
+        <p
+          className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+        >
+          <a
+            className="SignInWithEmail-textLink"
+            href="/admin/forgot-password"
+            onClick={[Function]}
+          >
+            Forgot your password?
+          </a>
+        </p>
+      </div>
     </div>
     <button
       className="BaseButton-root Button-root Button-sizeLarge Button-colorBrand Button-variantFilled Button-fullWidth"
@@ -766,6 +841,21 @@ exports[`shows server error 1`] = `
             </i>
           </div>
         </div>
+      </div>
+      <div
+        className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd"
+      >
+        <p
+          className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
+        >
+          <a
+            className="SignInWithEmail-textLink"
+            href="/admin/forgot-password"
+            onClick={[Function]}
+          >
+            Forgot your password?
+          </a>
+        </p>
       </div>
     </div>
     <button

--- a/src/core/client/admin/test/configure/__snapshots__/advanced.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/advanced.spec.tsx.snap
@@ -245,7 +245,7 @@ each of your site’s stories.
                 <p
                   className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary"
                 >
-                  When enabled, there will be real-time loading and updating of comments. 
+                  When enabled, there will be real-time loading and updating of comments.
 When disabled, users will have to refresh the page to see new comments.
                 </p>
                 <div>

--- a/src/core/client/admin/test/configure/__snapshots__/general.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/general.spec.tsx.snap
@@ -211,9 +211,9 @@ exports[`renders configure general 1`] = `
               <p
                 className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary"
               >
-                Open or close comment streams for new comments sitewide. 
-When new comments are turned off, new comments cannot be 
-submitted, but existing comments can continue to receive 
+                Open or close comment streams for new comments sitewide.
+When new comments are turned off, new comments cannot be
+submitted, but existing comments can continue to receive
 reactions, be reported, and be shared.
               </p>
               <fieldset
@@ -386,9 +386,9 @@ reactions, be reported, and be shared.
                 <p
                   className="Box-root Typography-root Typography-fieldDescription Typography-colorTextSecondary"
                 >
-                  This will appear above the comments sitewide. 
-You can format the text using Markdown. 
-More information on how to use Markdown 
+                  This will appear above the comments sitewide.
+You can format the text using Markdown.
+More information on how to use Markdown
 
                   <a
                     className="ExternalLink-root"
@@ -858,7 +858,7 @@ moderation panel.
                 className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary"
               >
                 Allow your community to engage with one another and express themselves
-with one-click reactions. By default, Coral allows commenters to "Respect" 
+with one-click reactions. By default, Coral allows commenters to "Respect"
 each other's comments.
               </p>
               <div

--- a/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
@@ -318,9 +318,9 @@ approved by a moderator.
                 <p
                   className="Box-root Typography-root Typography-fieldDescription Typography-colorTextSecondary"
                 >
-                  Prevents repeat offenders from publishing comments without approval. 
-When a commenter's rejection rate is above the threshold, their 
-comments are sent to Pending for moderator approval. This does not 
+                  Prevents repeat offenders from publishing comments without approval.
+When a commenter's rejection rate is above the threshold, their
+comments are sent to Pending for moderator approval. This does not
 apply to Staff comments.
                 </p>
                 <div>
@@ -385,8 +385,8 @@ apply to Staff comments.
                 <p
                   className="Box-root Typography-root Typography-fieldDescription Typography-colorTextSecondary"
                 >
-                  Rejected comments ÷ (rejected comments + published comments) 
-over the timeframe above, as a percentage. It does not include 
+                  Rejected comments ÷ (rejected comments + published comments)
+over the timeframe above, as a percentage. It does not include
 comments pending for toxicity, spam or pre-moderation.
                 </p>
                 <div
@@ -435,9 +435,9 @@ comments pending for toxicity, spam or pre-moderation.
               <p
                 className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary"
               >
-                Using the Perspective API, the Toxic Comment filter warns users 
-when comments exceed the predefined toxicity threshold. 
-Comments with a toxicity score above the threshold 
+                Using the Perspective API, the Toxic Comment filter warns users
+when comments exceed the predefined toxicity threshold.
+Comments with a toxicity score above the threshold
 
                 <strong>
                   will not be published
@@ -447,7 +447,7 @@ the
                 <strong>
                   Pending Queue for review by a moderator
                 </strong>
-                . 
+                .
 If approved by a moderator, the comment will be published.
               </p>
               <fieldset
@@ -566,7 +566,7 @@ comment is toxic, according to Perspective API. By default the threshold is set 
                 <p
                   className="Box-root Typography-root Typography-fieldDescription Typography-colorTextSecondary"
                 >
-                  Choose your Perspective Model. The default is TOXICITY. 
+                  Choose your Perspective Model. The default is TOXICITY.
 You can find out more about model choices 
                   <a
                     className="ExternalLink-root"
@@ -783,9 +783,9 @@ improve the API over time.
               <p
                 className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary"
               >
-                The Akismet API filter warns users when a comment is determined likely 
-to be spam. Comments that Akismet thinks are spam will not be published 
-and are placed in the Pending Queue for review by a moderator. 
+                The Akismet API filter warns users when a comment is determined likely
+to be spam. Comments that Akismet thinks are spam will not be published
+and are placed in the Pending Queue for review by a moderator.
 If approved by a moderator, the comment will be published.
               </p>
               <fieldset

--- a/src/core/client/install/App/steps/AddOrganizationStep.tsx
+++ b/src/core/client/install/App/steps/AddOrganizationStep.tsx
@@ -119,6 +119,9 @@ class AddOrganizationStep extends React.Component<Props> {
                         placeholder="Organization Contact Email"
                         color={colorFromMeta(meta)}
                         disabled={submitting}
+                        type="email"
+                        autoCapitalize="off"
+                        autoCorrect="off"
                         fullWidth
                         {...input}
                       />

--- a/src/core/client/install/App/steps/CreateYourAccountStep.tsx
+++ b/src/core/client/install/App/steps/CreateYourAccountStep.tsx
@@ -89,6 +89,9 @@ class CreateYourAccountStep extends Component<Props> {
                         placeholder="Email"
                         color={colorFromMeta(meta)}
                         disabled={submitting}
+                        type="email"
+                        autoCapitalize="off"
+                        autoCorrect="off"
                         fullWidth
                         {...input}
                       />
@@ -121,6 +124,8 @@ class CreateYourAccountStep extends Component<Props> {
                         placeholder="Username"
                         color={colorFromMeta(meta)}
                         disabled={submitting}
+                        autoCapitalize="off"
+                        autoCorrect="off"
                         fullWidth
                         {...input}
                       />

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -88,9 +88,9 @@ configure-permissionField-dontAllow = Don't allow
 ### General
 configure-general-guidelines-title = Community guidelines summary
 configure-general-guidelines-explanation =
-  This will appear above the comments sitewide. 
-  You can format the text using Markdown. 
-  More information on how to use Markdown 
+  This will appear above the comments sitewide.
+  You can format the text using Markdown.
+  More information on how to use Markdown
   <externalLink>here</externalLink>.
 configure-general-guidelines-showCommunityGuidelines = Show community guidelines summary
 
@@ -101,9 +101,9 @@ configure-general-locale-chooseLanguage = Choose the language for your Coral com
 #### Sitewide Commenting
 configure-general-sitewideCommenting-title = Sitewide commenting
 configure-general-sitewideCommenting-explanation =
-  Open or close comment streams for new comments sitewide. 
-  When new comments are turned off, new comments cannot be 
-  submitted, but existing comments can continue to receive 
+  Open or close comment streams for new comments sitewide.
+  When new comments are turned off, new comments cannot be
+  submitted, but existing comments can continue to receive
   reactions, be reported, and be shared.
 configure-general-sitewideCommenting-enableNewCommentsSitewide =
   Enable new comments sitewide
@@ -243,7 +243,7 @@ configure-auth-oidc-tokenURL = Token URL
 configure-auth-oidc-jwksURI = JWKS URI
 configure-auth-oidc-useLoginOn = Use OpenID Connect login on
 
-configure-auth-settings = Session settings 
+configure-auth-settings = Session settings
 configure-auth-settings-session-duration-label = Session duration
 
 ### Moderation
@@ -256,14 +256,14 @@ configure-moderation-recentCommentHistory-timeFrame-description =
   Amount of time to calculate a commenter's rejection rate.
 configure-moderation-recentCommentHistory-enabled = Recent history filter
 configure-moderation-recentCommentHistory-enabled-description =
-  Prevents repeat offenders from publishing comments without approval. 
-  When a commenter's rejection rate is above the threshold, their 
-  comments are sent to Pending for moderator approval. This does not 
+  Prevents repeat offenders from publishing comments without approval.
+  When a commenter's rejection rate is above the threshold, their
+  comments are sent to Pending for moderator approval. This does not
   apply to Staff comments.
 configure-moderation-recentCommentHistory-triggerRejectionRate = Rejection rate threshold
 configure-moderation-recentCommentHistory-triggerRejectionRate-description =
-  Rejected comments ÷ (rejected comments + published comments) 
-  over the timeframe above, as a percentage. It does not include 
+  Rejected comments ÷ (rejected comments + published comments)
+  over the timeframe above, as a percentage. It does not include
   comments pending for toxicity, spam or pre-moderation.
 
 #### Pre-Moderation
@@ -280,9 +280,9 @@ configure-moderation-apiKey = API key
 
 configure-moderation-akismet-title = Spam detection filter
 configure-moderation-akismet-explanation =
-  The Akismet API filter warns users when a comment is determined likely 
-  to be spam. Comments that Akismet thinks are spam will not be published 
-  and are placed in the Pending Queue for review by a moderator. 
+  The Akismet API filter warns users when a comment is determined likely
+  to be spam. Comments that Akismet thinks are spam will not be published
+  and are placed in the Pending Queue for review by a moderator.
   If approved by a moderator, the comment will be published.
 
 #### Akismet
@@ -296,11 +296,11 @@ configure-moderation-akismet-siteURL = Site URL
 #### Perspective
 configure-moderation-perspective-title = Toxic comment filter
 configure-moderation-perspective-explanation =
-  Using the Perspective API, the Toxic Comment filter warns users 
-  when comments exceed the predefined toxicity threshold. 
-  Comments with a toxicity score above the threshold 
+  Using the Perspective API, the Toxic Comment filter warns users
+  when comments exceed the predefined toxicity threshold.
+  Comments with a toxicity score above the threshold
   <strong>will not be published</strong> and are placed in
-  the <strong>Pending Queue for review by a moderator</strong>. 
+  the <strong>Pending Queue for review by a moderator</strong>.
   If approved by a moderator, the comment will be published.
 configure-moderation-perspective-filter = Toxic comment filter
 configure-moderation-perspective-toxicityThreshold = Toxicity threshold
@@ -309,7 +309,7 @@ configure-moderation-perspective-toxicityThresholdDescription =
   comment is toxic, according to Perspective API. By default the threshold is set to { $default }.
 configure-moderation-perspective-toxicityModel = Toxicity model
 configure-moderation-perspective-toxicityModelDescription =
-  Choose your Perspective Model. The default is { $default }. 
+  Choose your Perspective Model. The default is { $default }.
   You can find out more about model choices <externalLink>here</externalLink>.
 configure-moderation-perspective-allowStoreCommentData = Allow Google to store comment data
 configure-moderation-perspective-allowStoreCommentDataDescription =
@@ -338,7 +338,7 @@ configure-wordList-suspect-explanation =
   published (if comments are not pre-moderated).</strong>
 configure-wordList-suspect-wordList = Suspect word list
 configure-wordList-suspect-wordListDetail =
-  Separate suspect words or phrases with a new line. 
+  Separate suspect words or phrases with a new line.
 
 ### Advanced
 configure-advanced-customCSS = Custom CSS
@@ -353,7 +353,7 @@ configure-advanced-permittedDomains-description =
 
 configure-advanced-liveUpdates = Comment stream live updates
 configure-advanced-liveUpdates-explanation =
-  When enabled, there will be real-time loading and updating of comments. 
+  When enabled, there will be real-time loading and updating of comments.
   When disabled, users will have to refresh the page to see new comments.
 
 configure-advanced-embedCode-title = Embed code
@@ -525,7 +525,7 @@ moderate-user-drawer-recent-history-calculated =
 moderate-user-drawer-recent-history-rejected = Rejected
 moderate-user-drawer-recent-history-tooltip-title = How is this calculated?
 moderate-user-drawer-recent-history-tooltip-body =
-  Rejected comments ÷ (rejected comments + published comments). 
+  Rejected comments ÷ (rejected comments + published comments).
   The threshold can be changed by administrators in Configure > Moderation.
 moderate-user-drawer-recent-history-tooltip-button =
   .aria-label = Toggle recent comment history tooltip
@@ -737,8 +737,8 @@ userDetails-suspension-end = <strong>End:</strong> { $timestamp }
 configure-general-reactions-title = Reactions
 configure-general-reactions-explanation =
   Allow your community to engage with one another and express themselves
-  with one-click reactions. By default, Coral allows commenters to "Respect" 
-  each other's comments. 
+  with one-click reactions. By default, Coral allows commenters to "Respect"
+  each other's comments.
 configure-general-reactions-label = Reaction label
 configure-general-reactions-input =
   .placeholder = E.g. Respect
@@ -767,7 +767,7 @@ configure-account-features-delete-account = Delete their account
 configure-account-features-delete-account-details =
   Removes all of their comment data, username, and email address from the site and the database.
 
-configure-account-features-delete-account-fieldDescriptions = 
+configure-account-features-delete-account-fieldDescriptions =
   Removes all of their comment data, username, and email
   address from the site and the database.
 
@@ -787,9 +787,9 @@ forgotPassword-forgotPasswordHeader = Forgot password?
 forgotPassword-checkEmailHeader = Check your email
 forgotPassword-gotBackToSignIn = Go back to sign in page
 forgotPassword-checkEmail-receiveEmail =
-  If there is an account associated with <email></email>,
+  If there is an account associated with <strong>{ $email }</strong>,
   you will receive an email with a link to create a new password.
-forgotPassword-enterEmailAndGetALink = 
+forgotPassword-enterEmailAndGetALink =
   Enter your email address below and we will send you a link
   to reset your password.
 forgotPassword-emailAddressLabel = Email address

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -59,6 +59,7 @@ login-signIn-passwordTextField =
 
 login-signIn-signInWithEmail = Sign in with Email
 login-signIn-orSeparator = Or
+login-signIn-forgot-password = Forgot your password?
 
 login-signInWithFacebook = Sign in with Facebook
 login-signInWithGoogle = Sign in with Google
@@ -781,3 +782,17 @@ configure-advanced-stories-proxy-detail =
   When specified, allows scraping requests to use the provided
   proxy. All requests will then be passed through the appropriote
   proxy as parsed by the <externalLink>npm proxy-agent</externalLink> package.
+
+forgotPassword-forgotPasswordHeader = Forgot password?
+forgotPassword-checkEmailHeader = Check your email
+forgotPassword-gotBackToSignIn = Go back to sign in page
+forgotPassword-checkEmail-receiveEmail =
+  If there is an account associated with <email></email>,
+  you will receive an email with a link to create a new password.
+forgotPassword-enterEmailAndGetALink = 
+  Enter your email address below and we will send you a link
+  to reset your password.
+forgotPassword-emailAddressLabel = Email address
+forgotPassword-emailAddressTextField =
+  .placeholder = Email Address
+forgotPassword-sendEmailButton = Send email


### PR DESCRIPTION
Adds "forgot password" page to admin at /admin/forgot-password and adds link to admin sign in. Otherwise the same as the reset password flow from stream. 
<img width="424" alt="Screen Shot 2019-09-11 at 11 58 20 AM" src="https://user-images.githubusercontent.com/1789029/64713918-b7297180-d48b-11e9-8e9e-b06f2bbe8128.png">

<img width="461" alt="Screen Shot 2019-09-11 at 11 58 25 AM" src="https://user-images.githubusercontent.com/1789029/64713940-c0b2d980-d48b-11e9-9e6a-6c7a317710bb.png">

<img width="560" alt="Screen Shot 2019-09-11 at 11 58 14 AM" src="https://user-images.githubusercontent.com/1789029/64713948-c4466080-d48b-11e9-935f-c16b16dcb459.png">
