### PR TITLE
[CORL-1229] Scrollbar Bug

### DIFF
--- a/src/core/client/admin/components/PaginatedSelect/PaginatedSelect.css
+++ b/src/core/client/admin/components/PaginatedSelect/PaginatedSelect.css
@@ -9,7 +9,7 @@
 }
 
 .wrapper {
-  overflow-x: hidden;
+  overflow: hidden;
   /* adjust for button line-height being > 1 */
   margin-top: -2px;
 }
@@ -41,6 +41,6 @@
 }
 
 .buttonText {
-  overflow-x: hidden;
+  overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/src/core/client/admin/routes/Moderate/SectionSelector/SectionSelector.css
+++ b/src/core/client/admin/routes/Moderate/SectionSelector/SectionSelector.css
@@ -3,6 +3,6 @@
 }
 
 .buttonText {
-  overflow-x: hidden;
+  overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/src/core/client/admin/routes/Moderate/SiteSelector/SiteSelector.css
+++ b/src/core/client/admin/routes/Moderate/SiteSelector/SiteSelector.css
@@ -3,6 +3,6 @@
 }
 
 .buttonText {
-  overflow-x: hidden;
+  overflow: hidden;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

Some dropdowns had the wrong `overflow` property, this corrects that so that the text when it overflows doesn't trigger a scrollbar to appear in the small dropdown area.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

With a scroll wheel mouse attached, look at the sites selector and see no mini-scrollbar!