### PR TITLE
[CORL-1086] Support `bodyClassName` in embed

### DIFF
--- a/src/core/client/embed/Coral.ts
+++ b/src/core/client/embed/Coral.ts
@@ -15,8 +15,9 @@ export interface Config {
   autoRender?: boolean;
   events?: (eventEmitter: EventEmitter2) => void;
   accessToken?: string;
-  bodyClassName?: string;
   enableDeprecatedEvents?: boolean;
+  /** Allow setting className of body tag inside iframe */
+  bodyClassName?: string;
 }
 
 export function createStreamEmbed(config: Config): StreamEmbed {

--- a/src/core/client/embed/Coral.ts
+++ b/src/core/client/embed/Coral.ts
@@ -15,6 +15,7 @@ export interface Config {
   autoRender?: boolean;
   events?: (eventEmitter: EventEmitter2) => void;
   accessToken?: string;
+  bodyClassName?: string;
   enableDeprecatedEvents?: boolean;
 }
 
@@ -37,6 +38,7 @@ export function createStreamEmbed(config: Config): StreamEmbed {
     autoRender: config.autoRender,
     eventEmitter,
     accessToken: config.accessToken,
+    bodyClassName: config.bodyClassName,
     enableDeprecatedEvents: config.enableDeprecatedEvents,
   });
 }

--- a/src/core/client/embed/StreamEmbed.ts
+++ b/src/core/client/embed/StreamEmbed.ts
@@ -33,6 +33,7 @@ export interface StreamEmbedConfig {
   id: string;
   rootURL: string;
   accessToken?: string;
+  bodyClassName?: string;
   enableDeprecatedEvents?: boolean;
 }
 
@@ -131,6 +132,7 @@ export class StreamEmbed {
 
     const externalConfig: ExternalConfig = {
       accessToken: this.config.accessToken,
+      bodyClassName: this.config.bodyClassName,
     };
 
     const streamDecorators: ReadonlyArray<Decorator> = [

--- a/src/core/client/embed/decorators/withConfig.spec.ts
+++ b/src/core/client/embed/decorators/withConfig.spec.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import withConfig from "./withConfig";
 
 it("should emit events from pym to Config", () => {
-  const config = { accessToken: "token" };
+  const config = { accessToken: "token", bodyClassName: "custom" };
   const fakePym = {
     onMessage: (type: string, callback: () => void) => {
       expect(type).toBe("getConfig");

--- a/src/core/client/framework/lib/externalConfig.ts
+++ b/src/core/client/framework/lib/externalConfig.ts
@@ -4,6 +4,7 @@ import { areWeInIframe } from "coral-framework/utils";
 
 export interface ExternalConfig {
   accessToken?: string;
+  bodyClassName?: string;
 }
 
 export function getExternalConfig(

--- a/src/core/client/stream/local/initLocalState.ts
+++ b/src/core/client/stream/local/initLocalState.ts
@@ -18,8 +18,14 @@ export default async function initLocalState(
   auth?: AuthState
 ) {
   const config = await getExternalConfig(context.pym);
-  if (config && config.accessToken) {
-    auth = storeAccessToken(config.accessToken);
+  if (config) {
+    if (config.accessToken) {
+      auth = storeAccessToken(config.accessToken);
+    }
+    // append body class name if set in config.
+    if (config.bodyClassName) {
+      document.body.classList.add(config.bodyClassName);
+    }
   }
 
   initLocalBaseState(environment, context, auth);


### PR DESCRIPTION
## What does this PR do?
- Support parameter `bodyClassName` in embed configuration. Class name will be attached to `body` tag in the iframe.
- This parameter can be used to e.g. support theming like darkmode

## How do I test this PR?
```ts
const CoralStreamEmbed = Coral.createStreamEmbed({
  id: "coralStreamEmbed",
  bodyClassName: "custom-class",
});
```