### PR TITLE
[CORL-1345] Disable build cache for production builds

### DIFF
--- a/src/core/build/createWebpackConfig.ts
+++ b/src/core/build/createWebpackConfig.ts
@@ -56,6 +56,7 @@ export default function createWebpackConfig(
   const isProduction = env.NODE_ENV === "production";
   const minimize = isProduction && !config.get("disableMinimize");
   const treeShake = config.get("enableTreeShake");
+  const enableBuildCache = !isProduction;
 
   const envStringified = {
     "process.env": Object.keys(env).reduce<Record<string, string>>(
@@ -199,7 +200,7 @@ export default function createWebpackConfig(
             },
             safari10: true,
           },
-          cache: true,
+          cache: enableBuildCache,
           parallel: true,
           sourceMap: !disableSourcemaps,
         }),
@@ -393,7 +394,7 @@ export default function createWebpackConfig(
                     // This is a feature of `babel-loader` for webpack (not Babel itself).
                     // It enables caching results in ./node_modules/.cache/babel-loader/
                     // directory for faster rebuilds.
-                    cacheDirectory: true,
+                    cacheDirectory: enableBuildCache,
                   },
                 },
               ],
@@ -417,7 +418,7 @@ export default function createWebpackConfig(
                     // This is a feature of `babel-loader` for webpack (not Babel itself).
                     // It enables caching results in ./node_modules/.cache/babel-loader/
                     // directory for faster rebuilds.
-                    cacheDirectory: true,
+                    cacheDirectory: enableBuildCache,
                   },
                 },
                 {
@@ -450,7 +451,7 @@ export default function createWebpackConfig(
                 {
                   loader: require.resolve("babel-loader"),
                   options: {
-                    cacheDirectory: true,
+                    cacheDirectory: enableBuildCache,
                   },
                 },
               ],


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

This disables the build cache for production builds. The cache folder was taking up hundreds of MB's in situations where the cache is never re-used (in production builds), this disables that.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".



-->

None.

## How do I test this PR?

Wait for CI to pass!

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
