### PR TITLE
[CORL-1209] remove hook causing crash from conversation modal replies

### DIFF
--- a/src/core/client/admin/components/ConversationModal/ConversationModalRepliesQuery.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalRepliesQuery.tsx
@@ -1,5 +1,5 @@
 import { Localized } from "@fluent/react/compat";
-import React, { FunctionComponent, useMemo } from "react";
+import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import { QueryRenderData, QueryRenderer } from "coral-framework/lib/relay";
@@ -60,17 +60,13 @@ const ConversationModalRepliesQuery: FunctionComponent<Props> = ({
           );
         }
 
-        const replies = useMemo(
-          () => props.comment!.replies.edges.map((edge) => edge.node),
-          [props.comment.replies]
-        );
         return (
           <div>
-            {replies.map((reply) => (
-              <div key={reply.id}>
+            {props.comment.replies.edges.map((reply) => (
+              <div key={reply.node.id}>
                 <ConversationModalCommentContainer
-                  key={reply.id}
-                  comment={reply}
+                  key={reply.node.id}
+                  comment={reply.node}
                   settings={props.settings}
                   isHighlighted={false}
                   isReply={true}


### PR DESCRIPTION

## What does this PR do?

`useMemo` hook was being used after a conditional statement in a function component, which is a weird thing that you can't do in react and was causing the crash logged in 1209. Removed the hook and the crash is fixed. 

## What changes to the GraphQL/Database Schema does this PR introduce?
none