### PR TITLE
[CORL-1179] Enforce max width/auto scroll on mod card embeds

### DIFF
--- a/src/core/client/admin/components/ModerateCard/GiphyMedia.tsx
+++ b/src/core/client/admin/components/ModerateCard/GiphyMedia.tsx
@@ -28,7 +28,13 @@ const GiphyMedia: FunctionComponent<Props> = ({
     <div className={styles.embed}>
       {!showAnimated && still && (
         <BaseButton onClick={toggleImage} className={styles.toggle}>
-          <img src={still} className={styles.image} alt={title || ""} />
+          <img
+            src={still}
+            className={styles.image}
+            width={width || undefined}
+            height={height || undefined}
+            alt={title || ""}
+          />
           <Flex
             direction="column"
             alignItems="center"
@@ -47,8 +53,10 @@ const GiphyMedia: FunctionComponent<Props> = ({
       {showAnimated && video && (
         <BaseButton onClick={toggleImage}>
           <video
+            className={styles.image}
             width={width || undefined}
             height={height || undefined}
+            title={title || ""}
             autoPlay
             loop
           >

--- a/src/core/client/admin/components/ModerateCard/Media.css
+++ b/src/core/client/admin/components/ModerateCard/Media.css
@@ -1,5 +1,10 @@
 .embed {
   margin: var(--spacing-2) 0;
+
+  max-width: 100%;
+  & > iframe {
+    max-width: 100%;
+  }
 }
 
 .toggle {
@@ -30,4 +35,5 @@
 
 .image {
   display: block;
+  max-width: 100%;
 }


### PR DESCRIPTION
Some gifs are too wide for the mod cards. Set
a max-width and allow it to scroll if it exceeds
the set width.

<img width="846" alt="image" src="https://user-images.githubusercontent.com/5751504/87595816-633f7880-c6ac-11ea-8b57-f2f759cf1a07.png">
