### PR TITLE
Update pt-BR translation

### DIFF
--- a/src/core/server/locales/pt-BR/common.ftl
+++ b/src/core/server/locales/pt-BR/common.ftl
@@ -13,3 +13,6 @@ comment-count =
   }</span>
 
 staff-label = Staff
+
+experimental-tag = Experimental
+experimental-tag-tooltip-title = Funcionalidade experimental

--- a/src/core/server/locales/pt-BR/errors.ftl
+++ b/src/core/server/locales/pt-BR/errors.ftl
@@ -46,6 +46,9 @@ error-userAlreadySuspended = O usuário já tem uma suspensão ativa até {$unti
 error-userAlreadyBanned = O usuário já está banido.
 error-userBanned = Sua conta está banida.
 error-userSuspended = Sua conta está suspensa no momento até {$until}.
+error-userWarned =
+  Foi emitido um aviso para sua conta: {$message}.
+  Para continuar participando das discussões, pressione o botão "Reconhecer" abaixo.
 error-integrationDisabled = A integração especificada está desativada.
 error-passwordResetTokenExpired = Link de redefinição de senha expirado.
 error-emailConfirmTokenExpired = Link de confirmação de email expirado.

--- a/src/locales/pt-BR/account.ftl
+++ b/src/locales/pt-BR/account.ftl
@@ -3,6 +3,10 @@
 account-tokenNotFound =
   O link especificado é inválido, verifique se foi copiado corretamente.
 
+## Not Found
+
+notFound = Não encontrado
+
 ## Password Reset
 
 resetPassword-resetPassword = Redefinir senha
@@ -22,7 +26,9 @@ resetPassword-missingResetToken = O token de redefinição parece estar faltando
 
 ## Email Confirmation
 
-confirmEmail-emailConfirmation = Confirmação do email
+confirmEmail-emailConfirmation =
+confirmEmail-confirmYourEmailAddress =
+  Confirme seu endereço de email
 confirmEmail-confirmEmail = Confirmar email
 confirmEmail-pleaseClickToConfirm = Clique a baixo para confirmar seu email
 confirmEmail-oopsSorry = Oops, desculpe!
@@ -37,7 +43,7 @@ download-landingPage-title = Faça o download do seu histórico de comentários
 download-landingPage-description =
   Seu histórico de comentários será salvo em um arquivo .zip. Depois que o seu
   arquivo for descompactado, você terá um aquivo de valor separado por vírgula
-  (ou .csv), que você pode importar facilmente nas suas planilhas 
+  (ou .csv), que você pode importar facilmente nas suas planilhas
   favoritas.
 download-landingPage-contentsDescription =
   Para cada um dos seus comentários, as seguintes informações serão inseridas:
@@ -49,13 +55,21 @@ download-landingPage-contentsText =
   O texto comentado
 download-landingPage-contentsStoryUrl =
   A URL no artigo ou na história onde o comentário aparece
+download-landingPage-download = Fazer download
 download-landingPage-downloadComments =
-  Fazer o download do meu histórico de comentário
 download-landingPage-sorry = Seu link de download é inválido
 
 ## Unsubscribe
 
+unsubscribe-confirm =
+unsubscribe-successfullyUnsubscribed =
+
+unsubscribe-unsubscribeFromEmails = Cancelar inscrição de notificações por email
 unsubscribe-oopsSorry = Oops Desculpe!
-unsubscribe-successfullyUnsubscribed = Agora você está desinscrito de todas as notificações
-unsubscribe-clickToConfirm = Clique abaixo para confirmar que deseja cancelar a inscrição de todas as notificações.
-unsubscribe-confirm = Confirmar
+unsubscribe-clickToConfirm =
+  Clique abaixo para confirmar que deseja cancelar a inscrição de todas as notificações.
+unsubscribe-submit-unsubscribe = Cancelar inscrição
+unsubscribe-unsubscribedSuccessfully =
+  Inscrição de notificações por email cancelada com sucesso
+unsubscribe-youMayNowClose =
+  Agora você pode fechar esta janela

--- a/src/locales/pt-BR/admin.ftl
+++ b/src/locales/pt-BR/admin.ftl
@@ -10,6 +10,8 @@ storyStatus-closed = Fechado
 ## Roles
 role-admin = Administrador
 role-moderator = Moderador
+role-siteModerator = Moderador do site
+role-organizationModerator = Moderador da Organização
 role-staff = Staff
 role-commenter = Comentador
 
@@ -23,12 +25,14 @@ userStatus-active = Ativo
 userStatus-banned = Banido
 userStatus-suspended = Suspenso
 userStatus-premod = Sempre pré-moderado
+userStatus-warned = Avisado
 
 ## Navigation
 navigation-moderate = Moderação
 navigation-community = Comunidade
 navigation-stories = Histórias
 navigation-configure = Configuração
+navigation-dashboard = Dashboard
 
 ## User Menu
 userMenu-signOut = Sair
@@ -145,8 +149,9 @@ configure-sideBarNavigation-general = Geral
 configure-sideBarNavigation-authentication = Autenticação
 configure-sideBarNavigation-moderation = Moderação
 configure-sideBarNavigation-organization = Organização
+configure-sideBarNavigation-moderationPhases = Fases de moderação
 configure-sideBarNavigation-advanced = Avançado
-configure-sideBarNavigation-email = E-mail
+configure-sideBarNavigation-email = Email
 configure-sideBarNavigation-bannedAndSuspectWords = Palavras banidas e suspeitas
 configure-sideBarNavigation-slack = Slack
 configure-sideBarNavigation-webhooks = Webhooks
@@ -158,7 +163,116 @@ configure-onOffField-off = Desligado
 configure-radioButton-allow = Permitir
 configure-radioButton-dontAllow = Não permitir
 
+### Moderation Phases
+
+configure-moderationPhases-generatedAt = CHAVE GERADA EM:
+  { DATETIME($date, year: "numeric", month: "numeric", day: "numeric", hour: "numeric", minute: "numeric") }
+configure-moderationPhases-phaseNotFound = Fase de moderação externa não encontrada
+configure-moderationPhases-experimentalFeature =
+  O recurso de fases de moderação personalizadas está atualmente em desenvolvimento ativo.
+  <ContactUsLink>Entre em contato conosco para qualquer feedback ou solicitação</ContactUsLink>.
+configure-moderationPhases-header-title = Fases de moderação
+configure-moderationPhases-description =
+  Configure uma fase de moderação externa para automatizar alguma ação de moderação
+  . Requisições de moderação são enviadas e assinadas como JSON. Para
+  saber mais sobre as requisições de moderação, acesse nossa <externalLink>documentação</externalLink>.
+configure-moderationPhases-addExternalModerationPhaseButton =
+  Adicionar fase de moderação externa
+configure-moderationPhases-moderationPhases = Fases de moderação
+configure-moderationPhases-name = Nome
+configure-moderationPhases-status = Status
+configure-moderationPhases-noExternalModerationPhases =
+  Não há fases de moderação externa configuradas, adicione uma acima.
+configure-moderationPhases-enabledModerationPhase = Ativado
+configure-moderationPhases-disableModerationPhase = Desativado
+configure-moderationPhases-detailsButton = Detalhes <icon>keyboard_arrow_right</icon>
+configure-moderationPhases-addExternalModerationPhase = Adicionar fase de moderação externa
+configure-moderationPhases-updateExternalModerationPhaseButton = Atualizar detalhes
+configure-moderationPhases-cancelButton = Cancelar
+configure-moderationPhases-format = Formato do corpo do comentário
+configure-moderationPhases-endpointURL = URL de callback
+configure-moderationPhases-timeout = Tempo limite
+configure-moderationPhases-timeout-details =
+  O tempo que o Coral aguardará pela sua resposta de moderação, em milissegundos.
+configure-moderationPhases-format-details =
+  O formato em que Coral enviará o corpo do comentário. Por padrão, o Coral enviará
+  o comentário no formato HTML original. Se "Texto Simples" for
+  selecionado, a versão sem HTML será enviada.
+configure-moderationPhases-format-html = HTML
+configure-moderationPhases-format-plain = Texto Simples
+configure-moderationPhases-endpointURL-details =
+  A URL para a qual as requisições de moderação do Coral serão enviadas, via POST. O URL fornecido
+  deve responder dentro do tempo limite definido ou a decisão da ação de moderação
+  será ignorada.
+configure-moderationPhases-configureExternalModerationPhase =
+  Configurar fase de moderação externa
+configure-moderationPhases-phaseDetails = Detalhes da fase
+onfigure-moderationPhases-status = Status
+configure-moderationPhases-signingSecret = Segredo da assinatura
+configure-moderationPhases-signingSecretDescription =
+  O seguinte segredo de assinatura é usado para assinar o payload das requisições enviadas
+  para a URL. Para saber mais sobre a assinatura de webhook, acesse nossa <externalLink>documentação</externalLink>.
+configure-moderationPhases-phaseStatus = Status da fase
+configure-moderationPhases-status = Status
+configure-moderationPhases-signingSecret = Segredo de assinatura
+configure-moderationPhases-signingSecretDescription =
+  O seguinte segredo de assinatura é usado para assinar o payload das requisições enviadas
+  para a URL. Para saber mais sobre a assinatura de webhook, acesse nossa <externalLink>documentação</externalLink>.
+configure-moderationPhases-dangerZone = Zona de perigo
+configure-moderationPhases-rotateSigningSecret = Rotacionar segredo de assinatura
+configure-moderationPhases-rotateSigningSecretDescription =
+  Rotacionar o segredo de assinatura permitirá que você substitua com segurança um
+  segredo usado na produção com atraso.
+configure-moderationPhases-rotateSigningSecretButton = Rotacionar segredo de assinatura
+
+configure-moderationPhases-disableExternalModerationPhase =
+  Desativar fase de moderação externa
+configure-moderationPhases-disableExternalModerationPhaseDescription =
+  Esta fase de moderação externa está atualmente habilitada. Ao desativar, nenhuma nova
+  requisição de moderação será enviada para a URL fornecida.
+configure-moderationPhases-disableExternalModerationPhaseButton = Desativar fase
+configure-moderationPhases-enableExternalModerationPhase =
+  Ativar fase de moderação externa
+configure-moderationPhases-enableExternalModerationPhaseDescription =
+  Esta fase de moderação externa está atualmente desativada. Ao ativar, novas consultas
+  de moderação passarão a ser enviadas para a URL fornecida.
+configure-moderationPhases-enableExternalModerationPhaseButton = Ativar fase
+configure-moderationPhases-deleteExternalModerationPhase =
+  Excluir fase de moderação externa
+configure-moderationPhases-deleteExternalModerationPhaseDescription =
+  A exclusao desta fase de moderacao externa impedira que quaisquer novas consultas
+  de moderacao sejam enviadas para esta URL e removera todas as configuracoes associadas.
+configure-moderationPhases-deleteExternalModerationPhaseButton = Excluir fase
+configure-moderationPhases-rotateSigningSecret = Rotacionar segredo de assinatura
+configure-moderationPhases-rotateSigningSecretHelper =
+  Depois de expirar, as assinaturas não serão mais geradas com o segredo antigo.
+configure-moderationPhases-expiresOldSecret =
+  Expirar o segredo antigo
+configure-moderationPhases-expiresOldSecretImmediately =
+  Imediatamente
+configure-moderationPhases-expiresOldSecretHoursFromNow =
+  { $hours ->
+    [1] 1 hora
+    *[other] { $hours } horas
+  } a partir de agora
+configure-moderationPhases-rotateSigningSecretSuccessUseNewSecret =
+  O segredo de assinatura da fase de moderação externa foi alternado. Certifique-se
+  de atualizar suas integrações para usar o novo segredo abaixo.
+configure-moderationPhases-confirmDisable =
+  Desativar esta fase de moderação externa irá impedir que quaisquer novas consultas
+  de moderação sejam enviadas para esta URL. Você tem certeza que quer continuar?
+configure-moderationPhases-confirmEnable =
+  Habilitando a fase de moderação externa fará com que as consultas de moderação
+  para esta URL passem a ser enviadas. Você tem certeza que quer continuar?
+configure-moderationPhases-confirmDelete =
+  A exclusão desta fase de moderação externa interromperá o envio de novas consultas
+  de moderação para esta URL e também removerá todas as configurações associadas.
+  Você tem certeza que quer continuar?
+
 ### Webhooks
+
+configure-webhooks-generatedAt = CHAVE GERADA EM:
+  { DATETIME($date, year: "numeric", month: "numeric", day: "numeric", hour: "numeric", minute: "numeric") }
 configure-webhooks-experimentalFeature =
   A funcionalidade de Webhooks atualmente está em desenvolvimento ativo. Eventos podem
   ser adicionados ou removidos. Por favor <ContactUsLink>entre em contato conosco com qualquer feedback ou pedido</ContactUsLink>.
@@ -273,6 +387,36 @@ configure-general-sitewideCommenting-message = Mensagem de Comentários Fechados
 configure-general-sitewideCommenting-messageExplanation =
   Escreva uma mensagem que será exibida quando o fluxo de comentários estiver fechado em todo o site
 
+#### Embed Links
+configure-general-embedLinks-title = Mídia incorporada
+configure-general-embedLinks-desc = Permitir que os comentadores adicionem um vídeo do YouTube, tweet ou GIF da biblioteca do GIPHY ao final do comentário
+configure-general-embedLinks-enableTwitterEmbeds = Permitir incorporações do Twitter
+configure-general-embedLinks-enableYouTubeEmbeds = Permitir incorporações do YouTube
+configure-general-embedLinks-enableGiphyEmbeds = Permitir GIFs do GIPHY
+
+configure-general-embedLinks-On = Sim
+configure-general-embedLinks-Off = Não
+
+configure-general-embedLinks-giphyMaxRating = Classificação de conteúdo GIF
+configure-general-embedLinks-giphyMaxRating-desc = Selecione a classificação máxima de conteúdo para os GIFs que aparecerão nos resultados de pesquisa dos comentadores
+
+configure-general-embedLinks-giphyMaxRating-g = G
+configure-general-embedLinks-giphyMaxRating-g-desc = Conteúdo apropriado para todas as idades
+configure-general-embedLinks-giphyMaxRating-pg = PG
+configure-general-embedLinks-giphyMaxRating-pg-desc = Conteúdo que geralmente é seguro para todos, mas a orientação dos pais para crianças é recomendada.
+configure-general-embedLinks-giphyMaxRating-pg13 = PG-13
+configure-general-embedLinks-giphyMaxRating-pg13-desc = Insinuações sexuais moderadas, uso moderado de substâncias, linguagem obscena moderada ou imagens ameaçadoras. Pode incluir imagens de pessoas seminuas, mas NÃO mostra a genitália humana real ou nudez.
+configure-general-embedLinks-giphyMaxRating-r = R
+configure-general-embedLinks-giphyMaxRating-r-desc = Linguagem forte, forte insinuação sexual, violência e uso de drogas ilegais; não é adequado para adolescentes ou mais jovens. Sem nudez.
+
+configure-general-embedLinks-configuration = Configuração
+configure-general-embedLinks-configuration-desc =
+  Para mais informações sobre a API do GIPHY, acesse: <externalLink>https://developers.giphy.com/docs/api</externalLink>
+configure-general-embedLinks-giphyAPIKey = Chave de API do GIPHY
+
+
+### Configure Announcements
+
 configure-general-announcements-title = Anúncio da comunidade
 configure-general-announcements-description =
   Adicione um anúncio temporário que aparecerá na parte superior de todos os fluxos de comentários da sua organização por um período específico.
@@ -364,6 +508,23 @@ stories-filter-statuses = Status
 stories-column-site = Site
 site-table-siteName = Nome do Site
 stories-filter-sites = Site
+
+stories-column-actions = Ações
+stories-column-rescrape = Re-coletar
+
+stories-actionsButton =
+  .aria-label = Selecionar ação
+stories-actions-popover =
+  .description = Uma lista para selecionar as ações da história
+stories-actions-rescrape = Re-coletar
+stories-actions-close = Fechar história
+stories-actions-open = Abrir história
+
+### Sections
+
+moderate-section-selector-allSections = Todas as seções
+moderate-section-selector-uncategorized = Sem categoria
+moderate-section-uncategorized = Sem categoria
 
 ### Email
 
@@ -689,19 +850,25 @@ moderate-navigation-comment-count = { SHORT_NUMBER($count) }
 moderate-marker-preMod = Pré-Moderado
 moderate-marker-link = Link
 moderate-marker-bannedWord = Palavra Banida
+moderate-marker-possibleBannedWord = Possível Palavra Banida
 moderate-marker-suspectWord = Palavra Suspeita
+moderate-marker-possibleSuspectWord = Possível Palavra Suspeita
 moderate-marker-spam = Spam
 moderate-marker-spamDetected = Spam detectado
 moderate-marker-toxic = Tóxico
 moderate-marker-recentHistory = Histórico recente
 moderate-marker-bodyCount = Tamanho do conteúdo
 moderate-marker-offensive = Ofensivo
+moderate-marker-abusive = Abusivo
 moderate-marker-newCommenter = Novo comentador
 moderate-marker-repeatPost = Comentário repetido
+moderate-marker-other = Outro
 
 moderate-markers-details = Detalhes
 moderate-flagDetails-offensive = Ofensivo
+moderate-flagDetails-abusive = Abusivo
 moderate-flagDetails-spam = Spam
+moderate-flagDetails-other = Outro
 
 moderate-flagDetails-toxicityScore = Score de toxicidade
 moderate-toxicityLabel-likely = Provável <score></score>
@@ -734,6 +901,8 @@ moderate-comment-featureText = Destaque
 moderate-comment-featuredText = Destacado
 moderate-comment-moderatedBy = Moderado por
 moderate-comment-moderatedBySystem = Sistema
+moderate-comment-play-gif = Executar GIF
+moderate-comment-load-video = Carregar vídeo
 
 moderate-single-goToModerationQueues = Ir para a fila de moderação
 moderate-single-singleCommentView = Visualização única de comentários
@@ -948,6 +1117,15 @@ community-premodModal-consequence =
 community-premodModal-cancel = Cancelar
 community-premodModal-premodUser = Sim, sempre pré-moderar
 
+community-siteModeratorModal-assignSites =
+  Atribuir sites para <strong>{ $username }</strong>
+community-siteModeratorModal-assignSitesDescription =
+  Os moderadores de sites têm permissão para tomar decisões de moderação e emitir suspensões nos sites que lhes são atribuídos.
+community-siteModeratorModal-cancel = Cancelar
+community-siteModeratorModal-assign = Atribuir
+community-siteModeratorModal-selectSites = Selecionar sites para moderar
+community-siteModeratorModal-noSites = Sem sites
+
 community-invite-inviteMember = Convidar membros para sua organização
 community-invite-emailAddressLabel = Endereço de e-mail:
 community-invite-inviteMore = Convidar mais
@@ -972,6 +1150,18 @@ community-invite-role-admin =
 community-invite-invitationsSent = Seus convites foram enviados!
 community-invite-close = Fechar
 community-invite-invite = Convidar
+
+community-warnModal-success =
+  Um aviso foi enviado para <strong>{ $username }</strong>.
+community-warnModal-success-close = Ok
+community-warnModal-areYouSure = Avisar <strong>{ $username }</strong>?
+community-warnModal-consequence = Um aviso pode melhorar a conduta de um comentador sem suspensão ou proibição. O usuário deve reconhecer o aviso antes de continuar comentando.
+community-warnModal-message-label = Mensagem
+community-warnModal-message-required = Obrigatório
+community-warnModal-message-description = Explique a este usuário como ele deve mudar o comportamento em seu site.
+community-warnModal-cancel = Cancelar
+community-warnModal-warnUser = Avisar usuário
+community-userStatus-warn = Avisar
 
 ## Stories
 stories-emptyMessage = Atualmente não há histórias publicadas.
@@ -1034,6 +1224,10 @@ userDetails-suspended-by = <strong>Suspendido por</strong> { $username }
 userDetails-suspension-start = <strong>Início:</strong> { $timestamp }
 userDetails-suspension-end = <strong>Fim:</strong> { $timestamp }
 
+userDetails-warned-on = <strong>Avisado em</strong> { $timestamp }
+userDetails-warned-by = <strong>por</strong> { $username }
+userDetails-warned-explanation = Usuário não reconheceu o aviso.
+
 configure-general-reactions-title = Reações
 configure-general-reactions-explanation =
   Permitir a interação da sua comunidade através de reações expressadas
@@ -1059,6 +1253,17 @@ configure-general-staff-label = Texto do crachá
 configure-general-staff-input =
   .placeholder = Ex: Staff
 configure-general-staff-preview = Pré-visualização
+
+configure-general-rte-title = Comentários em texto rico
+configure-general-rte-express = Dê à sua comunidade mais maneiras de se expressar além do texto simples com formatação de texto rico.
+configure-general-rte-richTextComments = Comentários em texto rico
+configure-general-rte-onBasicFeatures = Ativado - negrito, itálico, citações em bloco e listas com marcadores
+configure-general-rte-additional = Opções de texto rico adicionais
+configure-general-rte-strikethrough = Tachado
+configure-general-rte-spoiler = Spoiler
+configure-general-rte-spoilerDesc =
+  Palavras e frases formatadas como spoiler ficam escondidas atrás de
+  um fundo escuro até que o leitor decida revelar o texto.
 
 configure-account-features-title = Gerenciamento de recursos da conta de comentaristas
 configure-account-features-explanation =
@@ -1116,3 +1321,28 @@ hotkeysModal-shortcuts-ban = Banir autor do comentário
 hotkeysModal-shortcuts-zen = Alternar visualização de comentário único
 
 authcheck-network-error = Ocorreu um erro de rede. Por favor, atualize a página.
+
+dashboard-heading-last-updated = Última atualização:
+
+dashboard-today-heading = Atividade de hoje
+dashboard-today-new-comments = Novos comentários
+dashboard-alltime-new-comments = Total de todos os tempos
+dashboard-today-rejections = Taxa de rejeição
+dashboard-alltime-rejections = Média de todos os tempos
+dashboard-today-staff-comments = Comentários da equipe
+dashboard-alltime-staff-comments = Total de todos os tempos
+dashboard-today-signups = Novos membros da comunidade
+dashboard-alltime-signups = Total de membros
+dashboard-today-bans = Membros banidos
+dashboard-alltime-bans = Total de membros banidos
+
+dashboard-top-stories-today-heading = As histórias mais comentadas de hoje
+dashboard-top-stories-table-header-story = História
+dashboard-top-stories-table-header-comments = Comentários
+dashboard-top-stories-no-comments = Sem comentários hoje
+
+dashboard-commenters-activity-heading = Novos membros da comunidade esta semana
+
+dashboard-comment-activity-heading = Atividade de comentários por hora
+dashboard-comment-activity-tooltip-comments = Comentários
+dashboard-comment-activity-legend = Média dos últimos 3 dias

--- a/src/locales/pt-BR/auth.ftl
+++ b/src/locales/pt-BR/auth.ftl
@@ -96,7 +96,8 @@ resetPassword-resetPasswordButton = Redefinir Senha
 
 ## Create Username
 
-createUsername-createUsernameHeader = Criar nome de usuário
+createUsername-createUsernameHeader =
+createUsername-createAUsername = Create um usuário
 createUsername-whatItIs =
   Seu nome de usuário é o identificador que irá aparecer em todos os seus comentários.
 createUsername-createUsernameButton = Criar usuário
@@ -122,7 +123,8 @@ addEmailAddress-addEmailAddressButton =
   Adicionar Endereço de E-mail
 
 ## Create Password
-createPassword-createPasswordHeader = Criar Senha
+createPassword-createPasswordHeader =
+createPassword-createAPassword = Criar uma senha
 createPassword-whatItIs =
   Para proteger contra alterações não autorizadas na sua conta,
   Nós exigimos que os usuários criem uma senha.

--- a/src/locales/pt-BR/common.ftl
+++ b/src/locales/pt-BR/common.ftl
@@ -5,3 +5,6 @@ common-banEmailTemplate =
   Olá { $username },
 
   Alguém com acesso à sua conta violou nossas diretrizes da comunidade. Como resultado, sua conta foi banida. Você não poderá mais comentar, reagir ou relatar comentários.
+
+common-embedNotFound = A mídia solicitada não foi encontrada. Ela pode ter sido excluída.
+common-networkError = Erro de rede. Por favor, atualize a página e tente novamente

--- a/src/locales/pt-BR/stream.ftl
+++ b/src/locales/pt-BR/stream.ftl
@@ -2,19 +2,41 @@
 
 ## General
 
+general-moderate = Moderar
+
 general-userBoxUnauthenticated-joinTheConversation = Participe da conversa
 general-userBoxUnauthenticated-signIn = Entrar
 general-userBoxUnauthenticated-register = Cadastre-se
 
 general-userBoxAuthenticated-signedInAs =
-  Logado como <username></username>.
-
+general-userBoxAuthenticated-signedIn =
+  Logado como
 general-userBoxAuthenticated-notYou =
   Não é você? <button>Sair</button>
 
+general-userBox-youHaveBeenSuccessfullySignedOut =
+  Você foi desconectado com sucesso
+
 general-tabBar-commentsTab = Comentários
 general-tabBar-myProfileTab = Meu Perfil
+general-tabBar-discussionsTab = Discussões
 general-tabBar-configure = Configurações
+
+general-tabBar-aria-comments =
+  .aria-label = Comentários
+  .title = Comentários
+general-tabBar-aria-qa =
+  .aria-label = Q&A
+  .title = Q&A
+general-tabBar-aria-myProfile =
+  .aria-label = Meu Perfil
+  .title = Meu Perfil
+general-tabBar-aria-configure =
+  .aria-label = Configurações
+  .title = My Perfil
+general-tabBar-aria-discussions =
+  .aria-label = Discussões
+  .title = Discussões
 
 ## Comment Count
 
@@ -33,8 +55,11 @@ comments-featuredCommentTooltip-how = Como um comentário é destacado?
 comments-featuredCommentTooltip-handSelectedComments =
   Os comentários são selecionados por nossa equipe como merecedores de serem lidos.
 comments-featuredCommentTooltip-toggleButton =
-  .aria-label = Ative a dica de comentários
+  .aria-label = Alternar sugestão de comentários em destaque
+  .title = Alternar sugestão de comentários em destaque
 
+comments-collapse-toggle =
+  .aria-label = Recolher tópico de comentários
 comments-bannedInfo-bannedFromCommenting = Sua conta foi banida de comentar.
 comments-bannedInfo-violatedCommunityGuidelines =
   Alguém com acesso à sua conta violou nossas diretrizes da comunidade.
@@ -47,10 +72,27 @@ comments-noCommentsYet = Ainda não há comentários. Seja o primeiro a comentar
 
 comments-streamQuery-storyNotFound = História não encontrada
 
+comments-commentForm-cancel = Cancelar
+comments-commentForm-saveChanges = Salvar alterações
+comments-commentForm-submit = Enviar
+
 comments-postCommentForm-submit = Enviar
 comments-replyList-showAll = Mostrar Tudo
 comments-replyList-showMoreReplies = Carregar Mais
 
+comments-postCommentForm-gifSeach = Procurar por um GIF
+comments-postComment-gifSearch-loading = Carregando...
+comments-postComment-gifSearch-no-results = Nenhum resultado encontrado para {$query}
+comments-postComment-gifSearch-powered-by-giphy =
+  .alt = Desenvolvido por giphy
+
+comments-postComment-confirmMedia-youtube = Adicionar este vídeo do YouTube ao final do seu comentário?
+comments-postComment-confirmMedia-twitter = Adicionar este Tweet ao final do seu comentário?
+comments-postComment-confirmMedia-cancel = Cancelar
+comments-postComment-confirmMedia-add-tweet = Adicionar Tweet
+comments-postComment-confirmMedia-add-video = Adicionar vídeo
+comments-postComment-confirmMedia-remove = Remover
+comments-commentForm-gifPreview-remove = Remover
 comments-viewNew =
   { $count ->
     [1] Visualizar {$count} Novo Comentário
@@ -63,6 +105,8 @@ comments-permalinkPopover =
 comments-permalinkPopover-permalinkToComment =
   .aria-label = Link permanente para o comentário
 comments-permalinkButton-share = Compartilhar
+comments-permalinkButton =
+  .aria-label = Compartilhar
 comments-permalinkView-viewFullDiscussion = Ver discussão completa
 comments-permalinkView-commentRemovedOrDoesNotExist = Este comentário foi removido ou não existe.
 
@@ -74,6 +118,14 @@ comments-rte-italic =
 
 comments-rte-blockquote =
   .title = Citação
+
+comments-rte-bulletedList =
+  .title = Lista com marcadores
+
+comments-rte-strikethrough =
+  .title = Tachado
+
+comments-rte-spoiler = Spoiler
 
 comments-remainingCharacters = { $remaining } caracteres restantes
 
@@ -91,6 +143,8 @@ comments-postCommentForm-userScheduledForDeletion-warning =
   Os comentários ficam desativados quando sua conta está agendada para exclusão.
 
 comments-replyButton-reply = Responder
+comments-replyButton =
+  .aria-label = Responder
 
 comments-permalinkViewQuery-storyNotFound = { comments-streamQuery-storyNotFound }
 
@@ -115,13 +169,19 @@ comments-showConversationLink-readMore = Leia mais desta conversa >
 comments-conversationThread-showMoreOfThisConversation =
   Mostrar mais desta conversa
 
-comments-permalinkView-currentViewing = Você está visualizando um
-comments-permalinkView-singleConversation = CONVERSAÇÃO ÚNICA
+comments-permalinkView-currentViewing =
+comments-permalinkView-singleConversation =
+comments-permalinkView-youAreCurrentlyViewing =
+  Você está visualizando um
 comments-inReplyTo = Em resposta a <username></username>
-comments-replyTo = Respondendo a: <username></username>
+comments-replyingTo = Respondendo para <Username></Username>
 
 comments-reportButton-report = Denunciar
 comments-reportButton-reported = Denunciado
+comments-reportButton-aria-report =
+  .aria-label = Denunciar
+comments-reportButton-aria-reported =
+  .aria-label = Denunciado
 
 comments-sortMenu-sortBy = Ordenar Por
 comments-sortMenu-newest = Mais novos
@@ -159,12 +219,15 @@ comments-moderationDropdown-reject = Rejeitar
 comments-moderationDropdown-rejected = Rejeitado
 comments-moderationDropdown-ban = Banir Usuário
 comments-moderationDropdown-banned = Banido
-comments-moderationDropdown-goToModerate = Moderar
+comments-moderationDropdown-goToModerate =
+comments-moderationDropdown-moderationView = Visão de moderação
+comments-moderationDropdown-moderateStory = Moderar história
 comments-moderationDropdown-caretButton =
-  .aria-label = Moderado
+  .aria-label = Moderar
 
-comments-rejectedTombstone =
-  Você rejeitou este comentário. <TextLink> Vá para Moderados para rever esta decisão. </TextLink>
+comments-rejectedTombstone-title = Você rejeitou este comentário.
+comments-rejectedTombstone-moderateLink =
+  Vá para moderação para revisar esta decisão
 
 comments-featuredTag = Destaques
 
@@ -199,6 +262,10 @@ qa-expert-tag = especialista
 
 qa-reaction-vote = Votar
 qa-reaction-voted = Votado
+qa-reaction-aria-vote =
+  .aria-label = Votar
+qa-reaction-voted =
+  .aria-label = Votado
 
 qa-unansweredTab-doneAnswering = Feito
 
@@ -209,6 +276,8 @@ qa-answeredTooltip-answeredComments =
   Perguntas são respondidas por um especialista Perguntas & Respostas.
 qa-answeredTooltip-toggleButton =
   .aria-label = Alternar dica de ferramenta das perguntas respondidas
+  .title = Alternar dic de ferramenta das perguntas respondidas
+
 ### Account Deletion Stream
 
 comments-stream-deleteAccount-callOut-title =
@@ -220,6 +289,22 @@ comments-stream-deleteAccount-callOut-cancelDesc =
   você pode cancelar sua solicitação para excluir sua conta antes de { $date }.
 comments-stream-deleteAccount-callOut-cancel =
   Cancelar solicitação de exclusão de conta
+comments-stream-deleteAccount-callOut-cancelAccountDeletion =
+  Cancelar exclusão de conta
+
+### Embed Links
+
+comments-embedLinks-showEmbeds = Mostrar conteúdo embutido
+comments-embedLinks-hideEmbeds = Esconder conteúdo embutido
+
+comments-embedLinks-show-giphy = Mostrar GIF
+comments-embedLinks-hide-giphy = Esconder GIF
+
+comments-embedLinks-show-youtube = Mostrar vídeo
+comments-embedLinks-hide-youtube = ESconder vídeo
+
+comments-embedLinks-show-twitter = Mostrar Tweet
+comments-embedLinks-hide-twitter = Esconder Tweet
 
 ### Featured Comments
 comments-featured-gotoConversation = Ir para a conversa
@@ -232,14 +317,14 @@ profile-myCommentsTab-comments = Meus comentários
 profile-accountTab = Conta
 profile-preferencesTab = Preferências
 
-accountSettings-manage-account = Gerencie a sua conta
-
 ### Account Deletion
 
 profile-accountDeletion-deletionDesc =
   Sua conta está agendada para ser excluída em { $date }.
 profile-accountDeletion-cancelDeletion =
   Cancelar solicitação de exclusão de conta
+profile-accountDeletion-cancelAccountDeletion =
+  Cancelar exclusão de conta
 
 ### Comment History
 profile-historyComment-viewConversation = Ver conversa
@@ -253,6 +338,15 @@ profile-commentHistory-loadMore = Carregar Mais
 profile-commentHistory-empty = Você não escreveu nenhum comentário
 profile-commentHistory-empty-subheading = Um histórico dos seus comentários aparecerá aqui
 
+### Preferences
+
+profile-preferences-mediaPreferences = Preferências de mídia
+profile-preferences-mediaPreferences-alwaysShow = Sempre mostrar GIFs, Tweets, YouTube, etc.
+profile-preferences-mediaPreferences-thisMayMake = Isso pode tornar o carregamento de comentários mais lento
+profile-preferences-mediaPreferences-update = Atualizar
+profile-preferences-mediaPreferences-preferencesUpdated =
+  Suas preferências de mídia foram atualizadas
+
 ### Account
 profile-account-ignoredCommenters = Usuários ignorados
 profile-account-ignoredCommenters-description =
@@ -262,8 +356,11 @@ profile-account-ignoredCommenters-description =
    ver seus comentários.
 profile-account-ignoredCommenters-empty = Você não está ignorando ninguém
 profile-account-ignoredCommenters-stopIgnoring = Parar de ignorar
+profile-account-ignoredCommenters-youAreNoLonger =
+  Você não está mais ignorando
 profile-account-ignoredCommenters-manage = Gerenciar
 profile-account-ignoredCommenters-cancel = Cancelar
+profile-account-ignoredCommenters-close = Fechar
 
 profile-account-changePassword-cancel = Cancelar
 profile-account-changePassword = Alterar a Senha
@@ -285,13 +382,22 @@ profile-account-download-comments-request-icon =
   .title = Solicitar histórico de comentários
 profile-account-download-comments-recentRequest =
   Sua solicitação mais recente: { $timeStamp }
+profile-account-download-comments-yourMostRecentRequest =
+  Sua solicitação mais recente ocorreu nos últimos 14 dias. Você pode
+  solicitar o download de seus comentários novamente em: { $timeStamp }
 profile-account-download-comments-requested =
   Solicitação submetida. Você pode submeter outra solicitação em { framework-timeago-time }.
 profile-account-download-comments-request-button = Solicitar
+profile-account-download-comments-requestSubmitted =
+  O seu pedido foi enviado com sucesso. Você pode solicitar o
+  download do seu histórico de comentários novamente em { framework-timeago-time }.
+profile-account-download-comments-error =
+  Não foi possível concluir sua solicitação de download.
 
 ## Delete Account
 
 profile-account-deleteAccount-title = Deletar minha conta
+profile-account-deleteAccount-deleteMyAccount = Deletar minha conta
 profile-account-deleteAccount-description =
   A exclusão de sua conta apagará permanentemente seu perfil e removerá
   todos os seus comentários deste site.
@@ -310,7 +416,9 @@ profile-account-deleteAccount-pages-cancel = Cancelar
 profile-account-deleteAccount-pages-proceed = Continuar
 profile-account-deleteAccount-pages-done = Pronto
 profile-account-deleteAccount-pages-phrase =
-  .aria-label = Frase
+  .aria-label = Fase
+
+profile-account-deleteAccount-pages-sharedHeader = Deletar minha conta
 
 profile-account-deleteAccount-pages-descriptionHeader = Deletar minha conta?
 profile-account-deleteAccount-pages-descriptionText =
@@ -323,6 +431,7 @@ profile-account-deleteAccount-pages-emailRemoved =
   O seu endereço de email foi removido do nosso sistema
 
 profile-account-deleteAccount-pages-whenHeader = Deletar minha conta: quando?
+profile-account-deleteAccount-pages-whenSubHeader = Quando?
 profile-account-deleteAccount-pages-whenSec1Header =
   Quando minha conta será excluída?
 profile-account-deleteAccount-pages-whenSec1Content =
@@ -334,6 +443,7 @@ profile-account-deleteAccount-pages-whenSec2Content =
   responda a comentários ou selecione reações.
 
 profile-account-deleteAccount-pages-downloadCommentHeader = Baixar meus comentários?
+profile-account-deleteAccount-pages-downloadSubHeader = Baixar meus comentários
 profile-account-deleteAccount-pages-downloadCommentsDesc =
   Antes de sua conta ser excluída, recomendamos que você baixe seu comentário
   histórico para seus registros. Depois que sua conta for excluída, você será
@@ -342,6 +452,7 @@ profile-account-deleteAccount-pages-downloadCommentsPath =
   Meu perfil > Baixar meu histórico de comentários
 
 profile-account-deleteAccount-pages-confirmHeader = Confirmar exclusão da conta?
+profile-account-deleteAccount-pages-confirmSubHeader = Você tem certeza?
 profile-account-deleteAccount-pages-confirmDescHeader =
   Tem certeza de que deseja excluir sua conta?
 profile-account-deleteAccount-confirmDescContent =
@@ -353,6 +464,7 @@ profile-account-deleteAccount-pages-confirmPasswordLabel =
   Insira sua senha:
 
 profile-account-deleteAccount-pages-completeHeader = Exclusão de conta solicitada
+profile-account-deleteAccount-pages-completeSubHeader = Solicitação enviada
 profile-account-deleteAccount-pages-completeDescript =
   Sua solicitação foi enviada e uma confirmação foi enviada para o e-mail
   endereço associado à sua conta.
@@ -367,6 +479,7 @@ profile-account-deleteAccount-pages-completeWhyDeleteAccount =
   Gostaríamos de saber por que você optou por excluir sua conta. Envie-nos um feedback sobre
   nosso sistema de comentários por e-mail { $email }.
 profile-account-changePassword-edit = Editar
+profile-account-changePassword-change = Alterar
 
 
 ## Notifications
@@ -393,14 +506,18 @@ comments-reportPopover-reportThisComment = Denunciar este comentário
 comments-reportPopover-whyAreYouReporting = Por que você está denunciando este comentário?
 
 comments-reportPopover-reasonOffensive = Este comentário é ofensivo
+comments-reportPopover-reasonAbusive = Este é um comportamento abusivo
 comments-reportPopover-reasonIDisagree = Eu não concordo com esse comentário
 comments-reportPopover-reasonSpam = Isso parece um anúncio ou marketing
 comments-reportPopover-reasonOther = Outros
 
+comments-reportPopover-additionalInformation =
+  Informação adicional <optional>Opcional</optional>
 comments-reportPopover-pleaseLeaveAdditionalInformation =
   Por favor, deixe qualquer informação adicional que possa ser útil para nossos moderadores. (Opcional)
 
 comments-reportPopover-maxCharacters = Máximo { $maxCharacters } Caracteres
+comments-reportPopover-restrictToMaxCharacters = Restrinja seu relatório a { $maxCharacters } caracteres
 comments-reportPopover-cancel = Cancelar
 comments-reportPopover-submit = Denunciar
 
@@ -425,7 +542,9 @@ configure-configureQuery-storyNotFound = História não encontrada
 profile-changeUsername-username = Usuário
 profile-changeUsername-success = Seu nome de usuário foi atualizado com sucesso
 profile-changeUsername-edit = Editar
+profile-changeUsername-change = Alterar
 profile-changeUsername-heading = Edite seu nome de usuário
+profile-changeUsername-heading-changeYourUsername = Alterar seu nome de usuário
 profile-changeUsername-desc = Altere o nome de usuário que aparecerá em todos os seus comentários anteriores e futuros. <strong> Nomes de usuário podem ser alterados uma vez a cada { framework-timeago-time }. </strong>
 profile-changeUsername-desc-text = Altere o nome de usuário que aparecerá em todos os seus comentários anteriores e futuros. Os nomes de usuário podem ser alterados uma vez a cada { framework-timeago-time }.
 profile-changeUsername-current = Nome de usuário atual
@@ -433,35 +552,81 @@ profile-changeUsername-newUsername-label = Novo usuário
 profile-changeUsername-confirmNewUsername-label = Confirme o novo nome de usuário
 profile-changeUsername-cancel = Cancelar
 profile-changeUsername-save = Salvar
+profile-changeUsername-saveChanges = Salvar alterações
 profile-changeUsername-recentChange = Seu nome de usuário foi alterado em { framework-timeago-time }. Você pode alterar seu nome de usuário novamente em { $nextUpdate }
+profile-changeUsername-youChangedYourUsernameWithin =
+  Você alterou seu nome de usuário no(s) último(s) { framework-timeago-time }. Você pode alterar seu nome de usuário novamente em: { $nextUpdate }.
 profile-changeUsername-close = Fechar
 
+## Discussions tab
+
+discussions-mostActiveDiscussions = Discussões mais ativas
+discussions-mostActiveDiscussions-subhead = Classificado com o maior número de comentários recebidos nas últimas 24 horas em { $siteName }
+discussions-mostActiveDiscussions-empty = Você não participou de nenhuma discussão
+discussions-myOngoingDiscussions = Minhas discussões em andamento
+discussions-myOngoingDiscussions-subhead = Onde você comentou via { $orgName }
+discussions-viewFullHistory = Ver o histórico de comentários completo
+discussions-discussionsQuery-errorLoadingProfile = Erro ao carregar perfil
+discussions-discussionsQuery-storyNotFound = História não encontrada
+
 ## Comment Stream
-configure-stream-title = Configurar este fluxo de comentários
+configure-stream-title =
 configure-stream-title-configureThisStream =
   Configurar este Fluxo
-configure-stream-apply = Aplicar
+configure-stream-apply =
+configure-stream-update = Atualizar
+configure-stream-streamHasBeenUpdated =
+  Este fluxo foi atualizado
 
-configure-premod-title = Ativar Pré-Moderação
+configure-premod-title =
+configure-premod-premoderateAllComments = Pré-moderar todos os comentários
 configure-premod-description =
   Os moderadores devem aprovar qualquer comentário antes de ser publicado neste fluxo.
 
-configure-premodLink-title = Comentários pré-moderados contendo links
+configure-premodLink-title =
+configure-premodLink-commentsContainingLinks =
+  Pré-moderar comentários que possuem links
 configure-premodLink-description =
   Os moderadores devem aprovar qualquer comentário que contenha um link antes de ser publicado.
 
-configure-liveUpdates-title = Ativar atualizações em tempo real para esta história
+configure-liveUpdates-title =
+configure-enableLiveUpdates-title = Ativar atualizações em tempo real
 configure-liveUpdates-description =
+configure-enableLiveUpdates-description =
   Quando ativado, os comentários serão atualizados instantaneamente
   assim como novos comentários e respostas, ao invés de exigir
   o recarregamento da página. Você pode desabilitar esta opção
   em certas situações, como um alto volume de acesso que pode fazer com que os comentários fiquem lentos.
+configure-enableLiveUpdates-enable = Ativar
 
-configure-messageBox-title = Ativar caixa de mensagens para este fluxo
+configure-disableLiveUpdates-title = Desativar atualizações em tempo real
+configure-disableLiveUpdates-description =
+  Quando desativado, novos comentários e respostas não serão mais atualizados instantaneamente
+  à medida que são enviados. Os comentaristas precisarão atualizar a página para ver
+  novos comentários. Recomendamos isso na situação incomum de uma história
+  recebendo tanto tráfego que os comentários estão carregando lentamente.
+configure-disableLiveUpdates-disable = Desativar
+
+configure-liveUpdates-disabledSuccess = As atualizações em tempo real agora estão desativadas
+configure-liveUpdates-enabledSuccess = As atualizações em tempo real agora estão ativadas
+
+configure-messageBox-title =
+configure-addMessage-title =
+  Adicione uma mensagem ou pergunta
 configure-messageBox-description =
+configure-addMessage-description =
   Adicione uma mensagem ao topo da caixa de comentários para seus leitores.
   Use isso para representar um tópico, faça uma pergunta ou faça anúncios
   relacionados a essa história.
+configure-addMessage-addMessage = Adicionar mensagem
+configure-addMessage-removed = A mensagem foi removida
+config-addMessage-messageHasBeenAdded =
+  A mensagem foi adicionada à caixa de comentários
+configure-addMessage-remove = Remover
+configure-addMessage-submitUpdate = Atualizar
+configure-addMessage-cancel = Cancelar
+configure-addMessage-submitAdd = Adicionar mensagem
+
 configure-messageBox-preview = Visualizar
 configure-messageBox-selectAnIcon = Selecione um ícone
 configure-messageBox-iconConversation = Conversa
@@ -472,32 +637,46 @@ configure-messageBox-iconChatBubble = Chat
 configure-messageBox-noIcon = Sem ícone
 configure-messageBox-writeAMessage = Escreve uma mensagem
 
-configure-closeStream-title = Fechar fluxo de comentários
+configure-closeStream-title =
+configure-closeStream-closeCommentStream =
+  Fechar fluxo de comentários
 configure-closeStream-description =
   Este fluxo de comentários está aberto no momento. Ao fechar este fluxo de comentários,
   nenhum novo comentário pode ser enviado e todos os comentários enviados anteriormente
   ainda serão exibidos.
 configure-closeStream-closeStream = Fechar Fluxo de Comentários
+configure-closeStream-theStreamIsNowOpen = O flxuo agora está aberto
 
 configure-openStream-title = Fluxo aberto
 configure-openStream-description =
   Este fluxo de comentários está atualmente fechado. Abrindo este fluxo de comentários
   novos comentários podem ser enviados e exibidos.
 configure-openStream-openStream = Abrir Fluxo
+configure-openStream-theStreamIsNowClosed = O fluxo agora está fechado
 
-configure-moderateThisStream = Moderar esta história
+configure-moderateThisStream =
 
-configure-enableQA-title = Mudar para formato Perguntas & Respostas
+qa-experimental-tag-tooltip-content =
+  O formato de perguntas e respostas está atualmente em desenvolvimento ativo. Entre em
+  contato conosco para qualquer feedback ou solicitação.
+
+configure-enableQA-title =
+configure-enableQA-switchToQA =
+  Mudar para formato Perguntas & Respostas
 configure-enableQA-description =
   O formato de Perguntas & Respostas permite aos membros da comunidade
   enviar perguntas para especialistas selecionados responderem.
 configure-enableQA-enableQA = Mudar para Perguntas & Respostas
+configure-enableQA-streamIsNowComments =
+  Este fluxo está agora em formato de comentários
 
 configure-disableQA-title = Configurar esta Perguntas & Respostas
 configure-disableQA-description =
   O formato de Perguntas & Respostas permite membros da comunidade
   enviarem perguntas para especialistas responderem.
 configure-disableQA-disableQA = Trocar para Comentários
+configure-disableQA-streamIsNowQA =
+  Este stream está agora em formato de perguntas e respostas
 
 configure-experts-title = Adicionar um Especialista
 configure-experts-filter-searchField =
@@ -513,21 +692,36 @@ configure-experts-search-none-found = Nenhum usuário foi encontrado com esse em
 configure-experts-remove-button = Remover
 configure-experts-load-more = Carregar Mais
 configure-experts-none-yet = Não existem especialistas para estas Peguntas & Respostas no momento.
+configure-experts-search-title = Procurar por um especialista
 configure-experts-assigned-title = Especialistas
-
+configure-experts-noLongerAnExpert = Não é mais um especialista
 comments-tombstone-ignore = Este comentário está oculto porque você ignorou {$username}
+comments-tombstone-showComment = Mostrar comentário
 comments-tombstone-deleted =
   Este comentário não está mais disponível. O usuário excluiu sua conta.
 
-suspendInfo-heading = Sua conta foi temporariamente suspensa de comentar.
+suspendInfo-heading =
+suspendInfo-heading-yourAccountHasBeen =
+  Sua conta foi temporariamente suspensa de comentar.
 suspendInfo-info =
+suspendInfo-description-inAccordanceWith =
   Em concordância com as regras da comunidade { $organization }, sua
   conta foi temporariamente suspensa. Enquanto suspenso, você não
   poderá comentar, respeitar ou denunciar comentários. Por favor, junte-se a conversa
   em { $until }.
+suspendInfo-until-pleaseRejoinThe =
+  Volte a conversa em { $until }
+
+warning-heading = Sua conta recebeu um aviso
+warning-explanation =
+  De acordo com as diretrizes da nossa comunidade, foi emitido um aviso para sua conta.
+warning-instructions =
+  Para continuar participando das discussões, pressione o botão "Reconhecer" abaixo.
+warning-acknowledge = Reconhecer
 
 profile-changeEmail-unverified = (Não verificado)
 profile-changeEmail-edit = Editar
+profile-changeEmail-change = Alterar
 profile-changeEmail-please-verify = Verifique seu endereço de e-mail
 profile-changeEmail-please-verify-details =
   Um email foi enviado para { $email } para verificar sua conta.
@@ -535,6 +729,8 @@ profile-changeEmail-please-verify-details =
   para fazer login na sua conta ou receber notificações.
 profile-changeEmail-resend = Reenviar notificação
 profile-changeEmail-heading = Edite seu endereço de email
+profile-changeEmail-changeYourEmailAddress =
+  Alterar o seu endereço de email
 profile-changeEmail-desc = Altere o endereço de email usado para fazer login e receber comunicações sobre sua conta.
 profile-changeEmail-current = Email atual
 profile-changeEmail-newEmail-label = Novo Endereço de Email
@@ -543,4 +739,7 @@ profile-changeEmail-password-input =
   .placeholder = Senha
 profile-changeEmail-cancel = Cancelar
 profile-changeEmail-submit = Salvar
+profile-changeEmail-saveChanges = Salvar alterações
 profile-changeEmail-email = Email
+profile-changeEmail-title = Endereço de email
+profile-changeEmail-success = Seu e-mail foi atualizado com sucesso


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

This PR updates pt-BR translation for features that were introduced up to version 6.3.2
As it is just an update of the fluent language files, there was no change in the GraphQL schema/Database. To test you can run coraltalk, selecting Portuguese (Brazil) language. It's expected that there will be no English term for the interface, unless the English word also applies to Portuguese :D