### PR TITLE
[CORL-756] Search Bug

### DIFF
--- a/src/core/server/graph/tenant/loaders/Comments.ts
+++ b/src/core/server/graph/tenant/loaders/Comments.ts
@@ -50,7 +50,7 @@ const tagFilter = (tag?: GQLTAG): CommentConnectionInput["filter"] => {
 
 const queryFilter = (query?: string): CommentConnectionInput["filter"] => {
   if (query) {
-    return { $text: { $search: `"${query}"` } };
+    return { $text: { $search: JSON.stringify(query) } };
   }
 
   return {};

--- a/src/core/server/graph/tenant/loaders/Users.ts
+++ b/src/core/server/graph/tenant/loaders/Users.ts
@@ -27,7 +27,7 @@ const roleFilter = (role?: GQLUSER_ROLE): UserConnectionFilterInput => {
 
 const queryFilter = (query?: string): UserConnectionFilterInput => {
   if (query) {
-    return { $text: { $search: `"${query}"` } };
+    return { $text: { $search: JSON.stringify(query) } };
   }
 
   return {};


### PR DESCRIPTION
This PR serves to address when the search term contains a `"` which would escape the literal wrapping for the MongoDB Text Search feature.