### PR TITLE
[CORL-743] Fix sort menu on small screens

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/SortMenu.css
+++ b/src/core/client/stream/tabs/Comments/Stream/SortMenu.css
@@ -1,8 +1,16 @@
 .mobileSelect {
-  padding: 11px;
-  width: 0px;
-  font-size: 0;
+  padding: 3px;
+  font-size: 16px;
+  line-height: 0;
+  height: 24px;
+  width: 24px;
+  opacity: 0;
 }
 .mobileAfterWrapper {
-  right: 5px;
+  height: 24px;
+  width: 24px;
+  right: 0px;
+  border: 1px solid var(--palette-text-primary);
+  box-sizing: border-box;
+  border-radius: var(--round-corners);
 }

--- a/src/core/client/stream/tabs/Comments/Stream/SortMenu.css
+++ b/src/core/client/stream/tabs/Comments/Stream/SortMenu.css
@@ -1,9 +1,11 @@
 .mobileSelect {
+  /* This adds left padding to Chrome on windows.. */
   padding: 3px;
   font-size: 16px;
   line-height: 0;
   height: 24px;
   width: 24px;
+  /* Make the native select invisible */
   opacity: 0;
 }
 .mobileAfterWrapper {

--- a/src/core/client/ui/components/SelectField/SelectField.css
+++ b/src/core/client/ui/components/SelectField/SelectField.css
@@ -26,6 +26,7 @@
   outline: none;
   color: var(--palette-text-primary);
   width: 100%;
+  font-family: system-ui !important;
 
   &::-moz-focus-inner {
     border: 0;


### PR DESCRIPTION
## What does this PR do?
- Fixes the sort menu on small screens for Chrome on Windows and Firefox.

## How do I test this PR?
- Use Firefox or Chrome on Windows. Make screen smaller to trigger mobile view.
- Sort menu should correctly render in mobile view.