### PR TITLE
[CORL-1186] Tweak up indent level padding/margins

### DIFF
--- a/src/core/client/stream/tabs/Comments/Indent.css
+++ b/src/core/client/stream/tabs/Comments/Indent.css
@@ -1,40 +1,40 @@
-.root {
-}
+.root {}
 
-.collapsed {
-}
+.collapsed {}
 
-.open {
+.open {}
+
+.openPadded {
   padding-left: var(--spacing-1);
 }
 
 .level1 {
-  margin-left: var(--spacing-5);
+  margin-left: var(--spacing-3);
   border-left: 2px solid var(--palette-grey-600);
 }
 
 .level2 {
-  margin-left: calc(var(--spacing-5) + var(--spacing-2));
+  margin-left: calc(2 * var(--spacing-3));
   border-left: 2px solid var(--palette-grey-500);
 }
 
 .level3 {
-  margin-left: calc(var(--spacing-5) + 2 * var(--spacing-2));
+  margin-left: calc(3 * var(--spacing-3));
   border-left: 2px solid #8e9ba5;
 }
 
 .level4 {
-  margin-left: calc(var(--spacing-5) + 3 * var(--spacing-2));
+  margin-left: calc(4 * var(--spacing-3));
   border-left: 2px solid #b8bcbd;
 }
 
 .level5 {
-  margin-left: calc(var(--spacing-5) + 4 * var(--spacing-2));
+  margin-left: calc(5 * var(--spacing-3));
   border-left: 2px solid #cccfd0;
 }
 
 .level6 {
-  margin-left: calc(var(--spacing-5) + 5 * var(--spacing-2));
+  margin-left: calc(6 * var(--spacing-3));
   border-left: 2px solid #e1e2e3;
 }
 

--- a/src/core/client/stream/tabs/Comments/Indent.tsx
+++ b/src/core/client/stream/tabs/Comments/Indent.tsx
@@ -38,6 +38,8 @@ const Indent: FunctionComponent<IndentProps> = (props) => {
           [styles.noBorder]: props.noBorder,
           [styles.collapsed]: props.collapsed,
           [styles.open]: !props.collapsed,
+          [styles.openPadded]:
+            !props.collapsed && props.level ? props.level > 0 : false,
         })}
       >
         {props.children}

--- a/src/core/client/stream/tabs/Comments/__snapshots__/Indent.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/__snapshots__/Indent.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`renders level1 1`] = `
   className="Indent-root"
 >
   <div
-    className="Indent-level1 coral coral-indent coral-indent-1 Indent-open"
+    className="Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
   >
     <div>
       Hello World
@@ -33,7 +33,7 @@ exports[`renders without border 1`] = `
   className="Indent-root"
 >
   <div
-    className="Indent-level1 coral coral-indent coral-indent-1 Indent-noBorder Indent-open"
+    className="Indent-level1 coral coral-indent coral-indent-1 Indent-noBorder Indent-open Indent-openPadded"
   >
     <div>
       Hello World

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
@@ -913,7 +913,7 @@ exports[`renders permalink view 1`] = `
                   className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
                 >
                   <div
-                    className="Indent-level1 coral coral-indent coral-indent-1 Indent-open"
+                    className="Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
                   >
                     <div
                       className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -1205,7 +1205,7 @@ exports[`renders permalink view 1`] = `
                   className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
                 >
                   <div
-                    className="Indent-level1 coral coral-indent coral-indent-1 Indent-open"
+                    className="Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
                   >
                     <div
                       className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`post a reply: open reply form 1`] = `
       className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
     >
       <div
-        className="Indent-level3 coral coral-indent coral-indent-3 Indent-open"
+        className="Indent-level3 coral coral-indent coral-indent-3 Indent-open Indent-openPadded"
       >
         <div
           className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -497,7 +497,7 @@ exports[`post a reply: optimistic response 1`] = `
           className="IndentedComment-open IndentedComment-blur coral coral-comment-collapse-toggle-indent Indent-root"
         >
           <div
-            className="Indent-level3 coral coral-indent coral-indent-3 Indent-open"
+            className="Indent-level3 coral coral-indent coral-indent-3 Indent-open Indent-openPadded"
           >
             <div
               className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -1071,7 +1071,7 @@ exports[`renders comment stream 1`] = `
                 className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
               >
                 <div
-                  className="Indent-level1 coral coral-indent coral-indent-1 Indent-open"
+                  className="Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
                 >
                   <div
                     className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -1368,7 +1368,7 @@ exports[`renders comment stream 1`] = `
                       className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
                     >
                       <div
-                        className="Indent-level2 coral coral-indent coral-indent-2 Indent-open"
+                        className="Indent-level2 coral coral-indent coral-indent-2 Indent-open Indent-openPadded"
                       >
                         <div
                           className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -1665,7 +1665,7 @@ exports[`renders comment stream 1`] = `
                             className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
                           >
                             <div
-                              className="Indent-level3 coral coral-indent coral-indent-3 Indent-open"
+                              className="Indent-level3 coral coral-indent coral-indent-3 Indent-open Indent-openPadded"
                             >
                               <div
                                 className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
@@ -453,7 +453,7 @@ exports[`post a reply: optimistic response 1`] = `
           className="IndentedComment-open IndentedComment-blur coral coral-comment-collapse-toggle-indent Indent-root"
         >
           <div
-            className="Indent-level1 coral coral-indent coral-indent-1 Indent-open"
+            className="Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
           >
             <div
               className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders reply list 1`] = `
           className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
         >
           <div
-            className="Indent-level1 coral coral-indent coral-indent-1 Indent-open"
+            className="Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
           >
             <div
               className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -318,7 +318,7 @@ exports[`renders reply list 1`] = `
                 className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
               >
                 <div
-                  className="Indent-level2 coral coral-indent coral-indent-2 Indent-open"
+                  className="Indent-level2 coral coral-indent coral-indent-2 Indent-open Indent-openPadded"
                 >
                   <div
                     className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -610,7 +610,7 @@ exports[`renders reply list 1`] = `
                 className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
               >
                 <div
-                  className="Indent-level2 coral coral-indent coral-indent-2 Indent-open"
+                  className="Indent-level2 coral coral-indent coral-indent-2 Indent-open Indent-openPadded"
                 >
                   <div
                     className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -905,7 +905,7 @@ exports[`renders reply list 1`] = `
           className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
         >
           <div
-            className="Indent-level1 coral coral-indent coral-indent-1 Indent-open"
+            className="Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
           >
             <div
               className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/showAllReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/showAllReplies.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders comment stream 1`] = `
           className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
         >
           <div
-            className="Indent-level1 coral coral-indent coral-indent-1 Indent-open"
+            className="Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
           >
             <div
               className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
@@ -276,7 +276,7 @@ exports[`renders comment stream 1`] = `
     className="Indent-root"
   >
     <div
-      className="Indent-level1 coral coral-indent coral-indent-1 Indent-noBorder Indent-open"
+      className="Indent-level1 coral coral-indent coral-indent-1 Indent-noBorder Indent-open Indent-openPadded"
     >
       <button
         aria-controls="coral-comments-replyList-log--comment-0"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/showConversation.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/showConversation.spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`renders deepest comment with link 1`] = `
       className="IndentedComment-open coral coral-comment-collapse-toggle-indent Indent-root"
     >
       <div
-        className="Indent-level3 coral coral-indent coral-indent-3 Indent-open"
+        className="Indent-level3 coral coral-indent coral-indent-3 Indent-open Indent-openPadded"
       >
         <div
           className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"


### PR DESCRIPTION
## What does this PR do?

Reduces the comment indent margins (not the tiered padding, but the offset on it) to better fit comments on smaller screens.

Also removes a small pad on the left of the comment when the vertical bar isn't visible so top level comments get a few more pixels breathing room.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Load the comment stream
- Switch to mobile views
- See that it looks better and less squished

## Preview

<img width="313" alt="image" src="https://user-images.githubusercontent.com/5751504/87697553-75bebe00-c74f-11ea-858d-80475c653e41.png">
