### PR TITLE
don't save clientMutationId when creating announcement

### DIFF
--- a/src/core/server/graph/mutators/Settings.ts
+++ b/src/core/server/graph/mutators/Settings.ts
@@ -71,11 +71,8 @@ export const Settings = ({
     enableFeatureFlag(mongo, redis, tenantCache, tenant, flag),
   disableFeatureFlag: (flag: GQLFEATURE_FLAG) =>
     disableFeatureFlag(mongo, redis, tenantCache, tenant, flag),
-  createAnnouncement: ({ content, duration }: GQLCreateAnnouncementInput) =>
-    createAnnouncement(mongo, redis, tenantCache, tenant, {
-      content,
-      duration,
-    }),
+  createAnnouncement: (input: WithoutMutationID<GQLCreateAnnouncementInput>) =>
+    createAnnouncement(mongo, redis, tenantCache, tenant, input),
   deleteAnnouncement: () =>
     deleteAnnouncement(mongo, redis, tenantCache, tenant),
   createWebhookEndpoint: (

--- a/src/core/server/graph/mutators/Settings.ts
+++ b/src/core/server/graph/mutators/Settings.ts
@@ -71,8 +71,11 @@ export const Settings = ({
     enableFeatureFlag(mongo, redis, tenantCache, tenant, flag),
   disableFeatureFlag: (flag: GQLFEATURE_FLAG) =>
     disableFeatureFlag(mongo, redis, tenantCache, tenant, flag),
-  createAnnouncement: (input: GQLCreateAnnouncementInput) =>
-    createAnnouncement(mongo, redis, tenantCache, tenant, input),
+  createAnnouncement: ({ content, duration }: GQLCreateAnnouncementInput) =>
+    createAnnouncement(mongo, redis, tenantCache, tenant, {
+      content,
+      duration,
+    }),
   deleteAnnouncement: () =>
     deleteAnnouncement(mongo, redis, tenantCache, tenant),
   createWebhookEndpoint: (

--- a/src/core/server/graph/resolvers/Mutation.ts
+++ b/src/core/server/graph/resolvers/Mutation.ts
@@ -251,9 +251,13 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     flags: await ctx.mutators.Settings.disableFeatureFlag(input.flag),
     clientMutationId: input.clientMutationId,
   }),
-  createAnnouncement: async (source, { input }, ctx) => ({
+  createAnnouncement: async (
+    source,
+    { input: { clientMutationId, ...input } },
+    ctx
+  ) => ({
     settings: await ctx.mutators.Settings.createAnnouncement(input),
-    clientMutationId: input.clientMutationId,
+    clientMutationId,
   }),
   deleteAnnouncement: async (source, { input }, ctx) => ({
     settings: await ctx.mutators.Settings.deleteAnnouncement(),


### PR DESCRIPTION
## What does this PR do?

I don't think this fixes the bug we're seeing with announcements but we shouldn't be storing clientMutationId in the db. 

## What changes to the GraphQL/Database Schema does this PR introduce?

none