### PR TITLE
[CORL-645] Create Slack integration documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -98,6 +98,8 @@ sidebar:
               url: /v5/integrating/gdpr/
             - title: Comment Count
               url: /v5/integrating/counts/
+            - title: Slack
+              url: /v5/integrating/slack/
         - title: API
           children:
             - title: GraphQL Overview

--- a/docs/source/version-5-slack.md
+++ b/docs/source/version-5-slack.md
@@ -1,0 +1,28 @@
+---
+title: Slack
+permalink: /v5/integrating/slack/
+---
+
+Coral version 5 supports built-in Slack integration to help you forward comments from your moderation queues into appropriate Slack channels.
+
+## Creating a Slack App
+
+To enable web hooks that we will use to forward comments, you'll need to create an App and give it permissions over a channel.
+
+For details on how to create a Slack app with webhooks, please go to:
+
+https://slack.com/intl/en-ca/help/articles/115005265063-incoming-webhooks-for-slack
+
+After you have created a Slack app with a webhook, you can use it in your Coral configuration.
+
+1. Sign into the administration side of your Coral deployment.
+2. Select _Configure_ from the top navigation.
+3. Select _Slack_ from the side navigation for the configuration area.
+4. Here you can configure a Slack channel.
+5. Paste in the webhook URL you created for your Slack app and select which comment categories you want to receive notifications for.
+
+## I need to find the webhook URL again, where is it?
+
+Webhooks options are tied to a Slack app and can be found under your app settings at:
+
+https://api.slack.com/apps


### PR DESCRIPTION
Explains how to create a Slack App and hook it into
Coral as well as how to re-find your webhook URLs if you have lost them.