### PR TITLE
[CORL-961] use getModerationLink helper in moderateSearchBar

### DIFF
--- a/src/core/client/admin/routes/Moderate/ModerateSearchBar/ModerateSearchBarContainer.tsx
+++ b/src/core/client/admin/routes/Moderate/ModerateSearchBar/ModerateSearchBarContainer.tsx
@@ -97,7 +97,7 @@ function getContextOptionsWhenModeratingStory(
     {
       element: (
         <Option
-          href={`/admin/moderate/${story.id}`}
+          href={getModerationLink({ storyID: story.id })}
           details={story.metadata && story.metadata.author}
         >
           <GoToAriaInfo /> {story.metadata && story.metadata.title}
@@ -180,7 +180,10 @@ function useSearchOptions(
           nextSearchOptions.push({
             element: (
               <Option
-                href={getModerationLink({ storyID: e.node.id })}
+                href={getModerationLink({
+                  storyID: e.node.id,
+                  siteID: e.node.site.id,
+                })}
                 details={
                   <Flex itemGutter>
                     <strong>{e.node.site.name}</strong>
@@ -311,6 +314,7 @@ const enhanced = withRouter(
         id
         site {
           name
+          id
         }
         metadata {
           title

--- a/src/core/client/admin/routes/Moderate/ModerateSearchBar/SearchStoryFetch.ts
+++ b/src/core/client/admin/routes/Moderate/ModerateSearchBar/SearchStoryFetch.ts
@@ -26,6 +26,7 @@ const SearchStoryFetch = createFetch(
                 id
                 site {
                   name
+                  id
                 }
                 metadata {
                   title


### PR DESCRIPTION
## What does this PR do?
Uses the `getModerationLink` helper to get moderation links in the search bar to make sure we don't send people to routes that don't exist

## What changes to the GraphQL/Database Schema does this PR introduce?
none

## How do I test this PR?

try searching for a story in the moderation search bar and clicking on a result