### PR TITLE
[CORL-395] Update COMMENT_DETECTED_SPAM marker text to Spam Detected

### DIFF
--- a/src/core/client/admin/components/ModerateCard/MarkersContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/MarkersContainer.tsx
@@ -63,8 +63,8 @@ const markers: Array<
   c =>
     (c.revision &&
       c.revision.actionCounts.flag.reasons.COMMENT_DETECTED_SPAM && (
-        <Localized id="moderate-marker-spam" key={keyCounter++}>
-          <Marker color="error">Spam</Marker>
+        <Localized id="moderate-marker-spamDetected" key={keyCounter++}>
+          <Marker color="error">Spam Detected</Marker>
         </Localized>
       )) ||
     null,

--- a/src/core/client/admin/components/ModerateCard/__snapshots__/MarkersContainer.spec.tsx.snap
+++ b/src/core/client/admin/components/ModerateCard/__snapshots__/MarkersContainer.spec.tsx.snap
@@ -81,12 +81,12 @@ exports[`renders all markers 1`] = `
     </withPropsOnChange(Marker)>
   </Localized>
   <Localized
-    id="moderate-marker-spam"
+    id="moderate-marker-spamDetected"
   >
     <withPropsOnChange(Marker)
       color="error"
     >
-      Spam
+      Spam Detected
     </withPropsOnChange(Marker)>
   </Localized>
   <Localized

--- a/src/locales/da/admin.ftl
+++ b/src/locales/da/admin.ftl
@@ -355,6 +355,7 @@ moderate-marker-link = Link
 moderate-marker-bannedWord = Forbudt ord
 moderate-marker-suspectWord = Mistænkte ord
 moderate-marker-spam = Spam
+moderate-marker-spamDetected = Spam opdaget
 moderate-marker-toxic = Giftig
 moderate-marker-karma = Karma
 moderate-marker-bodyCount = Ordtælling

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -391,6 +391,7 @@ moderate-marker-link = Link
 moderate-marker-bannedWord = Banned Word
 moderate-marker-suspectWord = Suspect Word
 moderate-marker-spam = Spam
+moderate-marker-spamDetected = Spam Detected
 moderate-marker-toxic = Toxic
 moderate-marker-recentHistory = Recent History
 moderate-marker-bodyCount = Body Count

--- a/src/locales/pt-BR/admin.ftl
+++ b/src/locales/pt-BR/admin.ftl
@@ -330,6 +330,7 @@ moderate-marker-link = Link
 moderate-marker-bannedWord = Palavra Banida
 moderate-marker-suspectWord = Palavra Suspeita
 moderate-marker-spam = Spam
+moderate-marker-spamDetected = Spam detectado
 moderate-marker-toxic = Tóxico
 moderate-marker-karma = Karma
 moderate-marker-bodyCount = Tamanho do conteúdo


### PR DESCRIPTION
Since this is used by Akismet and other spam detection tools, this
wording matches what Wordpress users will expect when seeing comments
detected as spam.