### PR TITLE
[CORL-693] Redirection Loop

### DIFF
--- a/src/core/client/auth/views/SignIn/SignIn.tsx
+++ b/src/core/client/auth/views/SignIn/SignIn.tsx
@@ -53,21 +53,25 @@ const SignIn: FunctionComponent<SignInForm> = ({
         subtitle={<Subtitle />}
       >
         <Bar>
-          {
-            "<title>Sign In</title><subtitle>to join the conversation</subtitle>"
-          }
+          <Title>Sign In</Title>
+          <Subtitle>to join the conversation</Subtitle>
         </Bar>
       </Localized>
-      <SubBar>
-        <Localized
-          id="signIn-noAccountSignUp"
-          textlink={<TextLink onClick={onGotoSignUp} href={signUpHref} />}
-        >
-          <Typography variant="bodyCopy" container={Flex}>
-            {"Don't have an account? <textlink>Sign Up</textlink>"}
-          </Typography>
-        </Localized>
-      </SubBar>
+      {emailEnabled && (
+        <SubBar>
+          <Localized
+            id="signIn-noAccountSignUp"
+            textlink={<TextLink onClick={onGotoSignUp} href={signUpHref} />}
+          >
+            <Typography variant="bodyCopy" container={Flex}>
+              Don't have an account?{" "}
+              <TextLink onClick={onGotoSignUp} href={signUpHref}>
+                Sign Up
+              </TextLink>
+            </Typography>
+          </Localized>
+        </SubBar>
+      )}
       <Main data-testid="signIn-main">
         <HorizontalGutter size="oneAndAHalf">
           {error && (

--- a/src/core/client/auth/views/SignIn/SignInContainer.tsx
+++ b/src/core/client/auth/views/SignIn/SignInContainer.tsx
@@ -51,8 +51,9 @@ const SignInContainer: FunctionComponent<Props> = ({
   // If there's only one enabled auth integration, we should just perform
   // the redirect now.
   if (
-    !auth.integrations.local.enabled ||
-    !auth.integrations.local.targetFilter.stream
+    !local.error &&
+    (!auth.integrations.local.enabled ||
+      !auth.integrations.local.targetFilter.stream)
   ) {
     // Local isn't enabled, so we can look into the rest of the integrations
     // now.

--- a/src/core/client/auth/views/SignIn/__snapshots__/SignIn.spec.tsx.snap
+++ b/src/core/client/auth/views/SignIn/__snapshots__/SignIn.spec.tsx.snap
@@ -10,7 +10,12 @@ exports[`renders correctly 1`] = `
     title={<Title />}
   >
     <Bar>
-      &lt;title&gt;Sign In&lt;/title&gt;&lt;subtitle&gt;to join the conversation&lt;/subtitle&gt;
+      <Title>
+        Sign In
+      </Title>
+      <Subtitle>
+        to join the conversation
+      </Subtitle>
     </Bar>
   </Localized>
   <SubBar>
@@ -32,7 +37,14 @@ exports[`renders correctly 1`] = `
         }
         variant="bodyCopy"
       >
-        Don't have an account? &lt;textlink&gt;Sign Up&lt;/textlink&gt;
+        Don't have an account?
+         
+        <withPropsOnChange(TextLinkProps)
+          href="/signUp"
+          onClick={[Function]}
+        >
+          Sign Up
+        </withPropsOnChange(TextLinkProps)>
       </ForwardRef(forwardRef)>
     </Localized>
   </SubBar>
@@ -70,7 +82,12 @@ exports[`renders error 1`] = `
     title={<Title />}
   >
     <Bar>
-      &lt;title&gt;Sign In&lt;/title&gt;&lt;subtitle&gt;to join the conversation&lt;/subtitle&gt;
+      <Title>
+        Sign In
+      </Title>
+      <Subtitle>
+        to join the conversation
+      </Subtitle>
     </Bar>
   </Localized>
   <SubBar>
@@ -92,7 +109,14 @@ exports[`renders error 1`] = `
         }
         variant="bodyCopy"
       >
-        Don't have an account? &lt;textlink&gt;Sign Up&lt;/textlink&gt;
+        Don't have an account?
+         
+        <withPropsOnChange(TextLinkProps)
+          href="/signUp"
+          onClick={[Function]}
+        >
+          Sign Up
+        </withPropsOnChange(TextLinkProps)>
       </ForwardRef(forwardRef)>
     </Localized>
   </SubBar>
@@ -136,32 +160,14 @@ exports[`renders without email login 1`] = `
     title={<Title />}
   >
     <Bar>
-      &lt;title&gt;Sign In&lt;/title&gt;&lt;subtitle&gt;to join the conversation&lt;/subtitle&gt;
+      <Title>
+        Sign In
+      </Title>
+      <Subtitle>
+        to join the conversation
+      </Subtitle>
     </Bar>
   </Localized>
-  <SubBar>
-    <Localized
-      id="signIn-noAccountSignUp"
-      textlink={
-        <withPropsOnChange(TextLinkProps)
-          href="/signUp"
-          onClick={[Function]}
-        />
-      }
-    >
-      <ForwardRef(forwardRef)
-        container={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "render": [Function],
-          }
-        }
-        variant="bodyCopy"
-      >
-        Don't have an account? &lt;textlink&gt;Sign Up&lt;/textlink&gt;
-      </ForwardRef(forwardRef)>
-    </Localized>
-  </SubBar>
   <Main
     data-testid="signIn-main"
   >

--- a/src/core/client/auth/views/SignUp/SignUp.tsx
+++ b/src/core/client/auth/views/SignUp/SignUp.tsx
@@ -50,21 +50,25 @@ const SignUp: FunctionComponent<Props> = ({
         subtitle={<Subtitle />}
       >
         <Bar>
-          {
-            "<title>Sign Up</title><subtitle>to join the conversation</subtitle>"
-          }
+          <Title>Sign Up</Title>
+          <Subtitle>to join the conversation</Subtitle>
         </Bar>
       </Localized>
-      <SubBar>
-        <Localized
-          id="signUp-accountAvailableSignIn"
-          textlink={<TextLink onClick={onGotoSignIn} href={signInHref} />}
-        >
-          <Typography variant="bodyCopy" container={Flex}>
-            {"Already have an account? <textlink>Sign In</textlink>"}
-          </Typography>
-        </Localized>
-      </SubBar>
+      {emailEnabled && (
+        <SubBar>
+          <Localized
+            id="signUp-accountAvailableSignIn"
+            textlink={<TextLink onClick={onGotoSignIn} href={signInHref} />}
+          >
+            <Typography variant="bodyCopy" container={Flex}>
+              Already have an account?{" "}
+              <TextLink onClick={onGotoSignIn} href={signInHref}>
+                Sign In
+              </TextLink>
+            </Typography>
+          </Localized>
+        </SubBar>
+      )}
       <Main data-testid="signUp-main">
         <HorizontalGutter size="oneAndAHalf">
           {emailEnabled && <SignUpWithEmailContainer />}

--- a/src/core/client/auth/views/SignUp/__snapshots__/SignUp.spec.tsx.snap
+++ b/src/core/client/auth/views/SignUp/__snapshots__/SignUp.spec.tsx.snap
@@ -10,7 +10,12 @@ exports[`renders correctly 1`] = `
     title={<Title />}
   >
     <Bar>
-      &lt;title&gt;Sign Up&lt;/title&gt;&lt;subtitle&gt;to join the conversation&lt;/subtitle&gt;
+      <Title>
+        Sign Up
+      </Title>
+      <Subtitle>
+        to join the conversation
+      </Subtitle>
     </Bar>
   </Localized>
   <SubBar>
@@ -32,7 +37,14 @@ exports[`renders correctly 1`] = `
         }
         variant="bodyCopy"
       >
-        Already have an account? &lt;textlink&gt;Sign In&lt;/textlink&gt;
+        Already have an account?
+         
+        <withPropsOnChange(TextLinkProps)
+          href="/signIn"
+          onClick={[Function]}
+        >
+          Sign In
+        </withPropsOnChange(TextLinkProps)>
       </ForwardRef(forwardRef)>
     </Localized>
   </SubBar>
@@ -70,32 +82,14 @@ exports[`renders without email sign up 1`] = `
     title={<Title />}
   >
     <Bar>
-      &lt;title&gt;Sign Up&lt;/title&gt;&lt;subtitle&gt;to join the conversation&lt;/subtitle&gt;
+      <Title>
+        Sign Up
+      </Title>
+      <Subtitle>
+        to join the conversation
+      </Subtitle>
     </Bar>
   </Localized>
-  <SubBar>
-    <Localized
-      id="signUp-accountAvailableSignIn"
-      textlink={
-        <withPropsOnChange(TextLinkProps)
-          href="/signIn"
-          onClick={[Function]}
-        />
-      }
-    >
-      <ForwardRef(forwardRef)
-        container={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "render": [Function],
-          }
-        }
-        variant="bodyCopy"
-      >
-        Already have an account? &lt;textlink&gt;Sign In&lt;/textlink&gt;
-      </ForwardRef(forwardRef)>
-    </Localized>
-  </SubBar>
   <Main
     data-testid="signUp-main"
   >


### PR DESCRIPTION
When an authentication error occurs, don't continue auto redirection cycle and instead display the error message.

To replicate, only enable a non-email based authentication mode for the stream, and attempt to login with an email that already exists via email based auth. Note that you instead get the error message instead of an infinite loop prior to this fix.