### PR TITLE
fix error thrown attempting to remove announcements

### DIFF
--- a/src/core/server/graph/resolvers/Mutation.ts
+++ b/src/core/server/graph/resolvers/Mutation.ts
@@ -257,6 +257,7 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
   }),
   deleteAnnouncement: async (source, { input }, ctx) => ({
     settings: await ctx.mutators.Settings.deleteAnnouncement(),
+    clientMutationId: input.clientMutationId,
   }),
   createSite: async (source, { input }, ctx) => ({
     site: await ctx.mutators.Sites.create(input),


### PR DESCRIPTION
I think this probably got messed up in a merge conflict. 
