### PR TITLE
[CORL-1121] Remove username validation when updated by admin

### DIFF
--- a/src/core/common/helpers/validate.ts
+++ b/src/core/common/helpers/validate.ts
@@ -1,7 +1,6 @@
 import url from "url-regex";
 
 export const USERNAME_REGEX = new RegExp(/^[a-zA-ZÀ-ÖØ-öø-ÿ0-9_.]+$/);
-export const SSO_USERNAME_REGEX = new RegExp(/^[a-zA-ZÀ-ÖØ-öø-ÿ0-9_.\s]+$/);
 export const USERNAME_MAX_LENGTH = 30;
 export const USERNAME_MIN_LENGTH = 3;
 

--- a/src/core/common/helpers/validate.ts
+++ b/src/core/common/helpers/validate.ts
@@ -1,6 +1,7 @@
 import url from "url-regex";
 
 export const USERNAME_REGEX = new RegExp(/^[a-zA-ZÀ-ÖØ-öø-ÿ0-9_.]+$/);
+export const SSO_USERNAME_REGEX = new RegExp(/^[a-zA-ZÀ-ÖØ-öø-ÿ0-9_.\s]+$/);
 export const USERNAME_MAX_LENGTH = 30;
 export const USERNAME_MIN_LENGTH = 3;
 

--- a/src/core/server/services/users/helpers.ts
+++ b/src/core/server/services/users/helpers.ts
@@ -5,7 +5,6 @@ import {
   USERNAME_MIN_LENGTH,
   USERNAME_REGEX,
 } from "coral-common/helpers/validate";
-
 import {
   EmailExceedsMaxLengthError,
   EmailInvalidFormatError,
@@ -22,10 +21,12 @@ import {
  *
  * @param username the username to be tested
  */
-export function validateUsername(username: string) {
+export function validateUsername(username: string, userNameRegex?: RegExp) {
   // TODO: replace these static regex/length with database options in the Tenant eventually
 
-  if (!USERNAME_REGEX.test(username)) {
+  if (userNameRegex && !userNameRegex.test(username)) {
+    throw new UsernameContainsInvalidCharactersError();
+  } else if (!userNameRegex && !USERNAME_REGEX.test(username)) {
     throw new UsernameContainsInvalidCharactersError();
   }
 

--- a/src/core/server/services/users/helpers.ts
+++ b/src/core/server/services/users/helpers.ts
@@ -21,12 +21,10 @@ import {
  *
  * @param username the username to be tested
  */
-export function validateUsername(username: string, userNameRegex?: RegExp) {
+export function validateUsername(username: string) {
   // TODO: replace these static regex/length with database options in the Tenant eventually
 
-  if (userNameRegex && !userNameRegex.test(username)) {
-    throw new UsernameContainsInvalidCharactersError();
-  } else if (!userNameRegex && !USERNAME_REGEX.test(username)) {
+  if (!USERNAME_REGEX.test(username)) {
     throw new UsernameContainsInvalidCharactersError();
   }
 

--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -8,6 +8,7 @@ import {
   DOWNLOAD_LIMIT_TIMEFRAME_DURATION,
   SCHEDULED_DELETION_WINDOW_DURATION,
 } from "coral-common/constants";
+import { SSO_USERNAME_REGEX } from "coral-common/helpers";
 import { Config } from "coral-server/config";
 import {
   DuplicateEmailError,
@@ -631,7 +632,7 @@ export async function updateUsernameByID(
   createdBy: User
 ) {
   // Validate the username.
-  validateUsername(username);
+  validateUsername(username, SSO_USERNAME_REGEX);
 
   return updateUserUsername(mongo, tenant.id, userID, username, createdBy.id);
 }

--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -8,7 +8,6 @@ import {
   DOWNLOAD_LIMIT_TIMEFRAME_DURATION,
   SCHEDULED_DELETION_WINDOW_DURATION,
 } from "coral-common/constants";
-import { SSO_USERNAME_REGEX } from "coral-common/helpers";
 import { Config } from "coral-server/config";
 import {
   DuplicateEmailError,
@@ -631,9 +630,6 @@ export async function updateUsernameByID(
   username: string,
   createdBy: User
 ) {
-  // Validate the username.
-  validateUsername(username, SSO_USERNAME_REGEX);
-
   return updateUserUsername(mongo, tenant.id, userID, username, createdBy.id);
 }
 


### PR DESCRIPTION
## What does this PR do?

Applies no validation when an admin updates a username.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

Use the following mutation:

```
mutation ($id: ID!, $name: String!, $clientMutationId: String!) {
  updateUserUsername(
    input: {
      userID: $id,
      username: $name,
      clientMutationId: $clientMutationId
    })
      {
        user {
          id
          username
        }
      }
}
```

where:
- `$id` is some valid userID.
- `$name` is a username with spaces in it.
- `$clientMutationId` is `"1"`
