### PR TITLE
[DOCS Day] Break contributing docs out into sub-sections

### DIFF
--- a/docs/source/version-5-development.md
+++ b/docs/source/version-5-development.md
@@ -103,9 +103,13 @@ npm run docz -- dev
 After compilation has finished you can access docz at http://localhost:3030/.
 
 
-## Contributing a Translation
+## Contributing
 
-We welcome contributions from the open source community! To get started contributing check out our [Contribution Guidelines](https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md).
+We welcome contributions from the open source community!
+
+To get started contributing, check out our [Contribution Guidelines](https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md).
+
+### Contributing a Translation
 
 We’re so proud to have received submissions from a lot of 3rd party contributors translating Coral into their own languages.
 


### PR DESCRIPTION
## What does this PR do?

- Breaks out the contributing section under "Developing" into a main section with sub-sections

## How do I test this PR?

- Have a look at the docs manually
OR
- Host it and have a look at it in browser
