### PR TITLE
Add CHANGE_STORY_STATUS permission to Moderators

### DIFF
--- a/src/core/client/admin/permissions.tsx
+++ b/src/core/client/admin/permissions.tsx
@@ -19,7 +19,7 @@ const permissionMap = {
   CHANGE_ROLE: [GQLUSER_ROLE.ADMIN],
   // Mutation.openStory
   // Mutation.closeStory
-  CHANGE_STORY_STATUS: [GQLUSER_ROLE.ADMIN],
+  CHANGE_STORY_STATUS: [GQLUSER_ROLE.ADMIN, GQLUSER_ROLE.MODERATOR],
   // Mutation.inviteUsers
   INVITE_USERS: [GQLUSER_ROLE.ADMIN],
 };


### PR DESCRIPTION
Moderatos can change story status on comment stream but they can't change in administration.

**Administration**
![screen_shot_2019-10-08_at_6 14 20_pm](https://user-images.githubusercontent.com/25023177/66434330-b9cea680-e9f8-11e9-8740-949d724bc20a.png)


**Comment Stream**

![screen_shot_2019-10-08_at_6 13 53_pm](https://user-images.githubusercontent.com/25023177/66434287-9c99d800-e9f8-11e9-9289-1e2719637de4.png)
