### PR TITLE
[CORL-956] Add flag to optionally enable Q&A

### DIFF
--- a/src/core/client/stream/tabs/Configure/Configure.tsx
+++ b/src/core/client/stream/tabs/Configure/Configure.tsx
@@ -13,7 +13,8 @@ import { QAConfigContainer } from "./Q&A";
 export interface Props {
   viewer: PropTypesOf<typeof UserBoxContainer>["viewer"];
   settings: PropTypesOf<typeof UserBoxContainer>["settings"] &
-    PropTypesOf<typeof ModerateStreamContainer>["settings"];
+    PropTypesOf<typeof ModerateStreamContainer>["settings"] &
+    PropTypesOf<typeof QAConfigContainer>["settings"];
   story: PropTypesOf<typeof ConfigureStreamContainer>["story"] &
     PropTypesOf<typeof OpenOrCloseStreamContainer>["story"] &
     PropTypesOf<typeof ModerateStreamContainer>["story"] &
@@ -31,8 +32,7 @@ const Configure: FunctionComponent<Props> = props => {
         />
         <HorizontalRule />
         <ConfigureStreamContainer story={props.story} />
-        <HorizontalRule />
-        <QAConfigContainer story={props.story} />
+        <QAConfigContainer story={props.story} settings={props.settings} />
         <HorizontalRule />
         <OpenOrCloseStreamContainer story={props.story} />
       </HorizontalGutter>

--- a/src/core/client/stream/tabs/Configure/ConfigureContainer.tsx
+++ b/src/core/client/stream/tabs/Configure/ConfigureContainer.tsx
@@ -44,6 +44,7 @@ const enhanced = withFragmentContainer<ConfigureContainerProps>({
     fragment ConfigureContainer_settings on Settings {
       ...UserBoxContainer_settings
       ...ModerateStreamContainer_settings
+      ...QAConfigContainer_settings
     }
   `,
 })(StreamContainer);

--- a/src/core/client/stream/tabs/Configure/Q&A/QAConfigContainer.tsx
+++ b/src/core/client/stream/tabs/Configure/Q&A/QAConfigContainer.tsx
@@ -5,10 +5,12 @@ import {
   useMutation,
   withFragmentContainer,
 } from "coral-framework/lib/relay";
-import { GQLSTORY_MODE } from "coral-framework/schema";
+import { GQLFEATURE_FLAG, GQLSTORY_MODE } from "coral-framework/schema";
 
+import { QAConfigContainer_settings } from "coral-stream/__generated__/QAConfigContainer_settings.graphql";
 import { QAConfigContainer_story } from "coral-stream/__generated__/QAConfigContainer_story.graphql";
 
+import HorizontalRule from "../HorizontalRule";
 import DisableQA from "./DisableQA";
 import EnableQA from "./EnableQA";
 import ExpertSelectionQuery from "./ExpertSelectionQuery";
@@ -16,9 +18,10 @@ import UpdateStoryModeMutation from "./UpdateStoryModeMutation";
 
 interface Props {
   story: QAConfigContainer_story;
+  settings: QAConfigContainer_settings;
 }
 
-const QAConfigContainer: FunctionComponent<Props> = ({ story }) => {
+const QAConfigContainer: FunctionComponent<Props> = ({ story, settings }) => {
   const [waiting, setWaiting] = useState(false);
   const updateStoryMode = useMutation(UpdateStoryModeMutation);
 
@@ -36,13 +39,22 @@ const QAConfigContainer: FunctionComponent<Props> = ({ story }) => {
 
   const isQA = story.settings.mode === GQLSTORY_MODE.QA;
 
+  // Check if we're allowed to show Q&A based on feature flags
+  if (!settings.featureFlags.includes(GQLFEATURE_FLAG.ENABLE_QA)) {
+    return null;
+  }
+
   return isQA ? (
     <>
+      <HorizontalRule />
       <DisableQA onClick={handleOnClick} disableButton={waiting} />
       <ExpertSelectionQuery storyID={story.id} />
     </>
   ) : (
-    <EnableQA onClick={handleOnClick} disableButton={waiting} />
+    <>
+      <HorizontalRule />
+      <EnableQA onClick={handleOnClick} disableButton={waiting} />
+    </>
   );
 };
 
@@ -53,6 +65,11 @@ const enhanced = withFragmentContainer<Props>({
       settings {
         mode
       }
+    }
+  `,
+  settings: graphql`
+    fragment QAConfigContainer_settings on Settings {
+      featureFlags
     }
   `,
 })(QAConfigContainer);

--- a/src/core/client/stream/test/configure/__snapshots__/renderConfigure.spec.tsx.snap
+++ b/src/core/client/stream/test/configure/__snapshots__/renderConfigure.spec.tsx.snap
@@ -288,43 +288,6 @@ announcements relating to the comments on this story.
         className="HorizontalRule-root"
       />
       <div
-        className="coral coral-openCommentStream"
-      >
-        <h1
-          className="Box-root Typography-root Typography-heading2 Typography-colorTextPrimary EnableQA-heading"
-        >
-          Switch to Q&A Format
-        </h1>
-        <div
-          className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-alignFlexStart gutter"
-        >
-          <p
-            className="Box-root Typography-root Typography-bodyCopy Typography-colorTextPrimary"
-          >
-            The Q&A format allows community members to submit questions for chosen
-experts to answer.
-          </p>
-          <button
-            className="BaseButton-root Button-root Button-sizeRegular Button-colorPrimary Button-variantOutlined EnableQA-button coral coral-openCommentStream-openButton"
-            data-color="primary"
-            data-variant="outlined"
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onMouseOut={[Function]}
-            onMouseOver={[Function]}
-            onTouchEnd={[Function]}
-            type="button"
-          >
-            Switch to Q&A
-          </button>
-        </div>
-      </div>
-      <hr
-        className="HorizontalRule-root"
-      />
-      <div
         className="coral coral-closeCommentStream"
       >
         <h1

--- a/src/core/client/stream/test/fixtures.ts
+++ b/src/core/client/stream/test/fixtures.ts
@@ -109,6 +109,7 @@ export const settings = createFixture<GQLSettings>({
     deleteAccount: true,
   },
   multisite: false,
+  featureFlags: [],
 });
 
 export const site = createFixture<GQLSite>({

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -341,6 +341,11 @@ enum FEATURE_FLAG {
   toxic comments.
   """
   DISABLE_WARN_USER_OF_TOXIC_COMMENT
+
+  """
+  ENABLE_QA when enabled will turn off Q&A features client side.
+  """
+  ENABLE_QA
 }
 
 # The moderation mode of the site.
@@ -1481,7 +1486,7 @@ type Settings {
   """
   featureFlags provides the enabled feature flags.
   """
-  featureFlags: [FEATURE_FLAG!]! @auth(roles: [ADMIN])
+  featureFlags: [FEATURE_FLAG!]! @auth(roles: [ADMIN, MODERATOR])
 
   """
   createdAt is the time that the Settings was created at.


### PR DESCRIPTION
## What does this PR do?

Adds a feature flag to enable Q&A features client side, otherwise hidden by default.

## What changes to the GraphQL/Database Schema does this PR introduce?

- Adds `ENABLE_QA` feature flag to Feature Flags types.
- Makes feature flags visible to moderators so we can tap it on the stream-side Configure tab.

## How do I test this PR?

- go to the stream as Admin/Mod
- go to Configure tab
- see that switch to Q&A is not available

- Use the following mutation to enable the Q&A feature flag (you will need Admin/Mod Auth credentials on your request):

```
variables: {
	"flag": "ENABLE_QA",
	"clientMutationId": "1"
}
```

```
mutation ($flag: FEATURE_FLAG!, $clientMutationId: String!) {
  enableFeatureFlag(input: {
    flag: $flag,
    clientMutationId: $clientMutationId
  }) {
    flags
  }
}
```

- go to the stream as Admin/Mod
- go to Configure tab
- see that "Switch to Q&A" button is visible