### PR TITLE
Fix optmisticResponse bug when posting comment

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
@@ -232,7 +232,7 @@ async function commit(
                   id: input.storyID,
                   settings: {
                     live: {
-                      enabled: storySettings.live.enabled,
+                      enabled: Boolean(storySettings.live?.enabled),
                     },
                   },
                 },


### PR DESCRIPTION
## What does this PR do?
- Posting a comment without ever opening the _AllCommentsTab_ results in an error during the optimistic response. This patch fixes it. 

## How do I test this PR?
- Login, don't open _AllCommentsTab_, post a comment, it should work ;-)
