### PR TITLE
[CORL-1306] Use v3 buttons on CommentForm

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/CommentForm/CommentForm.css
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentForm/CommentForm.css
@@ -11,3 +11,7 @@ $commentsBorder: var(--palette-grey-300);
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
+
+.icon {
+  margin-right: 2px;
+}

--- a/src/core/client/stream/tabs/Comments/Stream/CommentForm/CommentForm.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentForm/CommentForm.tsx
@@ -18,8 +18,6 @@ import { FormError, OnSubmit } from "coral-framework/lib/form";
 import { PropTypesOf } from "coral-framework/types";
 import CLASSES from "coral-stream/classes";
 import {
-  Button,
-  ButtonIcon,
   Flex,
   HorizontalGutter,
   Icon,
@@ -28,7 +26,7 @@ import {
   MessageIcon,
   RelativeTime,
 } from "coral-ui/components/v2";
-import { CallOut } from "coral-ui/components/v3";
+import { Button, CallOut } from "coral-ui/components/v3";
 
 import { getCommentBodyValidators } from "../../helpers";
 import RemainingCharactersContainer from "../../RemainingCharacters";
@@ -181,13 +179,16 @@ const CommentForm: FunctionComponent<Props> = (props) => {
                             props.mediaConfig.giphy.enabled ? (
                               <>
                                 <Button
-                                  color="mono"
-                                  variant={showGifSelector ? "regular" : "flat"}
+                                  color="secondary"
+                                  variant={showGifSelector ? "filled" : "flat"}
                                   onClick={toggleGIFSelector}
-                                  iconLeft
+                                  fontSize="small"
+                                  paddingSize="extraSmall"
                                 >
-                                  <ButtonIcon>add</ButtonIcon>
-                                  GIF
+                                  <Flex alignItems="center">
+                                    <Icon className={styles.icon}>add</Icon>
+                                    GIF
+                                  </Flex>
                                 </Button>
                               </>
                             ) : null
@@ -290,12 +291,13 @@ const CommentForm: FunctionComponent<Props> = (props) => {
                       {props.onCancel && (
                         <Localized id="comments-commentForm-cancel">
                           <Button
-                            color="mono"
+                            color="secondary"
                             variant="outlined"
                             disabled={submitting}
                             onClick={props.onCancel}
                             fullWidth={matches}
                             className={CLASSES[props.classNameRoot].cancel}
+                            upperCase
                           >
                             Cancel
                           </Button>
@@ -309,8 +311,8 @@ const CommentForm: FunctionComponent<Props> = (props) => {
                         }
                       >
                         <Button
-                          color="stream"
-                          variant="regular"
+                          color="primary"
+                          variant="filled"
                           disabled={
                             hasValidationErrors ||
                             submitting ||
@@ -320,6 +322,7 @@ const CommentForm: FunctionComponent<Props> = (props) => {
                           type="submit"
                           fullWidth={matches}
                           className={CLASSES[props.classNameRoot].submit}
+                          upperCase
                         >
                           {props.editableUntil ? "Save changes" : "Submit"}
                         </Button>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
@@ -453,7 +453,7 @@ exports[`edit a comment and handle server error: edit form 1`] = `
             className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd gutter Flex-spacing-1"
           >
             <button
-              className="BaseButton-root Button-root Button-sizeRegular Button-colorMono Button-variantOutline Button-uppercase coral coral-editComment-cancel"
+              className="BaseButton-root Button-base Button-outlined Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorSecondary Button-upperCase coral coral-editComment-cancel"
               data-variant="outlined"
               disabled={false}
               onBlur={[Function]}
@@ -467,8 +467,8 @@ exports[`edit a comment and handle server error: edit form 1`] = `
               Cancel
             </button>
             <button
-              className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantRegular Button-uppercase Button-disabled coral coral-editComment-submit"
-              data-variant="regular"
+              className="BaseButton-root Button-base Button-filled Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorPrimary Button-disabled Button-upperCase coral coral-editComment-submit"
+              data-variant="filled"
               disabled={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -649,7 +649,7 @@ exports[`edit a comment: edit form 1`] = `
             className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd gutter Flex-spacing-1"
           >
             <button
-              className="BaseButton-root Button-root Button-sizeRegular Button-colorMono Button-variantOutline Button-uppercase coral coral-editComment-cancel"
+              className="BaseButton-root Button-base Button-outlined Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorSecondary Button-upperCase coral coral-editComment-cancel"
               data-variant="outlined"
               disabled={false}
               onBlur={[Function]}
@@ -663,8 +663,8 @@ exports[`edit a comment: edit form 1`] = `
               Cancel
             </button>
             <button
-              className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantRegular Button-uppercase Button-disabled coral coral-editComment-submit"
-              data-variant="regular"
+              className="BaseButton-root Button-base Button-filled Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorPrimary Button-disabled Button-upperCase coral coral-editComment-submit"
+              data-variant="filled"
               disabled={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -845,7 +845,7 @@ exports[`edit a comment: optimistic response 1`] = `
             className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd gutter Flex-spacing-1"
           >
             <button
-              className="BaseButton-root Button-root Button-sizeRegular Button-colorMono Button-variantOutline Button-uppercase Button-disabled coral coral-editComment-cancel"
+              className="BaseButton-root Button-base Button-outlined Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorSecondary Button-disabled Button-upperCase coral coral-editComment-cancel"
               data-variant="outlined"
               disabled={true}
               onBlur={[Function]}
@@ -859,8 +859,8 @@ exports[`edit a comment: optimistic response 1`] = `
               Cancel
             </button>
             <button
-              className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantRegular Button-uppercase Button-disabled coral coral-editComment-submit"
-              data-variant="regular"
+              className="BaseButton-root Button-base Button-filled Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorPrimary Button-disabled Button-upperCase coral coral-editComment-submit"
+              data-variant="filled"
               disabled={true}
               onBlur={[Function]}
               onFocus={[Function]}
@@ -1932,7 +1932,7 @@ exports[`shows expiry message: edit time expired 1`] = `
             className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd gutter Flex-spacing-1"
           >
             <button
-              className="BaseButton-root Button-root Button-sizeRegular Button-colorMono Button-variantOutline Button-uppercase coral coral-editComment-cancel"
+              className="BaseButton-root Button-base Button-outlined Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorSecondary Button-upperCase coral coral-editComment-cancel"
               data-variant="outlined"
               disabled={false}
               onBlur={[Function]}
@@ -1946,8 +1946,8 @@ exports[`shows expiry message: edit time expired 1`] = `
               Cancel
             </button>
             <button
-              className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantRegular Button-uppercase Button-disabled coral coral-editComment-submit"
-              data-variant="regular"
+              className="BaseButton-root Button-base Button-filled Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorPrimary Button-disabled Button-upperCase coral coral-editComment-submit"
+              data-variant="filled"
               disabled={true}
               onBlur={[Function]}
               onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
@@ -440,7 +440,7 @@ exports[`post a reply: open reply form 1`] = `
               className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd gutter Flex-spacing-1"
             >
               <button
-                className="BaseButton-root Button-root Button-sizeRegular Button-colorMono Button-variantOutline Button-uppercase coral coral-createReplyComment-cancel"
+                className="BaseButton-root Button-base Button-outlined Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorSecondary Button-upperCase coral coral-createReplyComment-cancel"
                 data-variant="outlined"
                 disabled={false}
                 onBlur={[Function]}
@@ -454,8 +454,8 @@ exports[`post a reply: open reply form 1`] = `
                 Cancel
               </button>
               <button
-                className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantRegular Button-uppercase Button-disabled coral coral-createReplyComment-submit"
-                data-variant="regular"
+                className="BaseButton-root Button-base Button-filled Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorPrimary Button-disabled Button-upperCase coral coral-createReplyComment-submit"
+                data-variant="filled"
                 disabled={true}
                 onBlur={[Function]}
                 onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
@@ -397,7 +397,7 @@ exports[`post a reply: open reply form 1`] = `
               className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd gutter Flex-spacing-1"
             >
               <button
-                className="BaseButton-root Button-root Button-sizeRegular Button-colorMono Button-variantOutline Button-uppercase coral coral-createReplyComment-cancel"
+                className="BaseButton-root Button-base Button-outlined Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorSecondary Button-upperCase coral coral-createReplyComment-cancel"
                 data-variant="outlined"
                 disabled={false}
                 onBlur={[Function]}
@@ -411,8 +411,8 @@ exports[`post a reply: open reply form 1`] = `
                 Cancel
               </button>
               <button
-                className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantRegular Button-uppercase Button-disabled coral coral-createReplyComment-submit"
-                data-variant="regular"
+                className="BaseButton-root Button-base Button-filled Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorPrimary Button-disabled Button-upperCase coral coral-createReplyComment-submit"
+                data-variant="filled"
                 disabled={true}
                 onBlur={[Function]}
                 onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
@@ -444,8 +444,8 @@ exports[`renders message box when logged in 1`] = `
               className="Box-root Flex-root Flex-flex Flex-justifyFlexEnd gutter Flex-spacing-1"
             >
               <button
-                className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantRegular Button-uppercase Button-disabled coral coral-createComment-submit"
-                data-variant="regular"
+                className="BaseButton-root Button-base Button-filled Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorPrimary Button-disabled Button-upperCase coral coral-createComment-submit"
+                data-variant="filled"
                 disabled={true}
                 onBlur={[Function]}
                 onFocus={[Function]}


### PR DESCRIPTION
## What does this PR do?

Swaps out the old v2 buttons for equivalent (but easier to style) v3 buttons on the comment form.

This is in response to feedback that it was difficult to override buttons because of the specificity of the v2 buttons.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- go to stream
- see that Submit, Cancel, and +GIF buttons are the same as before