### PR TITLE
[CORL-1199] Show nice error message on network time out

### DIFF
--- a/src/core/client/framework/components/NetworkError.css
+++ b/src/core/client/framework/components/NetworkError.css
@@ -1,0 +1,13 @@
+.root {
+  background-color: var(--palette-error-300);
+
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-semi-bold);
+  font-size: var(--font-size-3);
+  line-height: var(--line-height-3);
+  color: var(--palette-text-500);
+
+  border-radius: var(--round-corners);
+
+  padding: var(--spacing-3);
+}

--- a/src/core/client/framework/components/NetworkError.tsx
+++ b/src/core/client/framework/components/NetworkError.tsx
@@ -1,0 +1,16 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent } from "react";
+
+import styles from "./NetworkError.css";
+
+const NetworkError: FunctionComponent = () => {
+  return (
+    <div className={styles.root}>
+      <Localized id="common-networkError">
+        <div>Network error. Please refresh your page and try again.</div>
+      </Localized>
+    </div>
+  );
+};
+
+export default NetworkError;

--- a/src/core/client/framework/lib/relay/QueryRenderer.tsx
+++ b/src/core/client/framework/lib/relay/QueryRenderer.tsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { QueryRenderer } from "react-relay";
 import { OperationType } from "relay-runtime";
 
+import NetworkError from "coral-framework/components/NetworkError";
 import { PropTypesOf } from "coral-framework/types";
 
 import { CoralContextConsumer } from "../bootstrap/CoralContext";
@@ -33,7 +34,20 @@ class CoralQueryRenderer<
     return (
       <CoralContextConsumer>
         {({ relayEnvironment }) => (
-          <QueryRenderer environment={relayEnvironment} {...this.props} />
+          <QueryRenderer
+            environment={relayEnvironment}
+            {...this.props}
+            render={(args) => {
+              if (
+                args.error &&
+                args.error.name === "RRNLRetryMiddlewareError"
+              ) {
+                return <NetworkError />;
+              }
+
+              return this.props.render(args);
+            }}
+          />
         )}
       </CoralContextConsumer>
     );

--- a/src/locales/en-US/common.ftl
+++ b/src/locales/en-US/common.ftl
@@ -7,3 +7,4 @@ common-banEmailTemplate =
   Someone with access to your account has violated our community guidelines. As a result, your account has been banned. You will no longer be able to comment, react or report comments.
 
 common-embedNotFound = Requested media could not be found. May have been deleted.
+common-networkError = Network error. Please refresh your page and try again.


### PR DESCRIPTION
## What does this PR do?

Shows "Network error. Please refresh your page and try again." when the retry middleware times out from too many attempts on failed/timed out requests.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Add the following function above `retrieveCommentConnection` in `comment.ts` (line 655)

```
function sleep(ms: number) {
  return new Promise((resolve) => setTimeout(resolve, ms));
}
```

- Inside of `retrieveCommentConnection`, before `return retrieveConnection(input, query);` (line 668) put the following:

```
await sleep(60000);
```

- Load up the stream and wait for the error to show up inside a nice callout.

Note: you can use the `sleep` function to time out any request you want, feel free to test the other query renderer's that have this network error check implemented.