### PR TITLE
[CORL-826] Fix incorrectly set tabID on moderate card details

### DIFF
--- a/src/core/client/admin/components/ModerateCard/ModerateCardDetailsContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCardDetailsContainer.tsx
@@ -48,7 +48,7 @@ const ModerateCardDetailsContainer: FunctionComponent<Props> = ({
         onTabClick={id => setActiveTab(id as DetailsTabs)}
       >
         {hasDetails && (
-          <Tab tabID="INFO" classes={styles}>
+          <Tab tabID="DETAILS" classes={styles}>
             <Flex alignItems="center" itemGutter>
               <Icon size="md">list</Icon>
               <Localized id="moderateCardDetails-tab-info">


### PR DESCRIPTION

## What does this PR do?

Fixes a tab ID that was updated to `INFO` when the actual type is supposed to be `DETAILS`.
Likely caused by changing the name details to info when we started adding more stuff to the details tab and wanted to call it info.

## How do I test this PR?

- Head to admin > moderation
- Find a comment in the moderation queues
- Open the Details tab, select the inner `INFO` tab
- The contents of the info tab no longer disappears
