### PR TITLE
[CORL-600] move toxic comment detection ahead of recent history in moderation pipeline

### DIFF
--- a/src/core/server/services/comments/pipeline/phases/index.ts
+++ b/src/core/server/services/comments/pipeline/phases/index.ts
@@ -24,9 +24,9 @@ export const moderationPhases: IntermediateModerationPhase[] = [
   purify,
   wordList,
   staff,
+  toxic,
   recentCommentHistory,
   spam,
-  toxic,
   detectLinks,
   preModerate,
 ];


### PR DESCRIPTION
update order of moderation pipeline to put toxicity detection earlier. 