### PR TITLE
Changing passport-google-oauth2 to 0.2.0 #2777

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24716,9 +24716,9 @@
       }
     },
     "passport-google-oauth2": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/passport-google-oauth2/-/passport-google-oauth2-0.1.6.tgz",
-      "integrity": "sha1-39cBasdEn+J8/rJSrpdK/CMleg0=",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth2/-/passport-google-oauth2-0.2.0.tgz",
+      "integrity": "sha512-62EdPtbfVdc55nIXi0p1WOa/fFMM8v/M8uQGnbcXA4OexZWCnfsEi3wo2buag+Is5oqpuHzOtI64JpHk0Xi5RQ==",
       "requires": {
         "passport-oauth2": "^1.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "on-finished": "^2.3.0",
     "passport": "^0.4.0",
     "passport-facebook": "^2.1.1",
-    "passport-google-oauth2": "^0.1.6",
+    "passport-google-oauth2": "^0.2.0",
     "passport-local": "^1.0.0",
     "passport-oauth2": "^1.4.0",
     "passport-strategy": "^1.0.0",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please note that by contributing to Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your PR, please verify that:
* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md
-->

## What does this PR do?
Google auth. gives   an error: "Cannot fetch user profile".
I've changed "passport-google-oauth2": "^0.1.6" to 0.2.0 (latest now).
See #2777

## How do I test this PR?
The project was deployed on Azure VM and checked. Seems work fine. No more error. 