### PR TITLE
[CORL-953] Story Count Cache

### DIFF
--- a/src/core/server/app/router/api/account.ts
+++ b/src/core/server/app/router/api/account.ts
@@ -1,5 +1,4 @@
 import bodyParser from "body-parser";
-import express from "express";
 
 import { AppOptions } from "coral-server/app";
 import {
@@ -17,11 +16,13 @@ import { jsonMiddleware } from "coral-server/app/middleware/json";
 import { authenticate } from "coral-server/app/middleware/passport";
 import { RouterOptions } from "coral-server/app/router/types";
 
+import { createAPIRouter } from "./helpers";
+
 export function createNewAccountRouter(
   app: AppOptions,
   { passport }: Pick<RouterOptions, "passport">
 ) {
-  const router = express.Router();
+  const router = createAPIRouter();
 
   router.post(
     "/confirm",

--- a/src/core/server/app/router/api/auth.ts
+++ b/src/core/server/app/router/api/auth.ts
@@ -19,6 +19,8 @@ import {
 } from "coral-server/app/middleware/passport";
 import { RouterOptions } from "coral-server/app/router/types";
 
+import { createAPIRouter } from "./helpers";
+
 function wrapPath(
   app: AppOptions,
   { passport }: Pick<RouterOptions, "passport">,
@@ -36,7 +38,7 @@ export function createNewAuthRouter(
   app: AppOptions,
   { passport }: Pick<RouterOptions, "passport">
 ) {
-  const router = express.Router();
+  const router = createAPIRouter();
 
   // Mount the Local Authentication handlers.
   router.post(

--- a/src/core/server/app/router/api/helpers.ts
+++ b/src/core/server/app/router/api/helpers.ts
@@ -1,0 +1,16 @@
+import express from "express";
+
+import { cacheHeadersMiddleware } from "coral-server/app/middleware/cacheHeaders";
+
+interface Options {
+  cache?: false | string;
+}
+
+export function createAPIRouter({ cache = false }: Options = {}) {
+  const router = express.Router();
+
+  // Add the cache headers middleware.
+  router.use(cacheHeadersMiddleware(cache));
+
+  return router;
+}

--- a/src/core/server/app/router/api/index.ts
+++ b/src/core/server/app/router/api/index.ts
@@ -36,6 +36,9 @@ export function createAPIRouter(app: AppOptions, options: RouterOptions) {
   // only proceed if there is a valid Tenant for the hostname.
   router.use(tenantMiddleware({ cache: app.tenantCache }));
 
+  // We don't need auth for the story router, so mount it earlier.
+  router.use("/story", createStoryRouter(app));
+
   // Setup Passport middleware.
   router.use(passport.initialize());
 
@@ -43,7 +46,6 @@ export function createAPIRouter(app: AppOptions, options: RouterOptions) {
   router.use("/auth", createNewAuthRouter(app, options));
   router.use("/account", createNewAccountRouter(app, options));
   router.use("/user", createNewUserRouter(app));
-  router.use("/story", createStoryRouter(app));
 
   // Configure the GraphQL route.
   router.use(

--- a/src/core/server/app/router/api/install.ts
+++ b/src/core/server/app/router/api/install.ts
@@ -1,13 +1,15 @@
-import express, { Router } from "express";
+import { Router } from "express";
 
 import { AppOptions } from "coral-server/app";
 import { installCheckHandler, installHandler } from "coral-server/app/handlers";
 import { jsonMiddleware } from "coral-server/app/middleware/json";
 import { tenantMiddleware } from "coral-server/app/middleware/tenant";
 
+import { createAPIRouter } from "./helpers";
+
 export function createNewInstallRouter(app: AppOptions): Router {
   // Create a router.
-  const router = express.Router();
+  const router = createAPIRouter();
 
   router.get(
     "/",

--- a/src/core/server/app/router/api/story.ts
+++ b/src/core/server/app/router/api/story.ts
@@ -1,13 +1,13 @@
-import express from "express";
-
 import { AppOptions } from "coral-server/app";
 import { countHandler } from "coral-server/app/handlers";
-import { cacheHeadersMiddleware } from "coral-server/app/middleware/cacheHeaders";
+
+import { createAPIRouter } from "./helpers";
 
 export function createStoryRouter(app: AppOptions) {
-  const router = express.Router();
-
   // TODO: (cvle) make caching time configurable?
-  router.get("/count.js", cacheHeadersMiddleware("2m"), countHandler(app));
+  const router = createAPIRouter({ cache: "2m" });
+
+  router.get("/count.js", countHandler(app));
+
   return router;
 }

--- a/src/core/server/app/router/api/user.ts
+++ b/src/core/server/app/router/api/user.ts
@@ -1,10 +1,10 @@
-import express from "express";
-
 import { AppOptions } from "coral-server/app";
 import { userDownloadHandler } from "coral-server/app/handlers";
 
+import { createAPIRouter } from "./helpers";
+
 export function createNewUserRouter(app: AppOptions) {
-  const router = express.Router();
+  const router = createAPIRouter();
 
   router.get("/download", userDownloadHandler(app));
 

--- a/src/core/server/app/router/index.ts
+++ b/src/core/server/app/router/index.ts
@@ -18,12 +18,7 @@ export function createRouter(app: AppOptions, options: RouterOptions) {
   const router = express.Router();
 
   // Attach the API router.
-  router.use(
-    "/api",
-    noCacheMiddleware,
-    cookies(),
-    createAPIRouter(app, options)
-  );
+  router.use("/api", cookies(), createAPIRouter(app, options));
 
   // Attach the GraphiQL if enabled.
   if (app.config.get("enable_graphiql")) {


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

Fixes problem where the story count route had the wrong middleware attached and double-set the cache headers resulting in a SKIP from the CDN.

## What changes to the GraphQL/Database Schema does this PR introduce?

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

None
## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

Perform a cURL to the count URL:

```sh
# set this to an ID of a story that has comments
STORY_ID=""
curl -I http://localhost:3000/api/story/count.js?callback=CoralCount.setCount&id=${STORY_ID}&notext=true&ref=ref
```