### PR TITLE
Avoid compute metrics with 404 status code

### DIFF
--- a/src/core/server/app/middleware/metrics.ts
+++ b/src/core/server/app/middleware/metrics.ts
@@ -20,12 +20,14 @@ export const metricsRecorder = ({
       // Increment the request counter.
       httpRequestsTotal.labels(`${res.statusCode}`, req.method).inc();
 
-      // Add the request duration.
-      httpRequestDurationMilliseconds
-        .labels(req.method, req.baseUrl + req.path)
-        .observe(responseTime);
+      // Only compute the request path when status code isn't 404 to avoid flood
+      if (res.statusCode !== 404) {
+        // Add the request duration.
+        httpRequestDurationMilliseconds
+          .labels(req.method, req.baseUrl + req.path)
+          .observe(responseTime);
+      }
     });
-
     next();
   };
 };


### PR DESCRIPTION
If we don't limit the creation of metrics to known paths only, malicious users can flood talk metrics with random paths.