### PR TITLE
Add tenantDomain to StoryCreatedEventPayload

### DIFF
--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -180,7 +180,7 @@ function when comparing signatures.
    */
   tenantID: string;
 
-    /**
+  /**
    * tenantDomain is the domain that is associated with this Tenant that this event originated at.
    */
   tenantDomain: string;

--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -174,6 +174,11 @@ function when comparing signatures.
    * date when this event was created.
    */
   createdAt: string;
+
+  /**
+   * tenantID is the ID of the Tenant that this event originated at.
+   */
+  tenantID: string;
 }
 ```
 
@@ -199,6 +204,11 @@ function when comparing signatures.
      * storyURL is the URL of the newly created Story.
      */
     storyURL: string;
+
+    /**
+     * siteID is the Site that the newly created Story was created on.
+     */
+    siteID: string;
   }
   createdAt: string;
 }

--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -179,6 +179,11 @@ function when comparing signatures.
    * tenantID is the ID of the Tenant that this event originated at.
    */
   tenantID: string;
+
+    /**
+   * tenantDomain is the domain that is associated with this Tenant that this event originated at.
+   */
+  tenantDomain: string;
 }
 ```
 

--- a/src/core/server/events/events.ts
+++ b/src/core/server/events/events.ts
@@ -79,6 +79,8 @@ export type StoryCreatedCoralEventPayload = CoralEventPayload<
   {
     storyID: string;
     storyURL: string;
+    tenantID: string;
+    siteID: string;
   }
 >;
 

--- a/src/core/server/events/events.ts
+++ b/src/core/server/events/events.ts
@@ -79,7 +79,6 @@ export type StoryCreatedCoralEventPayload = CoralEventPayload<
   {
     storyID: string;
     storyURL: string;
-    tenantID: string;
     siteID: string;
   }
 >;

--- a/src/core/server/queue/tasks/webhook/processor.ts
+++ b/src/core/server/queue/tasks/webhook/processor.ts
@@ -87,6 +87,10 @@ type CoralWebhookEventPayload = CoralEventPayload & {
    * tenantID is the ID of the Tenant that this event originated at.
    */
   readonly tenantID: string;
+  /**
+   * tenantDomain is the domain that is associated with this Tenant that this event originated at.
+   */
+  readonly tenantDomain: string;
 };
 
 export function generateFetchOptions(
@@ -158,7 +162,11 @@ export function createJobProcessor({
     const now = new Date();
 
     // Get the fetch options.
-    const options = generateFetchOptions(endpoint, { ...event, tenantID }, now);
+    const options = generateFetchOptions(
+      endpoint,
+      { ...event, tenantID, tenantDomain: tenant.domain },
+      now
+    );
 
     // Send the request.
     const startedSendingAt = getNow();

--- a/src/core/server/queue/tasks/webhook/processor.ts
+++ b/src/core/server/queue/tasks/webhook/processor.ts
@@ -82,9 +82,16 @@ export function generateSignatures(
     .join(",");
 }
 
+type CoralWebhookEventPayload = CoralEventPayload & {
+  /**
+   * tenantID is the ID of the Tenant that this event originated at.
+   */
+  readonly tenantID: string;
+};
+
 export function generateFetchOptions(
   endpoint: Pick<Endpoint, "signingSecrets">,
-  data: CoralEventPayload,
+  data: CoralWebhookEventPayload,
   now: Date
 ): FetchOptions {
   // Serialize the body and signature to include in the request.
@@ -151,7 +158,7 @@ export function createJobProcessor({
     const now = new Date();
 
     // Get the fetch options.
-    const options = generateFetchOptions(endpoint, event, now);
+    const options = generateFetchOptions(endpoint, { ...event, tenantID }, now);
 
     // Send the request.
     const startedSendingAt = getNow();

--- a/src/core/server/queue/tasks/webhook/processor.ts
+++ b/src/core/server/queue/tasks/webhook/processor.ts
@@ -87,6 +87,7 @@ type CoralWebhookEventPayload = CoralEventPayload & {
    * tenantID is the ID of the Tenant that this event originated at.
    */
   readonly tenantID: string;
+
   /**
    * tenantDomain is the domain that is associated with this Tenant that this event originated at.
    */

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -66,7 +66,7 @@ export async function findOrCreate(
   scraper: ScraperQueue,
   now = new Date()
 ) {
-  let siteID = "";
+  let siteID = null;
   if (input.url) {
     const site = await findSiteByURL(mongo, tenant.id, input.url);
     // If the URL is provided, and the url is not associated with a site, then refuse
@@ -94,8 +94,7 @@ export async function findOrCreate(
     StoryCreatedCoralEvent.publish(broker, {
       storyID: story.id,
       storyURL: story.url,
-      tenantID: tenant.id,
-      siteID,
+      siteID: story.siteID,
     });
   }
 
@@ -224,7 +223,6 @@ export async function create(
   StoryCreatedCoralEvent.publish(broker, {
     storyID: story.id,
     storyURL: story.url,
-    tenantID: tenant.id,
     siteID: site.id,
   });
 

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -66,7 +66,7 @@ export async function findOrCreate(
   scraper: ScraperQueue,
   now = new Date()
 ) {
-  let siteID = null;
+  let siteID = "";
   if (input.url) {
     const site = await findSiteByURL(mongo, tenant.id, input.url);
     // If the URL is provided, and the url is not associated with a site, then refuse
@@ -94,6 +94,8 @@ export async function findOrCreate(
     StoryCreatedCoralEvent.publish(broker, {
       storyID: story.id,
       storyURL: story.url,
+      tenantID: tenant.id,
+      siteID,
     });
   }
 
@@ -222,6 +224,8 @@ export async function create(
   StoryCreatedCoralEvent.publish(broker, {
     storyID: story.id,
     storyURL: story.url,
+    tenantID: tenant.id,
+    siteID: site.id,
   });
 
   return story;


### PR DESCRIPTION
## What does this PR do?
When you have multiple Talk instances running, it seems to make sense to specify from which tenant a given event was sent.

This PR add `tenantDomain`  to `StoryCreatedCoralEventPayload`.

## How do I test this PR?
Create a webhook, access some story and look at the request body.
