### PR TITLE
[CORL-1172] Send staff comments to Slack with all comments enabled

### DIFF
--- a/src/core/server/events/listeners/slack/slack.ts
+++ b/src/core/server/events/listeners/slack/slack.ts
@@ -34,9 +34,9 @@ export class SlackCoralEventListener
    * postMessage will prepare and send the incoming Slack webhook.
    *
    * @param hookURL url to the Slack webhook that we should send the message to
-   * @param blocks the blocks for the message
+   * @param content the content for the message
    */
-  private async postMessage(hookURL: string, blocks: any[]) {
+  private async postMessage(hookURL: string, content: any) {
     // Send the post to the Slack URL. We don't wrap this in a try/catch because
     // it's handled in the calling function.
     const res = await this.fetch(hookURL, {
@@ -44,9 +44,7 @@ export class SlackCoralEventListener
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        blocks,
-      }),
+      body: JSON.stringify(content),
     });
 
     // Check that the request was completed successfully.
@@ -131,7 +129,7 @@ export class SlackCoralEventListener
       if (publishEvent.shouldPublishToChannel(channel)) {
         try {
           // Post the message to slack.
-          await this.postMessage(channel.hookURL, publishEvent.getBlocks(ctx));
+          await this.postMessage(channel.hookURL, publishEvent.getContent(ctx));
         } catch (err) {
           logger.error(
             { err, tenantID, payload, channel },


### PR DESCRIPTION
## What does this PR do?

When we set up a Slack channel, you can select to have
"All comments" sent to the slack channel. If we do this
we want staff comments to come through as well.

This wasn't happening before because there is a `staffCreated`
flag instead of `created` when a staff member comments.

So we change the trigger return type to an array, and when
a staff comment appears, return `staffCreated` as well as
`created` so the all filter lets it through.

I also changed `getBlocks(...)` to `getContent(...)` as it
now returns a JSON object with both a `blocks` array and a
`text` string field. This fixes the problem where Slack would
notifications would say "this content cannot be displayed".
Now it will say the text provided.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Create or update an existing slack channel
- Set it to only have `All comments` checked under the channel options
- Post a comment as a staff user
- See it show up in Slack