### PR TITLE
[CORL-661] Encode Story ID

### DIFF
--- a/src/core/client/admin/helpers/getModerationLink.ts
+++ b/src/core/client/admin/helpers/getModerationLink.ts
@@ -5,6 +5,6 @@ export default function getModerationLink(
   storyID?: string | null
 ) {
   const queuePart = queue && queue !== "default" ? `/${queue}` : "";
-  const storyPart = storyID ? `/${storyID}` : "";
+  const storyPart = storyID ? `/${encodeURIComponent(storyID)}` : "";
   return `${basePath}${queuePart}${storyPart}`;
 }

--- a/src/core/client/admin/routes/Moderate/ModerateSearchBar/ModerateSearchBarContainer.tsx
+++ b/src/core/client/admin/routes/Moderate/ModerateSearchBar/ModerateSearchBarContainer.tsx
@@ -10,6 +10,7 @@ import React, {
 import { graphql } from "react-relay";
 
 import { ModerateSearchBarContainer_story as ModerationQueuesData } from "coral-admin/__generated__/ModerateSearchBarContainer_story.graphql";
+import { getModerationLink } from "coral-admin/helpers";
 import { useEffectWhenChanged } from "coral-framework/hooks";
 import { useFetch, withFragmentContainer } from "coral-framework/lib/relay";
 import { PropTypesOf } from "coral-framework/types";
@@ -160,7 +161,7 @@ function useSearchOptions(
           nextSearchOptions.push({
             element: (
               <Option
-                href={`/admin/moderate/${encodeURIComponent(e.node.id)}`}
+                href={getModerationLink("default", e.node.id)}
                 details={e.node.metadata && e.node.metadata.author}
               >
                 <GoToAriaInfo /> {e.node.metadata && e.node.metadata.title}

--- a/src/core/client/admin/routes/Moderate/ModerateSearchBar/ModerateSearchBarContainer.tsx
+++ b/src/core/client/admin/routes/Moderate/ModerateSearchBar/ModerateSearchBarContainer.tsx
@@ -160,7 +160,7 @@ function useSearchOptions(
           nextSearchOptions.push({
             element: (
               <Option
-                href={`/admin/moderate/${e.node.id}`}
+                href={`/admin/moderate/${encodeURIComponent(e.node.id)}`}
                 details={e.node.metadata && e.node.metadata.author}
               >
                 <GoToAriaInfo /> {e.node.metadata && e.node.metadata.title}


### PR DESCRIPTION
This resolves #2611 where a story containing a slash breaks the routing. We resolve this by encoding the ID with `encodeURIComponent`.