### PR TITLE
[CORL-1184] Replace Dashboard - staff comments icon

### DIFF
--- a/src/core/client/admin/routes/Dashboard/components/TodayDashboardBox.tsx
+++ b/src/core/client/admin/routes/Dashboard/components/TodayDashboardBox.tsx
@@ -9,7 +9,7 @@ import Loader from "./Loader";
 import styles from "./TodayDashboardBox.css";
 
 interface Props {
-  icon: "forum" | "close" | "badge" | "person_add" | "block";
+  icon: "forum" | "close" | "recent_actors" | "person_add" | "block";
   loading: boolean;
 }
 
@@ -28,7 +28,7 @@ const TodayDashboardBox: FunctionComponent<Props> = ({
             className={cn(styles.icon, {
               [styles.tealIcon]: icon === "forum",
               [styles.redIcon]: icon === "close" || icon === "block",
-              [styles.greyIcon]: icon === "badge",
+              [styles.greyIcon]: icon === "recent_actors",
               [styles.blueIcon]: icon === "person_add",
             })}
           >

--- a/src/core/client/admin/routes/Dashboard/sections/Today.tsx
+++ b/src/core/client/admin/routes/Dashboard/sections/Today.tsx
@@ -89,7 +89,10 @@ const TodayTotals: FunctionComponent<Props> = ({ siteID, lastUpdated }) => {
             </Localized>
           </TodayCompareValue>
         </TodayDashboardBox>
-        <TodayDashboardBox icon="badge" loading={loading || totalLoading}>
+        <TodayDashboardBox
+          icon="recent_actors"
+          loading={loading || totalLoading}
+        >
           <TodayValue value={today?.comments.staff.toString()}>
             <Localized id="dashboard-today-staff-comments">
               Staff comments


### PR DESCRIPTION
## What does this PR do?

Swaps out the `badge` icon for `recent_actors` since badge is no longer available in the material icons collection.

## What changes to the GraphQL/Database Schema does this PR introduce?

No

## How do I test this PR?

Go to the Dashboard and see that all the icons are showing.

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/5751504/87699128-a7d11f80-c751-11ea-9b77-e30ac19db67e.png">

