### PR TITLE
[CORL-887] commentCounts Migration Fix

### DIFF
--- a/src/core/server/services/migrate/migrations/1580404849316_user_comment_counts.ts
+++ b/src/core/server/services/migrate/migrations/1580404849316_user_comment_counts.ts
@@ -1,0 +1,33 @@
+import { Db } from "mongodb";
+
+import Migration from "coral-server/services/migrate/migration";
+import collections from "coral-server/services/mongodb/collections";
+
+export default class extends Migration {
+  public async up(mongo: Db, tenantID: string) {
+    const result = await collections.users(mongo).updateMany(
+      { tenantID, commentCounts: null },
+      {
+        $set: {
+          commentCounts: {
+            status: {
+              APPROVED: 0,
+              NONE: 0,
+              PREMOD: 0,
+              REJECTED: 0,
+              SYSTEM_WITHHELD: 0,
+            },
+          },
+        },
+      }
+    );
+
+    this.log(tenantID).warn(
+      {
+        matchedCount: result.matchedCount,
+        modifiedCount: result.modifiedCount,
+      },
+      "applied fix to users"
+    );
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please note that by contributing to Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your PR, please verify that:
* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md
-->

## What does this PR do?

When a user did not have any comments when the migration 1575649180000
hits, they are not migrated to get a `commentCounts` property. This
migration finds those users without `commentCounts` and sets them to the
empty comment counts.

## How do I test this PR?

If you have a user that was created prior to v5.4.0 that had not written any comments, have them write a comment before and after you apply the fix. This fix should address those users.