### PR TITLE
[CORL-849] Fix text field adornments to use correct font

### DIFF
--- a/src/core/client/ui/components/v2/TextField/TextField.css
+++ b/src/core/client/ui/components/v2/TextField/TextField.css
@@ -49,6 +49,11 @@ $input-dark-focused-border: var(--v2-colors-blue-500);
 
 .adornment {
   margin-left: var(--v2-spacing-2);
+
+  font-family: var(--v2-font-family-primary);
+  font-weight: var(--v2-font-weight-primary-regular);
+  font-size: var(--v2-font-size-3);
+  line-height: var(--v2-line-height-reset);
 }
 
 .colorRegular {


### PR DESCRIPTION
## What does this PR do?

Font styling for text field adornments now matches the text field input.

## How do I test this PR?

Head to `Moderation > New commenter approval` and see the following for "Number of comments that must be approved":

<img width="332" alt="image" src="https://user-images.githubusercontent.com/5751504/72368099-a0ee2500-36ba-11ea-81f3-8cb3e264d3ee.png">

