### PR TITLE
[CORL-606] fix incorrect translation string

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Organization/OrganizationURLConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Organization/OrganizationURLConfig.tsx
@@ -39,7 +39,7 @@ const OrganizationURLConfig: FunctionComponent<Props> = ({ disabled }) => (
           id="configure-organization-urlExplanation"
           strong={<strong />}
         >
-          <Typography variant="detail">This URL will be used</Typography>
+          <Typography variant="bodyShort">This URL will be used</Typography>
         </Localized>
         <Field
           name="organization.url"

--- a/src/core/client/admin/test/configure/__snapshots__/organization.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/organization.spec.tsx.snap
@@ -179,10 +179,10 @@ exports[`renders configure organization 1`] = `
                 <p
                   className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary"
                 >
-                  Open or close comment streams for new comments sitewide. When new comments
-are turned off sitewide, new comments cannot be submitted, but existing
-comments can continue to receive reactions, be reported, and be
-shared.
+                  This email address will be used as in emails and across the platform
+for community members to get in touch with the organization should
+they have any questions about the status of their accounts or
+moderation questions.
                 </p>
                 <div
                   className="TextField-root TextField-fullWidth"
@@ -223,7 +223,7 @@ shared.
                 className="Box-root HorizontalGutter-root SectionContent-sectionContent HorizontalGutter-double"
               >
                 <p
-                  className="Box-root Typography-root Typography-detail Typography-colorTextPrimary"
+                  className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary"
                 >
                   Your organization url will appear on emails sent by Coral to your community and organization members.
                 </p>

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -153,10 +153,10 @@ configure-organization-nameExplanation =
   Your organization name will appear on emails sent by { -product-name } to your community and organization members.
 configure-organization-email = Organization email
 configure-organization-emailExplanation =
-  Open or close comment streams for new comments sitewide. When new comments
-  are turned off sitewide, new comments cannot be submitted, but existing
-  comments can continue to receive reactions, be reported, and be
-  shared.
+  This email address will be used as in emails and across the platform
+  for community members to get in touch with the organization should
+  they have any questions about the status of their accounts or
+  moderation questions.
 configure-organization-url = Organization URL
 configure-organization-urlExplanation =
   Your organization url will appear on emails sent by { -product-name } to your community and organization members.


### PR DESCRIPTION
Not sure how this happened but this was clearly the wrong string. I also updated the typography variant in the configure url component to match the other two components. 