### PR TITLE
[v4] fix: Pin node-gyp to address issue building on Node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            yarn global add node-gyp &&
+            yarn global add node-gyp@6.1.0 &&
             yarn install --frozen-lockfile
       - save_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ ARG REVISION_HASH
 ENV REVISION_HASH=${REVISION_HASH}
 
 # Install app dependencies and build static assets.
-RUN yarn global add node-gyp && \
+# Pin node-gyp@6.1.0 as newer versions do not build on Node 8.
+RUN yarn global add node-gyp@6.1.0 && \
     yarn install --frozen-lockfile && \
     yarn build && \
     yarn cache clean


### PR DESCRIPTION
This PR fixes https://github.com/coralproject/talk/issues/2941 - an issue that is causing Talk v4 to not be able to build as newer versions of `node-gyp` require Node versions 10 or higher.
