### PR TITLE
[CORL-1238] Duplicate User Race

### DIFF
--- a/src/core/server/errors/index.ts
+++ b/src/core/server/errors/index.ts
@@ -252,8 +252,8 @@ export class StoryURLInvalidError extends CoralError {
 }
 
 export class DuplicateUserError extends CoralError {
-  constructor() {
-    super({ code: ERROR_CODES.DUPLICATE_USER });
+  constructor(cause?: Error) {
+    super({ cause, code: ERROR_CODES.DUPLICATE_USER });
   }
 }
 

--- a/src/core/server/models/user/user.ts
+++ b/src/core/server/models/user/user.ts
@@ -637,7 +637,9 @@ export async function findOrCreateUser(
       if (err.errmsg && err.errmsg.includes("tenantID_1_email_1")) {
         throw new DuplicateEmailError(input.email!);
       }
-      throw new DuplicateUserError();
+
+      // Some other error occured.
+      throw new DuplicateUserError(err);
     }
 
     throw err;
@@ -666,7 +668,8 @@ export async function createUser(
         throw new DuplicateEmailError(input.email!);
       }
 
-      throw new DuplicateUserError();
+      // Some other error occured.
+      throw new DuplicateUserError(err);
     }
 
     throw err;


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

As reported in #3061, sometimes SSO authentications can cause a duplicate user error to be thrown when multiple requests are sent at the same time. This introduces a single retry if the operation fails due to a duplicate user error.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

This is pretty difficult to test in action because it involves a database race to occur. This change was motivated from the documentation provided in https://github.com/coralproject/talk/issues/3061#issuecomment-668088389 (seen here: https://docs.mongodb.com/manual/reference/method/db.collection.findAndModify/#upsert-and-unique-index)