### PR TITLE
[CORL-1227] Fix scroll-able modal position popping

### DIFF
--- a/src/core/client/admin/components/UserRole/SiteModeratorModal.tsx
+++ b/src/core/client/admin/components/UserRole/SiteModeratorModal.tsx
@@ -56,7 +56,7 @@ const SiteModeratorModal: FunctionComponent<Props> = ({
   );
 
   return (
-    <Modal open={open} onClose={onCancel}>
+    <Modal open={open} onClose={onCancel} disableScroll>
       {({ firstFocusableRef, lastFocusableRef }) => (
         <Card className={styles.root}>
           <Flex justifyContent="flex-end">

--- a/src/core/client/ui/components/v2/CheckBox/CheckBox.css
+++ b/src/core/client/ui/components/v2/CheckBox/CheckBox.css
@@ -1,10 +1,12 @@
 .root {
+  position: relative;
 }
 
 .input {
   cursor: pointer;
   position: absolute; /* take it out of document flow */
   opacity: 0; /* hide it */
+  top: 0;
 }
 
 .label {

--- a/src/core/client/ui/components/v2/Modal/Modal.css
+++ b/src/core/client/ui/components/v2/Modal/Modal.css
@@ -8,12 +8,20 @@
   z-index: $zindex-modal;
 }
 
-.scroll {
+.baseScroll {
   pointer-events: none;
   position: relative;
-  overflow-y: auto;
+
   width: 100%;
   height: 100%;
+}
+
+.noScroll {
+  overflow-y: hidden;
+}
+
+.scroll {
+  overflow-y: auto;
 }
 
 .alignContainer1 {

--- a/src/core/client/ui/components/v2/Modal/Modal.tsx
+++ b/src/core/client/ui/components/v2/Modal/Modal.tsx
@@ -59,6 +59,7 @@ export interface ModalProps {
   classes: typeof styles;
   open?: boolean;
   children?: PropTypesOf<typeof TrapFocus>["children"];
+  disableScroll?: boolean;
 }
 
 const Modal: FunctionComponent<ModalProps> = ({
@@ -69,6 +70,7 @@ const Modal: FunctionComponent<ModalProps> = ({
   onBackdropClick,
   onEscapeKeyDown,
   children,
+  disableScroll = false,
   ...rest
 }) => {
   const rootClassName = cn(classes.root, className);
@@ -110,7 +112,10 @@ const Modal: FunctionComponent<ModalProps> = ({
         />
         <div
           role="presentation"
-          className={styles.scroll}
+          className={cn(
+            styles.baseScroll,
+            disableScroll ? styles.noScroll : styles.scroll
+          )}
           onKeyDown={handleEscapeKeyDown}
         >
           <div className={styles.alignContainer1}>

--- a/src/core/client/ui/components/v2/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/src/core/client/ui/components/v2/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`renders correctly 1`] = `
     onClick={[Function]}
   />
   <div
-    className="Modal-scroll"
+    className="Modal-baseScroll Modal-scroll"
     onKeyDown={[Function]}
     role="presentation"
   >


### PR DESCRIPTION
## What does this PR do?

**Adds a `disableScroll` option onto modals and uses it for the `SiteModeratorModal`.**

The site moderator modal already has a scroll bar inside it and its height is less than 480px. We don't need a scrollbar on the modal background since the modal window will always be fully visible on even the smallest screens.

This eliminates the bug of the modal sliding away when there are enough sites in the org to cause the background scroll to be activated.

**Fixes the input element positioning on our custom Checkboxes**

The checkboxes use a `::before` to create a custom styled checkbox that matches our theming. They also hide away the actual input element, which was not being positioned relative to the checkbox root. Because of this, they were appearing relative to the scrolled modal root, sometimes far below the modal's scroll-able area, which shoved the modal way up on the screen.

This positions the checkbox input element relative to the checkbox root and fixes it to the positioning of the stylized checkbox. This prevents it from appearing in weird places due to being inside a scroll-able element or paginated, scroll-able element.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Enable the `SITE_MODERATOR` feature flag
- Create a lot of sites under your org (10-20 should do)
- Shrink the height of your window to roughly 600px
- Go to the community page
- Go to change a user's role to site moderator
- Scroll down through your massive list of sites
- See that the modal background does not have a scroll bar
- See that the modal does not scroll up and away through the top of the screen