### PR TITLE
[CORL-1319] Set width and height on avatar container

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.css
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.css
@@ -55,10 +55,11 @@ $commenterActionEditColorActive: var(--palette-primary-300);
 }
 
 .avatarContainer {
+  width: 24px;
+  height: 24px;
 }
 
 .avatar {
-  width: 24px;
-  height: 24px;
-  display: block;
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
## What does this PR do?

Sets the 24px width and height on the avatar container div and lets the avatar image fill the div via a 100% width, height css properties.

This prevents a rendering bug where iOS Chrome would squish the width of avatars when a parent comment width was small.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Modify your tenant to have its domain be your public ip (not localhost or 127.0.0.1)
- Build a local development version of coral using `npm run build:development`
- Start up the develop server with `npm run start:development`
- Use a separate web server to emulate an external host site for Coral 
    - Make sure that it has a pasted embed pointing to Coral's publicly hosted IP
    - Make sure this is also available on your public ip
    - Make sure the Coral embed iframe is less than 300 pixels wide (~80% of an iPhone X's scaled screen width)
    - Make sure you have `<meta name="viewport" content="width=device-width, initial-scale=1">` set on your external host site (this is usually in the `<head>` tag).
- Allow the public IP:Port combo for the separate web host site on your Coral Organization's Site
- Under Config > Advanced, set the site's custom CSS to use SBN's theming (https://www.sbnation.com/style/coral_fonts/247/index.css)
- Enable avatars in Coral
    - If you don't know how to do this, contact me
- Login on your local computer
- Sign in via Google so you have an Avatar
- Create a comment, then reply to it multiple times so you get it to be 4 levels deep
    - It is vital that this comment WITH AN AVATAR be 4 levels down so the width is tiny
- Sign in as an admin user
- Feature the 4 level down, Google account, avatar-ed comment using the moderation caret
    - I featured all the comments I made with this user for good measure
- Grab an iPhone running iOS
- Install the Chrome browser (yes, I know all browsers SHOULD be the same webkit rendering on iOS, but they're not... Safari and Firefox for iOS will NOT REPRODUCE this squished rendering bug)
    - If you are using Chrome that is already installed you need to clear your cache, any prior visit to Coral will cache the styles for the avatar images
        - You can clear the cache using: ... > Settings > Privacy > Clear Browsing Data
            - Probably best to set the Time Range to "All Time" to clear all cached Coral data
            - Then you can click the "Clear browsing data" at the bottom
- Use the chrome browser to point to your public host site
- Switch to All Comments
- Look at the comments and find the 4 level deep, Google account, avatar'ed comment
- Notice that the avatar is NOT squished when sitting beside the Featured tag