### PR TITLE
[CORL-829] Bump line-height on select fields

### DIFF
--- a/src/core/client/ui/components/v2/SelectField/SelectField.css
+++ b/src/core/client/ui/components/v2/SelectField/SelectField.css
@@ -25,7 +25,7 @@
   font-family: var(--v2-font-family-primary);
   font-weight: var(--v2-font-weight-primary-regular);
   font-size: var(--v2-font-size-3);
-  line-height: 1.2rem;
+  line-height: var(--v2-line-height-tall);
   appearance: none;
   outline: none;
   color: var(--v2-palette-input-value);

--- a/src/core/client/ui/components/v2/SelectField/SelectField.css
+++ b/src/core/client/ui/components/v2/SelectField/SelectField.css
@@ -25,7 +25,7 @@
   font-family: var(--v2-font-family-primary);
   font-weight: var(--v2-font-weight-primary-regular);
   font-size: var(--v2-font-size-3);
-  line-height: var(--v2-line-height-reset);
+  line-height: 1.2rem;
   appearance: none;
   outline: none;
   color: var(--v2-palette-input-value);

--- a/src/core/client/ui/theme/variables2.ts
+++ b/src/core/client/ui/theme/variables2.ts
@@ -277,6 +277,7 @@ const variables2 = {
     bodyShort: 1.3,
     reset: 1,
     title: 1.15,
+    tall: 1.3,
   },
   fontSize: {
     1: "0.75rem",


### PR DESCRIPTION
Bump line-height on select to account for hanging font characters

## What does this PR do?

Prevents characters like "g" or "j" being cut off at the bottom of the select text area.

## How do I test this PR?

Head to Admin > Configure > General.
See that the select drop down is no longer cutting off the text.

<img width="369" alt="image" src="https://user-images.githubusercontent.com/5751504/71826172-900a3780-305a-11ea-9622-50fb2d6535ba.png">
