### PR TITLE
Fix for Unanswered tab inconsistent translation key and missing from stream.ftl

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -255,7 +255,7 @@ export const StreamContainer: FunctionComponent<Props> = props => {
                   )}
                 >
                   <Flex alignItems="center" spacing={1}>
-                    <Localized id="comments-unansweredCommentsTab">
+                    <Localized id="qa-unansweredTab">
                       <span>Unanswered</span>
                     </Localized>
                     <Counter

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -173,6 +173,7 @@ comments-featuredTag = Featured
 general-tabBar-qaTab = Q&A
 
 qa-answeredTab = Answered
+qa-unansweredTab = Unanswered
 qa-allCommentsTab = All
 
 qa-noQuestionsAtAll =


### PR DESCRIPTION
## What does this PR do?

While working on a polish translation for Q&A I found that string for Unanswered tab is not being included in the src/locales/en-US/stream.ftl file and also that it has a key inconsistent with strings for other tabs. It seems to be an omission, and here's a small PR to replace the key and include the string itself streams file. 

## How do I test this PR?

This is the string for the Unanswered tab in a Q&A type of comments stream. 