### PR TITLE
[CORL-1330] Viewers + Comment Ordering

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -6,6 +6,7 @@ import { graphql, RelayPaginationProp } from "react-relay";
 import FadeInTransition from "coral-framework/components/FadeInTransition";
 import { useLive } from "coral-framework/hooks";
 import { useViewerNetworkEvent } from "coral-framework/lib/events";
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import {
   combineDisposables,
   useLoadMore,
@@ -37,6 +38,7 @@ import CollapsableComment from "../../Comment/CollapsableComment";
 import IgnoredTombstoneOrHideContainer from "../../IgnoredTombstoneOrHideContainer";
 import { ReplyListContainer } from "../../ReplyList";
 import { PostCommentFormContainer } from "../PostCommentForm";
+import ViewersWatchingContainer from "../ViewersWatchingContainer";
 import AllCommentsLinks from "./AllCommentsLinks";
 import AllCommentsTabViewNewMutation from "./AllCommentsTabViewNewMutation";
 import CommentCreatedSubscription from "./CommentCreatedSubscription";
@@ -269,7 +271,10 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
         )}
       </HorizontalGutter>
       {alternateOldestViewEnabled && (
-        <HorizontalGutter mt={6} spacing={6}>
+        <HorizontalGutter mt={6} spacing={4}>
+          <IntersectionProvider>
+            <ViewersWatchingContainer story={story} settings={settings} />
+          </IntersectionProvider>
           {showCommentForm && (
             <PostCommentFormContainer
               story={story}
@@ -334,6 +339,7 @@ const enhanced = withPaginationContainer<
         ...ReplyListContainer1_story
         ...CreateCommentReplyMutation_story
         ...CreateCommentMutation_story
+        ...ViewersWatchingContainer_story
       }
     `,
     viewer: graphql`
@@ -361,6 +367,7 @@ const enhanced = withPaginationContainer<
         ...ReplyListContainer1_settings
         ...CommentContainer_settings
         ...PostCommentFormContainer_settings
+        ...ViewersWatchingContainer_settings
       }
     `,
   },

--- a/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -164,6 +164,7 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
       GQLFEATURE_FLAG.ALTERNATE_OLDEST_FIRST_VIEW
     ) &&
     local.commentsOrderBy === GQLCOMMENT_SORT.CREATED_AT_ASC &&
+    local.commentsTab === "ALL_COMMENTS" &&
     !props.story.isClosed &&
     !props.settings.disableCommenting.enabled;
 

--- a/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -165,6 +165,7 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
     ) &&
     local.commentsOrderBy === GQLCOMMENT_SORT.CREATED_AT_ASC &&
     local.commentsTab === "ALL_COMMENTS" &&
+    !isQA &&
     !props.story.isClosed &&
     !props.settings.disableCommenting.enabled;
 

--- a/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -233,14 +233,22 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
           (alternateOldestViewEnabled ? (
             <AddACommentButton />
           ) : (
-            <PostCommentFormContainer
-              settings={props.settings}
-              story={props.story}
-              viewer={props.viewer}
-              tab={local.commentsTab}
-              onChangeTab={onChangeTab}
-              commentsOrderBy={local.commentsOrderBy}
-            />
+            <>
+              <IntersectionProvider>
+                <ViewersWatchingContainer
+                  story={props.story}
+                  settings={props.settings}
+                />
+              </IntersectionProvider>
+              <PostCommentFormContainer
+                settings={props.settings}
+                story={props.story}
+                viewer={props.viewer}
+                tab={local.commentsTab}
+                onChangeTab={onChangeTab}
+                commentsOrderBy={local.commentsOrderBy}
+              />
+            </>
           ))}
         {(banned || warned || suspended) && (
           <div id={VIEWER_STATUS_CONTAINER_ID}>
@@ -254,12 +262,6 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
             {warned && <WarningContainer viewer={props.viewer} />}
           </div>
         )}
-        <IntersectionProvider>
-          <ViewersWatchingContainer
-            story={props.story}
-            settings={props.settings}
-          />
-        </IntersectionProvider>
         <HorizontalGutter spacing={4} className={styles.tabBarContainer}>
           <Flex
             direction="row"

--- a/src/core/client/stream/tabs/Comments/Stream/ViewersWatchingContainer.css
+++ b/src/core/client/stream/tabs/Comments/Stream/ViewersWatchingContainer.css
@@ -1,23 +1,11 @@
-$start-color: var(--palette-success-500);
-$end-color: var(--palette-success-400);
-
-@keyframes color {
-  0% {
-    color: $start-color;
-  }
-  50% {
-    color: $end-color;
-  }
-  100% {
-    color: $start-color;
-  }
-}
-
-.title,
-.icon {
-  animation: color 1s ease-in-out infinite;
-}
-
 .icon {
   flex-basis: calc(var(--spacing-3) + var(--spacing-1) + 8px);
+}
+
+.title {
+  color: var(--palette-primary-500);
+}
+
+.container {
+  align-items: baseline;
 }

--- a/src/core/client/stream/tabs/Comments/Stream/ViewersWatchingContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/ViewersWatchingContainer.tsx
@@ -116,13 +116,25 @@ const ViewersWatchingContainer: FunctionComponent<Props> = ({
   }
 
   // We always add one for the current viewer!
-  const viewerCount = refreshed ? story.viewerCount : story.viewerCount + 1;
+  const viewerCount = refreshed
+    ? // If we have refreshed the count, we will use the viewer count as is, but
+      // if the count is zero, it should be one because at least this one user
+      // is viewing.
+      story.viewerCount || 1
+    : // If we haven't refreshed, we should probably add one here because the
+      // count is queried before the websocket subscription is created.
+      story.viewerCount + 1;
 
   return (
     <div ref={intersectionRef}>
       <CallOut
-        classes={{ icon: styles.icon, title: styles.title }}
+        classes={{
+          icon: styles.icon,
+          title: styles.title,
+          container: styles.container,
+        }}
         icon={<Icon size="md">play_circle_filled</Icon>}
+        color="primary"
         title={
           <Localized id="comments-watchers" $count={viewerCount}>
             <span>{viewerCount} people is online</span>

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -51,11 +51,8 @@ comment-count-text =
 comments-allCommentsTab = All Comments
 comments-featuredTab = Featured
 comments-counter-shortNum = { SHORT_NUMBER($count) }
-comments-watchers = { SHORT_NUMBER($count) } {
-  $count ->
-    [one] person is online
-    *[other] people are online
-}
+comments-watchers = { SHORT_NUMBER($count) } online
+
 comments-featuredCommentTooltip-how = How is a comment featured?
 comments-featuredCommentTooltip-handSelectedComments =
   Comments are chosen by our team as worth reading.


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

- Adds some tweaks to the viewer count to match primary colours.
- Fixed edge case where all comments is not the active tab when trying to view oldest first.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

Enable both the `ALTERNATE_OLDEST_FIRST_VIEW` and the `VIEWER_COUNT` feature flags with one featured comment. Note that there's better visual representation of the viewer count widget and it does not show the "Add a comment" button when on the featured tab!