### PR TITLE
[CORL-682] OIDC Email and `setEmail` mutation

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,6 +21,10 @@
     "ENABLE_GRAPHIQL": {
       "description": "When true, this will enable the GraphiQL routes",
       "value": "false"
+    },
+    "TRUST_PROXY": {
+      "description": "When set to 1, it instructs Coral to trust up to one proxy, this is needed for authentication support",
+      "value": "1"
     }
   },
   "addons": [

--- a/src/core/server/app/middleware/passport/strategies/oidc/index.ts
+++ b/src/core/server/app/middleware/passport/strategies/oidc/index.ts
@@ -39,7 +39,7 @@ export interface OIDCIDToken {
   iss: string;
   sub: string;
   exp: number; // TODO: use this as the source for how long an OIDC user can be logged in for
-  email: string;
+  email?: string;
   email_verified?: boolean;
   picture?: string;
   name?: string;
@@ -52,7 +52,7 @@ export const OIDCIDTokenSchema = Joi.object()
     sub: Joi.string().required(),
     iss: Joi.string().required(),
     aud: Joi.string().required(),
-    email: Joi.string().required(),
+    email: Joi.string().default(undefined),
     email_verified: Joi.boolean().default(false),
     picture: Joi.string().default(undefined),
     name: Joi.string().default(undefined),
@@ -61,6 +61,7 @@ export const OIDCIDTokenSchema = Joi.object()
   })
   .optionalKeys([
     "picture",
+    "email",
     "email_verified",
     "name",
     "nickname",

--- a/src/core/server/graph/tenant/schema/schema.graphql
+++ b/src/core/server/graph/tenant/schema/schema.graphql
@@ -1714,10 +1714,7 @@ type User {
   """
   moderatorNotes are notes left by moderators about the User.
   """
-  moderatorNotes: [ModeratorNote!]!
-    @auth(
-      roles: [ADMIN, MODERATOR]
-    )
+  moderatorNotes: [ModeratorNote!]! @auth(roles: [ADMIN, MODERATOR])
 
   """
   ignoreable is a computed property based on the
@@ -5238,7 +5235,9 @@ type Mutation {
   one already. This mutation will fail if the email address is already set.
   """
   setEmail(input: SetEmailInput!): SetEmailPayload!
-    @auth(permit: [MISSING_EMAIL, SUSPENDED, BANNED, PENDING_DELETION])
+    @auth(
+      permit: [MISSING_NAME, MISSING_EMAIL, SUSPENDED, BANNED, PENDING_DELETION]
+    )
 
   """
   setPassword will set the password on the current User if they have not set
@@ -5400,12 +5399,16 @@ type Mutation {
   """
   createModeratorNote creates a note on a user account.
   """
-  createModeratorNote(input: CreateModeratorNoteInput!): CreateModeratorNotePayload! @auth(roles: [ADMIN, MODERATOR])
+  createModeratorNote(
+    input: CreateModeratorNoteInput!
+  ): CreateModeratorNotePayload! @auth(roles: [ADMIN, MODERATOR])
 
   """
   deleteModeratorNote deletes a note on a user account.
   """
-  deleteModeratorNote(input: DeleteModeratorNoteInput!): DeleteModeratorNotePayload! @auth(roles: [ADMIN, MODERATOR])
+  deleteModeratorNote(
+    input: DeleteModeratorNoteInput!
+  ): DeleteModeratorNotePayload! @auth(roles: [ADMIN, MODERATOR])
 }
 
 ##################


### PR DESCRIPTION
This addresses the situation where when an OIDC provider does not provide an email address, which should cause us to prompt instead (fixes #2622).

This also addresses where the `setEmail` mutation should not depend on the username status (as that's handled separately)