### PR TITLE
Banned Tag Fix

### DIFF
--- a/src/core/client/admin/components/ModerateCard/CommentAuthorContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/CommentAuthorContainer.tsx
@@ -18,11 +18,11 @@ const CommentAuthorContainer: FunctionComponent<Props> = ({ comment }) => {
   }
   return (
     <>
-      <Localized id="commentAuthor-status-banned">
-        <div className={styles.authorStatus}>
+      <div className={styles.authorStatus}>
+        <Localized id="commentAuthor-status-banned">
           <Tag color="error">BANNED</Tag>
-        </div>
-      </Localized>
+        </Localized>
+      </div>
     </>
   );
 };

--- a/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
@@ -185,14 +185,16 @@ const ModerateCard: FunctionComponent<Props> = ({
           >
             <Flex alignItems="center">
               {!hideUsername && username && (
-                <BaseButton
-                  onClick={commentAuthorClick}
-                  className={styles.usernameButton}
-                >
-                  <Username>{username}</Username>
-                </BaseButton>
+                <>
+                  <BaseButton
+                    onClick={commentAuthorClick}
+                    className={styles.usernameButton}
+                  >
+                    <Username>{username}</Username>
+                  </BaseButton>
+                  <CommentAuthorContainer comment={comment} />
+                </>
               )}
-              <CommentAuthorContainer comment={comment} />
               <Timestamp>{createdAt}</Timestamp>
               {edited && (
                 <Localized id="moderate-comment-edited">

--- a/src/core/client/admin/components/ModerateCard/__snapshots__/ModerateCard.spec.tsx.snap
+++ b/src/core/client/admin/components/ModerateCard/__snapshots__/ModerateCard.spec.tsx.snap
@@ -18,17 +18,19 @@ exports[`renders approved correctly 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
         >
-          <ForwardRef(forwardRef)
-            className="ModerateCard-usernameButton"
-            onClick={[Function]}
-          >
-            <Username>
-              Theon
-            </Username>
-          </ForwardRef(forwardRef)>
-          <Relay(CommentAuthorContainer)
-            comment={Object {}}
-          />
+          <React.Fragment>
+            <ForwardRef(forwardRef)
+              className="ModerateCard-usernameButton"
+              onClick={[Function]}
+            >
+              <Username>
+                Theon
+              </Username>
+            </ForwardRef(forwardRef)>
+            <Relay(CommentAuthorContainer)
+              comment={Object {}}
+            />
+          </React.Fragment>
           <Timestamp
             toggleAbsolute={true}
           >
@@ -146,17 +148,19 @@ exports[`renders correctly 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
         >
-          <ForwardRef(forwardRef)
-            className="ModerateCard-usernameButton"
-            onClick={[Function]}
-          >
-            <Username>
-              Theon
-            </Username>
-          </ForwardRef(forwardRef)>
-          <Relay(CommentAuthorContainer)
-            comment={Object {}}
-          />
+          <React.Fragment>
+            <ForwardRef(forwardRef)
+              className="ModerateCard-usernameButton"
+              onClick={[Function]}
+            >
+              <Username>
+                Theon
+              </Username>
+            </ForwardRef(forwardRef)>
+            <Relay(CommentAuthorContainer)
+              comment={Object {}}
+            />
+          </React.Fragment>
           <Timestamp
             toggleAbsolute={true}
           >
@@ -274,17 +278,19 @@ exports[`renders dangling correctly 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
         >
-          <ForwardRef(forwardRef)
-            className="ModerateCard-usernameButton"
-            onClick={[Function]}
-          >
-            <Username>
-              Theon
-            </Username>
-          </ForwardRef(forwardRef)>
-          <Relay(CommentAuthorContainer)
-            comment={Object {}}
-          />
+          <React.Fragment>
+            <ForwardRef(forwardRef)
+              className="ModerateCard-usernameButton"
+              onClick={[Function]}
+            >
+              <Username>
+                Theon
+              </Username>
+            </ForwardRef(forwardRef)>
+            <Relay(CommentAuthorContainer)
+              comment={Object {}}
+            />
+          </React.Fragment>
           <Timestamp
             toggleAbsolute={true}
           >
@@ -402,17 +408,19 @@ exports[`renders rejected correctly 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
         >
-          <ForwardRef(forwardRef)
-            className="ModerateCard-usernameButton"
-            onClick={[Function]}
-          >
-            <Username>
-              Theon
-            </Username>
-          </ForwardRef(forwardRef)>
-          <Relay(CommentAuthorContainer)
-            comment={Object {}}
-          />
+          <React.Fragment>
+            <ForwardRef(forwardRef)
+              className="ModerateCard-usernameButton"
+              onClick={[Function]}
+            >
+              <Username>
+                Theon
+              </Username>
+            </ForwardRef(forwardRef)>
+            <Relay(CommentAuthorContainer)
+              comment={Object {}}
+            />
+          </React.Fragment>
           <Timestamp
             toggleAbsolute={true}
           >
@@ -530,17 +538,19 @@ exports[`renders reply correctly 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
         >
-          <ForwardRef(forwardRef)
-            className="ModerateCard-usernameButton"
-            onClick={[Function]}
-          >
-            <Username>
-              Theon
-            </Username>
-          </ForwardRef(forwardRef)>
-          <Relay(CommentAuthorContainer)
-            comment={Object {}}
-          />
+          <React.Fragment>
+            <ForwardRef(forwardRef)
+              className="ModerateCard-usernameButton"
+              onClick={[Function]}
+            >
+              <Username>
+                Theon
+              </Username>
+            </ForwardRef(forwardRef)>
+            <Relay(CommentAuthorContainer)
+              comment={Object {}}
+            />
+          </React.Fragment>
           <Timestamp
             toggleAbsolute={true}
           >
@@ -667,17 +677,19 @@ exports[`renders story info 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
         >
-          <ForwardRef(forwardRef)
-            className="ModerateCard-usernameButton"
-            onClick={[Function]}
-          >
-            <Username>
-              Theon
-            </Username>
-          </ForwardRef(forwardRef)>
-          <Relay(CommentAuthorContainer)
-            comment={Object {}}
-          />
+          <React.Fragment>
+            <ForwardRef(forwardRef)
+              className="ModerateCard-usernameButton"
+              onClick={[Function]}
+            >
+              <Username>
+                Theon
+              </Username>
+            </ForwardRef(forwardRef)>
+            <Relay(CommentAuthorContainer)
+              comment={Object {}}
+            />
+          </React.Fragment>
           <Timestamp
             toggleAbsolute={true}
           >
@@ -829,17 +841,19 @@ exports[`renders tombstoned when comment is deleted 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
         >
-          <ForwardRef(forwardRef)
-            className="ModerateCard-usernameButton"
-            onClick={[Function]}
-          >
-            <Username>
-              Theon
-            </Username>
-          </ForwardRef(forwardRef)>
-          <Relay(CommentAuthorContainer)
-            comment={Object {}}
-          />
+          <React.Fragment>
+            <ForwardRef(forwardRef)
+              className="ModerateCard-usernameButton"
+              onClick={[Function]}
+            >
+              <Username>
+                Theon
+              </Username>
+            </ForwardRef(forwardRef)>
+            <Relay(CommentAuthorContainer)
+              comment={Object {}}
+            />
+          </React.Fragment>
           <Timestamp
             toggleAbsolute={true}
           >


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please note that by contributing to Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your PR, please verify that:
* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md
-->

## What does this PR do?

- Fixes a bug with the localization tag where the styling didn't appear
- Hides the banned tag in the user drawer when the username is also hidden from the moderate card

It changes this:

![Screen Shot 2020-01-10 at 10 04 42 AM](https://user-images.githubusercontent.com/633002/72171883-c2ee5b80-33cb-11ea-8e01-6ec950381a53.png)

To this:

![Screen Shot 2020-01-10 at 10 05 42 AM](https://user-images.githubusercontent.com/633002/72171897-c84ba600-33cb-11ea-9930-0f9efe752115.png)

## How do I test this PR?

1. Ban a user with a comment from the user drawer
2. See the styles reflect correctly.