### PR TITLE
[CORL-943] Send test emails

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Email/EmailConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Email/EmailConfigContainer.tsx
@@ -94,12 +94,14 @@ const EmailConfigContainer: React.FunctionComponent<Props> = ({
       {disabledInside => (
         <>
           <Flex justifyContent="flex-end">
-            <Button
-              disabled={disabledInside || loading || !email.enabled}
-              onClick={sendTestEmail}
-            >
-              Send test email
-            </Button>
+            <Localized id="configure-email-send-test">
+              <Button
+                disabled={disabledInside || loading || !email.enabled}
+                onClick={sendTestEmail}
+              >
+                Send test email
+              </Button>
+            </Localized>
           </Flex>
           {submitError && (
             <CallOut fullWidth color="error">

--- a/src/core/client/admin/routes/Configure/sections/Email/EmailConfigRoute.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Email/EmailConfigRoute.tsx
@@ -26,6 +26,7 @@ class EmailConfigRoute extends React.Component<Props> {
       <EmailConfigContainer
         email={this.props.data.settings.email}
         submitting={this.props.submitting}
+        viewer={this.props.data.viewer}
       />
     );
   }
@@ -34,6 +35,9 @@ class EmailConfigRoute extends React.Component<Props> {
 const enhanced = withRouteConfig<Props>({
   query: graphql`
     query EmailConfigRouteQuery {
+      viewer {
+        ...EmailConfigContainer_viewer
+      }
       settings {
         email {
           ...EmailConfigContainer_email

--- a/src/core/client/admin/routes/Configure/sections/Email/TestSMTPMutation.ts
+++ b/src/core/client/admin/routes/Configure/sections/Email/TestSMTPMutation.ts
@@ -1,0 +1,34 @@
+import { graphql } from "react-relay";
+import { Environment } from "relay-runtime";
+
+import {
+  commitMutationPromiseNormalized,
+  createMutation,
+  MutationInput,
+} from "coral-framework/lib/relay";
+
+import { TestSMTPMutation as MutationTypes } from "coral-admin/__generated__/TestSMTPMutation.graphql";
+
+const clientMutationId = 0;
+
+const TestSMTPMutation = createMutation(
+  "testSMTP",
+  (environment: Environment, input: MutationInput<MutationTypes>) => {
+    return commitMutationPromiseNormalized<MutationTypes>(environment, {
+      mutation: graphql`
+        mutation TestSMTPMutation($input: TestSMTPInput!) {
+          testSMTP(input: $input) {
+            clientMutationId
+          }
+        }
+      `,
+      variables: {
+        input: {
+          clientMutationId: clientMutationId.toString(),
+        },
+      },
+    });
+  }
+);
+
+export default TestSMTPMutation;

--- a/src/core/server/graph/mutators/Settings.ts
+++ b/src/core/server/graph/mutators/Settings.ts
@@ -16,6 +16,7 @@ import {
   rotateWebhookEndpointSecret,
   update,
   updateWebhookEndpoint,
+  sendSMTPTest,
 } from "coral-server/services/tenant";
 
 import {
@@ -42,6 +43,8 @@ export const Settings = ({
   tenant,
   config,
   now,
+  mailerQueue,
+  user,
 }: GraphContext) => ({
   update: (
     input: WithoutMutationID<GQLUpdateSettingsInput>
@@ -101,4 +104,5 @@ export const Settings = ({
       input.inactiveIn,
       now
     ),
+  testSMTP: () => sendSMTPTest(tenant, user!, mailerQueue),
 });

--- a/src/core/server/graph/mutators/Settings.ts
+++ b/src/core/server/graph/mutators/Settings.ts
@@ -14,9 +14,9 @@ import {
   regenerateSSOKey,
   rotateSSOKey,
   rotateWebhookEndpointSecret,
+  sendSMTPTest,
   update,
   updateWebhookEndpoint,
-  sendSMTPTest,
 } from "coral-server/services/tenant";
 
 import {

--- a/src/core/server/graph/resolvers/Mutation.ts
+++ b/src/core/server/graph/resolvers/Mutation.ts
@@ -326,4 +326,10 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     endpoint: await ctx.mutators.Settings.rotateWebhookEndpointSecret(input),
     clientMutationId,
   }),
+  testSMTP: async (source, { input: { clientMutationId } }, ctx) => {
+    await ctx.mutators.Settings.testSMTP();
+    return {
+      clientMutationId,
+    };
+  },
 };

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -6244,6 +6244,14 @@ type UpdateSitePayload {
   site: Site!
 }
 
+input TestSMTPInput {
+  clientMutationId: String!
+}
+
+type TestSMTPPayload {
+  clientMutationId: String!
+}
+
 ##################
 ## Mutation
 ##################
@@ -6712,6 +6720,12 @@ type Mutation {
   removeStoryExpert removes an expert from a story.
   """
   removeStoryExpert(input: RemoveStoryExpertInput!): RemoveStoryExpertPayload!
+    @auth(roles: [ADMIN, MODERATOR])
+
+  """
+  testSMTP sends a test email.
+  """
+  testSMTP(input: TestSMTPInput!): TestSMTPPayload!
     @auth(roles: [ADMIN, MODERATOR])
 }
 

--- a/src/core/server/locales/en-US/email.ftl
+++ b/src/core/server/locales/en-US/email.ftl
@@ -121,3 +121,6 @@ email-template-notificationOnCommentRejected =
 # Notification Digest
 
 email-subject-notificationDigest = Your latest comment activity at { $organizationName }
+
+email-subject-testSmtpTest = Test email from Coral
+email-template-testSmtpTest = This is a test email sent to { $email }

--- a/src/core/server/queue/tasks/mailer/templates/index.ts
+++ b/src/core/server/queue/tasks/mailer/templates/index.ts
@@ -3,6 +3,15 @@ interface EmailTemplate<T extends string, U extends {}> {
   context: U;
 }
 
+type TestContext<T extends string, U extends {}> = EmailTemplate<T, U>;
+
+export type SMTPTestTemplate = TestContext<
+  "test/smtp-test",
+  {
+    email: string;
+  }
+>;
+
 /**
  * NotificationContext
  */
@@ -203,6 +212,7 @@ type Templates =
   | OnFeaturedTemplate
   | DigestTemplate
   | OnCommentRejectedTemplate
+  | SMTPTestTemplate
   | OnCommentApprovedTemplate;
 
 export { Templates as EmailTemplate };

--- a/src/core/server/queue/tasks/mailer/templates/test/smtp-test.html
+++ b/src/core/server/queue/tasks/mailer/templates/test/smtp-test.html
@@ -1,0 +1,8 @@
+{% extends "layouts/base.html" %} {% block content %}
+<div
+  data-l10n-id="email-template-testSmtpTest"
+  data-l10n-args="{{ context | dump }}"
+>
+  This is a test email sent to {{ context.email }}
+</div>
+{% endblock %}

--- a/src/core/server/services/tenant/tenant.ts
+++ b/src/core/server/services/tenant/tenant.ts
@@ -26,6 +26,8 @@ import {
   updateTenantWebhookEndpoint,
   UpdateTenantWebhookEndpointInput,
 } from "coral-server/models/tenant";
+import { User } from "coral-server/models/user";
+import { MailerQueue } from "coral-server/queue/tasks/mailer";
 import { I18n } from "coral-server/services/i18n";
 
 import {
@@ -497,4 +499,29 @@ export async function deleteAnnouncement(
   }
   await cache.update(redis, updated);
   return updated;
+}
+
+export async function sendSMTPTest(
+  tenant: Tenant,
+  user: User,
+  mailer: MailerQueue
+) {
+  if (user.email) {
+    if (!tenant.email.enabled) {
+      throw new Error("Must enable email");
+    }
+    await mailer.add({
+      tenantID: tenant.id,
+      message: {
+        to: user.email,
+      },
+      template: {
+        name: "test/smtp-test",
+        context: {
+          email: user.email,
+        },
+      },
+    });
+  }
+  return tenant;
 }

--- a/src/core/server/services/tenant/tenant.ts
+++ b/src/core/server/services/tenant/tenant.ts
@@ -508,7 +508,7 @@ export async function sendSMTPTest(
 ) {
   if (user.email) {
     if (!tenant.email.enabled) {
-      throw new Error("Must enable email");
+      throw new Error("Email not enabled");
     }
     await mailer.add({
       tenantID: tenant.id,

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -384,6 +384,7 @@ configure-email-smtpAuthenticationLabel = SMTP authentication
 configure-email-smtpCredentialsHeader = Email credentials
 configure-email-smtpUsernameLabel = Username
 configure-email-smtpPasswordLabel = Password
+configure-email-send-test = Send test email
 
 ### Authentication
 


### PR DESCRIPTION
## What does this PR do?

adds a "Send test email" button to SMTP config so newsroom devs can confirm they've configured correctly. 

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds a new mutation `testSMTP` and respective input and payload types. This mutation *does not* mutate the database and the database schema doesn't change.

## How do I test this PR?

Configure SMTP, click "send test email" and check inbucket.  