### PR TITLE
[CORL-626] Update MongoDB Version

### DIFF
--- a/docs/source/version-5-development.md
+++ b/docs/source/version-5-development.md
@@ -20,14 +20,14 @@ npm install
 
 Running Coral with default settings assumes that you have:
 
-- MongoDB >=3.6 running on `127.0.0.1:27017`
+- MongoDB >=4.2 running on `127.0.0.1:27017`
 - Redis >=3.2 running on `127.0.0.1:6379`
 
 If you don't already have these databases running, you can execute the following
 assuming you have Docker installed on your local machine:
 
 ```bash
-docker run -d -p 27017:27017 --restart always --name mongo mongo:3.6
+docker run -d -p 27017:27017 --restart always --name mongo mongo:4.2
 docker run -d -p 6379:6379 --restart always --name redis redis:3.2
 ```
 

--- a/docs/source/version-5-installation.md
+++ b/docs/source/version-5-installation.md
@@ -16,7 +16,7 @@ Preview Coral easily by running Coral via a Heroku App:
 
 ## Requirements
 
-- MongoDB >=3.6
+- MongoDB >=4.2
 - Redis >=3.2
 - NodeJS >=10
 - NPM >=6.7
@@ -58,7 +58,7 @@ services:
       - REDIS_URI=redis://redis:6379
       - SIGNING_SECRET=<replace me with something secret>
   mongo:
-    image: mongo:3.6
+    image: mongo:4.2
     volumes:
       - ./data/mongo:/data/db
   redis:
@@ -95,14 +95,14 @@ This should output all the compiled application code to `./dist`.
 
 Running Coral with default settings assumes that you have:
 
-- MongoDB >=3.6 running on `127.0.0.1:27017`
+- MongoDB >=4.2 running on `127.0.0.1:27017`
 - Redis >=3.2 running on `127.0.0.1:6379`
 
 If you don't already have these databases running, you can execute the following
 assuming you have Docker installed on your local machine:
 
 ```bash
-docker run -d -p 27017:27017 --restart always --name mongo mongo:3.6
+docker run -d -p 27017:27017 --restart always --name mongo mongo:4.2
 docker run -d -p 6379:6379 --restart always --name redis redis:3.2
 ```
 


### PR DESCRIPTION
This bumps the minimum MongoDB version to 4.2 in our documentation.