### PR TITLE
[CORL-867] Version SSL Bypass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/src/core/server/app/index.ts
+++ b/src/core/server/app/index.ts
@@ -27,7 +27,7 @@ import { PersistedQueryCache } from "coral-server/services/queries";
 import { AugmentedRedis } from "coral-server/services/redis";
 import TenantCache from "coral-server/services/tenant/cache";
 
-import { healthHandler } from "./handlers";
+import { healthHandler, versionHandler } from "./handlers";
 import { compileTrust } from "./helpers";
 import { accessLogger, errorLogger } from "./middleware/logging";
 import { metricsRecorder } from "./middleware/metrics";
@@ -74,6 +74,9 @@ export async function createApp(options: AppOptions): Promise<Express> {
 
   // Configure the health check endpoint.
   parent.get("/api/health", healthHandler);
+
+  // Configure the version route.
+  parent.get("/api/version", versionHandler);
 
   // Configure the SSL requirement after the health check endpoint.
   configureApplicationHTTPS(options);

--- a/src/core/server/app/router/api/index.ts
+++ b/src/core/server/app/router/api/index.ts
@@ -2,7 +2,7 @@ import express from "express";
 import passport from "passport";
 
 import { AppOptions } from "coral-server/app";
-import { graphQLHandler, versionHandler } from "coral-server/app/handlers";
+import { graphQLHandler } from "coral-server/app/handlers";
 import { JSONErrorHandler } from "coral-server/app/middleware/error";
 import { persistedQueryMiddleware } from "coral-server/app/middleware/graphql";
 import { jsonMiddleware } from "coral-server/app/middleware/json";
@@ -28,9 +28,6 @@ export interface RouterOptions {
 export function createAPIRouter(app: AppOptions, options: RouterOptions) {
   // Create a router.
   const router = express.Router();
-
-  // Configure the version route.
-  router.get("/version", versionHandler);
 
   // Installation router.
   router.use("/install", createNewInstallRouter(app));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please note that by contributing to Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your PR, please verify that:
* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md
-->

## What does this PR do?

Much like #2796 bypassed the SSL wrap for `/api/health`, this moves the `/api/version` outside as well. This is a temporary fix to address some deployment issues around updating K8s healthchecks that prevent us from updating them post creation (See https://github.com/kubernetes/ingress-gce/issues/39).

## How do I test this PR?

```
curl -v http://localhost:3000/api/version
```

Notice that it returns 200, not a 301.