### PR TITLE
Fix banned words RegExp so consecutive banned words display properly in moderation view

### DIFF
--- a/src/core/client/admin/components/ModerateCard/CommentContent.spec.tsx
+++ b/src/core/client/admin/components/ModerateCard/CommentContent.spec.tsx
@@ -22,6 +22,24 @@ it("renders correctly", () => {
   expect(renderer.getRenderOutput()).toMatchSnapshot();
 });
 
+it("renders correctly even if it has consecutive banned words on comments", () => {
+  const props: PropTypesOf<typeof CommentContent> = {
+    phrases: {
+      locale: "en-US",
+      wordList: {
+        suspect: ["worse"],
+        banned: ["bad"],
+      },
+    },
+    className: "custom",
+    children:
+      "This is a very long comment with bad words. Let's try bad and bad. Now bad bad.\nBad BAD bad.\n",
+  };
+  const renderer = createRenderer();
+  renderer.render(<CommentContent {...props} />);
+  expect(renderer.getRenderOutput()).toMatchSnapshot();
+});
+
 it("renders empty words correctly", () => {
   const props: PropTypesOf<typeof CommentContent> = {
     phrases: {

--- a/src/core/client/admin/components/ModerateCard/CommentContent.tsx
+++ b/src/core/client/admin/components/ModerateCard/CommentContent.tsx
@@ -37,10 +37,10 @@ function markPhrasesHTML(text: string, expression: RegExp) {
   return tokens
     .map((token, i) =>
       // Using our Regexp patterns it returns tokens arranged this way
-      // [STRING_WITH_NO_MATCH, NEW_WORD_DELIMITER, MATCHED_WORD, ...].
+      // [STRING_WITH_NO_MATCH, MATCHED_WORD, ...].
       // This pattern repeats throughout. Next line will mark MATCHED_WORD
       // and escape all tokens.
-      i % 3 === 2 ? `<mark>${escapeHTML(token)}</mark>` : escapeHTML(token)
+      i % 2 === 1 ? `<mark>${escapeHTML(token)}</mark>` : escapeHTML(token)
     )
     .join("");
 }

--- a/src/core/client/admin/components/ModerateCard/__snapshots__/CommentContent.spec.tsx.snap
+++ b/src/core/client/admin/components/ModerateCard/__snapshots__/CommentContent.spec.tsx.snap
@@ -11,6 +11,19 @@ exports[`renders correctly 1`] = `
 />
 `;
 
+exports[`renders correctly even if it has consecutive banned words on comments 1`] = `
+<div
+  className="custom CommentContent-root"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<span>This is a very long comment with <mark>bad</mark> words. Let's try <mark>bad</mark> and <mark>bad</mark>. Now <mark>bad</mark> <mark>bad</mark>.
+<mark>Bad</mark> <mark>BAD</mark> <mark>bad</mark>.
+</span>",
+    }
+  }
+/>
+`;
+
 exports[`renders empty words correctly 1`] = `
 <div
   className="custom CommentContent-root"

--- a/src/core/common/utils/createWordListRegExp.ts
+++ b/src/core/common/utils/createWordListRegExp.ts
@@ -65,7 +65,7 @@ export default function createWordListRegExp(
     .join("|");
 
   // Wrap the pattern in split rules.
-  const pattern = `(^|${rule.split})(${words})($|${rule.split})`;
+  const pattern = `(?<=^|${rule.split})(${words})(?=$|${rule.split})`;
 
   try {
     return new RegExp(pattern, "iu");


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?
It changes regular expression for  matching banned/suspect words in comments, as detailed in #2908 . The current regular expression does match correctly banned/suspect words, however, it captures (returns as a match) separators around banned words. Take this regular expression for banned words `bad` and `worse`:

`/(^|[^\w])(bad|worse)($|[^\w])/iu`

It has two three groups that returns their matches: `(^|[^\w])`, `(bad|worse)` and `($|[^\w])`, being the first and last one for word separators (spaces, line breaks, etc).

A problem arises when we call `split` (as it happens in `CommentContent`, line 33) to separate comment text  in smaller parts according to this regular expression, because since these are _groups_, they'll return their matches for word separators as well. Let's suppose we have the following comment:

`Hey, I'm bad bad, very bad`

Now let's try to reproduce this `split` logic: 

![image](https://user-images.githubusercontent.com/5360796/77565440-015fc680-6ea3-11ea-9b1f-13b017b38551.png)

The array returned isn't in the format expected in the expected format `[STRING_WITH_NO_MATCH, NEW_WORD_DELIMITER, MATCHED_WORD, ...]` in `CommentContent`. This is happening because spaces are being returned as well.

To overcome this limitation, I changed the logic a little bit, so instead of using groups, I'm using a positive lookahead (?= ...) and positive lookbehind (?<= ...) in regular expression. For this example, that would be:

`(?<=^|[^\w])(bad|worse)(?=$|[^\w])`

This way, I'm not returning word separators as a match, but just using them to check if banned words are surrounded by word separators. If I do this, `split` would work like this:

![image](https://user-images.githubusercontent.com/5360796/77566184-10934400-6ea4-11ea-82fe-85544874edc8.png)

No matter if I have consecutive words or not, I'll always have this structure in array: `[STRING_WITH_NO_MATCH, MATCHED_WORD, ...]`. That's what this PR does, it marks banned words according to this new regular expression / split logic.


<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?
None.
<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?
Try typing consecutive banned words and see if they are marked correctly in Moderate section.
<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
