### PR TITLE
[CORL-846] Restructure the slack comment message format

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Slack/SlackChannel.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Slack/SlackChannel.tsx
@@ -151,93 +151,63 @@ const SlackChannel: FunctionComponent<Props> = ({
                   <Label>Receive notifications in this Slack channel for</Label>
                 </Localized>
               </div>
-              <Field
-                name={`${channel}.triggers.allComments`}
-                subscription={{ value: true }}
-              >
-                {({ input: { value: allCommentsValue } }) => (
-                  <div className={styles.notificationToggles}>
-                    <Field
-                      name={`${channel}.triggers.allComments`}
-                      type="checkbox"
-                      parse={parseBool}
+
+              <div className={styles.notificationToggles}>
+                <Field
+                  name={`${channel}.triggers.reportedComments`}
+                  type="checkbox"
+                  parse={parseBool}
+                >
+                  {({ input }) => (
+                    <CheckBox
+                      id={`configure-slack-channel-triggers-reportedComments-${input.name}`}
+                      disabled={disabled || !channelEnabled}
+                      className={styles.trigger}
+                      {...input}
                     >
-                      {({ input }) => (
-                        <CheckBox
-                          id={`configure-slack-channel-triggers-allComments-${input.name}`}
-                          disabled={disabled || !channelEnabled}
-                          className={styles.trigger}
-                          {...input}
-                        >
-                          <Localized id="configure-slack-channel-triggers-allComments">
-                            All Comments
-                          </Localized>
-                        </CheckBox>
-                      )}
-                    </Field>
-                    <Field
-                      name={`${channel}.triggers.reportedComments`}
-                      type="checkbox"
-                      parse={parseBool}
+                      <Localized id="configure-slack-channel-triggers-reportedComments">
+                        Reported Comments
+                      </Localized>
+                    </CheckBox>
+                  )}
+                </Field>
+                <Field
+                  name={`${channel}.triggers.pendingComments`}
+                  type="checkbox"
+                  parse={parseBool}
+                >
+                  {({ input }) => (
+                    <CheckBox
+                      id={`configure-slack-channel-triggers-pendingComments-${input.name}`}
+                      disabled={disabled || !channelEnabled}
+                      className={styles.trigger}
+                      {...input}
                     >
-                      {({ input }) => (
-                        <CheckBox
-                          id={`configure-slack-channel-triggers-reportedComments-${input.name}`}
-                          disabled={
-                            disabled || allCommentsValue || !channelEnabled
-                          }
-                          className={styles.trigger}
-                          {...input}
-                        >
-                          <Localized id="configure-slack-channel-triggers-reportedComments">
-                            Reported Comments
-                          </Localized>
-                        </CheckBox>
-                      )}
-                    </Field>
-                    <Field
-                      name={`${channel}.triggers.pendingComments`}
-                      type="checkbox"
-                      parse={parseBool}
+                      <Localized id="configure-slack-channel-triggers-pendingComments">
+                        Pending Comments
+                      </Localized>
+                    </CheckBox>
+                  )}
+                </Field>
+                <Field
+                  name={`${channel}.triggers.featuredComments`}
+                  type="checkbox"
+                  parse={parseBool}
+                >
+                  {({ input }) => (
+                    <CheckBox
+                      id={`configure-slack-channel-triggers-featuredComments-${input.name}`}
+                      disabled={disabled || !channelEnabled}
+                      className={styles.trigger}
+                      {...input}
                     >
-                      {({ input }) => (
-                        <CheckBox
-                          id={`configure-slack-channel-triggers-pendingComments-${input.name}`}
-                          disabled={
-                            disabled || allCommentsValue || !channelEnabled
-                          }
-                          className={styles.trigger}
-                          {...input}
-                        >
-                          <Localized id="configure-slack-channel-triggers-pendingComments">
-                            Pending Comments
-                          </Localized>
-                        </CheckBox>
-                      )}
-                    </Field>
-                    <Field
-                      name={`${channel}.triggers.featuredComments`}
-                      type="checkbox"
-                      parse={parseBool}
-                    >
-                      {({ input }) => (
-                        <CheckBox
-                          id={`configure-slack-channel-triggers-featuredComments-${input.name}`}
-                          disabled={
-                            disabled || allCommentsValue || !channelEnabled
-                          }
-                          className={styles.trigger}
-                          {...input}
-                        >
-                          <Localized id="configure-slack-channel-triggers-featuredComments">
-                            Featured Comments
-                          </Localized>
-                        </CheckBox>
-                      )}
-                    </Field>
-                  </div>
-                )}
-              </Field>
+                      <Localized id="configure-slack-channel-triggers-featuredComments">
+                        Featured Comments
+                      </Localized>
+                    </CheckBox>
+                  )}
+                </Field>
+              </div>
             </FormField>
             <div>
               <Button

--- a/src/core/client/admin/routes/Configure/sections/Slack/SlackConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Slack/SlackConfigContainer.tsx
@@ -41,7 +41,6 @@ const SlackConfigContainer: FunctionComponent<Props> = ({ form, settings }) => {
           name: "",
           hookURL: "",
           triggers: {
-            allComments: false,
             reportedComments: false,
             pendingComments: false,
             featuredComments: false,
@@ -57,7 +56,6 @@ const SlackConfigContainer: FunctionComponent<Props> = ({ form, settings }) => {
       enabled: true,
       hookURL: "",
       triggers: {
-        allComments: false,
         reportedComments: false,
         pendingComments: false,
         featuredComments: false,
@@ -143,7 +141,6 @@ const enhanced = withFragmentContainer<Props>({
           name
           hookURL
           triggers {
-            allComments
             reportedComments
             pendingComments
             featuredComments

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -966,11 +966,6 @@ type SlackConfiguration {
 
 type SlackChannelTriggers {
   """
-  allComments is whether this channel will receive all comments entering moderation
-  """
-  allComments: Boolean!
-
-  """
   reportedComments is whether this channel will receive reported comments
   """
   reportedComments: Boolean!
@@ -3539,11 +3534,6 @@ input CommenterAccountFeaturesInput {
 }
 
 input SlackTriggersConfigurationInput {
-  """
-  allComments is whether this channel will receive all comments entering moderation
-  """
-  allComments: Boolean
-
   """
   reportedComments is whether this channel will receive reported comments
   """

--- a/src/core/server/services/slack/publisher.ts
+++ b/src/core/server/services/slack/publisher.ts
@@ -36,20 +36,18 @@ function isFeatured(channel: SUBSCRIPTION_CHANNELS) {
 }
 
 function isReported(channel: SUBSCRIPTION_CHANNELS, payload: Payload) {
-  const p: any = payload;
   return (
     channel === SUBSCRIPTION_CHANNELS.COMMENT_ENTERED_MODERATION_QUEUE &&
-    p.hasOwnProperty("queue") &&
-    p.queue === GQLMODERATION_QUEUE.REPORTED
+    (payload as CommentEnteredModerationQueueInput).queue ===
+      GQLMODERATION_QUEUE.REPORTED
   );
 }
 
 function isPending(channel: SUBSCRIPTION_CHANNELS, payload: Payload) {
-  const p: any = payload;
   return (
     channel === SUBSCRIPTION_CHANNELS.COMMENT_ENTERED_MODERATION_QUEUE &&
-    p.hasOwnProperty("queue") &&
-    p.queue === GQLMODERATION_QUEUE.PENDING
+    (payload as CommentEnteredModerationQueueInput).queue ===
+      GQLMODERATION_QUEUE.PENDING
   );
 }
 
@@ -64,6 +62,7 @@ function createModerationLink(ctx: SlackContext, commentID: string) {
 
 async function postCommentToSlack(
   ctx: SlackContext,
+  message: string,
   commentID: string,
   hookURL: string
 ) {
@@ -90,30 +89,12 @@ async function postCommentToSlack(
   const body = commentBody.replace(/<br\/?>/g, "\n");
 
   const data = {
-    text: `${author.username} commented on: ${storyTitle}`,
-    blocks: [
+    text: `${message} on *<${story.url}|${storyTitle}>*`,
+    attachments: [
       {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `${author.username} commented on\n<${story.url}|${storyTitle}>`,
-        },
+        text: body,
+        footer: `Authored by *${author.username}* | <${moderateLink}|Go to Moderation> | <${commentLink}|See Comment>`,
       },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: body,
-        },
-      },
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `<${moderateLink}|Go to Moderation> | <${commentLink}|See Comment>`,
-        },
-      },
-      { type: "divider" },
     ],
   };
 
@@ -165,6 +146,12 @@ function createSlackPublisher(
       const pending = isPending(channel, payload);
       const featured = isFeatured(channel);
 
+      // If the comment doesn't match any filter, then we don't need to send
+      // anything.
+      if (!reported && !pending && !featured) {
+        return;
+      }
+
       const { commentID } = payload;
 
       for (const ch of channels) {
@@ -183,29 +170,29 @@ function createSlackPublisher(
           return;
         }
 
-        if (
-          triggers.allComments &&
-          channel === SUBSCRIPTION_CHANNELS.COMMENT_ENTERED_MODERATION_QUEUE
-        ) {
-          await postCommentToSlack(ctx, commentID, hookURL);
-        } else if (
-          !triggers.allComments &&
-          triggers.reportedComments &&
-          reported
-        ) {
-          await postCommentToSlack(ctx, commentID, hookURL);
-        } else if (
-          !triggers.allComments &&
-          triggers.pendingComments &&
-          pending
-        ) {
-          await postCommentToSlack(ctx, commentID, hookURL);
-        } else if (
-          !triggers.allComments &&
-          triggers.featuredComments &&
-          featured
-        ) {
-          await postCommentToSlack(ctx, commentID, hookURL);
+        // Add ticket to add back all comments option (including approved)
+
+        if (triggers.reportedComments && reported) {
+          await postCommentToSlack(
+            ctx,
+            "This comment has been reported",
+            commentID,
+            hookURL
+          );
+        } else if (triggers.pendingComments && pending) {
+          await postCommentToSlack(
+            ctx,
+            "This comment is pending",
+            commentID,
+            hookURL
+          );
+        } else if (triggers.featuredComments && featured) {
+          await postCommentToSlack(
+            ctx,
+            "This comment has been featured",
+            commentID,
+            hookURL
+          );
         }
       }
     } catch (err) {

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -423,7 +423,6 @@ configure-slack-channel-hookURL-description =
   follow the instructions <externalLink>here</externalLink>.
 configure-slack-channel-triggers-label =
   Receive notifications in this Slack channel for
-configure-slack-channel-triggers-allComments = All Comments
 configure-slack-channel-triggers-reportedComments = Reported Comments
 configure-slack-channel-triggers-pendingComments = Pending Comments
 configure-slack-channel-triggers-featuredComments = Featured Comments


### PR DESCRIPTION
## What does this PR do?

Cleans up the formatting on the slack comment messages.
Also fixes a bug around all comments not coming through correctly.

## How do I test this PR?

- Set up a slack channel in the config
- Make some comments
- See them come through to the slack channel with the following format:

```
[username] commented on
[Headline - Site]

[comment text]

Go to Moderation | See Comment
[horizontal rule]
```