### PR TITLE
[CORL-896] Perspective Timeout

### DIFF
--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -51,9 +51,15 @@ convict.addFormat({
 convict.addFormat({
   name: "ms",
   validate: (val: number) => {
-    Joi.assert(val, Joi.number().min(0));
+    Joi.assert(
+      val,
+      Joi.number()
+        .positive()
+        .integer()
+        .required()
+    );
   },
-  coerce: (val: string) => ms(val),
+  coerce: (val: string): number => ms(val),
 });
 
 const algorithms = [
@@ -254,6 +260,14 @@ const config = convict({
     default: "10 seconds",
     env: "SCRAPE_TIMEOUT",
     arg: "scrapeTimeout",
+  },
+  perspective_timeout: {
+    doc:
+      "The request timeout (in ms) for perspective comment checking operations.",
+    format: "ms",
+    default: "800 milliseconds",
+    env: "PERSPECTIVE_TIMEOUT",
+    arg: "perspectiveTimeout",
   },
   disable_force_ssl: {
     doc:

--- a/src/core/server/services/comments/pipeline/phases/toxic.ts
+++ b/src/core/server/services/comments/pipeline/phases/toxic.ts
@@ -1,5 +1,4 @@
 import { isNil } from "lodash";
-import ms from "ms";
 import fetch from "node-fetch";
 import path from "path";
 import { URL } from "url";
@@ -32,12 +31,13 @@ export const toxic: IntermediateModerationPhase = async ({
   nudge,
   log,
   htmlStripped,
+  config,
   // FEATURE_FLAG:DISABLE_WARN_USER_OF_TOXIC_COMMENT
   comment: { body },
 }: Pick<
   ModerationPhaseContext,
   // FEATURE_FLAG:DISABLE_WARN_USER_OF_TOXIC_COMMENT
-  "tenant" | "nudge" | "log" | "htmlStripped" | "comment"
+  "tenant" | "nudge" | "log" | "htmlStripped" | "comment" | "config"
 >): Promise<IntermediatePhaseResult | void> => {
   if (!htmlStripped) {
     return;
@@ -89,8 +89,9 @@ export const toxic: IntermediateModerationPhase = async ({
     );
   }
 
-  // TODO: (wyattjoh) replace hardcoded default with config.
-  const timeout = ms("800ms");
+  // This typecast is needed because the custom `ms` format does not return the
+  // desired `number` type even though that's the only type it can output.
+  const timeout = (config.get("perspective_timeout") as unknown) as number;
 
   try {
     // FEATURE_FLAG:DISABLE_WARN_USER_OF_TOXIC_COMMENT


### PR DESCRIPTION

## What does this PR do?

Allows reconfiguration of the perspective timeout for all tenants on an installation via the `PERSPECTIVE_TIMEOUT` environment variable.

Example:

```sh
# One second.
PERSPECTIVE_TIMEOUT=1 second

# Two thousand milliseconds.
PERSPECTIVE_TIMEOUT=2000
```

## How do I test this PR?

Try setting the configuration variable and inspect using a breakpoint to see the new value picked up.