### PR TITLE
[CORL-765] Fix delete account modal closing prematurely

### DIFF
--- a/src/core/client/ui/components/Modal/Modal.tsx
+++ b/src/core/client/ui/components/Modal/Modal.tsx
@@ -98,6 +98,9 @@ const Modal: FunctionComponent<Props> = ({
     },
     [onBackdropClick, onClose]
   );
+  const handleWrapperClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+  }, []);
 
   if (open && modalDOMNode) {
     return ReactDOM.createPortal(
@@ -115,7 +118,11 @@ const Modal: FunctionComponent<Props> = ({
           >
             <div className={styles.alignContainer1}>
               <div className={styles.alignContainer2}>
-                <div className={styles.wrapper}>
+                <div
+                  className={styles.wrapper}
+                  role="presentation"
+                  onClick={handleWrapperClick}
+                >
                   <TrapFocus>{children}</TrapFocus>
                 </div>
               </div>

--- a/src/core/client/ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/src/core/client/ui/components/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -23,6 +23,8 @@ exports[`renders correctly 1`] = `
         >
           <div
             className="Modal-wrapper"
+            onClick={[Function]}
+            role="presentation"
           >
             <div
               onFocus={[Function]}


### PR DESCRIPTION
It turned out that modal click events were propagating out to the backdrop and triggering the close click event. This resulted in the modal closing whenever you clicked on anything.

This appears to also fix CORL-767.

## How to test?

- Go to the stream
- Login
- Head to your Account settings
- Try to Delete your account
- See that you can now click `Proceed` and other controls without the modal closing on you