### PR TITLE
[CORL-1321] Fix external image input/submit on small mobile screens

### DIFF
--- a/src/core/client/stream/tabs/Comments/ExternalImageInput/ExternalImageInput.tsx
+++ b/src/core/client/stream/tabs/Comments/ExternalImageInput/ExternalImageInput.tsx
@@ -9,6 +9,7 @@ import React, {
 
 import {
   Button,
+  Flex,
   HorizontalGutter,
   InputLabel,
   TextField,
@@ -51,26 +52,26 @@ const ExternalImageInput: FunctionComponent<Props> = ({ onSelect }) => {
           <Localized id="comments-postComment-pasteImage">
             <InputLabel>Paste image URL</InputLabel>
           </Localized>
-          <TextField
-            className={styles.input}
-            value={url}
-            onChange={onChange}
-            onKeyPress={onKeyPress}
-            fullWidth
-            variant="seamlessAdornment"
-            color="streamBlue"
-            adornment={
-              <Localized id="comments-postComment-insertImage">
-                <Button
-                  color="stream"
-                  onClick={onClick}
-                  className={styles.insertButton}
-                >
-                  Insert
-                </Button>
-              </Localized>
-            }
-          />
+          <Flex>
+            <TextField
+              className={styles.input}
+              value={url}
+              onChange={onChange}
+              onKeyPress={onKeyPress}
+              fullWidth
+              variant="seamlessAdornment"
+              color="streamBlue"
+            />
+            <Localized id="comments-postComment-insertImage">
+              <Button
+                color="stream"
+                onClick={onClick}
+                className={styles.insertButton}
+              >
+                Insert
+              </Button>
+            </Localized>
+          </Flex>
         </HorizontalGutter>
       </HorizontalGutter>
     </div>


### PR DESCRIPTION
## What does this PR do?

Fix external image input/submit on small mobile screens

Use flex instead of a text field adornment so that the
flex scaling works properly at small screen sizes.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Enable external images on your Coral instance
- Switch your browser's dev tools to simulate a tiny phone screen (may I suggest iPhone 5/SE?)
- Go to add an external media/image link to your comment
- See that the input text field and its submit button are no longer cut off
