### PR TITLE
[CORL-833] Trust Proxy Configuration

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,12 @@ const { HELMET_CONFIGURATION } = require('./config');
 const { MOUNT_PATH } = require('./url');
 const routes = require('./routes');
 const debug = require('debug')('talk:app');
-const { ENABLE_TRACING, APOLLO_ENGINE_KEY, PORT } = require('./config');
+const {
+  ENABLE_TRACING,
+  APOLLO_ENGINE_KEY,
+  PORT,
+  TRUST_PROXY,
+} = require('./config');
 
 const app = express();
 
@@ -58,7 +63,26 @@ if (ENABLE_TRACING && APOLLO_ENGINE_KEY) {
 
 // Trust the first proxy in front of us, this will enable us to trust the fact
 // that SSL was terminated correctly.
-app.set('trust proxy', 1);
+app.set(
+  'trust proxy',
+  (function() {
+    if (!TRUST_PROXY) {
+      return null;
+    }
+
+    const lowercase = TRUST_PROXY.toLowerCase();
+    if (lowercase === 'true' || lowercase === 'false') {
+      return lowercase === 'true';
+    }
+
+    const parsed = Number(TRUST_PROXY);
+    if (!isNaN(parsed)) {
+      return parsed;
+    }
+
+    return TRUST_PROXY;
+  })()
+);
 
 // Enable a suite of security good practices through helmet. We disable
 // frameguard to allow crossdomain injection of the embed.

--- a/config.js
+++ b/config.js
@@ -85,6 +85,9 @@ const CONFIG = {
   // as report CSP violations.
   ENABLE_STRICT_CSP: process.env.TALK_ENABLE_STRICT_CSP === 'TRUE',
 
+  // TRUST_PROXY allows control over the `trust proxy` configuration on express.
+  TRUST_PROXY: process.env.TALK_TRUST_PROXY || '1',
+
   // LOGGING_LEVEL specifies the logging level used by the bunyan logger.
   LOGGING_LEVEL: ['fatal', 'error', 'warn', 'info', 'debug', 'trace'].includes(
     process.env.TALK_LOGGING_LEVEL

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "talk",
-  "version": "4.11.2",
+  "version": "4.11.3",
   "description": "A better commenting experience from Vox Media.",
   "main": "app.js",
   "private": true,


### PR DESCRIPTION
## What does this PR do?

Adds support to v4 for configuring the `trust proxy` setting for Express via the `TALK_TRUST_PROXY` environment variable. Valid values of this parameter are found: https://expressjs.com/en/guide/behind-proxies.html