### PR TITLE
[CORL-992] update click to copy link button styles

### DIFF
--- a/src/core/client/admin/components/ModerateCard/LinkDetailsContainer.css
+++ b/src/core/client/admin/components/ModerateCard/LinkDetailsContainer.css
@@ -9,8 +9,3 @@
   display: inline-block;
   padding-right: var(--spacing-2);
 }
-
-.button {
-  border-bottom-left-radius: 0px;
-  border-bottom-right-radius: 0px;
-}

--- a/src/core/client/admin/components/ModerateCard/LinkDetailsContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/LinkDetailsContainer.tsx
@@ -5,7 +5,7 @@ import CopyToClipboard from "react-copy-to-clipboard";
 import { getURLWithCommentID } from "coral-framework/helpers";
 import { graphql, withFragmentContainer } from "coral-framework/lib/relay";
 import { getLocationOrigin } from "coral-framework/utils";
-import { Button, Icon } from "coral-ui/components";
+import { Button, Icon } from "coral-ui/components/v2";
 
 import { LinkDetailsContainer_comment } from "coral-admin/__generated__/LinkDetailsContainer_comment.graphql";
 import { LinkDetailsContainer_settings } from "coral-admin/__generated__/LinkDetailsContainer_settings.graphql";
@@ -32,12 +32,7 @@ const LinkDetailsContainer: FunctionComponent<Props> = ({
         <CopyToClipboard
           text={getURLWithCommentID(comment.story.url, comment.id)}
         >
-          <Button
-            color="primary"
-            variant="filled"
-            size="small"
-            className={styles.button}
-          >
+          <Button>
             <Icon size="md">link</Icon>
             <Localized id="moderate-in-stream-link-copy">
               <span>In Stream</span>
@@ -49,12 +44,7 @@ const LinkDetailsContainer: FunctionComponent<Props> = ({
         <CopyToClipboard
           text={`${getLocationOrigin()}/admin/moderate/comment/${comment.id}`}
         >
-          <Button
-            color="primary"
-            variant="filled"
-            size="small"
-            className={styles.button}
-          >
+          <Button>
             <Icon size="md">link</Icon>
             <Localized id="moderate-in-moderation-link-copy">
               <span>In Moderation</span>


### PR DESCRIPTION
## What does this PR do?
Updates the copy link to comment components to use the redesigned buttons with the correct colours.

![image](https://user-images.githubusercontent.com/1789029/77683202-70eeb800-6f6e-11ea-97c1-2d81e89e1e27.png)


## What changes to the GraphQL/Database Schema does this PR introduce?
none

## How do I test this PR?

click "details" on a moderation card