### PR TITLE
Make default Sarcasm font smaller

### DIFF
--- a/src/core/client/stream/shared/htmlContent.css
+++ b/src/core/client/stream/shared/htmlContent.css
@@ -55,6 +55,6 @@ $commentsLinkColorHovered: var(--palette-primary-700);
   }
   & :global(.coral-rte-sarcasm) {
     font-family: monospace;
-    font-size: var(--font-size-4);
+    font-size: var(--font-size-2);
   }
 }

--- a/src/core/client/stream/shared/htmlContent.css
+++ b/src/core/client/stream/shared/htmlContent.css
@@ -17,8 +17,7 @@ $commentsLinkColorHovered: var(--palette-primary-700);
     font-weight: var(--font-weight-primary-semi-bold);
   }
 
-  i
-  em {
+  i em {
     font-style: italic;
   }
   blockquote {
@@ -48,13 +47,12 @@ $commentsLinkColorHovered: var(--palette-primary-700);
     cursor: pointer;
   }
   & :global(.coral-rte-spoiler-reveal) {
-    opacity: 1.0;
+    opacity: 1;
     color: var(--palette-text-900);
     background-color: transparent;
     cursor: text;
   }
   & :global(.coral-rte-sarcasm) {
     font-family: monospace;
-    font-size: var(--font-size-2);
   }
 }


### PR DESCRIPTION
## What does this PR do?

Changes default font size from 4 to 2, so it matches the regular comment body fontsize.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

**BEFORE**

<img width="845" alt="sarcasm_font_before" src="https://user-images.githubusercontent.com/1077300/91857396-d9387880-ec35-11ea-8a9c-f2d9e2018933.png">

**AFTER**

<img width="853" alt="sarcasm_font_after" src="https://user-images.githubusercontent.com/1077300/91857431-e5bcd100-ec35-11ea-8b4c-bb57dc3e69f7.png">

