### PR TITLE
[CORL-979] Auto-pause updates

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/CreateCommentReplyMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/CreateCommentReplyMutation.ts
@@ -136,6 +136,15 @@ const mutation = graphql`
           ...AllCommentsTabContainer_comment @relay(mask: false)
           id
           status
+          story {
+            settings {
+              # Load the story live settings so new comments can verify if live
+              # updates are still enabled (and enable then if they are).
+              live {
+                enabled
+              }
+            }
+          }
           parent {
             id
             tags {
@@ -233,6 +242,14 @@ async function commit(
                   reaction: false,
                   dontAgree: false,
                   flag: false,
+                },
+                story: {
+                  id: input.storyID,
+                  settings: {
+                    live: {
+                      enabled: storySettings.live.enabled,
+                    },
+                  },
                 },
                 replies: {
                   edges: [],

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
@@ -131,6 +131,15 @@ const mutation = graphql`
         node {
           ...AllCommentsTabContainer_comment @relay(mask: false)
           status
+          story {
+            settings {
+              # Load the story live settings so new comments can verify if live
+              # updates are still enabled (and enable then if they are).
+              live {
+                enabled
+              }
+            }
+          }
         }
       }
       clientMutationId
@@ -218,6 +227,14 @@ async function commit(
                 replies: {
                   edges: [],
                   pageInfo: { endCursor: null, hasNextPage: false },
+                },
+                story: {
+                  id: input.storyID,
+                  settings: {
+                    live: {
+                      enabled: storySettings.live.enabled,
+                    },
+                  },
                 },
                 deleted: false,
               },

--- a/src/core/client/stream/test/fixtures.ts
+++ b/src/core/client/stream/test/fixtures.ts
@@ -260,6 +260,41 @@ export const commenters = createFixtures<GQLUser>(
   baseUser
 );
 
+export const baseStory = createFixture<GQLStory>({
+  id: "story-0",
+  metadata: {
+    title: "title",
+  },
+  isClosed: false,
+  comments: {
+    edges: [],
+    pageInfo: {
+      hasNextPage: false,
+    },
+  },
+  commentCounts: {
+    totalPublished: 0,
+    tags: {
+      FEATURED: 0,
+      UNANSWERED: 0,
+    },
+  },
+  settings: {
+    moderation: GQLMODERATION_MODE.POST,
+    premodLinksEnable: false,
+    messageBox: {
+      enabled: false,
+    },
+    live: {
+      enabled: true,
+      configurable: true,
+    },
+    mode: GQLSTORY_MODE.COMMENTS,
+    experts: [],
+  },
+  site,
+});
+
 export const baseComment = createFixture<GQLComment>({
   author: commenters[0],
   body: "Comment Body",
@@ -279,6 +314,7 @@ export const baseComment = createFixture<GQLComment>({
       total: 0,
     },
   },
+  story: baseStory,
   parent: undefined,
   viewerActionPresence: { reaction: false, dontAgree: false, flag: false },
   tags: [],
@@ -513,40 +549,6 @@ export const commentWithDeepestReplies = denormalizeComment(
     },
   })
 );
-
-export const baseStory = createFixture<GQLStory>({
-  metadata: {
-    title: "title",
-  },
-  isClosed: false,
-  comments: {
-    edges: [],
-    pageInfo: {
-      hasNextPage: false,
-    },
-  },
-  commentCounts: {
-    totalPublished: 0,
-    tags: {
-      FEATURED: 0,
-      UNANSWERED: 0,
-    },
-  },
-  settings: {
-    moderation: GQLMODERATION_MODE.POST,
-    premodLinksEnable: false,
-    messageBox: {
-      enabled: false,
-    },
-    live: {
-      enabled: true,
-      configurable: true,
-    },
-    mode: GQLSTORY_MODE.COMMENTS,
-    experts: [],
-  },
-  site,
-});
 
 export const moderators = createFixtures<GQLUser>(
   [

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -217,6 +217,13 @@ const config = convict({
     default: false,
     env: "DISABLE_LIVE_UPDATES",
   },
+  disable_live_updates_timeout: {
+    doc:
+      "Disables subscriptions for the comment stream for all stories across all tenants where a comment has not been left within the timeout",
+    format: "ms",
+    default: "2 weeks",
+    env: "DISABLE_LIVE_UPDATES_TIMEOUT",
+  },
   disable_client_routes: {
     doc:
       "Disables mounting of client routes for developing with Webpack Dev Server",

--- a/src/core/server/graph/resolvers/LiveConfiguration.ts
+++ b/src/core/server/graph/resolvers/LiveConfiguration.ts
@@ -1,9 +1,14 @@
 import { isUndefined } from "lodash";
+import { DateTime } from "luxon";
 
-import { GQLLiveConfigurationTypeResolver } from "coral-server/graph/schema/__generated__/types";
 import * as settings from "coral-server/models/settings";
 
-export type LiveConfigurationInput = settings.LiveConfiguration;
+import { GQLLiveConfigurationTypeResolver } from "coral-server/graph/schema/__generated__/types";
+
+export interface LiveConfigurationInput extends settings.LiveConfiguration {
+  lastCommentedAt?: Date;
+  createdAt?: Date;
+}
 
 export const LiveConfiguration: GQLLiveConfigurationTypeResolver<LiveConfigurationInput> = {
   configurable: (source, args, ctx) =>
@@ -11,6 +16,32 @@ export const LiveConfiguration: GQLLiveConfigurationTypeResolver<LiveConfigurati
   enabled: (source, args, ctx) => {
     if (ctx.config.get("disable_live_updates")) {
       return false;
+    }
+
+    // This typecast is needed because the custom `ms` format does not return the
+    // desired `number` type even though that's the only type it can output.
+    const disableLiveUpdatesTimeout = (ctx.config.get(
+      "disable_live_updates_timeout"
+    ) as unknown) as number;
+    if (disableLiveUpdatesTimeout > 0) {
+      // If one of these is available, use it to determine the time since the
+      // last comment.
+      const lastCommentedAt = source.lastCommentedAt || source.createdAt;
+      if (
+        // If a date is found...
+        lastCommentedAt &&
+        // And the date (when we add the timeout duration) is before the current
+        // date...
+        DateTime.fromJSDate(lastCommentedAt)
+          .plus({
+            milliseconds: disableLiveUpdatesTimeout,
+          })
+          .toJSDate() <= ctx.now
+      ) {
+        // Then we know that the last comment (or lack there of) was left more
+        // than the timeout specified in configuration.
+        return false;
+      }
     }
 
     if (isUndefined(source.enabled)) {

--- a/src/core/server/graph/resolvers/Story.ts
+++ b/src/core/server/graph/resolvers/Story.ts
@@ -11,6 +11,7 @@ import {
 
 import { CommentCountsInput } from "./CommentCounts";
 import { storyModerationInputResolver } from "./ModerationQueues";
+import { StorySettingsInput } from "./StorySettings";
 
 export const Story: GQLStoryTypeResolver<story.Story> = {
   comments: (s, input, ctx) => ctx.loaders.Comments.forStory(s.id, input),
@@ -26,7 +27,16 @@ export const Story: GQLStoryTypeResolver<story.Story> = {
   commentCounts: (s): CommentCountsInput => s,
   // Merge tenant settings into the story settings so we can easily inherit the
   // options if they exist.
-  settings: (s, input, ctx) => defaultsDeep({}, s.settings, ctx.tenant),
+  settings: (s, input, ctx): StorySettingsInput =>
+    defaultsDeep(
+      {
+        // Pass these options as required by StorySettingsInput.
+        lastCommentedAt: s.lastCommentedAt,
+        createdAt: s.createdAt,
+      },
+      s.settings,
+      ctx.tenant
+    ),
   moderationQueues: storyModerationInputResolver,
   site: (s, input, ctx) => ctx.loaders.Sites.site.load(s.siteID),
 };

--- a/src/core/server/graph/resolvers/StorySettings.ts
+++ b/src/core/server/graph/resolvers/StorySettings.ts
@@ -7,8 +7,21 @@ import {
   GQLStorySettingsTypeResolver,
 } from "../schema/__generated__/types";
 
-export const StorySettings: GQLStorySettingsTypeResolver<story.StorySettings> = {
-  live: (s) => s.live || {},
+import { LiveConfigurationInput } from "./LiveConfiguration";
+
+export interface StorySettingsInput extends story.StorySettings {
+  lastCommentedAt?: Date;
+  createdAt?: Date;
+}
+
+export const StorySettings: GQLStorySettingsTypeResolver<StorySettingsInput> = {
+  live: (s): LiveConfigurationInput => ({
+    // Live may not be available sometimes, fix it here with the inline ||.
+    ...(s.live || { enabled: false }),
+    // Pass these options as required by LiveConfigurationInput.
+    lastCommentedAt: s.lastCommentedAt,
+    createdAt: s.createdAt,
+  }),
   moderation: (s, input, ctx) => s.moderation || ctx.tenant.moderation,
   premodLinksEnable: (s, input, ctx) =>
     s.premodLinksEnable || ctx.tenant.premodLinksEnable,

--- a/src/core/server/models/story/index.ts
+++ b/src/core/server/models/story/index.ts
@@ -48,11 +48,9 @@ export interface StreamModeSettings {
   expertIDs?: string[];
 }
 
-export type StorySettings = DeepPartial<
-  StreamModeSettings &
-    GlobalModerationSettings &
-    Pick<GQLStorySettings, "messageBox" | "mode" | "experts">
->;
+export type StorySettings = StreamModeSettings &
+  GlobalModerationSettings &
+  Pick<GQLStorySettings, "messageBox" | "mode" | "experts">;
 
 export type StoryMetadata = GQLStoryMetadata;
 
@@ -83,7 +81,7 @@ export interface Story extends TenantResource {
    * settings provides a point where the settings can be overridden for a
    * specific Story.
    */
-  settings: StorySettings;
+  settings: DeepPartial<StorySettings>;
 
   /**
    * closedAt is the date that the Story was forced closed at, or false to
@@ -378,7 +376,7 @@ export async function updateStory(
     throw err;
   }
 }
-export type UpdateStorySettingsInput = StorySettings;
+export type UpdateStorySettingsInput = DeepPartial<StorySettings>;
 
 export async function updateStorySettings(
   mongo: Db,


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

When a story has not received any comments within the timeout specified by `DISABLE_LIVE_UPDATES_TIMEOUT` (defaults to 2 weeks), live updates will be paused until the story receives a new comment. You can specify `0` to disable this feature.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

1. Visit a story that has not recieved a comment within 2 weeks. If you don't have one of these stories, update the `createdAt` date to be outside this window and remove the `lastCommentedAt` (if it exists).
2. Refresh the story page and see inside the web inspector that the `/live` endpoint does not appear.
3. Post a comment on this story, see the `/live` endpoint appear.
4. Refresh the page, and see the `/live` endpoint appear.