### PR TITLE
[CORL-1159] Fix deleting old SSO keys

### DIFF
--- a/src/core/server/models/tenant/sso.ts
+++ b/src/core/server/models/tenant/sso.ts
@@ -31,8 +31,8 @@ export async function deactivateTenantSSOSigningSecret(
     { id },
     {
       $set: {
-        "auth.integrations.sso.keys.$[keys].inactiveAt": inactiveAt,
-        "auth.integrations.sso.keys.$[keys].rotatedAt": now,
+        "auth.integrations.sso.signingSecrets.$[signingSecrets].inactiveAt": inactiveAt,
+        "auth.integrations.sso.signingSecrets.$[signingSecrets].rotatedAt": now,
       },
     },
     {
@@ -40,7 +40,7 @@ export async function deactivateTenantSSOSigningSecret(
       // document.
       returnOriginal: false,
       // Add an ArrayFilter to only update one of the keys.
-      arrayFilters: [{ "keys.kid": kid }],
+      arrayFilters: [{ "signingSecrets.kid": kid }],
     }
   );
 
@@ -57,7 +57,7 @@ export async function deleteTenantSSOSigningSecret(
     { id },
     {
       $pull: {
-        "auth.integrations.sso.keys": { kid },
+        "auth.integrations.sso.signingSecrets": { kid },
       },
     },
     {


### PR DESCRIPTION
## What does this PR do?

Fixes the deletion of rotated out SSO keys by replacing `keys` with the correct name `signingSecrets` in the `$pull` mongo call.

Looks like this was missed during the migration of `auth.integrations.sso.keys` renamed to `auth.integrations.sso.signingSecrets`.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Go to `Admin > Config > Authentication`
- Enable SSO 
- Create/rotate out a key
- Delete the old expired key
- See that it updates and key is deleted