### PR TITLE
[CORL-997] Removed crossorigin attribute for custom CSS

### DIFF
--- a/src/core/server/app/views/client.html
+++ b/src/core/server/app/views/client.html
@@ -11,7 +11,7 @@
     {% endfor %}
   {% endif %}
   {% if enableCustomCSS and tenant and tenant.customCSSURL %}
-    {{ macros.preload(tenant.customCSSURL, "style", crossorigin = true) }}
+    {{ macros.preload(tenant.customCSSURL, "style") }}
   {% endif %}
   {% if entrypoint.js %}
     {% for asset in entrypoint.js %}

--- a/src/core/server/app/views/macros.html
+++ b/src/core/server/app/views/macros.html
@@ -1,9 +1,5 @@
-{% macro preload(src, htmlAs, prefix = "", crossorigin = false) %}
-  {% if crossorigin %}
-    <link rel="preload" href="{{ prefix }}{{ src }}" as="{{ htmlAs }}" crossorigin>
-  {% else %}
-    <link rel="preload" href="{{ prefix }}{{ src }}" as="{{ htmlAs }}">
-  {% endif %}
+{% macro preload(src, htmlAs, prefix = "") %}
+  <link rel="preload" href="{{ prefix }}{{ src }}" as="{{ htmlAs }}">
 {% endmacro %}
 
 {% macro css(src, integrity = "", prefix = "") %}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

Removes the [`crossorigin`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) attribute for custom css stylesheets. It was incorrectly assumed that the `crossorigin` attribute would assist in the stylesheet requests, but it actually muddles the behaviour to cause CORS errors.

Note that this does not address cross-origin fonts, this is an ongoing issue.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

None

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

Add a stylesheet from an external domain and notice no errors.