### PR TITLE
[CORL-1246] Add read more opens new tab feature flag

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.spec.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.spec.tsx
@@ -60,6 +60,7 @@ function createDefaultProps(add: DeepPartial<Props> = {}): Props {
         disableCommenting: {
           enabled: false,
         },
+        featureFlags: [],
       },
       indentLevel: 1,
       showAuthPopup: noop as any,

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -9,7 +9,12 @@ import { isBeforeDate } from "coral-common/utils";
 import { getURLWithCommentID } from "coral-framework/helpers";
 import { withContext } from "coral-framework/lib/bootstrap";
 import withFragmentContainer from "coral-framework/lib/relay/withFragmentContainer";
-import { GQLSTORY_MODE, GQLTAG, GQLUSER_STATUS } from "coral-framework/schema";
+import {
+  GQLFEATURE_FLAG,
+  GQLSTORY_MODE,
+  GQLTAG,
+  GQLUSER_STATUS,
+} from "coral-framework/schema";
 import { PropTypesOf } from "coral-framework/types";
 import CLASSES from "coral-stream/classes";
 import {
@@ -191,7 +196,22 @@ export class CommentContainer extends Component<Props, State> {
       from: "COMMENT_STREAM",
     });
     e.preventDefault();
-    void this.props.setCommentID({ id: this.props.comment.id });
+
+    if (
+      this.props.settings.featureFlags.includes(
+        GQLFEATURE_FLAG.READ_MORE_NEW_TAB
+      )
+    ) {
+      const url = getURLWithCommentID(
+        this.props.story.url,
+        this.props.comment.id
+      );
+
+      window.open(url, "_blank", "noreferrer");
+    } else {
+      void this.props.setCommentID({ id: this.props.comment.id });
+    }
+
     return false;
   };
 
@@ -607,6 +627,7 @@ const enhanced = withContext(({ eventEmitter }) => ({ eventEmitter }))(
             disableCommenting {
               enabled
             }
+            featureFlags
             ...ReactionButtonContainer_settings
             ...ReplyCommentFormContainer_settings
             ...EditCommentFormContainer_settings

--- a/src/core/client/stream/tabs/Comments/Comment/__snapshots__/CommentContainer.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/Comment/__snapshots__/CommentContainer.spec.tsx.snap
@@ -60,6 +60,7 @@ exports[`hide reply button 1`] = `
                     "disableCommenting": Object {
                       "enabled": false,
                     },
+                    "featureFlags": Array [],
                   }
                 }
                 viewer={null}
@@ -159,6 +160,7 @@ exports[`hide reply button 1`] = `
               "disableCommenting": Object {
                 "enabled": false,
               },
+              "featureFlags": Array [],
             }
           }
         />
@@ -240,6 +242,7 @@ exports[`hide reply button 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -373,6 +376,7 @@ exports[`hide reply button 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -487,6 +491,7 @@ exports[`renders body only 1`] = `
                     "disableCommenting": Object {
                       "enabled": false,
                     },
+                    "featureFlags": Array [],
                   }
                 }
                 viewer={null}
@@ -593,6 +598,7 @@ exports[`renders body only 1`] = `
               "disableCommenting": Object {
                 "enabled": false,
               },
+              "featureFlags": Array [],
             }
           }
         />
@@ -674,6 +680,7 @@ exports[`renders body only 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -807,6 +814,7 @@ exports[`renders body only 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -921,6 +929,7 @@ exports[`renders disabled reply when commenting has been disabled 1`] = `
                     "disableCommenting": Object {
                       "enabled": true,
                     },
+                    "featureFlags": Array [],
                   }
                 }
                 viewer={null}
@@ -1027,6 +1036,7 @@ exports[`renders disabled reply when commenting has been disabled 1`] = `
               "disableCommenting": Object {
                 "enabled": true,
               },
+              "featureFlags": Array [],
             }
           }
         />
@@ -1108,6 +1118,7 @@ exports[`renders disabled reply when commenting has been disabled 1`] = `
                 "disableCommenting": Object {
                   "enabled": true,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -1241,6 +1252,7 @@ exports[`renders disabled reply when commenting has been disabled 1`] = `
                 "disableCommenting": Object {
                   "enabled": true,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -1355,6 +1367,7 @@ exports[`renders disabled reply when story is closed 1`] = `
                     "disableCommenting": Object {
                       "enabled": false,
                     },
+                    "featureFlags": Array [],
                   }
                 }
                 viewer={null}
@@ -1461,6 +1474,7 @@ exports[`renders disabled reply when story is closed 1`] = `
               "disableCommenting": Object {
                 "enabled": false,
               },
+              "featureFlags": Array [],
             }
           }
         />
@@ -1542,6 +1556,7 @@ exports[`renders disabled reply when story is closed 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -1675,6 +1690,7 @@ exports[`renders disabled reply when story is closed 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -1793,6 +1809,7 @@ exports[`renders in reply to 1`] = `
                     "disableCommenting": Object {
                       "enabled": false,
                     },
+                    "featureFlags": Array [],
                   }
                 }
                 viewer={null}
@@ -1907,6 +1924,7 @@ exports[`renders in reply to 1`] = `
               "disableCommenting": Object {
                 "enabled": false,
               },
+              "featureFlags": Array [],
             }
           }
         />
@@ -1996,6 +2014,7 @@ exports[`renders in reply to 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -2141,6 +2160,7 @@ exports[`renders in reply to 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -2259,6 +2279,7 @@ exports[`renders username and body 1`] = `
                     "disableCommenting": Object {
                       "enabled": false,
                     },
+                    "featureFlags": Array [],
                   }
                 }
                 viewer={null}
@@ -2365,6 +2386,7 @@ exports[`renders username and body 1`] = `
               "disableCommenting": Object {
                 "enabled": false,
               },
+              "featureFlags": Array [],
             }
           }
         />
@@ -2446,6 +2468,7 @@ exports[`renders username and body 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -2579,6 +2602,7 @@ exports[`renders username and body 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -2702,6 +2726,7 @@ exports[`shows conversation link 1`] = `
                     "disableCommenting": Object {
                       "enabled": false,
                     },
+                    "featureFlags": Array [],
                   }
                 }
                 viewer={null}
@@ -2814,6 +2839,7 @@ exports[`shows conversation link 1`] = `
               "disableCommenting": Object {
                 "enabled": false,
               },
+              "featureFlags": Array [],
             }
           }
         />
@@ -2895,6 +2921,7 @@ exports[`shows conversation link 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={
@@ -3028,6 +3055,7 @@ exports[`shows conversation link 1`] = `
                 "disableCommenting": Object {
                   "enabled": false,
                 },
+                "featureFlags": Array [],
               }
             }
             story={

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -407,6 +407,12 @@ enum FEATURE_FLAG {
   DISCUSSIONS will enable the discussions tab for the comment stream.
   """
   DISCUSSIONS
+
+  """
+  READ_MORE_NEW_TAB will enable opening a new tab when a user clicks on
+  "read more of this conversation" in the comment stream.
+  """
+  READ_MORE_NEW_TAB
 }
 
 # The moderation mode of the site.


### PR DESCRIPTION
## What does this PR do?

If the feature flag `READ_MORE_NEW_TAB` is set, then clicking on "Read more of this conversation" will open a new tab.

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds `READ_MORE_NEW_TAB` to the `FEATURE_FLAGS` enum on the schema.

## How do I test this PR?

- set `READ_MORE_NEW_TAB` feature flag
- go click on a "Read more of this conversation" link in stream
- see that it opens a new tab