### PR TITLE
[CORL-766] Update copy on SSO key regeneration and account deletion

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Auth/SSOKeyField.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/SSOKeyField.tsx
@@ -49,8 +49,8 @@ const SSOKeyField: FunctionComponent<Props> = ({
         <Icon className={styles.warnIcon}>warning</Icon>
         <Localized id="configure-auth-sso-regenerateWarning">
           <Typography className={styles.warn} variant="bodyShort">
-            Regenerating a key will invalidate any existing user sessions, and
-            all signed-in users will be signed out
+            When regenerating a key, tokens signed with the previous key will be
+            honored for 30 days.
           </Typography>
         </Localized>
       </Flex>

--- a/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
@@ -1925,8 +1925,7 @@ exports[`regenerate sso key 1`] = `
       <p
         className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary SSOKeyField-warn"
       >
-        Regenerating a key will invalidate any existing user sessions,
-and all signed-in users will be signed out.
+        When regenerating a key, tokens signed with the previous key will be honored for 30 days.
       </p>
     </div>
   </div>
@@ -3177,8 +3176,7 @@ Invalid Date
                           <p
                             className="Box-root Typography-root Typography-bodyShort Typography-colorTextPrimary SSOKeyField-warn"
                           >
-                            Regenerating a key will invalidate any existing user sessions,
-and all signed-in users will be signed out.
+                            When regenerating a key, tokens signed with the previous key will be honored for 30 days.
                           </p>
                         </div>
                       </div>

--- a/src/core/client/stream/tabs/Profile/Settings/DownloadCommentsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Settings/DownloadCommentsContainer.tsx
@@ -123,7 +123,8 @@ const DownloadCommentsContainer: FunctionComponent<Props> = ({ viewer }) => {
             $unit={unit}
           >
             <span>
-              You can submit another request in {scaled} {unit}
+              Request submitted. You can submit another request in {scaled}{" "}
+              {unit}
             </span>
           </Localized>
         </CallOut>

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -223,8 +223,7 @@ configure-auth-sso-regenerate = Regenerate
 configure-auth-sso-regenerateAt = KEY GENERATED AT:
   { DATETIME($date, year: "numeric", month: "numeric", day: "numeric", hour: "numeric", minute: "numeric") }
 configure-auth-sso-regenerateWarning =
-  Regenerating a key will invalidate any existing user sessions,
-  and all signed-in users will be signed out.
+  When regenerating a key, tokens signed with the previous key will be honored for 30 days.
 
 configure-auth-local-loginWith = Login with email authentication
 configure-auth-local-useLoginOn = Use email authentication login on

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -240,7 +240,7 @@ profile-account-download-comments-request-icon =
 profile-account-download-comments-recentRequest =
   Your most recent request: { $timeStamp }
 profile-account-download-comments-timeOut =
-  You can submit another request in { framework-timeago-time }
+  Request submitted. You can submit another request in { framework-timeago-time }
 profile-account-download-comments-request-button = Request
 
 ## Delete Account


### PR DESCRIPTION
Updates the copy shown when you are considering regenerating your SSO key and around the account deletion.

## Download comments:

![image](https://user-images.githubusercontent.com/5751504/68784348-a31ffe80-05f9-11ea-9208-9de54146be78.png)

Available at: `Stream > My Profile > Account > Download My Comment History`

## SSO Key Regeneration

![image](https://user-images.githubusercontent.com/5751504/68784361-a87d4900-05f9-11ea-98a8-b7fe9bcf4f8f.png)

Available at: `Admin > Config > Authentication > Login with Single Sign On`
