### PR TITLE
[CORL-686] Shortcut Fix

### DIFF
--- a/src/core/client/admin/routes/Moderate/Moderate.tsx
+++ b/src/core/client/admin/routes/Moderate/Moderate.tsx
@@ -37,18 +37,19 @@ const Moderate: FunctionComponent<Props> = ({
   const closeModal = useCallback(() => {
     setShowHotkeysModal(false);
   }, []);
-  const toggleModal = useCallback(() => {
-    setShowHotkeysModal(!showHotkeysModal);
-  }, [showHotkeysModal]);
 
   useEffect(() => {
+    const toggleModal = () => {
+      setShowHotkeysModal(was => !was);
+    };
+
     // Attach the modal toggle when the GUIDE button is pressed.
     key(HOTKEYS.GUIDE, toggleModal);
     return () => {
       // Detach the modal toggle if we have to rebind it.
       key.unbind(HOTKEYS.GUIDE);
     };
-  }, [toggleModal]);
+  }, []);
 
   return (
     <div data-testid="moderate-container">


### PR DESCRIPTION
This addresses where the `useEffect` call spins in a loop causing the UI thread to crash. I've adjusted the dependencies to accept nothing (does not re-run on re-renders) and instead uses the updater pattern for the `setState` function.