### PR TITLE
[CORL-824] Create endpoint to set feature flags

### DIFF
--- a/src/core/server/graph/tenant/mutators/Settings.ts
+++ b/src/core/server/graph/tenant/mutators/Settings.ts
@@ -1,7 +1,16 @@
 import TenantContext from "coral-server/graph/tenant/context";
-import { GQLUpdateSettingsInput } from "coral-server/graph/tenant/schema/__generated__/types";
 import { Tenant } from "coral-server/models/tenant";
-import { regenerateSSOKey, update } from "coral-server/services/tenant";
+import {
+  regenerateSSOKey,
+  setFeatureFlag,
+  update,
+} from "coral-server/services/tenant";
+
+import {
+  GQLFeatureFlagSettings,
+  GQLSetFeatureFlagInput,
+  GQLUpdateSettingsInput,
+} from "coral-server/graph/tenant/schema/__generated__/types";
 
 export const Settings = ({
   mongo,
@@ -15,4 +24,8 @@ export const Settings = ({
     update(mongo, redis, tenantCache, config, tenant, input.settings),
   regenerateSSOKey: (): Promise<Tenant | null> =>
     regenerateSSOKey(mongo, redis, tenantCache, tenant, now),
+  setFeatureFlag: (
+    input: GQLSetFeatureFlagInput
+  ): Promise<GQLFeatureFlagSettings | null> =>
+    setFeatureFlag(mongo, redis, tenantCache, tenant, input),
 });

--- a/src/core/server/graph/tenant/resolvers/Mutation.ts
+++ b/src/core/server/graph/tenant/resolvers/Mutation.ts
@@ -229,4 +229,8 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     user: await ctx.mutators.Users.deleteModeratorNote(input),
     clientMutationId: input.clientMutationId,
   }),
+  setFeatureFlag: async (source, { input }, ctx) => ({
+    settings: await ctx.mutators.Settings.setFeatureFlag(input),
+    clientMutationId: input.clientMutationId,
+  }),
 };

--- a/src/core/server/graph/tenant/schema/schema.graphql
+++ b/src/core/server/graph/tenant/schema/schema.graphql
@@ -3668,6 +3668,58 @@ type UpdateSettingsPayload {
 }
 
 ##################
+## setFeatureFlag
+##################
+
+input SetFeatureFlagInput {
+  """
+  flag is the name of the flag to set.
+  """
+  flag: String!
+
+  """
+  value is the value to set for the specified flag.
+  """
+  value: Boolean!
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+type FeatureFlag {
+  """
+  flag is the name of the flag that was set.
+  """
+  flag: String
+
+  """
+  value is the value that was set for the specified flag.
+  """
+  value: Boolean
+}
+
+type FeatureFlagSettings {
+  """
+  featureFlags are the feature flags that were updated on the tenant.
+  """
+  featureFlags: [FeatureFlag!]
+}
+
+type SetFeatureFlagPayload {
+  """
+  settings is the currently set feature flag options.
+  """
+  settings: FeatureFlagSettings
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+##################
 ## createCommentReaction
 ##################
 
@@ -5277,6 +5329,12 @@ type Mutation {
   updateSettings will update the Settings for the given Tenant.
   """
   updateSettings(input: UpdateSettingsInput!): UpdateSettingsPayload!
+    @auth(roles: [ADMIN])
+
+  """
+  setFeatureFlag will set a feature flag on the given Tenant.
+  """
+  setFeatureFlag(input: SetFeatureFlagInput!): SetFeatureFlagPayload!
     @auth(roles: [ADMIN])
 
   """

--- a/src/core/server/services/featureFlags/featureFlags.ts
+++ b/src/core/server/services/featureFlags/featureFlags.ts
@@ -13,6 +13,21 @@ export class FeatureFlag {
     true
   );
 
+  public static contains(id: string) {
+    for (const p in FeatureFlag) {
+      if (
+        typeof p !== "function" &&
+        p === id &&
+        p !== "id" &&
+        p !== "defaultValue"
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private constructor(id: string, defaulValue: boolean) {
     this.id = id;
     this.defaultValue = defaulValue;

--- a/src/core/server/services/featureFlags/featureFlags.ts
+++ b/src/core/server/services/featureFlags/featureFlags.ts
@@ -1,0 +1,65 @@
+import { Db } from "mongodb";
+
+import logger from "coral-server/logger";
+
+import collections from "../mongodb/collections";
+
+export class FeatureFlag {
+  public id: string;
+  public defaultValue: boolean;
+
+  public static warnUserOfToxicComment: FeatureFlag = new FeatureFlag(
+    "warnUserOfToxicComment",
+    true
+  );
+
+  private constructor(id: string, defaulValue: boolean) {
+    this.id = id;
+    this.defaultValue = defaulValue;
+  }
+}
+
+const loadFeatureFlag = async (
+  mongo: Db,
+  tenantID: string,
+  flag: FeatureFlag
+): Promise<boolean> => {
+  try {
+    const tenant: any = await collections
+      .tenants(mongo)
+      .findOne({ id: tenantID });
+
+    if (!tenant) {
+      logger.error(
+        `unable to find tenant while loading feature flag '${flag.id}', returning default value of: ${flag.defaultValue}`
+      );
+      return flag.defaultValue;
+    }
+    if (!tenant.hasOwnProperty("featureFlags")) {
+      logger.error(
+        `unable to find feature flags on tenant while loading '${flag.id}', returning default value of: ${flag.defaultValue}`
+      );
+      return flag.defaultValue;
+    }
+
+    const featureFlags = tenant.featureFlags;
+
+    if (!featureFlags.hasOwnProperty(flag.id)) {
+      logger.error(
+        `feature flags does not contain '${flag.id}', returning default value of: ${flag.defaultValue}`
+      );
+      return flag.defaultValue;
+    }
+
+    const value = featureFlags[flag.id];
+    return value;
+  } catch (err) {
+    logger.error(
+      { err },
+      `an error occurred attempting to load feature flag '${flag.id}', returning default value of: ${flag.defaultValue}`
+    );
+    return flag.defaultValue;
+  }
+};
+
+export default loadFeatureFlag;

--- a/src/core/server/services/tenant/index.ts
+++ b/src/core/server/services/tenant/index.ts
@@ -24,6 +24,7 @@ import {
   GQLSettingsWordListInput,
 } from "coral-server/graph/tenant/schema/__generated__/types";
 
+import { FeatureFlag } from "../featureFlags/featureFlags";
 import collections from "../mongodb/collections";
 import TenantCache from "./cache";
 
@@ -206,6 +207,12 @@ export async function setFeatureFlag(
   tenant: Tenant,
   input: GQLSetFeatureFlagInput
 ) {
+  if (!FeatureFlag.contains(input.flag)) {
+    throw new Error(
+      `feature flag '${input.flag}' does not match any known feature flag`
+    );
+  }
+
   const result = await collections.tenants(mongo).findOneAndUpdate(
     { id: tenant.id },
     {
@@ -217,10 +224,10 @@ export async function setFeatureFlag(
   );
 
   if (!result.ok) {
-    throw new Error("Unable to set feature flag on tenant.");
+    throw new Error("unable to set feature flag on tenant");
   }
   if (!result.value) {
-    throw new Error("Unable to set feature flag on tenant.");
+    throw new Error("unable to set feature flag on tenant");
   }
 
   const updatedTenant: any = result.value;


### PR DESCRIPTION
## What does this PR do?

- Creates a graphql endpoint to set feature flags
- Creates functionality for storing feature flags on a tenant
- Create the `warnUserOfToxicComment` feature flag
- Only show toxic comment warning nudge if the `warnUserOfToxicComment` feature flag is set

## How do I test this PR?

- Spin up coral
- Use the following GraphQL query or use the CLI tool to set the `warnUserOfToxicComment` flag to false

```
mutation {
  setFeatureFlag(input: {
    flag: "warnUserOfToxicComment",
    value: false,
    clientMutationId: "1"
  }) {
    settings {
      featureFlags {
        flag
        value
      }
    }
  }
}
```

- Attempt to post a comment with toxic text when perspective api is enabled
- Notice that the tool does not nudge you about the toxic comment text