### PR TITLE
Add flag deleted with value "true" to comments of deleted users

### DIFF
--- a/src/core/server/graph/resolvers/Comment.ts
+++ b/src/core/server/graph/resolvers/Comment.ts
@@ -54,6 +54,7 @@ export const Comment: GQLCommentTypeResolver<comment.Comment> = {
       : null,
   revisionHistory: (c) =>
     c.revisions.map((revision) => ({ revision, comment: c })),
+  deleted: ({ deletedAt }) => !!deletedAt,
   editing: ({ revisions, createdAt }, input, ctx) => ({
     // When there is more than one body history, then the comment has been
     // edited.

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -2625,6 +2625,9 @@ type Comment {
   """
   deleted: Boolean
 
+  """
+  site is the Site referenced by the Story for this Comment.
+  """
   site: Site!
 }
 

--- a/src/core/server/services/users/delete.ts
+++ b/src/core/server/services/users/delete.ts
@@ -115,7 +115,6 @@ async function deleteUserComments(
         revisions: [],
         tags: [],
         deletedAt: now,
-        deleted: true,
       },
     }
   );

--- a/src/core/server/services/users/delete.ts
+++ b/src/core/server/services/users/delete.ts
@@ -115,6 +115,7 @@ async function deleteUserComments(
         revisions: [],
         tags: [],
         deletedAt: now,
+        deleted: true,
       },
     }
   );


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

We noticed that when user deleted their accounts, their deleted comments would appear like this on admin:

![image](https://user-images.githubusercontent.com/5360796/81073266-c6977800-8ebd-11ea-9c21-dcbe5d8e798b.png)

Moderator users were confused because these looked like empty comments. Besides, they couldn't approve or reject those comments to move them away.

After debugging, we noticed the problem was that the component `ModerateCard` expect a `deleted` flag to determine if the comment was deleted or not. However, deleted comments were not setting this flag. This PR sets this flag to `true` as the default behaviour. After doing this, we could see the message of deleted comment:

![image](https://user-images.githubusercontent.com/5360796/81073649-589f8080-8ebe-11ea-808e-d9748f0aa008.png)

Just to be clear, this PR is not directly related to issue https://github.com/coralproject/talk/issues/2951 created recently. It would be nice if deleted comments had a different behaviour, actually. But assuming this is the expected behaviour, this PR solves this bug :) 

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?
None. Actually, `deleted` field was already specified at GraphQL Schema. 

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?
Delete a user account without this PR to see the bug happening. Then, apply this PR changes and try to delete a user account or a comment again, and you can see comments appearing with a default "comment deleted" message

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
