### PR TITLE
[CORL-728] Comment count translation fix

### DIFF
--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -19,7 +19,7 @@ general-tabBar-configure = Configure
 ## Comment Count
 
 comment-count-text =
-  { $number  ->
+  { $count  ->
     [one] Comment
     *[other] Comments
   }


### PR DESCRIPTION
Addresses an issue where previously, we had some poor snapping behaviour and the incorrect pluralization being used when a comment was singular:
 
![CommentCountWeirdness](https://user-images.githubusercontent.com/633002/67135272-8e716600-f207-11e9-909b-a55b560fd782.gif)

This corrects the bug in the translation.