### PR TITLE
Add Brazilian Portuguese case to generate Regular Expression of banned/suspect word list

### DIFF
--- a/src/core/client/admin/components/ModerateCard/CommentContent.spec.tsx
+++ b/src/core/client/admin/components/ModerateCard/CommentContent.spec.tsx
@@ -38,3 +38,37 @@ it("renders empty words correctly", () => {
   renderer.render(<CommentContent {...props} />);
   expect(renderer.getRenderOutput()).toMatchSnapshot();
 });
+
+it("renders correctly in Brazilian Portuguese: it doesn't treat accented characters as word separators", () => {
+  const props: PropTypesOf<typeof CommentContent> = {
+    phrases: {
+      locale: "pt-BR",
+      wordList: {
+        suspect: ["anual"],
+        banned: ["bi", "ESTRANHO"],
+      },
+    },
+    className: "custom",
+    children: "O biólogo analisou o caso.bi Mas não foi ao evento biánual",
+  };
+  const renderer = createRenderer();
+  renderer.render(<CommentContent {...props} />);
+  expect(renderer.getRenderOutput()).toMatchSnapshot();
+});
+
+it("renders empty words correctly in Brazilian Portuguese", () => {
+  const props: PropTypesOf<typeof CommentContent> = {
+    phrases: {
+      locale: "pt-BR",
+      wordList: {
+        suspect: [],
+        banned: [],
+      },
+    },
+    className: "custom",
+    children: "Olá <b>Bob</b>, você é um cara mau",
+  };
+  const renderer = createRenderer();
+  renderer.render(<CommentContent {...props} />);
+  expect(renderer.getRenderOutput()).toMatchSnapshot();
+});

--- a/src/core/client/admin/components/ModerateCard/__snapshots__/CommentContent.spec.tsx.snap
+++ b/src/core/client/admin/components/ModerateCard/__snapshots__/CommentContent.spec.tsx.snap
@@ -11,12 +11,34 @@ exports[`renders correctly 1`] = `
 />
 `;
 
+exports[`renders correctly in Brazilian Portuguese: it doesn't treat accented characters as word separators 1`] = `
+<div
+  className="custom CommentContent-root"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<span>O biólogo analisou o caso.<mark>bi</mark> Mas não foi ao evento biánual</span>",
+    }
+  }
+/>
+`;
+
 exports[`renders empty words correctly 1`] = `
 <div
   className="custom CommentContent-root"
   dangerouslySetInnerHTML={
     Object {
       "__html": "Hello <b>Bob</b>, you bad guy",
+    }
+  }
+/>
+`;
+
+exports[`renders empty words correctly in Brazilian Portuguese 1`] = `
+<div
+  className="custom CommentContent-root"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "Olá <b>Bob</b>, você é um cara mau",
     }
   }
 />

--- a/src/core/common/utils/createWordListRegExp.ts
+++ b/src/core/common/utils/createWordListRegExp.ts
@@ -15,8 +15,15 @@ const DefaultWordListRule: WordListRule = {
   whitespace: "\\s+",
 };
 
+const BrazilianPortugueseWordListRule: WordListRule = {
+  split: "[^a-zÀ-ÿ]",
+  punctuation: '[\\s"?!.]+',
+  whitespace: "\\s+",
+};
+
 const WordListRules: DeepPartial<Record<LanguageCode, WordListRule>> = {
   "en-US": DefaultWordListRule,
+  "pt-BR": BrazilianPortugueseWordListRule,
 };
 
 /**

--- a/src/core/server/services/comments/pipeline/wordList.spec.ts
+++ b/src/core/server/services/comments/pipeline/wordList.spec.ts
@@ -80,3 +80,59 @@ describe("en-US", () => {
     });
   });
 });
+
+describe("pt-BR", () => {
+  const list = new WordList();
+  const options: Options = {
+    id: "tenant_1",
+    locale: "pt-BR",
+    wordList: {
+      banned: ["bi", "outro", "café", "m e r d a", "Como fazer coisas ruins"],
+      suspect: [],
+    },
+  };
+
+  describe("containsMatchingPhrase", () => {
+    it("does match on a word in the list (considering Brazilian Portuguese accented characters not to be word separators)", () => {
+      [
+        "biólogo se soletra com: bi ",
+        "m.e.r.d.a",
+        "não tomo café pois faz mal",
+        "Como fazer coisas ruins",
+      ].forEach(word => {
+        expect(list.test(options, "banned", word)).toEqual(true);
+      });
+    });
+
+    it("does not match on a word not in the list", () => {
+      [
+        "O biólogo recomenda este artigo",
+        "cafe",
+        "Ser banido é uma merda",
+      ].forEach(word => {
+        expect(list.test(options, "banned", word)).toEqual(false);
+      });
+    });
+
+    it("allows an empty list", () => {
+      expect(list.test(options, "banned", "test")).toEqual(false);
+    });
+  });
+
+  describe("containsMatchingPhraseMemoized", () => {
+    it("return true for all cases after memoizing the first result", () => {
+      [
+        "bi 1",
+        "bi 2",
+        "bi 4",
+        "bi 5",
+        "this is for bi 6",
+        "this is for bi 7",
+        "this is for bi 8",
+        "this is for bi 9",
+      ].forEach(word => {
+        expect(list.test(options, "banned", word)).toEqual(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?
This PR adds the a custom rule to generate a regular expression of banned/suspect words for Brazilian Portuguese comments. It's needed to accented characters are not considered word separators, as commented in issue #2840 .
<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?
None.
<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?
You can set up Coral Talk to be in "pt-BR" language. Add some banned words and check comments with them being rejected. Also, try to reproduce the problem described in the issue #2840 , as it won't happen anymore.
<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
