### PR TITLE
2772: swapping a Perspective API link from a dead one to the README on their repo.

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Moderation/PerspectiveConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Moderation/PerspectiveConfig.tsx
@@ -224,7 +224,7 @@ const PerspectiveConfig: FunctionComponent<Props> = ({ disabled }) => {
           <HelperText>
             For additional information on how to set up the Perspective Toxic
             Comment Filter please visit:
-            https://github.com/conversationai/perspectiveapi/blob/master/quickstart.md
+            https://github.com/conversationai/perspectiveapi#readme
           </HelperText>
         </Localized>
       </HorizontalGutter>

--- a/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
@@ -756,11 +756,11 @@ improve the API over time.
 
                     <a
                       className="ExternalLink-root"
-                      href="https://github.com/conversationai/perspectiveapi/blob/master/quickstart.md"
+                      href="https://github.com/conversationai/perspectiveapi#readme"
                       rel="noopener noreferrer"
                       target="_blank"
                     >
-                      https://github.com/conversationai/perspectiveapi/blob/master/quickstart.md
+                      https://github.com/conversationai/perspectiveapi#readme
                     </a>
                   </p>
                 </div>

--- a/src/locales/da/admin.ftl
+++ b/src/locales/da/admin.ftl
@@ -289,7 +289,7 @@ configure-moderation-perspective-customEndpoint = Brugerdefineret slutpunkt
 configure-moderation-perspective-defaultEndpoint =
   Som standard er slutpunktet indstillet til { $default }. Du kan tilsidesætte dette her.
 configure-moderation-perspective-accountNote =
-  For yderligere information om, hvordan man konfigurerer filteret for perspektivtoksisk kommentar, kan du besøge: <externalLink>https://github.com/conversationai/perspectiveapi/blob/master/quickstart.md</externalLink>
+  For yderligere information om, hvordan man konfigurerer filteret for perspektivtoksisk kommentar, kan du besøge: <externalLink>https://github.com/conversationai/perspectiveapi#readme</externalLink>
 
 #### Banned Words Configuration
 configure-wordList-banned-bannedWordsAndPhrases = Forbudte ord og sætninger

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -321,7 +321,7 @@ configure-moderation-perspective-defaultEndpoint =
   By default the endpoint is set to { $default }. You may override this here.
 configure-moderation-perspective-accountNote =
   For additional information on how to set up the Perspective Toxic Comment Filter please visit:
-  <externalLink>https://github.com/conversationai/perspectiveapi/blob/master/quickstart.md</externalLink>
+  <externalLink>https://github.com/conversationai/perspectiveapi#readme</externalLink>
 
 #### Banned Words Configuration
 configure-wordList-banned-bannedWordsAndPhrases = Banned words and phrases

--- a/src/locales/fr-FR/admin.ftl
+++ b/src/locales/fr-FR/admin.ftl
@@ -333,7 +333,7 @@ configure-moderation-perspective-accountNote =
   Pour des informations complémentaires sur comment configurer le filtre
   de commentaires toxiques de perspective, rendez-vous sur :
 
-<externalLink>https://github.com/conversationai/perspectiveapi/blob/master/quickstart.md</externalLink>
+<externalLink>https://github.com/conversationai/perspectiveapi#readme</externalLink>
 
 #### Banned Words Configuration
 configure-wordList-banned-bannedWordsAndPhrases = Mots et phrases bannis

--- a/src/locales/pt-BR/admin.ftl
+++ b/src/locales/pt-BR/admin.ftl
@@ -321,7 +321,7 @@ configure-moderation-perspective-defaultEndpoint =
   Por padrão o endpoint é setado como { $default }. Você pode sobrescreve-lo aqui
 configure-moderation-perspective-accountNote =
   Para obter informações adicionais sobre como configurar o filtro de comentário tóxicos da Perspective API , visite:
-  <externalLink>https://github.com/conversationai/perspectiveapi/blob/master/quickstart.md</externalLink>
+  <externalLink>https://github.com/conversationai/perspectiveapi#readme</externalLink>
 
 #### Banned Words Configuration
 configure-wordList-banned-bannedWordsAndPhrases = Palavras e Frases Banidas


### PR DESCRIPTION

<!--
Thank you for submitting a pull request! Please note that by contributing to Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your PR, please verify that:
* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md
-->

## What does this PR do?

This PR aims to address the dead link noted in https://github.com/coralproject/talk/issues/2772. It changes https://github.com/conversationai/perspectiveapi/blob/master/quickstart.md to https://github.com/conversationai/perspectiveapi#readme. (Thanks, @kgardnr !)

## How do I test this PR?

I tested this by loading http://localhost:3000/admin/configure/moderation and ensuring the link in the Configuration section worked. Testing other locales would potentially be beneficial as well.