### PR TITLE
[CORL-764] Download My Comments Fix

### DIFF
--- a/src/core/client/account/routes/download/Download/DownloadForm.tsx
+++ b/src/core/client/account/routes/download/Download/DownloadForm.tsx
@@ -11,8 +11,9 @@ interface Props {
 
 const DownloadForm: FunctionComponent<Props> = ({ token }) => {
   const [submitted, setSubmitted] = useState(false);
-  const onClick = useCallback(() => {
+  const onSubmit = useCallback(() => {
     setSubmitted(true);
+    return true;
   }, [setSubmitted]);
 
   return (
@@ -21,15 +22,15 @@ const DownloadForm: FunctionComponent<Props> = ({ token }) => {
         className={styles.form}
         method="post"
         action="/api/account/download"
+        onSubmit={onSubmit}
       >
         <input name="token" type="hidden" value={token} />
-        <Localized id="download-landingPage-downloadComments ">
+        <Localized id="download-landingPage-downloadComments">
           <Button
             type="submit"
             variant="filled"
             color="primary"
             disabled={submitted}
-            onClick={onClick}
             className={styles.downloadButton}
           >
             Download My Comment History


### PR DESCRIPTION
## What does this PR do?

Fixes the comment download page in Chrome. Chrome changed it's behaviour of a submit button that has an `onClick` handler inside a form. This moves this attachment to the form's `onSubmit` method instead.

## How do I test this PR?

Try to download your comments in chrome!