### PR TITLE
[CORL-605] remove user agent margin on safari search bar

### DIFF
--- a/src/core/client/admin/routes/Community/UserTableFilter.css
+++ b/src/core/client/admin/routes/Community/UserTableFilter.css
@@ -6,6 +6,7 @@
 .textField {
   height: 31px;
   width: calc(45 * var(--mini-unit));
+  margin: 0;
 }
 
 .adornment {

--- a/src/core/client/admin/routes/Community/UserTableFilter.css
+++ b/src/core/client/admin/routes/Community/UserTableFilter.css
@@ -6,7 +6,6 @@
 .textField {
   height: 31px;
   width: calc(45 * var(--mini-unit));
-  margin: 0;
 }
 
 .adornment {

--- a/src/core/client/admin/routes/Moderate/ModerateSearchBar/Field.css
+++ b/src/core/client/admin/routes/Moderate/ModerateSearchBar/Field.css
@@ -56,11 +56,11 @@
   padding: calc(0.5 * var(--mini-unit));
   box-sizing: border-box;
   width: 100%;
-  line-height: 30px;
   align-self: stretch;
   color: var(--palette-text-light);
   border: 0;
   background-color: var(--palette-primary-darkest);
+  margin: 0;
 
   &:focus {
     outline: none;

--- a/src/core/client/ui/components/TextField/TextField.css
+++ b/src/core/client/ui/components/TextField/TextField.css
@@ -14,6 +14,8 @@
   border-radius: var(--round-corners);
   width: 100%;
   align-self: stretch;
+  margin-top: 0;
+  margin-bottom: 0;
 
   &:read-only {
     background-color: var(--palette-grey-lightest);


### PR DESCRIPTION
The admin search bars looked weird in safari because safari applies a margin-top and margin-bottom of 2px to input elements. We may want to look into resetting this globally, but for now I've just added a specific rule to each text input. 