### PR TITLE
[CORL-991] remove 'mailto:' prefix from links

### DIFF
--- a/src/core/common/utils/__snapshots__/purify.spec.ts.snap
+++ b/src/core/common/utils/__snapshots__/purify.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`allows anchor links 1`] = `
 Object {
-  "body": "<a href=\\"test\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">test</a>",
+  "body": "<a href=\\"http://test.com\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">http://test.com</a>",
   "linkCount": 1,
 }
 `;

--- a/src/core/common/utils/purify.spec.ts
+++ b/src/core/common/utils/purify.spec.ts
@@ -26,7 +26,10 @@ it("sanitizes out attributes not allowed", () => {
 
 it("allows anchor links", () => {
   expect(
-    sanitizeCommentBody(DOMPurify, '<a href="test">This is a link</a>')
+    sanitizeCommentBody(
+      DOMPurify,
+      '<a href="http://test.com">This is a link</a>'
+    )
   ).toMatchSnapshot();
 });
 

--- a/src/core/common/utils/purify.ts
+++ b/src/core/common/utils/purify.ts
@@ -1,6 +1,7 @@
 import createDOMPurify from "dompurify";
 
 type DOMPurify = ReturnType<typeof createDOMPurify>;
+const MAILTO_PROTOCOL = "mailto:";
 
 export function createPurify(window: Window, returnDOM = true) {
   // Initializing JSDOM and DOMPurify
@@ -26,8 +27,15 @@ export function createPurify(window: Window, returnDOM = true) {
       node.setAttribute("rel", "noopener noreferrer");
 
       // Ensure that all the links have the same link as they do text.
-      const href = node.getAttribute("href");
-      if (node.textContent !== href) {
+      let href = node.getAttribute("href");
+      if (href) {
+        if (node.textContent !== href) {
+          // remove "mailto:" prefix from link text
+          const url = new URL(href);
+          if (url.protocol === MAILTO_PROTOCOL) {
+            href = href.replace(url.protocol, "");
+          }
+        }
         node.textContent = href;
       }
     } else {


### PR DESCRIPTION
## What does this PR do?
custom code in our dompurify configuration was ensuring that link text matched the href value, which meant that mailto links would have the `mailto:` prefix in the text, which is confusing for users. This adds a check for mailto links, and removes the prefix from the link text. 

## What changes to the GraphQL/Database Schema does this PR introduce?
none

## How do I test this PR?
add a comment with an email address included in plain text.