### PR TITLE
[CORL-1122] Clear session token on tenant install

### DIFF
--- a/src/core/client/install/App/InstallMutation.ts
+++ b/src/core/client/install/App/InstallMutation.ts
@@ -2,6 +2,7 @@ import { Environment } from "relay-runtime";
 
 import { CoralContext } from "coral-framework/lib/bootstrap";
 import { createMutationContainer } from "coral-framework/lib/relay";
+import { SetAccessTokenMutation } from "coral-framework/mutations";
 import { install, InstallInput } from "coral-framework/rest";
 
 export type InstallMutation = (input: InstallInput) => Promise<void>;
@@ -9,9 +10,10 @@ export type InstallMutation = (input: InstallInput) => Promise<void>;
 export async function commit(
   environment: Environment,
   input: InstallInput,
-  { rest }: CoralContext
+  ctx: CoralContext
 ) {
-  await install(rest, input);
+  await install(ctx.rest, input);
+  await SetAccessTokenMutation.commit(environment, { accessToken: "" }, ctx);
 }
 
 export const withInstallMutation = createMutationContainer("install", commit);


### PR DESCRIPTION
## What does this PR do?

After we're done installing the first tenant + site, sign out the access token that was used.

The token that is signed in during install is a one-time token for install.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

Do a tenant install. Go to admin and see that you're logged out and not seeing a network error.
