### PR TITLE
[CORL-1191] Show rejected message when replying with banned word

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/ReplyEditSubmitStatus.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReplyEditSubmitStatus.tsx
@@ -23,8 +23,22 @@ function getMessage(
     case "RETRY":
       throw new Error(`Invalid status ${status}`);
     case "REJECTED":
-    // TODO: Show a different message when rejected?
-    // falls through
+      return (
+        <CallOut
+          className={cn(inReviewClassName)}
+          color="negative"
+          icon={<Icon size="sm">error</Icon>}
+          onClose={onDismiss}
+          titleWeight="semiBold"
+          title={
+            <Localized id="comments-submitStatus-submittedAndRejected">
+              <span>
+                This comment has been rejected for violating our guidelines
+              </span>
+            </Localized>
+          }
+        />
+      );
     case "IN_REVIEW":
       return (
         <CallOut


### PR DESCRIPTION
## What does this PR do?

Implements the proper callout for when a user submits a comment with a banned word when replying to another comment.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Ensure you have some banned words set in Admin > Config
- Reply to a comment with a banned word
- See the proper error message: `This comment has been rejected for violating our guidelines`
