### PR TITLE
Error responses from scraped pages should not return metadata

### DIFF
--- a/services/scraper/index.js
+++ b/services/scraper/index.js
@@ -74,6 +74,12 @@ const scraper = {
       agent,
     });
     const html = await res.text();
+    
+    if (!res.ok) {
+      let err = new Error(res.statusText)
+      err.response = res
+      throw err
+    }
 
     // Get the metadata from the scraped html.
     const meta = await metascraper({

--- a/services/scraper/index.js
+++ b/services/scraper/index.js
@@ -74,7 +74,7 @@ const scraper = {
       agent,
     });
     const html = await res.text();
-    
+
     if (!res.ok) {
       let err = new Error(res.statusText);
       err.response = res;

--- a/services/scraper/index.js
+++ b/services/scraper/index.js
@@ -76,9 +76,9 @@ const scraper = {
     const html = await res.text();
     
     if (!res.ok) {
-      let err = new Error(res.statusText)
-      err.response = res
-      throw err
+      let err = new Error(res.statusText);
+      err.response = res;
+      throw err;
     }
 
     // Get the metadata from the scraped html.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please note that by contributing to Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your PR, please verify that:
* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md
-->

## What does this PR do?

Throws an error in the scraper if the response of the page being scraped is an error status.

## How do I test this PR?

Valid pages that return 200 response should return scraped metadata, pages that return error responses should throw an error.