### PR TITLE
[CORL-750] Server SSO Key Rotation

### DIFF
--- a/src/core/server/app/middleware/passport/strategies/facebook.ts
+++ b/src/core/server/app/middleware/passport/strategies/facebook.ts
@@ -5,10 +5,9 @@ import OAuth2Strategy, {
 } from "coral-server/app/middleware/passport/strategies/oauth2";
 import { constructTenantURL } from "coral-server/app/url";
 import {
-  GQLAuthIntegrations,
-  GQLFacebookAuthIntegration,
-  GQLUSER_ROLE,
-} from "coral-server/graph/tenant/schema/__generated__/types";
+  AuthIntegrations,
+  FacebookAuthIntegration,
+} from "coral-server/models/settings";
 import { Tenant } from "coral-server/models/tenant";
 import {
   FacebookProfile,
@@ -16,10 +15,12 @@ import {
 } from "coral-server/models/user";
 import { findOrCreate } from "coral-server/services/users";
 
+import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
+
 export type FacebookStrategyOptions = OAuth2StrategyOptions;
 
 export default class FacebookStrategy extends OAuth2Strategy<
-  GQLFacebookAuthIntegration,
+  FacebookAuthIntegration,
   Strategy
 > {
   public name = "facebook";
@@ -34,12 +35,12 @@ export default class FacebookStrategy extends OAuth2Strategy<
     });
   }
 
-  protected getIntegration = (integrations: GQLAuthIntegrations) =>
+  protected getIntegration = (integrations: AuthIntegrations) =>
     integrations.facebook;
 
   protected async findOrCreateUser(
     tenant: Tenant,
-    integration: Required<GQLFacebookAuthIntegration>,
+    integration: Required<FacebookAuthIntegration>,
     { id, photos, emails }: Profile,
     now = new Date()
   ) {
@@ -94,7 +95,7 @@ export default class FacebookStrategy extends OAuth2Strategy<
 
   protected createStrategy(
     tenant: Tenant,
-    integration: Required<GQLFacebookAuthIntegration>
+    integration: Required<FacebookAuthIntegration>
   ) {
     return new Strategy(
       {

--- a/src/core/server/app/middleware/passport/strategies/google.ts
+++ b/src/core/server/app/middleware/passport/strategies/google.ts
@@ -5,10 +5,9 @@ import OAuth2Strategy, {
 } from "coral-server/app/middleware/passport/strategies/oauth2";
 import { constructTenantURL } from "coral-server/app/url";
 import {
-  GQLAuthIntegrations,
-  GQLGoogleAuthIntegration,
-  GQLUSER_ROLE,
-} from "coral-server/graph/tenant/schema/__generated__/types";
+  AuthIntegrations,
+  GoogleAuthIntegration,
+} from "coral-server/models/settings";
 import { Tenant } from "coral-server/models/tenant";
 import {
   GoogleProfile,
@@ -16,10 +15,12 @@ import {
 } from "coral-server/models/user";
 import { findOrCreate } from "coral-server/services/users";
 
+import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
+
 export type GoogleStrategyOptions = OAuth2StrategyOptions;
 
 export default class GoogleStrategy extends OAuth2Strategy<
-  GQLGoogleAuthIntegration,
+  GoogleAuthIntegration,
   Strategy
 > {
   public name = "google";
@@ -33,12 +34,12 @@ export default class GoogleStrategy extends OAuth2Strategy<
     });
   }
 
-  protected getIntegration = (integrations: GQLAuthIntegrations) =>
+  protected getIntegration = (integrations: AuthIntegrations) =>
     integrations.google;
 
   protected async findOrCreateUser(
     tenant: Tenant,
-    integration: Required<GQLGoogleAuthIntegration>,
+    integration: Required<GoogleAuthIntegration>,
     { id, photos, emails }: Profile,
     now = new Date()
   ) {
@@ -93,7 +94,7 @@ export default class GoogleStrategy extends OAuth2Strategy<
 
   protected createStrategy(
     tenant: Tenant,
-    integration: Required<GQLGoogleAuthIntegration>
+    integration: Required<GoogleAuthIntegration>
   ) {
     return new Strategy(
       {

--- a/src/core/server/graph/tenant/mutators/Settings.ts
+++ b/src/core/server/graph/tenant/mutators/Settings.ts
@@ -9,9 +9,10 @@ export const Settings = ({
   tenantCache,
   tenant,
   config,
+  now,
 }: TenantContext) => ({
   update: (input: GQLUpdateSettingsInput): Promise<Tenant | null> =>
     update(mongo, redis, tenantCache, config, tenant, input.settings),
   regenerateSSOKey: (): Promise<Tenant | null> =>
-    regenerateSSOKey(mongo, redis, tenantCache, tenant),
+    regenerateSSOKey(mongo, redis, tenantCache, tenant, now),
 });

--- a/src/core/server/graph/tenant/resolvers/SSOAuthIntegration.ts
+++ b/src/core/server/graph/tenant/resolvers/SSOAuthIntegration.ts
@@ -1,0 +1,30 @@
+import * as settings from "coral-server/models/settings";
+
+import { GQLSSOAuthIntegrationTypeResolver } from "coral-server/graph/tenant/schema/__generated__/types";
+
+function getActiveSSOKey(keys: settings.SSOKey[]) {
+  return keys.find(
+    key => Boolean(key.secret) && !key.deletedAt && !key.deprecateAt
+  );
+}
+
+export const SSOAuthIntegration: GQLSSOAuthIntegrationTypeResolver<
+  settings.SSOAuthIntegration
+> = {
+  key: ({ keys }) => {
+    const key = getActiveSSOKey(keys);
+    if (key) {
+      return key.secret;
+    }
+
+    return null;
+  },
+  keyGeneratedAt: ({ keys }) => {
+    const key = getActiveSSOKey(keys);
+    if (key) {
+      return key.createdAt;
+    }
+
+    return null;
+  },
+};

--- a/src/core/server/graph/tenant/resolvers/index.ts
+++ b/src/core/server/graph/tenant/resolvers/index.ts
@@ -1,6 +1,7 @@
 import Cursor from "coral-server/graph/common/scalars/cursor";
 import Locale from "coral-server/graph/common/scalars/locale";
 import Time from "coral-server/graph/common/scalars/time";
+
 import { GQLResolver } from "coral-server/graph/tenant/schema/__generated__/types";
 
 import { ApproveCommentPayload } from "./ApproveCommentPayload";
@@ -36,6 +37,7 @@ import { Profile } from "./Profile";
 import { Query } from "./Query";
 import { RecentCommentHistory } from "./RecentCommentHistory";
 import { RejectCommentPayload } from "./RejectCommentPayload";
+import { SSOAuthIntegration } from "./SSOAuthIntegration";
 import { Story } from "./Story";
 import { StorySettings } from "./StorySettings";
 import { Subscription } from "./Subscription";
@@ -56,10 +58,10 @@ const Resolvers: GQLResolver = {
   Comment,
   CommentCounts,
   CommentCreatedPayload,
-  CommentReleasedPayload,
   CommentEnteredModerationQueuePayload,
   CommentLeftModerationQueuePayload,
   CommentModerationAction,
+  CommentReleasedPayload,
   CommentReplyCreatedPayload,
   CommentRevision,
   CommentStatusUpdatedPayload,
@@ -71,8 +73,10 @@ const Resolvers: GQLResolver = {
   GoogleAuthIntegration,
   Invite,
   LiveConfiguration,
+  Locale,
   ModerationQueue,
   ModerationQueues,
+  ModeratorNote,
   Mutation,
   OIDCAuthIntegration,
   PremodStatus,
@@ -81,19 +85,18 @@ const Resolvers: GQLResolver = {
   Query,
   RecentCommentHistory,
   RejectCommentPayload,
+  SSOAuthIntegration,
   Story,
   StorySettings,
   Subscription,
   SuspensionStatus,
   SuspensionStatusHistory,
-  UsernameHistory,
   Tag,
   Time,
-  Locale,
   User,
-  UserStatus,
+  UsernameHistory,
   UsernameStatus,
-  ModeratorNote,
+  UserStatus,
 };
 
 export default Resolvers;

--- a/src/core/server/graph/tenant/subscriptions/server.ts
+++ b/src/core/server/graph/tenant/subscriptions/server.ts
@@ -15,7 +15,7 @@ import {
 } from "subscriptions-transport-ws";
 
 import { ACCESS_TOKEN_PARAM, CLIENT_ID_PARAM } from "coral-common/constants";
-import { Omit } from "coral-common/types";
+import { Omit, RequireProperty } from "coral-common/types";
 import { AppOptions } from "coral-server/app";
 import { getHostname } from "coral-server/app/helpers/hostname";
 import {
@@ -36,11 +36,12 @@ import {
 } from "coral-server/graph/common/extensions";
 import { getOperationMetadata } from "coral-server/graph/common/extensions/helpers";
 import { getPersistedQuery } from "coral-server/graph/common/persisted";
-import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
 import logger from "coral-server/logger";
 import { PersistedQuery } from "coral-server/models/queries";
 import { hasStaffRole } from "coral-server/models/user/helpers";
 import { extractTokenFromRequest } from "coral-server/services/jwt";
+
+import { GQLUSER_ROLE } from "coral-server/graph/tenant/schema/__generated__/types";
 
 import TenantContext, { TenantContextOptions } from "../context";
 
@@ -77,11 +78,10 @@ export function extractClientID(connectionParams: OperationMessagePayload) {
   return null;
 }
 
-export type OnConnectOptions = Omit<
-  TenantContextOptions,
-  "tenant" | "signingConfig" | "disableCaching"
-> &
-  Required<Pick<TenantContextOptions, "signingConfig">>;
+export type OnConnectOptions = RequireProperty<
+  Omit<TenantContextOptions, "tenant" | "disableCaching">,
+  "signingConfig"
+>;
 
 export function onConnect(options: OnConnectOptions): OnConnectFn {
   // Create the JWT verifiers that will be used to verify all the requests

--- a/src/core/server/models/settings.ts
+++ b/src/core/server/models/settings.ts
@@ -1,6 +1,8 @@
-import { Omit } from "coral-common/types";
+import { Omit, RequireProperty } from "coral-common/types";
+
 import {
   GQLAuth,
+  GQLAuthenticationTargetFilter,
   GQLEmailConfiguration,
   GQLFacebookAuthIntegration,
   GQLGoogleAuthIntegration,
@@ -9,7 +11,6 @@ import {
   GQLMODERATION_MODE,
   GQLOIDCAuthIntegration,
   GQLSettings,
-  GQLSSOAuthIntegration,
 } from "coral-server/graph/tenant/schema/__generated__/types";
 
 export type LiveConfiguration = Omit<GQLLiveConfiguration, "configurable">;
@@ -37,13 +38,52 @@ export type FacebookAuthIntegration = Omit<
   "callbackURL" | "redirectURL"
 >;
 
+export interface SSOKey {
+  /**
+   * kid is the identifier for the key used when verifying tokens issued by the
+   * provider.
+   */
+  kid: string;
+
+  /**
+   * secret is the actual underlying secret used to verify the tokens with. When
+   * this is not available, it indicates that the token secret was deleted.
+   */
+  secret?: string;
+
+  /**
+   * createdAt is the time that this key was created at.
+   */
+  createdAt: Date;
+
+  /**
+   * deprecateAt when provided is the time that the token should no longer be
+   * valid at.
+   */
+  deprecateAt?: Date;
+
+  /**
+   * deletedAt is the timestamp that the token was revoked.
+   */
+  deletedAt?: Date;
+}
+
+export type RequiredSSOKey = RequireProperty<SSOKey, "secret">;
+
+export interface SSOAuthIntegration {
+  enabled: boolean;
+  allowRegistration: boolean;
+  targetFilter: GQLAuthenticationTargetFilter;
+  keys: SSOKey[];
+}
+
 /**
  * AuthIntegrations are the set of configurations for the variations of
  * authentication solutions.
  */
 export interface AuthIntegrations {
   local: GQLLocalAuthIntegration;
-  sso: GQLSSOAuthIntegration;
+  sso: SSOAuthIntegration;
   oidc: OIDCAuthIntegration;
   google: GoogleAuthIntegration;
   facebook: FacebookAuthIntegration;

--- a/src/core/server/models/tenant/helpers.ts
+++ b/src/core/server/models/tenant/helpers.ts
@@ -7,6 +7,8 @@ import {
 } from "coral-server/graph/tenant/schema/__generated__/types";
 import { translate } from "coral-server/services/i18n";
 
+import { SSOKey } from "../settings";
+
 export const getDefaultReactionConfiguration = (
   bundle: FluentBundle
 ): GQLReactionConfiguration => ({
@@ -28,10 +30,19 @@ export const getDefaultStaffConfiguration = (
   label: translate(bundle, "Staff", "staff-label"),
 });
 
-export function generateSSOKey() {
+export function generateRandomString(size: number, drift = 5) {
+  return crypto
+    .randomBytes(size + Math.floor(Math.random() * drift))
+    .toString("hex");
+}
+
+export function generateSSOKey(createdAt: Date): SSOKey {
   // Generate a new key. We generate a key of minimum length 32 up to 37 bytes,
   // as 16 was the minimum length recommended.
   //
   // Reference: https://security.stackexchange.com/a/96176
-  return crypto.randomBytes(32 + Math.floor(Math.random() * 5)).toString("hex");
+  const secret = generateRandomString(32, 5);
+  const kid = generateRandomString(8, 3);
+
+  return { kid, secret, createdAt };
 }

--- a/src/core/server/services/migrate/migrations/1573073491825_sso_tokens.ts
+++ b/src/core/server/services/migrate/migrations/1573073491825_sso_tokens.ts
@@ -1,0 +1,67 @@
+import { Db } from "mongodb";
+
+import { SSOKey } from "coral-server/models/settings";
+import { generateSSOKey } from "coral-server/models/tenant";
+import Migration from "coral-server/services/migrate/migration";
+import collections from "coral-server/services/mongodb/collections";
+
+import { GQLTime } from "coral-server/graph/tenant/schema/__generated__/types";
+
+import { MigrationError } from "../error";
+
+interface Tenant {
+  auth: {
+    integrations: {
+      sso: {
+        key?: string;
+        keyGeneratedAt?: GQLTime;
+      };
+    };
+  };
+}
+
+export default class extends Migration {
+  public async up(mongo: Db, tenantID: string) {
+    // Get the Tenant so we can update it. We don't have to worry about two
+    // migration operations conflicting here because we will lock one instance
+    // to perform the operations.
+    const tenant = await collections
+      .tenants<Tenant>(mongo)
+      .findOne({ id: tenantID });
+    if (!tenant) {
+      throw new MigrationError(tenantID, "could not find tenant", "tenants", [
+        tenantID,
+      ]);
+    }
+
+    // Store the keys in an array.
+    const keys: SSOKey[] = [];
+
+    // Check to see if a key is set.
+    const sso = tenant.auth.integrations.sso;
+    if (sso.key && sso.keyGeneratedAt) {
+      // Create the new SSOKey based on this data.
+      const key = generateSSOKey(sso.keyGeneratedAt);
+
+      // Set the secret of the sso key to the secret of the current set key.
+      key.secret = sso.key;
+
+      // Add this key to the set of keys.
+      keys.push(key);
+    }
+
+    // Update the tenant with the new sso keys.
+    await collections.tenants(mongo).updateOne(
+      { id: tenantID },
+      {
+        $set: {
+          "auth.integrations.sso.keys": keys,
+        },
+        $unset: {
+          "auth.integrations.sso.key": "",
+          "auth.integrations.sso.keyGeneratedAt": "",
+        },
+      }
+    );
+  }
+}


### PR DESCRIPTION
This PR adds support for SSO Key rotation as a part of the server implementation. This is part 1 of a 3 part feature rollout that will eventually deprecate SSO tokens that are not issued with a [`kid`](https://tools.ietf.org/html/rfc7515#section-4.1.4). This value will be provided in the UI of Coral in the next release. This PR serves to provide a rollover behaviour transparently while providing a 30 day grace period of rolled over tokens by default.