### PR TITLE
Site Moderator Fixes

### DIFF
--- a/src/core/client/admin/routes/Moderate/ModerateContainer.tsx
+++ b/src/core/client/admin/routes/Moderate/ModerateContainer.tsx
@@ -84,8 +84,13 @@ const ModerateContainer: FunctionComponent<Props> = ({
 
     // If we've loaded a specific story, we'll have the site on that story too,
     // so check if we're allowed to moderate it.
-    if (data.story && !data.story.site.canModerate) {
-      redirect();
+    if (data.story) {
+      if (!data.story.site.canModerate) {
+        redirect();
+        return;
+      }
+
+      // The viewer can moderate this site on the story!
       return;
     }
 

--- a/src/core/client/stream/tabs/Comments/Comment/ModerationDropdown/ModerationActionsContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ModerationDropdown/ModerationActionsContainer.tsx
@@ -90,7 +90,7 @@ const ModerationActionsContainer: FunctionComponent<Props> = ({
   const showBanOption =
     !comment.author || !comment.author.id || viewer === null
       ? false
-      : comment.author.id !== viewer.id;
+      : comment.author.id !== viewer.id && !viewer.moderationScopes?.scoped;
   const isQA = story.settings.mode === GQLSTORY_MODE.QA;
 
   return (
@@ -285,6 +285,9 @@ const enhanced = withFragmentContainer<Props>({
   viewer: graphql`
     fragment ModerationActionsContainer_viewer on User {
       id
+      moderationScopes {
+        scoped
+      }
     }
   `,
 })(ModerationActionsContainer);


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

Fixes issues where:

- Site moderator still sees ban option in stream (CORL-1218)
- Site moderator couldn't click the story url from the stories tab to moderate stories that they're allowed to (CORL-1123)

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

As a site moderator with permission to moderate the current site, ensure you can click a story from the stories tab and arrive at the moderation screen for that story.

As a site moderator with permissions to moderate the current site, visit the stream of a comment on that site and ensure you don't see a ban user option.