### PR TITLE
[CORL-897] fix styling of icons and text in stream announcement

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/Announcement/Announcement.css
+++ b/src/core/client/stream/tabs/Comments/Stream/Announcement/Announcement.css
@@ -7,5 +7,6 @@
 
 .text {
   @mixin bodyCopy;
+  font-weight: var(--font-weight-medium);
   color: white;
 }

--- a/src/core/client/stream/tabs/Comments/Stream/Announcement/Announcement.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/Announcement/Announcement.tsx
@@ -15,13 +15,17 @@ const Announcement: FunctionComponent<Props> = props => {
   return (
     <div className={cn(styles.root, CLASSES.announcement)}>
       <Flex justifyContent="space-between" alignItems="center">
-        <Flex itemGutter>
-          <Icon size="lg">notifications</Icon>
+        <Flex itemGutter="double" alignItems="center">
+          <div>
+            <Icon size="lg">notifications</Icon>
+          </div>
           <span className={styles.text}>{props.children}</span>
         </Flex>
-        <Button color="light" onClick={props.onClose}>
-          <Icon>close</Icon>
-        </Button>
+        <div>
+          <Button color="light" onClick={props.onClose}>
+            <Icon>close</Icon>
+          </Button>
+        </div>
       </Flex>
     </div>
   );


### PR DESCRIPTION
## What does this PR do?
Fixes styling of announcement callout: 
![image](https://user-images.githubusercontent.com/1789029/73770956-5c025f00-474b-11ea-8df7-ee7e2d59810b.png)

