### PR TITLE
[CORL-1214] fix logic around repeat posts with or without media embeds:

### DIFF
--- a/src/core/server/services/comments/pipeline/phases/repeatPost.ts
+++ b/src/core/server/services/comments/pipeline/phases/repeatPost.ts
@@ -57,6 +57,13 @@ export const repeatPost: IntermediateModerationPhase = async ({
       // Giphy is enabled. If the medias are the same, then this is a repeat
       // comment otherwise they are not.
       if (
+        (!lastCommentRevision.media && !media) ||
+        (lastCommentRevision.media && !media)
+      ) {
+        // comment body was the same and neither comment has media OR the previous
+        // comment had media but the current one does not
+        similarity = true;
+      } else if (
         // Check to see if the last comment revision has a Giphy Media
         // object.
         lastCommentRevision.media &&
@@ -76,7 +83,7 @@ export const repeatPost: IntermediateModerationPhase = async ({
       }
     } else {
       // Body text was the same and Giphy support was not enabled.
-      similarity = false;
+      similarity = true;
     }
 
     if (similarity) {


### PR DESCRIPTION
## What does this PR do?

fixes some incorrect logic for determining if a post is a repeat post 

## What changes to the GraphQL/Database Schema does this PR introduce?
none

## How do I test this PR?
- enable gif support
- attempt to post the same text comment twice in a row. Second should withheld.
- attempt to post a comment with the same text and same gif twice in a row. second should be withheld.
- attempt to post a comment with the same text and a different gif. should not be withheld.
- attempt to post a comment with a gif, then the same comment text but no gif. should be withheld.
- attempt to post two different comments. Should not be withheld.
