### PR TITLE
[CORL-806] Add missing environment variables to v5 config docs

### DIFF
--- a/docs/source/version-5-configuration.md
+++ b/docs/source/version-5-configuration.md
@@ -57,6 +57,10 @@ the variables in a `.env` file in the root of the project in a simple
 - `WEBSOCKET_KEEP_ALIVE_TIMEOUT` - A duration in a parsable format (e.g. `30 seconds`
   , `1 minute`) that should be used to send keep alive messages through the
   websocket to keep the socket alive (Default `30 seconds`)
+- `DISABLE_CLIENT_ROUTES` - Disables mounting of client routes for developing with Webpack Dev Server (Default `false`)
+- `DISABLE_RATE_LIMITERS` - Disables the rate limiters in development. This will only work when also set to a development environment (Default `false`)
+- `SCRAPE_TIMEOUT` - The request timeout (in ms) for scraping operations (Default `10 seconds`)
+- `DISABLE_FORCE_SSL` - Disables forcing SSL in production environments. Should not be used except for testing (Default `false`)
 - `TRUST_PROXY` - When provided, it configures the "trust proxy" settings for Express (See https://expressjs.com/en/guide/behind-proxies.html)
 
 ## `TRUST_PROXY`


### PR DESCRIPTION
Documents the following environment variables

DISABLE_CLIENT_ROUTES
DISABLE_RATE_LIMITERS
SCRAPE_TIMEOUT
DISABLE_FORCE_SSL