### PR TITLE
ensure getlinkedRecord is truthy before retrieving value in queue subscription

### DIFF
--- a/src/core/client/admin/routes/Moderate/Queue/QueueCommentLeftSubscription.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/QueueCommentLeftSubscription.tsx
@@ -33,9 +33,12 @@ function handleCommentLeftModerationQueue(
   if (connection) {
     const linked = connection.getLinkedRecords("viewNewEdges") || [];
     connection.setLinkedRecords(
-      linked.filter(
-        (r) => r.getLinkedRecord("node")!.getValue("id") !== commentID
-      ),
+      linked.filter((r) => {
+        return (
+          r.getLinkedRecord("node") &&
+          r.getLinkedRecord("node")!.getValue("id") !== commentID
+        );
+      }),
       "viewNewEdges"
     );
   }


### PR DESCRIPTION
Ok I'm not sure this is actually the _real_ problem but this addresses the `cannot call getValue on undefined` error was seeing in prod on clicking "view x new comments" in the moderation queue. 
<img width="712" alt="Screen Shot 2020-08-17 at 12 43 38 PM" src="https://user-images.githubusercontent.com/1789029/90422276-a4022700-e088-11ea-959d-c25037d8a7db.png">

why was the `!` used in the first place, is there a reason `getLinkedRecord` should always be truthy here that I'm missing? If it's undefined, what could that mean? much to discuss, maybe