### PR TITLE
[CORL-917] Autofill in Chrome

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Auth/ClientSecretField.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/ClientSecretField.tsx
@@ -33,6 +33,7 @@ const ClientSecretField: FunctionComponent<Props> = ({
             {...input}
             id={input.name}
             disabled={disabled || meta.submitting}
+            autoComplete="new-password"
             // TODO: (wyattjoh) figure out how to add translations to these props
             hidePasswordTitle="Show Client Secret"
             showPasswordTitle="Hide Client Secret"

--- a/src/core/client/admin/routes/Configure/sections/Email/SMTP.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Email/SMTP.tsx
@@ -162,6 +162,7 @@ const SMTP: FunctionComponent<Props> = ({ disabled }) => (
                     {...input}
                     id={input.name}
                     disabled={disabled || !enabled}
+                    autoComplete="new-password"
                     fullWidth
                     color={colorFromMeta(meta)}
                   />

--- a/src/core/client/admin/routes/Configure/sections/Moderation/APIKeyField.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Moderation/APIKeyField.tsx
@@ -32,9 +32,10 @@ const APIKeyField: FunctionComponent<Props> = ({
             {...input}
             id={`configure-moderation-${input.name}`}
             disabled={disabled}
+            autoComplete="new-password"
             // TODO: (wyattjoh) figure out how to add translations to these props
-            hidePasswordTitle="Show API Key"
-            showPasswordTitle="Hide API Key"
+            hidePasswordTitle="Hide API Key"
+            showPasswordTitle="Show API Key"
             color={colorFromMeta(meta)}
             fullWidth
           />

--- a/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
@@ -869,7 +869,7 @@ needs to be displayed, e.g. “Log in with &lt;Facebook&gt;”.
                       >
                         <input
                           autoCapitalize="off"
-                          autoComplete="off"
+                          autoComplete="new-password"
                           autoCorrect="off"
                           className="PasswordField-colorRegular PasswordField-fullWidth PasswordField-input"
                           data-testid="password-field"
@@ -1602,7 +1602,7 @@ to create and set up a web application. For more information visit:
                       >
                         <input
                           autoCapitalize="off"
-                          autoComplete="off"
+                          autoComplete="new-password"
                           autoCorrect="off"
                           className="PasswordField-colorRegular PasswordField-fullWidth PasswordField-input"
                           data-testid="password-field"
@@ -1923,7 +1923,7 @@ For more information visit:
                       >
                         <input
                           autoCapitalize="off"
-                          autoComplete="off"
+                          autoComplete="new-password"
                           autoCorrect="off"
                           className="PasswordField-colorRegular PasswordField-fullWidth PasswordField-input"
                           data-testid="password-field"

--- a/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
@@ -974,7 +974,7 @@ community model building purposes to improve the API over time.
                     >
                       <input
                         autoCapitalize="off"
-                        autoComplete="off"
+                        autoComplete="new-password"
                         autoCorrect="off"
                         className="PasswordField-colorRegular PasswordField-fullWidth PasswordField-input"
                         data-testid="password-field"
@@ -995,7 +995,7 @@ community model building purposes to improve the API over time.
                         onKeyUp={[Function]}
                         role="button"
                         tabIndex={0}
-                        title="Hide API Key"
+                        title="Show API Key"
                       >
                         <i
                           aria-hidden="true"
@@ -1178,7 +1178,7 @@ in your Akismet account:
                     >
                       <input
                         autoCapitalize="off"
-                        autoComplete="off"
+                        autoComplete="new-password"
                         autoCorrect="off"
                         className="PasswordField-colorRegular PasswordField-fullWidth PasswordField-input"
                         data-testid="password-field"
@@ -1199,7 +1199,7 @@ in your Akismet account:
                         onKeyUp={[Function]}
                         role="button"
                         tabIndex={0}
-                        title="Hide API Key"
+                        title="Show API Key"
                       >
                         <i
                           aria-hidden="true"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! Please note that by contributing to Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your PR, please verify that:
* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.
  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md
-->

## What does this PR do?

Chrome incorrectly assumes all password fields on a page are associated with a user login, this causes issues where chrome automatically auto-fills logins without interaction. This PR serves to mark fields that are not user password fields as `new-password` fields, which is documented [here](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#Preventing_autofilling_with_autocompletenew-password) as the most reasonable solution to preventing this behaviour.

## How do I test this PR?

Try to visit the moderation page when on the `master` branch to see if chrome autofills your email/password into the perspective API settings. Try again on this branch and notice that it does not do that.