### PR TITLE
[CORL-680] Persist Fragment Access Tokens in sessionStorage

### DIFF
--- a/src/core/client/admin/constants.ts
+++ b/src/core/client/admin/constants.ts
@@ -1,4 +1,5 @@
-export const REDIRECT_PATH_KEY = "adminRedirectPath";
+export const REDIRECT_PATH_KEY = "coral:adminRedirectPath";
+export const ACCESS_TOKEN_KEY = "coral:accessToken";
 export const HOTKEYS = {
   NEXT: "j",
   PREV: "k",

--- a/src/core/client/admin/local/initLocalState.ts
+++ b/src/core/client/admin/local/initLocalState.ts
@@ -1,8 +1,9 @@
 import { commitLocalUpdate, Environment } from "relay-runtime";
 
-import { REDIRECT_PATH_KEY } from "coral-admin/constants";
+import { ACCESS_TOKEN_KEY, REDIRECT_PATH_KEY } from "coral-admin/constants";
 import { clearHash, getParamsFromHash } from "coral-framework/helpers";
 import { CoralContext } from "coral-framework/lib/bootstrap";
+import { parseJWT } from "coral-framework/lib/jwt";
 import { initLocalBaseState, LOCAL_ID } from "coral-framework/lib/relay";
 
 /**
@@ -12,18 +13,51 @@ export default async function initLocalState(
   environment: Environment,
   context: CoralContext
 ) {
-  const { error = null, accessToken } = getParamsFromHash();
+  // Get the access token from the session storage.
+  let accessToken = await context.sessionStorage.getItem(ACCESS_TOKEN_KEY);
+
+  // Initialize the redirect path in case we don't need to redirect somewhere.
   let redirectPath: string | null = null;
-  if (error || accessToken) {
-    // As there's an access token in the hash, let's clear it.
+  let errors: string | null = null;
+
+  // Get all the parameters from the hash.
+  const params = getParamsFromHash();
+  if (params) {
+    // If there were params in the hash, then clear them!
     clearHash();
 
-    // Keep redirect path as we are in the middle of an auth flow.
+    // If there was an error, add it.
+    if (params.errors) {
+      errors = params.errors;
+    }
+
+    // If there was an access token, store it and replace the one that was in
+    // the session storage before.
+    if (params.accessToken) {
+      accessToken = params.accessToken;
+      await context.sessionStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+    }
+
+    // As we are in the middle of an auth flow (given that there was something
+    // in the hash) we should now grab the redirect path.
     redirectPath =
       (await context.localStorage.getItem(REDIRECT_PATH_KEY)) || null;
   } else {
-    // Remove redirect path from local storage as we start a new auth flow.
+    // There was no auth flow in progress (given that we're now loading without
+    // a hash), so clear the redirect path just in case.
     await context.localStorage.setItem(REDIRECT_PATH_KEY, "");
+  }
+
+  if (accessToken) {
+    // As there's a token on the request, decode it, and check to see if it's
+    // expired already. If it is, this will send them back to the error page.
+    const { payload } = parseJWT(accessToken);
+    if (payload && payload.exp) {
+      if (payload.exp - Date.now() / 1000 <= 0) {
+        accessToken = null;
+        await context.sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+      }
+    }
   }
 
   await initLocalBaseState(environment, context, accessToken);
@@ -33,6 +67,6 @@ export default async function initLocalState(
 
     localRecord.setValue(redirectPath, "redirectPath");
     localRecord.setValue("SIGN_IN", "authView");
-    localRecord.setValue(error, "authError");
+    localRecord.setValue(errors, "authError");
   });
 }

--- a/src/core/client/admin/local/initLocalState.ts
+++ b/src/core/client/admin/local/initLocalState.ts
@@ -18,7 +18,7 @@ export default async function initLocalState(
 
   // Initialize the redirect path in case we don't need to redirect somewhere.
   let redirectPath: string | null = null;
-  let errors: string | null = null;
+  let error: string | null = null;
 
   // Get all the parameters from the hash.
   const params = getParamsFromHash();
@@ -27,8 +27,8 @@ export default async function initLocalState(
     clearHash();
 
     // If there was an error, add it.
-    if (params.errors) {
-      errors = params.errors;
+    if (params.error) {
+      error = params.error;
     }
 
     // If there was an access token, store it and replace the one that was in
@@ -67,6 +67,6 @@ export default async function initLocalState(
 
     localRecord.setValue(redirectPath, "redirectPath");
     localRecord.setValue("SIGN_IN", "authView");
-    localRecord.setValue(errors, "authError");
+    localRecord.setValue(error, "authError");
   });
 }

--- a/src/core/client/framework/helpers/getParamsFromHash.ts
+++ b/src/core/client/framework/helpers/getParamsFromHash.ts
@@ -2,13 +2,11 @@ import { parseQuery } from "coral-common/utils";
 
 export default function getParamsFromHash() {
   try {
-    const params = window.location.hash
+    return window.location.hash
       ? parseQuery(window.location.hash.substr(1))
-      : {};
-
-    return params;
+      : null;
   } catch (err) {
     window.console.error(err);
-    return {};
+    return null;
   }
 }

--- a/src/core/client/framework/helpers/getParamsFromHashAndClearIt.ts
+++ b/src/core/client/framework/helpers/getParamsFromHashAndClearIt.ts
@@ -3,7 +3,7 @@ import getParamsFromHash from "./getParamsFromHash";
 
 export default function getParamsFromHashAndClearIt() {
   try {
-    const params = getParamsFromHash();
+    const params = getParamsFromHash() || {};
 
     // Clear the hash contents.
     clearHash();


### PR DESCRIPTION
When access tokens are passed via a fragment (like in SSO), the tokens should be persisted to `sessionStorage` if they haven't expired.