### PR TITLE
[CORL-1263] Display warning messages in user account history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22089,7 +22089,7 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
@@ -22289,14 +22289,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -22307,7 +22307,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -22317,7 +22317,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -22606,7 +22606,7 @@
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -22646,7 +22646,7 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true

--- a/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.css
+++ b/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.css
@@ -25,11 +25,11 @@
 }
 
 .date {
-  min-width: 120px;
+  min-width: 80px;
 }
 
 .action {
-  min-width: 200px;
+  min-width: 150px;
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
@@ -37,11 +37,15 @@
 }
 
 .user {
-  min-width: 200px;
-  max-width: 200px;
+  min-width: 125px;
+  max-width: 125px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.description {
+  min-width: 150px;
 }
 
 .user > * {

--- a/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
+++ b/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
@@ -35,6 +35,7 @@ interface From {
 type HistoryRecord = HistoryActionProps & {
   date: Date;
   takenBy: React.ReactNode;
+  description?: string | null;
 };
 
 const UserDrawerAccountHistory: FunctionComponent<Props> = ({ user }) => {
@@ -154,6 +155,7 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({ user }) => {
             ? new Date(record.acknowledgedAt)
             : null,
         },
+        description: record.message,
       });
     });
 
@@ -184,6 +186,7 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({ user }) => {
             <TableCell>Date</TableCell>
             <TableCell>Action</TableCell>
             <TableCell>Taken By</TableCell>
+            <TableCell>Description</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>
@@ -196,6 +199,9 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({ user }) => {
                 <AccountHistoryAction {...history} />
               </TableCell>
               <TableCell className={styles.user}>{history.takenBy}</TableCell>
+              <TableCell className={styles.description}>
+                {history.description}
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -225,6 +231,7 @@ const enhanced = withFragmentContainer<any>({
             }
             acknowledgedAt
             createdAt
+            message
           }
         }
         ban {

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -2050,7 +2050,7 @@ type WarningStatusHistory {
   """
   message is the custom message sent to the commenter
   """
-  message: String!
+  message: String
 }
 
 type WarningStatus {


### PR DESCRIPTION
## What does this PR do?

Adds a description column to display user warning messages under the account history, user history drawer.

## What changes to the GraphQL/Database Schema does this PR introduce?

Removed the GraphQL required `!` off of `message` on `WarningStatusHistory`. This makes it identical to its parent `WarningStatus` which also has an optional `message` field. 

This seems to be how it was intended to be implemented as when we remove a warning from a user, it posts a warning state with no message. We probably didn't see this small requirement from GraphQL because no one was querying for this in the account history previous.

Without this small change, the account history errors out as GraphQL throws a fit because it finds a null/undefined for message on what is supposed to be a required prop.

## How do I test this PR?

- Go to the admin panel
- Find a username to click on and open the user drawer
- Use the user status drop down to issue a warning
- Type something in the warning description textbox
- Send out the warning
- Go to the `Account History` tab in the user drawer
- See the new column with the text you wrote for the warning listed
