### PR TITLE
[CORL-836] Create activeStories endpoint

### DIFF
--- a/src/core/server/graph/loaders/Comments.ts
+++ b/src/core/server/graph/loaders/Comments.ts
@@ -3,19 +3,6 @@ import { defaultTo, isNil, omitBy } from "lodash";
 import { DateTime } from "luxon";
 
 import Context from "coral-server/graph/context";
-import {
-  CommentToParentsArgs,
-  CommentToRepliesArgs,
-  GQLActionPresence,
-  GQLCOMMENT_SORT,
-  GQLTAG,
-  GQLUSER_ROLE,
-  QueryToCommentsArgs,
-  StoryToCommentsArgs,
-  UserToAllCommentsArgs,
-  UserToCommentsArgs,
-  UserToRejectedCommentsArgs,
-} from "coral-server/graph/schema/__generated__/types";
 import { retrieveManyUserActionPresence } from "coral-server/models/action/comment";
 import {
   Comment,
@@ -35,6 +22,20 @@ import { hasPublishedStatus } from "coral-server/models/comment/helpers";
 import { Connection } from "coral-server/models/helpers";
 import { retrieveSharedModerationQueueQueuesCounts } from "coral-server/models/story/counts/shared";
 import { User } from "coral-server/models/user";
+
+import {
+  CommentToParentsArgs,
+  CommentToRepliesArgs,
+  GQLActionPresence,
+  GQLCOMMENT_SORT,
+  GQLTAG,
+  GQLUSER_ROLE,
+  QueryToCommentsArgs,
+  StoryToCommentsArgs,
+  UserToAllCommentsArgs,
+  UserToCommentsArgs,
+  UserToRejectedCommentsArgs,
+} from "coral-server/graph/schema/__generated__/types";
 
 import { SingletonResolver } from "./util";
 

--- a/src/core/server/graph/loaders/Stories.ts
+++ b/src/core/server/graph/loaders/Stories.ts
@@ -2,12 +2,9 @@ import DataLoader from "dataloader";
 import { defaultTo } from "lodash";
 
 import GraphContext from "coral-server/graph/context";
-import {
-  GQLSTORY_STATUS,
-  QueryToStoriesArgs,
-} from "coral-server/graph/schema/__generated__/types";
 import { Connection } from "coral-server/models/helpers";
 import {
+  retrieveActiveStories,
   retrieveManyStories,
   retrieveStoryConnection,
   Story,
@@ -20,6 +17,11 @@ import {
   FindStory,
 } from "coral-server/services/stories";
 import { scraper } from "coral-server/services/stories/scraper";
+
+import {
+  GQLSTORY_STATUS,
+  QueryToStoriesArgs,
+} from "coral-server/graph/schema/__generated__/types";
 
 import { createManyBatchLoadFn } from "./util";
 
@@ -127,4 +129,6 @@ export default (ctx: GraphContext) => ({
       cache: !ctx.disableCaching,
     }
   ),
+  activeStories: (limit: number) =>
+    retrieveActiveStories(ctx.mongo, ctx.tenant.id, limit),
 });

--- a/src/core/server/graph/resolvers/Query.ts
+++ b/src/core/server/graph/resolvers/Query.ts
@@ -21,4 +21,6 @@ export const Query: Required<GQLQueryTypeResolver<void>> = {
   debugScrapeStoryMetadata: (source, { url }, ctx) =>
     ctx.loaders.Stories.debugScrapeMetadata.load(url),
   moderationQueues: moderationQueuesResolver,
+  activeStories: (source, { limit = 10 }, ctx) =>
+    ctx.loaders.Stories.activeStories(limit),
 };

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -769,10 +769,11 @@ type Auth {
   authentication solutions.
   """
   integrations: AuthIntegrations!
+
   """
   sessionDuration determines the duration in seconds for which an access token is valid
   """
-  sessionDuration: Int!
+  sessionDuration: Int! @auth(roles: [ADMIN])
 }
 
 ################################################################################
@@ -1597,6 +1598,7 @@ type PremodStatusHistory {
   active when true, indicates that the given user is premodded.
   """
   active: Boolean!
+
   """
   createdBy is the user that flagged the commenter as pre-mod
   """
@@ -1815,6 +1817,7 @@ type User {
   badges are user display badges
   """
   badges: [String!]
+
   """
   email is the current email address for the User.
   """
@@ -1953,17 +1956,32 @@ type User {
   of their account data.
   """
   lastDownloadedAt: Time
+    @auth(
+      userIDField: "id"
+      roles: [ADMIN, MODERATOR]
+      permit: [SUSPENDED, BANNED, PENDING_DELETION]
+    )
 
   """
   scheduledDeletionDate is the time when the User is
   scheduled to be deleted.
   """
   scheduledDeletionDate: Time
+    @auth(
+      userIDField: "id"
+      roles: [ADMIN, MODERATOR]
+      permit: [SUSPENDED, BANNED, PENDING_DELETION]
+    )
 
   """
   deletedAt is the time when the User was deleted.
   """
   deletedAt: Time
+    @auth(
+      userIDField: "id"
+      roles: [ADMIN, MODERATOR]
+      permit: [SUSPENDED, BANNED, PENDING_DELETION]
+    )
 }
 
 """
@@ -2583,7 +2601,7 @@ type Story {
   scrapedAt is the Time that the Story had it's metadata scraped at. If the time
   is null, the Story has not been scraped yet.
   """
-  scrapedAt: Time
+  scrapedAt: Time @auth(roles: [ADMIN, MODERATOR])
 
   """
   featuredComments are the Comments with the FEATURED tag on the Story.
@@ -2645,7 +2663,7 @@ type Story {
   """
   lastCommentedAt is the last time someone commented on this story.
   """
-  lastCommentedAt: Time
+  lastCommentedAt: Time @auth(roles: [ADMIN])
 }
 
 """
@@ -2790,7 +2808,9 @@ type Query {
   activeStories is the list of most recently commented on stories identified
   by their `lastCommentedAt` field
   """
-  activeStories(limit: Int = 10 @constraint(max: 25)): [Story!]! @auth(roles: [ADMIN]) @rate(seconds: 30)
+  activeStories(limit: Int = 10 @constraint(max: 25)): [Story!]!
+    @auth(roles: [ADMIN])
+    @rate(max: 2, seconds: 1)
 }
 
 ################################################################################

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -2641,6 +2641,11 @@ type Story {
   settings.
   """
   settings: StorySettings!
+
+  """
+  lastCommentedAt is the last time someone commented on this story.
+  """
+  lastCommentedAt: Time
 }
 
 """
@@ -2780,6 +2785,12 @@ type Query {
   """
   moderationQueues(storyID: ID): ModerationQueues!
     @auth(roles: [ADMIN, MODERATOR])
+
+  """
+  activeStories is the list of most recently commented on stories identified
+  by their `lastCommentedAt` field
+  """
+  activeStories(limit: Int = 10 @constraint(max: 25)): [Story!]! @auth(roles: [ADMIN]) @rate(seconds: 30)
 }
 
 ################################################################################

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -6,12 +6,6 @@ import uuid from "uuid";
 import { Omit, Sub } from "coral-common/types";
 import { dotize } from "coral-common/utils/dotize";
 import { CommentNotFoundError } from "coral-server/errors";
-import {
-  GQLCOMMENT_SORT,
-  GQLCOMMENT_STATUS,
-  GQLCommentTagCounts,
-  GQLTAG,
-} from "coral-server/graph/schema/__generated__/types";
 import logger from "coral-server/logger";
 import {
   EncodedCommentActionCounts,
@@ -30,6 +24,13 @@ import {
 } from "coral-server/models/helpers";
 import { TenantResource } from "coral-server/models/tenant";
 import { comments as collection } from "coral-server/services/mongodb/collections";
+
+import {
+  GQLCOMMENT_SORT,
+  GQLCOMMENT_STATUS,
+  GQLCommentTagCounts,
+  GQLTAG,
+} from "coral-server/graph/schema/__generated__/types";
 
 import { PUBLISHED_STATUSES } from "./constants";
 import {

--- a/src/core/server/services/migrate/migrations/1578604997397_story_add_last_commented_at.ts
+++ b/src/core/server/services/migrate/migrations/1578604997397_story_add_last_commented_at.ts
@@ -1,0 +1,21 @@
+import { Db } from "mongodb";
+
+import Migration from "coral-server/services/migrate/migration";
+import collections from "coral-server/services/mongodb/collections";
+
+import { createIndexFactory } from "../indexing";
+
+export default class extends Migration {
+  public async indexes(mongo: Db) {
+    const createIndex = createIndexFactory(collections.stories(mongo));
+
+    // Create a partial sparse index on lastCommentedAt:
+    //   tenantID: 1 <- ASC tenantIDs
+    //   lastCommentedAt: -1 <- DESC dates (more recent to latest)
+    //   ^ explained here: https://docs.mongodb.com/manual/core/index-compound/#sort-order
+    await createIndex(
+      { tenantID: 1, lastCommentedAt: -1 },
+      { partialFilterExpression: { lastCommentedAt: { $exists: true } } }
+    );
+  }
+}

--- a/src/core/server/stacks/createComment.ts
+++ b/src/core/server/stacks/createComment.ts
@@ -179,7 +179,7 @@ export default async function create(
 
   await Promise.all([
     updateUserLastCommentID(redis, tenant, author, comment.id),
-    updateStoryLastCommentedAt(mongo, tenant.id, story.id, now, log),
+    updateStoryLastCommentedAt(mongo, tenant.id, story.id, now),
   ]);
 
   // Pull the revision out.

--- a/src/core/server/stacks/createComment.ts
+++ b/src/core/server/stacks/createComment.ts
@@ -25,7 +25,10 @@ import {
   hasAncestors,
   hasPublishedStatus,
 } from "coral-server/models/comment/helpers";
-import { retrieveStory } from "coral-server/models/story";
+import {
+  retrieveStory,
+  updateStoryLastCommentedAt,
+} from "coral-server/models/story";
 import { Tenant } from "coral-server/models/tenant";
 import { User } from "coral-server/models/user";
 import {
@@ -174,7 +177,10 @@ export default async function create(
     now
   );
 
-  await updateUserLastCommentID(redis, tenant, author, comment.id);
+  await Promise.all([
+    updateUserLastCommentID(redis, tenant, author, comment.id),
+    updateStoryLastCommentedAt(mongo, tenant.id, story.id, now, log),
+  ]);
 
   // Pull the revision out.
   const revision = getLatestRevision(comment);


### PR DESCRIPTION
## What does this PR do?

Creates a new endpoint to query the most recently commented upon stories.

This adds a field that is set whenever a comment is created/edited on stories to store the date the last comment was created. We then use this to query active stories from our endpoint. The date field is partial indexed to improve performance.

## Behavior

`activeStories` endpoint returns (in one query):

- 10 most recently commented on stories, can request a max of 25 stories
- for each of those stories, you can pull default 20 comments, or request max 50

## How do I test this PR?

- Spin up coral
- Create some new comments on various stories
- Using a GraphQL request, hit this endpoint
```
query {
  activeStories {
    id
    lastCommentedAt
  }
}
```
- You should see a summary from newest to oldest, the stories you commented upon.
