### PR TITLE
[CORL-1174] Set height on iframe embeds in moderate cards

### DIFF
--- a/src/core/client/admin/components/ModerateCard/YouTubeMedia.tsx
+++ b/src/core/client/admin/components/ModerateCard/YouTubeMedia.tsx
@@ -50,7 +50,8 @@ const YouTubeMedia: FunctionComponent<Props> = ({
       {showAnimated && (
         <iframe
           frameBorder="0"
-          width={width || 450}
+          width={width || 480}
+          height={height || 270}
           allowFullScreen
           title="oEmbed"
           src={`/api/oembed?type=youtube&url=${cleanUrl}&siteID=${siteID}`}

--- a/src/core/server/app/handlers/api/oembed/oembed.ts
+++ b/src/core/server/app/handlers/api/oembed/oembed.ts
@@ -1,5 +1,4 @@
 import Joi from "@hapi/joi";
-import { stripIndent } from "common-tags";
 
 import { validate } from "coral-server/app/request/body";
 import { supportsMediaType } from "coral-server/models/tenant";
@@ -92,7 +91,7 @@ export const oembedHandler = (): RequestHandler => {
 
       // Send back the HTML for the oEmbed.
       res.send(
-        stripIndent`<html>
+        `<html>
           <style>
             ${style}
           </style>


### PR DESCRIPTION


## What does this PR do?
sets height if available on youtube iframe embeds in moderate cards

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## How do I test this PR?
