### PR TITLE
adds support for  a custom pre-mod message

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Moderation/PreModerationConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Moderation/PreModerationConfig.tsx
@@ -69,6 +69,14 @@ const PreModerationConfig: FunctionComponent<Props> = ({ disabled }) => {
         </Localized>
         <OnOffField name="premodLinksEnable" disabled={disabled} />
       </FormField>
+      <FormField container={<FieldSet />}>
+        <Localized id="configure-moderation-preModeration-onMessage">
+          <Label component="legend">
+            Toggle custom message for pre-mod streams
+          </Label>
+        </Localized>
+        <OnOffField name="premodMessageEnable" disabled={disabled} />
+      </FormField>
     </ConfigBox>
   );
 };

--- a/src/core/client/stream/tabs/Configure/ConfigureStream/PremodConfig.tsx
+++ b/src/core/client/stream/tabs/Configure/ConfigureStream/PremodConfig.tsx
@@ -31,6 +31,7 @@ const PremodConfig: FunctionComponent<Props> = ({ disabled }) => (
       <ToggleConfig
         {...input}
         id={input.name}
+        message={input.message}
         disabled={disabled}
         title={
           <Localized id="configure-premod-title">
@@ -42,6 +43,7 @@ const PremodConfig: FunctionComponent<Props> = ({ disabled }) => (
           <WidthLimitedDescription>
             Moderators must approve any comment before it is published to this
             stream.
+            {input.message}
           </WidthLimitedDescription>
         </Localized>
       </ToggleConfig>

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -276,7 +276,10 @@ configure-moderation-preModeration-moderation =
   Pre-moderate all comments sitewide
 configure-moderation-preModeration-premodLinksEnable =
   Pre-moderate comments containing links sitewide
-
+configure-moderation-preModeration-preModMessage = 
+  This stream is in Pre Moderation Mode. While in this mode,
+  your comment will not be visible to others until it is approved
+  by a moderator.
 configure-moderation-apiKey = API key
 
 configure-moderation-akismet-title = Spam detection filter


### PR DESCRIPTION


## What does this PR do?
This attempts to add support for an admin to choose a custom pre-mod message for their streams.
This may need more work
## How do I test this PR?
Go to Admin settings to add message
Go to stream to verify message appears