### PR TITLE
[CORL-1316] Adjust flex and text wrapping of external media url's

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/MediaConfirmation/MediaPreview.css
+++ b/src/core/client/stream/tabs/Comments/Comment/MediaConfirmation/MediaPreview.css
@@ -12,14 +12,16 @@
   color: var(--palette-primary-500);
   margin: 0;
   font-weight: var(--font-weight-primary-semi-bold);
+
+  overflow: hidden;
+  word-wrap: break-word;
+}
+
+.link {
+  overflow: hidden;
 }
 
 .removeButton {
-  flex: 1;
-  display: block;
-  width: 100%;
   margin-top: var(--spacing-1);
-}
-
-.icon {
+  margin-bottom: var(--spacing-3);
 }

--- a/src/core/client/stream/tabs/Comments/Comment/MediaConfirmation/MediaPreview.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MediaConfirmation/MediaPreview.tsx
@@ -8,16 +8,17 @@ import {
   YouTubeMedia,
 } from "coral-stream/common/Media";
 import {
-  Button,
-  ButtonIcon,
   Flex,
   HorizontalGutter,
+  Icon,
   MatchMedia,
 } from "coral-ui/components/v2";
+import { Button } from "coral-ui/components/v3";
 
 import MediaConfirmationIcon from "./MediaConfirmationIcon";
 
 import styles from "./MediaPreview.css";
+
 interface MediaConfig {
   giphy: {
     enabled: boolean;
@@ -48,56 +49,77 @@ const MediaPreview: FunctionComponent<Props> = ({
 }) => {
   return (
     <div>
-      <HorizontalGutter spacing={3} className={styles.root}>
-        <div>
-          <Flex justifyContent="space-between">
-            <Flex spacing={2}>
-              <div className={styles.icon}>
-                <MediaConfirmationIcon media={media} />
+      <MatchMedia gteWidth="xs">
+        {(matches) => (
+          <>
+            <HorizontalGutter spacing={3} className={styles.root}>
+              <div>
+                <Flex justifyContent="space-between" alignItems="center">
+                  <Flex
+                    spacing={2}
+                    alignItems="baseline"
+                    className={styles.link}
+                  >
+                    <div>
+                      <MediaConfirmationIcon media={media} />
+                    </div>
+                    <div className={styles.url}>
+                      <a
+                        href={media.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {media.url}
+                      </a>
+                    </div>
+                  </Flex>
+                  {matches && (
+                    <Button
+                      onClick={onRemove}
+                      color="secondary"
+                      variant="flat"
+                      paddingSize="extraSmall"
+                    >
+                      <Flex alignItems="flex-end" justifyContent="flex-end">
+                        <Icon size="sm">close</Icon>
+                        <Localized id="comments-postComment-confirmMedia-remove">
+                          <span>Remove</span>
+                        </Localized>
+                      </Flex>
+                    </Button>
+                  )}
+                </Flex>
               </div>
-              <a
-                href={media.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.url}
-              >
-                {media.url}
-              </a>
-            </Flex>
-            <MatchMedia gteWidth="xs">
-              <Localized id="comments-postComment-confirmMedia-remove">
-                <Button onClick={onRemove} color="mono" variant="text" iconLeft>
-                  <ButtonIcon>close</ButtonIcon>
-                  Remove
+              {media.type === "external" && (
+                <ExternalMedia url={media.url} siteID={siteID} />
+              )}
+              {media.type === "twitter" && (
+                <TwitterMedia url={media.url} siteID={siteID} />
+              )}
+              {media.type === "youtube" && (
+                <YouTubeMedia url={media.url} siteID={siteID} />
+              )}
+            </HorizontalGutter>
+            {!matches && (
+              <Flex justifyContent="center">
+                <Button
+                  onClick={onRemove}
+                  color="secondary"
+                  variant="flat"
+                  paddingSize="extraSmall"
+                  className={styles.removeButton}
+                >
+                  <Flex alignItems="flex-end">
+                    <Icon size="sm">close</Icon>
+                    <Localized id="comments-postComment-confirmMedia-remove">
+                      <span>Remove</span>
+                    </Localized>
+                  </Flex>
                 </Button>
-              </Localized>
-            </MatchMedia>
-          </Flex>
-        </div>
-        {media.type === "external" && (
-          <ExternalMedia url={media.url} siteID={siteID} />
+              </Flex>
+            )}
+          </>
         )}
-        {media.type === "twitter" && (
-          <TwitterMedia url={media.url} siteID={siteID} />
-        )}
-        {media.type === "youtube" && (
-          <YouTubeMedia url={media.url} siteID={siteID} />
-        )}
-      </HorizontalGutter>
-      <MatchMedia ltWidth="xs">
-        <Localized id="comments-postComment-confirmMedia-remove">
-          <Button
-            onClick={onRemove}
-            color="mono"
-            variant="text"
-            iconLeft
-            size="large"
-            className={styles.removeButton}
-          >
-            <ButtonIcon>close</ButtonIcon>
-            Remove
-          </Button>
-        </Localized>
       </MatchMedia>
     </div>
   );


### PR DESCRIPTION
## What does this PR do?

Adjusts flex and text wrapping of external media url's.

Prevents the scenario when long url's and invalid content make it impossible to click on the remove button.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Paste a long url into the external media and see it not push out the remove button
- Paste a long random piece of invalid text and see it not push out the remove button
- Paste a short piece of text and still be able to access the remove button
- Do the above 3 in a mobile small view and be able to use the remove button
- Remove button is always clickable and works to remove the content