### PR TITLE
[CORL-616] Set createdAt in optimistic response during SuspendUserMutation steps

### DIFF
--- a/src/core/client/admin/components/UserStatus/SuspendUserMutation.ts
+++ b/src/core/client/admin/components/UserStatus/SuspendUserMutation.ts
@@ -34,6 +34,7 @@ const SuspendUserMutation = createMutation(
                   active
                   history {
                     active
+                    createdAt
                     from {
                       start
                       finish
@@ -78,6 +79,7 @@ const SuspendUserMutation = createMutation(
                       id: viewer.id,
                       username: viewer.username,
                     },
+                    createdAt: now.toISOString(),
                   },
                 ],
               },


### PR DESCRIPTION
Prevents a white screen and/or error when suspending a user with the account history open on the user drawer.

## How to test

- Log in to moderation with a moderator user
- Go to community page
- Pick a user, select their username to open the user drawer
- Select `Account History` tab in user drawer
- Up by the username, select the drop down for status and `Suspend` the user
- Time frame doesn't matter, pick one
- Proceed with suspension steps
- Account history grid should update accordingly and not white screen since it now has a correct `createdAt` date coming through the mutation's optimisticResponse

GIF/Video attached in JIRA case notes if these steps are confusing:
https://vmproduct.atlassian.net/browse/CORL-616