### PR TITLE
[CORL-1351] External Images Fix

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/CommentForm/MediaField.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentForm/MediaField.tsx
@@ -80,6 +80,13 @@ const MediaField: FunctionComponent<Props> = ({
   }, [onChange, pastedMedia, setPastedMedia]);
 
   useEffect(() => {
+    // If the widget is not open and the field is dirty and invalid, then unset
+    // the current value. The user should be seeing a error now, but they closed
+    // the widget anyways.
+    if (!widget && dirty && !valid) {
+      onChange(undefined);
+    }
+
     // If a widget is not open, do nothing. The following checks are designed
     // to interact only when there is a widget open when there shouldn't be or
     // if the current value does not match the open widget.


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

When the media field has an error, and the widget is closed, it should unset the media value to prevent the comment form from being stuck.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

With the `EXTERNAL_MEDIA` feature flag enabled:

1. Click the "Add external image" button
2. Post a non-image into the input
3. Click insert
4. See an error
5. Click the "Add external image" button
6. See error go away
7. Add comment text and post comment successfully