### PR TITLE
[CORL-873] Fix radio button positioning on Firefox

### DIFF
--- a/src/core/client/ui/components/v2/RadioButton/RadioButton.css
+++ b/src/core/client/ui/components/v2/RadioButton/RadioButton.css
@@ -73,7 +73,6 @@
   border-radius: 50%;
   position: absolute;
   left: 3px;
-  top: 6px;
   width: 8px;
   height: 8px;
   box-sizing: border-box;


### PR DESCRIPTION
## What does this PR do?

Fix radio buttons so they render the selection dot perfectly centered on all major browsers (Firefox, Chrome, Safari, Edge).

## How do I test this PR?

Go look at some radio buttons in Firefox and see they're chillin' all balanced and centered like.
