### PR TITLE
remove debug style from comment stream

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.css
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.css
@@ -1,9 +1,3 @@
-.stream > *(:first-child):not(button) {
-  border-top: 0 !important;
-  /* border-bottom: 1px solid var(--palette-divider);
-  padding-top: var(--spacing-3); */
-}
-
 .borderedComment {
   border-bottom: 1px solid var(--palette-divider);
 }

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -165,7 +165,6 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = (props) => {
         role="log"
         aria-live="polite"
         size="oneAndAHalf"
-        className={styles.stream}
       >
         {comments.length <= 0 && (
           <NoComments

--- a/src/core/client/stream/test/comments/stream/__snapshots__/loadMore.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/loadMore.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders comment stream with load more button 1`] = `
 <div
   aria-live="polite"
-  className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
   data-testid="comments-allComments-log"
   id="comments-allComments-log"
   role="log"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
@@ -782,7 +782,7 @@ exports[`post a reply: optimistic response 1`] = `
 exports[`renders comment stream 1`] = `
 <div
   aria-live="polite"
-  className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
   data-testid="comments-allComments-log"
   id="comments-allComments-log"
   role="log"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderCommunityGuidelines.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderCommunityGuidelines.spec.tsx.snap
@@ -288,7 +288,7 @@ exports[`renders comment stream with community guidelines 1`] = `
       >
         <div
           aria-live="polite"
-          className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
           data-testid="comments-allComments-log"
           id="comments-allComments-log"
           role="log"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
@@ -233,7 +233,7 @@ exports[`renders message box when commenting disabled 1`] = `
       >
         <div
           aria-live="polite"
-          className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
           data-testid="comments-allComments-log"
           id="comments-allComments-log"
           role="log"
@@ -573,7 +573,7 @@ exports[`renders message box when logged in 1`] = `
       >
         <div
           aria-live="polite"
-          className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
           data-testid="comments-allComments-log"
           id="comments-allComments-log"
           role="log"
@@ -888,7 +888,7 @@ exports[`renders message box when not logged in 1`] = `
       >
         <div
           aria-live="polite"
-          className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
           data-testid="comments-allComments-log"
           id="comments-allComments-log"
           role="log"
@@ -1132,7 +1132,7 @@ exports[`renders message box when story isClosed 1`] = `
       >
         <div
           aria-live="polite"
-          className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
           data-testid="comments-allComments-log"
           id="comments-allComments-log"
           role="log"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderStream.spec.tsx.snap
@@ -326,7 +326,7 @@ exports[`renders comment stream 1`] = `
           >
             <div
               aria-live="polite"
-              className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+              className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
               data-testid="comments-allComments-log"
               id="comments-allComments-log"
               role="log"

--- a/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders app with comment stream 1`] = `
 <div
   aria-live="polite"
-  className="Box-root HorizontalGutter-root AllCommentsTabContainer-stream HorizontalGutter-oneAndAHalf"
+  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
   data-testid="comments-allComments-log"
   id="comments-allComments-log"
   role="log"


### PR DESCRIPTION
## What does this PR do?

removes an override style that removed the top border from the "no comments" callout. Not certain what the origin of this style is, probably leftover from pre-6.3 styles. 

## What changes to the GraphQL/Database Schema does this PR introduce?
none