### PR TITLE
Changed memoized RegExp to not be global

### DIFF
--- a/src/core/server/services/comments/pipeline/wordList.spec.ts
+++ b/src/core/server/services/comments/pipeline/wordList.spec.ts
@@ -1,4 +1,7 @@
-import { containsMatchingPhrase } from "coral-server/services/comments/pipeline/wordList";
+import {
+  containsMatchingPhrase,
+  containsMatchingPhraseMemoized,
+} from "coral-server/services/comments/pipeline/wordList";
 
 const phrases = [
   "cookies",
@@ -42,5 +45,22 @@ describe("containsMatchingPhrase", () => {
 
   it("allows an empty list", () => {
     expect(containsMatchingPhrase([], "test")).toEqual(false);
+  });
+});
+
+describe("containsMatchingPhraseMemoized", () => {
+  it("return true for all cases after memoizing the first result", () => {
+    [
+      "cookies 1",
+      "cookies 2",
+      "cookies 4",
+      "cookies 5",
+      "cookies 6",
+      "cookies 7",
+      "cookies 8",
+      "cookies 9",
+    ].forEach(word => {
+      expect(containsMatchingPhraseMemoized(phrases, word)).toEqual(true);
+    });
   });
 });

--- a/src/core/server/services/comments/pipeline/wordList.spec.ts
+++ b/src/core/server/services/comments/pipeline/wordList.spec.ts
@@ -55,10 +55,10 @@ describe("containsMatchingPhraseMemoized", () => {
       "cookies 2",
       "cookies 4",
       "cookies 5",
-      "cookies 6",
-      "cookies 7",
-      "cookies 8",
-      "cookies 9",
+      "this is for cookies 6",
+      "this is for cookies 7",
+      "this is for cookies 8",
+      "this is for cookies 9",
     ].forEach(word => {
       expect(containsMatchingPhraseMemoized(phrases, word)).toEqual(true);
     });

--- a/src/core/server/services/comments/pipeline/wordList.ts
+++ b/src/core/server/services/comments/pipeline/wordList.ts
@@ -22,7 +22,7 @@ export function generateRegExp(phrases: string[]) {
         .join('[\\s"?!.]+')
     )
     .join("|");
-  return new RegExp(`(^|[^\\w])(${inner})(?=[^\\w]|$)`, "gmiu");
+  return new RegExp(`(^|[^\\w])(${inner})(?=[^\\w]|$)`, "miu");
 }
 
 export const generateRegExpMemoized = memoize(generateRegExp);
@@ -33,11 +33,5 @@ export const containsMatchingPhrase = (phrases: string[], testString: string) =>
 export const containsMatchingPhraseMemoized = (
   phrases: string[],
   testString: string
-) => {
-  if (phrases.length > 0) {
-    const regExp = generateRegExpMemoized(phrases);
-    // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-    return !!testString.match(regExp);
-  }
-  return false;
-};
+) =>
+  phrases.length > 0 ? generateRegExpMemoized(phrases).test(testString) : false;

--- a/src/core/server/services/comments/pipeline/wordList.ts
+++ b/src/core/server/services/comments/pipeline/wordList.ts
@@ -33,5 +33,11 @@ export const containsMatchingPhrase = (phrases: string[], testString: string) =>
 export const containsMatchingPhraseMemoized = (
   phrases: string[],
   testString: string
-) =>
-  phrases.length > 0 ? generateRegExpMemoized(phrases).test(testString) : false;
+) => {
+  if (phrases.length > 0) {
+    const regExp = generateRegExpMemoized(phrases);
+    // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+    return !!testString.match(regExp);
+  }
+  return false;
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please note that by contributing to Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your PR, please verify that:
* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md
-->

## What does this PR do?
This PR exchanges .test() to test regular expression matching with .match(). It fixes the problem described and reproduced on [this issue](https://github.com/coralproject/talk/issues/2819).

## How do I test this PR?
You can create a blacklist with words "banned" and "banned2". Then, write the following comments: "banned 1", "banned 2", "banned 3", "banned 4". Without this fix, only "banned 1" and "banned 3" will be rejected. With this fix, all those comments will be rejected.