### PR TITLE
[CORL-959] pass siteID through to approved and rejected route queries

### DIFF
--- a/src/core/client/admin/routes/Moderate/Queue/ApprovedQueueRoute.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/ApprovedQueueRoute.tsx
@@ -17,6 +17,7 @@ interface ApprovedQueueRouteProps {
   query: ApprovedQueueRoute_query;
   relay: RelayPaginationProp;
   storyID?: string;
+  siteID?: string;
 }
 
 // TODO: use generated types
@@ -87,10 +88,12 @@ const enhanced = (withPaginationContainer<
           count: { type: "Int!", defaultValue: 5 }
           cursor: { type: "Cursor" }
           storyID: { type: "ID" }
+          siteID: { type: "ID" }
         ) {
         comments(
           status: APPROVED
           storyID: $storyID
+          siteID: $siteID
           first: $count
           after: $cursor
         ) @connection(key: "ApprovedQueue_comments") {
@@ -134,11 +137,17 @@ const enhanced = (withPaginationContainer<
       # Notice that we re-use our fragment, and the shape of this query matches our fragment spec.
       query ApprovedQueueRoutePaginationQuery(
         $storyID: ID
+        $siteID: ID
         $count: Int!
         $cursor: Cursor
       ) {
         ...ApprovedQueueRoute_query
-          @arguments(storyID: $storyID, count: $count, cursor: $cursor)
+          @arguments(
+            storyID: $storyID
+            siteID: $siteID
+            count: $count
+            cursor: $cursor
+          )
       }
     `,
   }
@@ -147,14 +156,20 @@ const enhanced = (withPaginationContainer<
 enhanced.routeConfig = {
   Component: enhanced,
   query: graphql`
-    query ApprovedQueueRouteQuery($storyID: ID) {
-      ...ApprovedQueueRoute_query @arguments(storyID: $storyID)
+    query ApprovedQueueRouteQuery($storyID: ID, $siteID: ID) {
+      ...ApprovedQueueRoute_query @arguments(storyID: $storyID, siteID: $siteID)
     }
   `,
   cacheConfig: { force: true },
   render: function RejectedRouteRender({ Component, props, match }) {
     if (Component && props) {
-      return <Component query={props} storyID={match.params.storyID} />;
+      return (
+        <Component
+          query={props}
+          storyID={match.params.storyID}
+          siteID={match.params.siteID}
+        />
+      );
     }
     return <LoadingQueue />;
   },

--- a/src/core/client/admin/routes/Moderate/Queue/RejectedQueueRoute.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/RejectedQueueRoute.tsx
@@ -17,6 +17,7 @@ interface RejectedQueueRouteProps {
   query: RejectedQueueRoute_query;
   relay: RelayPaginationProp;
   storyID?: string;
+  siteID?: string;
 }
 
 // TODO: use generated types
@@ -87,10 +88,12 @@ const enhanced = (withPaginationContainer<
           count: { type: "Int!", defaultValue: 5 }
           cursor: { type: "Cursor" }
           storyID: { type: "ID" }
+          siteID: { type: "ID" }
         ) {
         comments(
           status: REJECTED
           storyID: $storyID
+          siteID: $siteID
           first: $count
           after: $cursor
         ) @connection(key: "RejectedQueue_comments") {
@@ -134,11 +137,17 @@ const enhanced = (withPaginationContainer<
       # Notice that we re-use our fragment, and the shape of this query matches our fragment spec.
       query RejectedQueueRoutePaginationQuery(
         $storyID: ID
+        $siteID: ID
         $count: Int!
         $cursor: Cursor
       ) {
         ...RejectedQueueRoute_query
-          @arguments(storyID: $storyID, count: $count, cursor: $cursor)
+          @arguments(
+            storyID: $storyID
+            siteID: $siteID
+            count: $count
+            cursor: $cursor
+          )
       }
     `,
   }
@@ -147,14 +156,20 @@ const enhanced = (withPaginationContainer<
 enhanced.routeConfig = {
   Component: enhanced,
   query: graphql`
-    query RejectedQueueRouteQuery($storyID: ID) {
-      ...RejectedQueueRoute_query @arguments(storyID: $storyID)
+    query RejectedQueueRouteQuery($storyID: ID, $siteID: ID) {
+      ...RejectedQueueRoute_query @arguments(storyID: $storyID, siteID: $siteID)
     }
   `,
   cacheConfig: { force: true },
   render: function RejectedRouteRender({ Component, props, match }) {
     if (Component && props) {
-      return <Component query={props} storyID={match.params.storyID} />;
+      return (
+        <Component
+          query={props}
+          storyID={match.params.storyID}
+          siteID={match.params.siteID}
+        />
+      );
     }
     return <LoadingQueue />;
   },

--- a/src/core/client/admin/test/moderate/rejectedQueue.spec.tsx
+++ b/src/core/client/admin/test/moderate/rejectedQueue.spec.tsx
@@ -74,6 +74,7 @@ it("renders rejected queue with comments", async () => {
             first: 5,
             status: "REJECTED",
             storyID: null,
+            siteID: null,
           });
           return {
             edges: [
@@ -112,6 +113,7 @@ it("shows a moderate story", async () => {
             first: 5,
             status: "REJECTED",
             storyID: null,
+            siteID: null,
           });
           return {
             edges: [
@@ -155,6 +157,7 @@ it("renders rejected queue with comments and load more", async () => {
                 first: 5,
                 status: GQLCOMMENT_STATUS.REJECTED,
                 storyID: null,
+                siteID: null,
               });
               return {
                 edges: [
@@ -178,6 +181,7 @@ it("renders rejected queue with comments and load more", async () => {
                 after: rejectedComments[1].createdAt,
                 status: GQLCOMMENT_STATUS.REJECTED,
                 storyID: null,
+                siteID: null,
               });
               return {
                 edges: [
@@ -269,6 +273,7 @@ it("approves comment in rejected queue", async () => {
             first: 5,
             status: "REJECTED",
             storyID: null,
+            siteID: null,
           });
           return {
             edges: [

--- a/src/core/server/graph/loaders/Comments.ts
+++ b/src/core/server/graph/loaders/Comments.ts
@@ -138,6 +138,7 @@ export default (ctx: Context) => ({
     first,
     after,
     storyID,
+    siteID,
     status,
     tag,
     query,
@@ -151,6 +152,7 @@ export default (ctx: Context) => ({
           ...queryFilter(query),
           ...tagFilter(tag),
           storyID,
+          siteID,
           status,
         },
         isNil

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -2944,6 +2944,7 @@ type Query {
     first: Int = 10 @constraint(max: 50)
     after: Cursor
     storyID: ID
+    siteID: ID
     status: COMMENT_STATUS
     tag: TAG
     query: String
@@ -6415,16 +6416,14 @@ type Mutation {
   """
   addStoryExpert adds an expert to a story.
   """
-  addStoryExpert(
-    input: AddExpertInput!
-  ): AddExpertPayload! @auth(roles: [ADMIN, MODERATOR])
+  addStoryExpert(input: AddExpertInput!): AddExpertPayload!
+    @auth(roles: [ADMIN, MODERATOR])
 
   """
   removeStoryExpert removes an expert from a story.
   """
-  removeStoryExpert(
-    input: RemoveExpertInput!
-  ): RemoveExpertPayload! @auth(roles: [ADMIN, MODERATOR])
+  removeStoryExpert(input: RemoveExpertInput!): RemoveExpertPayload!
+    @auth(roles: [ADMIN, MODERATOR])
 }
 
 ##################


### PR DESCRIPTION
##  What does this PR do?
- passes siteID through to the query on the rejected/approved routes so they will filter by selected site

## What changes to the GraphQL/Database Schema does this PR introduce?
adds `siteID` to comments query

## How do I test this PR?

- select a site to filter by in the "approved" or "rejected" queue