### PR TITLE
[CORL-1040] Story Update Fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,11 @@
-const typescriptEslintRecommended = require('@typescript-eslint/eslint-plugin/dist/configs/eslint-recommended').default.overrides[0];
-const typescriptRecommended = require('@typescript-eslint/eslint-plugin/dist/configs/recommended.json');
-const typescriptRecommendedTypeChecking = require('@typescript-eslint/eslint-plugin/dist/configs/recommended-requiring-type-checking.json');
-const typescriptEslintPrettier = require('eslint-config-prettier/@typescript-eslint');
-const react = require('eslint-plugin-react').configs.recommended;
-const jsxA11y = require('eslint-plugin-jsx-a11y').configs.recommended;
-const reactPrettier = require('eslint-config-prettier/react');
+const typescriptEslintRecommended = require("@typescript-eslint/eslint-plugin/dist/configs/eslint-recommended")
+  .default.overrides[0];
+const typescriptRecommended = require("@typescript-eslint/eslint-plugin/dist/configs/recommended.json");
+const typescriptRecommendedTypeChecking = require("@typescript-eslint/eslint-plugin/dist/configs/recommended-requiring-type-checking.json");
+const typescriptEslintPrettier = require("eslint-config-prettier/@typescript-eslint");
+const react = require("eslint-plugin-react").configs.recommended;
+const jsxA11y = require("eslint-plugin-jsx-a11y").configs.recommended;
+const reactPrettier = require("eslint-config-prettier/react");
 
 const typescriptOverrides = {
   files: ["*.ts", "*.tsx"],
@@ -24,7 +25,7 @@ const typescriptOverrides = {
   settings: {
     react: {
       version: "detect",
-    }
+    },
   },
   rules: Object.assign(
     typescriptEslintRecommended.rules,
@@ -36,7 +37,10 @@ const typescriptOverrides = {
     {
       "@typescript-eslint/adjacent-overload-signatures": "error",
       // TODO: (cvle) change `readonly` param to `array-simple` when upgraded typescript.
-      "@typescript-eslint/array-type": ["error", { "default": "array-simple", "readonly": "generic"}],
+      "@typescript-eslint/array-type": [
+        "error",
+        { default: "array-simple", readonly: "generic" },
+      ],
       "@typescript-eslint/ban-types": "error",
       "@typescript-eslint/camelcase": "off",
       "@typescript-eslint/consistent-type-assertions": "error",
@@ -46,8 +50,8 @@ const typescriptOverrides = {
       "@typescript-eslint/explicit-member-accessibility": [
         "error",
         {
-          "overrides": {
-            "constructors": "off",
+          overrides: {
+            constructors: "off",
           },
         },
       ],
@@ -61,7 +65,10 @@ const typescriptOverrides = {
       "@typescript-eslint/no-namespace": "error",
       "@typescript-eslint/no-non-null-assertion": "off",
       "@typescript-eslint/no-parameter-properties": "off",
-      "@typescript-eslint/no-unused-vars": ["error", {"args": "none", "ignoreRestSiblings": true}],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { args: "none", ignoreRestSiblings: true },
+      ],
       "@typescript-eslint/no-use-before-define": "off", // TODO: (cvle) Should be on?
       "@typescript-eslint/no-use-before-declare": "off",
       "@typescript-eslint/no-var-requires": "error",
@@ -85,17 +92,21 @@ const typescriptOverrides = {
 let typescriptTypeCheckingOverrides = {
   files: ["*.ts", "*.tsx"],
   parserOptions: {
-    project: ["./tsconfig.json", "./src/tsconfig.json", "./src/core/client/tsconfig.json"],
+    project: [
+      "./tsconfig.json",
+      "./src/tsconfig.json",
+      "./src/core/client/tsconfig.json",
+    ],
     // TODO: (cvle) this is a workaround, see: https://github.com/typescript-eslint/typescript-eslint/issues/1091.
     createDefaultProgram: true,
   },
-  rules: Object.assign(
-    typescriptRecommendedTypeChecking.rules,
-    {
-      "@typescript-eslint/tslint/config": ["error", {
-        "rules": {
+  rules: Object.assign(typescriptRecommendedTypeChecking.rules, {
+    "@typescript-eslint/tslint/config": [
+      "error",
+      {
+        rules: {
           "ordered-imports": {
-            "options": {
+            options: {
               // Legacy sorting until this is fixed: https://github.com/SoominHan/import-sorter/issues/60
               "import-sources-order": "case-insensitive-legacy",
               "module-source-path": "full",
@@ -103,14 +114,14 @@ let typescriptTypeCheckingOverrides = {
             },
           },
         },
-      }],
-      // 28.11.19: (cvle) Disabled because behavior of regexp.exec seems different than str.match?
-      "@typescript-eslint/prefer-regexp-exec": "off",
-      "@typescript-eslint/require-await": "off",
-      "@typescript-eslint/no-misused-promises": "off",
-      "@typescript-eslint/unbound-method": "off", // 10.10.19: (cvle) seems to give false positive.
-    }
-  ),
+      },
+    ],
+    // 28.11.19: (cvle) Disabled because behavior of regexp.exec seems different than str.match?
+    "@typescript-eslint/prefer-regexp-exec": "off",
+    "@typescript-eslint/require-await": "off",
+    "@typescript-eslint/no-misused-promises": "off",
+    "@typescript-eslint/unbound-method": "off", // 10.10.19: (cvle) seems to give false positive.
+  }),
 };
 
 const jestOverrides = {
@@ -119,8 +130,8 @@ const jestOverrides = {
   },
   files: ["test/**/*.ts", "test/**/*.tsx"],
   globals: {
-    "expectAndFail": "readonly",
-    "fail": "readonly",
+    expectAndFail: "readonly",
+    fail: "readonly",
   },
 };
 
@@ -144,22 +155,19 @@ module.exports = {
     "plugin:prettier/recommended",
   ],
   parserOptions: {
-    "ecmaVersion": 2018,
+    ecmaVersion: 2018,
   },
   rules: {
     "arrow-body-style": "off",
-    "arrow-parens": [
-      "off",
-      "as-needed",
-    ],
-    "camelcase": "off",
-    "complexity": "off",
+    "arrow-parens": ["off", "as-needed"],
+    camelcase: "off",
+    complexity: "off",
     "constructor-super": "error",
     "spaced-comment": ["error", "always"],
-    "curly": "error",
+    curly: "error",
     "dot-notation": "error",
     "eol-last": "off",
-    "eqeqeq": "error",
+    eqeqeq: "error",
     "guard-for-in": "error",
     "jsdoc/require-jsdoc": "off",
     "jsdoc/require-returns": "off",
@@ -167,10 +175,7 @@ module.exports = {
     "jsdoc/require-param-type": "off",
     "jsdoc/require-returns-type": "off",
     "linebreak-style": "off",
-    "max-classes-per-file": [
-      "error",
-      1,
-    ],
+    "max-classes-per-file": ["error", 1],
     "member-ordering": "off",
     "new-parens": "off",
     "newline-per-chained-call": "off",
@@ -187,7 +192,7 @@ module.exports = {
     "no-irregular-whitespace": "off",
     "no-multiple-empty-lines": "off",
     "no-new-wrappers": "error",
-    "no-prototype-builtins": "off",
+    "no-prototype-builtins": "error",
     "no-shadow": "error",
     "no-throw-literal": "error",
     "no-undef": "off",
@@ -195,14 +200,14 @@ module.exports = {
     "no-unsafe-finally": "error",
     "no-unused-expressions": "error",
     "no-unused-labels": "error",
-    "no-unused-vars": ["error", {"args": "none", "ignoreRestSiblings": true}],
+    "no-unused-vars": ["error", { args: "none", ignoreRestSiblings: true }],
     "no-var": "error",
     "object-shorthand": "error",
     "one-var": "off",
     "prefer-arrow-callback": "off",
     "prefer-const": "error",
     "quote-props": "off",
-    "radix": "error",
+    radix: "error",
     "require-atomic-updates": "off",
     "space-before-function-paren": "off",
     "sort-imports": "off",

--- a/src/core/client/framework/lib/network/persistedQueriesGetMethodMiddleware.ts
+++ b/src/core/client/framework/lib/network/persistedQueriesGetMethodMiddleware.ts
@@ -31,7 +31,7 @@ const persistedQueriesGetMethodMiddleware: Middleware = (next) => async (
     // Rebuild the query parameters for GET.
     const params: Record<string, string> = { query: "" };
     for (const key in body) {
-      if (!body.hasOwnProperty(key)) {
+      if (!Object.prototype.hasOwnProperty.call(body, key)) {
         continue;
       }
 

--- a/src/core/common/utils/dotize.ts
+++ b/src/core/common/utils/dotize.ts
@@ -45,7 +45,7 @@ function reduce({
 
   if (isObject(obj)) {
     for (const property in obj) {
-      if (!obj.hasOwnProperty(property)) {
+      if (!Object.prototype.hasOwnProperty.call(obj, property)) {
         continue;
       }
 

--- a/src/core/server/app/helpers/entrypoints.ts
+++ b/src/core/server/app/helpers/entrypoints.ts
@@ -37,7 +37,7 @@ export default class Entrypoints {
 
   constructor(manifest: Manifest) {
     for (const entry in manifest.entrypoints) {
-      if (!manifest.entrypoints.hasOwnProperty(entry)) {
+      if (!Object.prototype.hasOwnProperty.call(manifest.entrypoints, entry)) {
         continue;
       }
 
@@ -47,7 +47,12 @@ export default class Entrypoints {
 
       // Itterate over the extension's in the entrypoint.
       for (const extension in manifest.entrypoints[entry]) {
-        if (!manifest.entrypoints[entry].hasOwnProperty(extension)) {
+        if (
+          !Object.prototype.hasOwnProperty.call(
+            manifest.entrypoints[entry],
+            extension
+          )
+        ) {
           continue;
         }
 
@@ -61,7 +66,10 @@ export default class Entrypoints {
         for (const src of assets) {
           // Search for the entry in the assets.
           for (const name in manifest) {
-            if (name !== "entrypoints" && !manifest.hasOwnProperty(name)) {
+            if (
+              name !== "entrypoints" &&
+              !Object.prototype.hasOwnProperty.call(manifest, name)
+            ) {
               continue;
             }
 

--- a/src/core/server/graph/errors.ts
+++ b/src/core/server/graph/errors.ts
@@ -20,7 +20,7 @@ export async function mapFieldsetToErrorCodes<T>(
     if (err instanceof CoralError) {
       // Then loop over all the fieldSpecs...
       for (const param in errorMap) {
-        if (!errorMap.hasOwnProperty(param)) {
+        if (!Object.prototype.hasOwnProperty.call(errorMap, param)) {
           continue;
         }
 

--- a/src/core/server/graph/persisted/loader.ts
+++ b/src/core/server/graph/persisted/loader.ts
@@ -36,7 +36,7 @@ export function loadPersistedQueries(): PersistedQuery[] {
     // Go over each of the persisted queries and collect the ID and query to
     // merge in.
     for (const id in persistedQueries) {
-      if (!persistedQueries.hasOwnProperty(id)) {
+      if (!Object.prototype.hasOwnProperty.call(persistedQueries, id)) {
         continue;
       }
 

--- a/src/core/server/models/action/comment.ts
+++ b/src/core/server/models/action/comment.ts
@@ -464,7 +464,7 @@ export function invertEncodedActionCounts(
   actionCounts: EncodedCommentActionCounts
 ): EncodedCommentActionCounts {
   for (const key in actionCounts) {
-    if (!actionCounts.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(actionCounts, key)) {
       continue;
     }
 

--- a/src/core/server/models/comment/counts/counts.ts
+++ b/src/core/server/models/comment/counts/counts.ts
@@ -101,7 +101,7 @@ export function mergeCommentStatusCount(
   const mergedStatusCounts = createEmptyCommentStatusCounts();
   for (const commentCounts of statusCounts) {
     for (const status in commentCounts) {
-      if (!commentCounts.hasOwnProperty(status)) {
+      if (!Object.prototype.hasOwnProperty.call(commentCounts, status)) {
         continue;
       }
 
@@ -147,7 +147,7 @@ export function calculateTotalCommentCount(
 ): number {
   let count = 0;
   for (const status in commentCounts) {
-    if (!commentCounts.hasOwnProperty(status)) {
+    if (!Object.prototype.hasOwnProperty.call(commentCounts, status)) {
       continue;
     }
 

--- a/src/core/server/models/comment/counts/shared.ts
+++ b/src/core/server/models/comment/counts/shared.ts
@@ -126,7 +126,7 @@ function fillAndConvertStringToNumber<
 >(input: T, initial: U): U {
   const result: U = Object.assign({}, initial);
   for (const key in input) {
-    if (!input.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(input, key)) {
       continue;
     }
 

--- a/src/core/server/services/stories/scraper/scraper.ts
+++ b/src/core/server/services/stories/scraper/scraper.ts
@@ -51,7 +51,7 @@ class Scraper {
 
     for (const rule of this.rules) {
       for (const property in rule) {
-        if (!rule.hasOwnProperty(property)) {
+        if (!Object.prototype.hasOwnProperty.call(rule, property)) {
           continue;
         }
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

It turns out, when some queries are formatted in a particular way, `graphql` will create javascript `Object`'s with `Object.create(null)` (ref: https://github.com/graphql/graphql-js/pull/504) even though this practice is discouraged (ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create).

This causes issues when you try to call prototype builtin's like `hasOwnProperty` on objects created this way.

This PR adjusts the linting rule for the [`no-prototype-builtins`](https://eslint.org/docs/rules/no-prototype-builtins) rule to prevent us from using these builtins to prevent this from causing issues in the future.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

None.

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

Previously, the following GraphQL mutation would return an error:

```graphql
mutation ($id: ID!, $url: String) {
  updateStory(input: {id: $id, story: {url: $url}, clientMutationId: ""}) {
    story {
      id
      url
    }
  }
}
```

Now, it does not. The is because the object created in `{url: $url}` is via `Object.create(null)`. Now that we no longer use prototype builtin's, we don't encounter this bug.