### PR TITLE
[CORL-1050] Add Perspective toxicity support for fr and pt

### DIFF
--- a/src/core/server/services/perspective/perspective.ts
+++ b/src/core/server/services/perspective/perspective.ts
@@ -12,7 +12,7 @@ const fetch = createFetch({ name: "perspective" });
  * Language is the language key that is supported by the Perspective API in the
  * ISO 631-1 format.
  */
-type PerspectiveLanguage = "en" | "es" | "fr" | "de";
+type PerspectiveLanguage = "en" | "es" | "fr" | "de" | "pt";
 
 /**
  * convertLanguage returns the language code for the related Perspective API
@@ -26,8 +26,12 @@ function convertLanguage(locale: LanguageCode): PerspectiveLanguage {
       return "en";
     case "es":
       return "es";
+    case "fr-FR":
+      return "fr";
     case "de":
       return "de";
+    case "pt-BR":
+      return "pt";
     default:
       return "en";
   }

--- a/src/core/server/services/perspective/perspective.ts
+++ b/src/core/server/services/perspective/perspective.ts
@@ -11,6 +11,9 @@ const fetch = createFetch({ name: "perspective" });
 /**
  * Language is the language key that is supported by the Perspective API in the
  * ISO 631-1 format.
+ *
+ * The current list of supported languages can be found:
+ *  https://github.com/conversationai/perspectiveapi/blob/master/2-api/models.md#languages-in-production
  */
 type PerspectiveLanguage = "en" | "es" | "fr" | "de" | "pt";
 


### PR DESCRIPTION
## What does this PR do?
- We automatically add Perspective language-based support according to the language that is selected for Coral
- This PR adds support for `fr-FR` and `pt-BR`, `fr` and `pt` in Perspective respectively

## What changes to the GraphQL/Database Schema does this PR introduce?
None

## How do I test this PR?
- Change the language in the ADMIN UI to French or Portuguese
- If Perspective is enabled, toxicity will work in that specific language