### PR TITLE
[CORL-987] Always show details on moderation card

### DIFF
--- a/src/core/client/admin/components/ModerateCard/MarkersContainer.spec.tsx
+++ b/src/core/client/admin/components/ModerateCard/MarkersContainer.spec.tsx
@@ -13,9 +13,6 @@ it("renders all markers", () => {
   const props: PropTypesOf<typeof MarkersContainerN> = {
     comment: {
       status: "PREMOD",
-      editing: {
-        edited: false,
-      },
       revision: {
         actionCounts: {
           flag: {
@@ -31,11 +28,6 @@ it("renders all markers", () => {
               COMMENT_DETECTED_NEW_COMMENTER: 0,
               COMMENT_DETECTED_REPEAT_POST: 1,
             },
-          },
-        },
-        metadata: {
-          perspective: {
-            score: 0,
           },
         },
       },
@@ -58,9 +50,6 @@ it("renders some markers", () => {
   const props: PropTypesOf<typeof MarkersContainerN> = {
     comment: {
       status: "PREMOD",
-      editing: {
-        edited: false,
-      },
       revision: {
         actionCounts: {
           flag: {
@@ -76,11 +65,6 @@ it("renders some markers", () => {
               COMMENT_DETECTED_NEW_COMMENTER: 0,
               COMMENT_DETECTED_REPEAT_POST: 0,
             },
-          },
-        },
-        metadata: {
-          perspective: {
-            score: 1,
           },
         },
       },

--- a/src/core/client/admin/components/ModerateCard/MarkersContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/MarkersContainer.tsx
@@ -17,14 +17,6 @@ interface MarkersContainerProps {
   settings: MarkersContainer_settings;
 }
 
-function hasDetails(c: MarkersContainer_comment) {
-  return c.revision
-    ? c.revision.actionCounts.flag.reasons.COMMENT_REPORTED_OFFENSIVE +
-        c.revision.actionCounts.flag.reasons.COMMENT_REPORTED_SPAM >
-        0 || c.revision.metadata.perspective
-    : false;
-}
-
 let keyCounter = 0;
 const markers: Array<(
   c: MarkersContainer_comment
@@ -135,25 +127,15 @@ export const MarkersContainer: React.FunctionComponent<MarkersContainerProps> = 
     () => markers.map((cb) => cb(props.comment)).filter((m) => m),
     [markers, props.comment]
   );
-  const doesHaveDetails = useMemo(() => hasDetails(props.comment), [
-    props.comment,
-  ]);
-  if (elements.length === 0 && !doesHaveDetails) {
-    return null;
-  }
 
   return (
     <Markers
       details={
-        doesHaveDetails || props.comment.editing.edited ? (
-          <ModerateCardDetailsContainer
-            hasDetails={!!doesHaveDetails}
-            hasRevisions={props.comment.editing.edited}
-            onUsernameClick={props.onUsernameClick}
-            comment={props.comment}
-            settings={props.settings}
-          />
-        ) : null
+        <ModerateCardDetailsContainer
+          onUsernameClick={props.onUsernameClick}
+          comment={props.comment}
+          settings={props.settings}
+        />
       }
     >
       {elements}
@@ -166,9 +148,6 @@ const enhanced = withFragmentContainer<MarkersContainerProps>({
     fragment MarkersContainer_comment on Comment {
       ...ModerateCardDetailsContainer_comment
       status
-      editing {
-        edited
-      }
       revision {
         actionCounts {
           flag {
@@ -184,11 +163,6 @@ const enhanced = withFragmentContainer<MarkersContainerProps>({
               COMMENT_DETECTED_NEW_COMMENTER
               COMMENT_DETECTED_REPEAT_POST
             }
-          }
-        }
-        metadata {
-          perspective {
-            score
           }
         }
       }

--- a/src/core/client/admin/components/ModerateCard/__snapshots__/MarkersContainer.spec.tsx.snap
+++ b/src/core/client/admin/components/ModerateCard/__snapshots__/MarkersContainer.spec.tsx.snap
@@ -6,9 +6,6 @@ exports[`renders all markers 1`] = `
     <Relay(ModerateCardDetailsContainer)
       comment={
         Object {
-          "editing": Object {
-            "edited": false,
-          },
           "revision": Object {
             "actionCounts": Object {
               "flag": Object {
@@ -26,17 +23,10 @@ exports[`renders all markers 1`] = `
                 },
               },
             },
-            "metadata": Object {
-              "perspective": Object {
-                "score": 0,
-              },
-            },
           },
           "status": "PREMOD",
         }
       }
-      hasDetails={true}
-      hasRevisions={false}
       onUsernameClick={[Function]}
       settings={
         Object {
@@ -161,9 +151,6 @@ exports[`renders some markers 1`] = `
     <Relay(ModerateCardDetailsContainer)
       comment={
         Object {
-          "editing": Object {
-            "edited": false,
-          },
           "revision": Object {
             "actionCounts": Object {
               "flag": Object {
@@ -181,17 +168,10 @@ exports[`renders some markers 1`] = `
                 },
               },
             },
-            "metadata": Object {
-              "perspective": Object {
-                "score": 1,
-              },
-            },
           },
           "status": "PREMOD",
         }
       }
-      hasDetails={true}
-      hasRevisions={false}
       onUsernameClick={[Function]}
       settings={
         Object {


### PR DESCRIPTION
## What does this PR do?
- Always show details on moderation card even if comment has no flags or toxicity score.

## How do I test this PR?
- Turn off toxicity checks, post a legitimate comment, details button should show on the moderation card
