### PR TITLE
[CORL-1280] set max-width for username on mobile

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/Comment.css
+++ b/src/core/client/stream/tabs/Comments/Comment/Comment.css
@@ -40,4 +40,5 @@ $commentTimestampColor: var(--palette-grey-500);
 
 .usernameFullRow {
   flex-basis: 100%;
+  max-width: 190px;
 }

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.css
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.css
@@ -63,3 +63,10 @@ $commenterActionEditColorActive: var(--palette-primary-300);
   width: 100%;
   height: 100%;
 }
+
+.usernameButton {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+  max-width: 100%;
+}

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -381,7 +381,10 @@ export const CommentContainer: FunctionComponent<Props> = ({
             username={
               comment.author && (
                 <UsernameWithPopoverContainer
-                  className={CLASSES.comment.topBar.username}
+                  className={cn(
+                    styles.usernameButton,
+                    CLASSES.comment.topBar.username
+                  )}
                   comment={comment}
                   viewer={viewer}
                 />

--- a/src/core/client/stream/tabs/Comments/Comment/__snapshots__/CommentContainer.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/Comment/__snapshots__/CommentContainer.spec.tsx.snap
@@ -280,7 +280,7 @@ exports[`hide reply button 1`] = `
       }
       username={
         <Relay(UsernameWithPopoverContainer)
-          className="coral coral-username coral-comment-username"
+          className="CommentContainer-usernameButton coral coral-username coral-comment-username"
           comment={
             Object {
               "actionCounts": Object {
@@ -609,7 +609,7 @@ exports[`renders body only 1`] = `
       }
       username={
         <Relay(UsernameWithPopoverContainer)
-          className="coral coral-username coral-comment-username"
+          className="CommentContainer-usernameButton coral coral-username coral-comment-username"
           comment={
             Object {
               "actionCounts": Object {
@@ -938,7 +938,7 @@ exports[`renders disabled reply when commenting has been disabled 1`] = `
       }
       username={
         <Relay(UsernameWithPopoverContainer)
-          className="coral coral-username coral-comment-username"
+          className="CommentContainer-usernameButton coral coral-username coral-comment-username"
           comment={
             Object {
               "actionCounts": Object {
@@ -1267,7 +1267,7 @@ exports[`renders disabled reply when story is closed 1`] = `
       }
       username={
         <Relay(UsernameWithPopoverContainer)
-          className="coral coral-username coral-comment-username"
+          className="CommentContainer-usernameButton coral coral-username coral-comment-username"
           comment={
             Object {
               "actionCounts": Object {
@@ -1617,7 +1617,7 @@ exports[`renders in reply to 1`] = `
       }
       username={
         <Relay(UsernameWithPopoverContainer)
-          className="coral coral-username coral-comment-username"
+          className="CommentContainer-usernameButton coral coral-username coral-comment-username"
           comment={
             Object {
               "actionCounts": Object {
@@ -1950,7 +1950,7 @@ exports[`renders username and body 1`] = `
       }
       username={
         <Relay(UsernameWithPopoverContainer)
-          className="coral coral-username coral-comment-username"
+          className="CommentContainer-usernameButton coral coral-username coral-comment-username"
           comment={
             Object {
               "actionCounts": Object {
@@ -2294,7 +2294,7 @@ exports[`shows conversation link 1`] = `
       }
       username={
         <Relay(UsernameWithPopoverContainer)
-          className="coral coral-username coral-comment-username"
+          className="CommentContainer-usernameButton coral coral-username coral-comment-username"
           comment={
             Object {
               "actionCounts": Object {

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
@@ -151,7 +151,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <button
                                       aria-controls="username-popover-comment-1"
-                                      className="BaseButton-root coral coral-username coral-comment-username"
+                                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onFocus={[Function]}
@@ -425,7 +425,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <button
                                       aria-controls="username-popover-comment-2"
-                                      className="BaseButton-root coral coral-username coral-comment-username"
+                                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onFocus={[Function]}
@@ -696,7 +696,7 @@ exports[`renders permalink view 1`] = `
                                 >
                                   <button
                                     aria-controls="username-popover-comment-with-replies"
-                                    className="BaseButton-root coral coral-username coral-comment-username"
+                                    className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                     onBlur={[Function]}
                                     onClick={[Function]}
                                     onFocus={[Function]}
@@ -977,7 +977,7 @@ exports[`renders permalink view 1`] = `
                               >
                                 <button
                                   aria-controls="username-popover-comment-3"
-                                  className="BaseButton-root coral coral-username coral-comment-username"
+                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}
@@ -1276,7 +1276,7 @@ exports[`renders permalink view 1`] = `
                               >
                                 <button
                                   aria-controls="username-popover-comment-4"
-                                  className="BaseButton-root coral coral-username coral-comment-username"
+                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewLoadMoreParents.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewLoadMoreParents.spec.tsx.snap
@@ -63,7 +63,7 @@ exports[`renders conversation thread 1`] = `
                           >
                             <button
                               aria-controls="username-popover-comment-from-staff-0"
-                              className="BaseButton-root coral coral-username coral-comment-username"
+                              className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                               onBlur={[Function]}
                               onClick={[Function]}
                               onFocus={[Function]}
@@ -383,7 +383,7 @@ exports[`renders conversation thread 1`] = `
                           >
                             <button
                               aria-controls="username-popover-comment-0"
-                              className="BaseButton-root coral coral-username coral-comment-username"
+                              className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                               onBlur={[Function]}
                               onClick={[Function]}
                               onFocus={[Function]}
@@ -675,7 +675,7 @@ exports[`shows more of this conversation 1`] = `
                             >
                               <button
                                 aria-controls="username-popover-comment-1"
-                                className="BaseButton-root coral coral-username coral-comment-username"
+                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onFocus={[Function]}
@@ -949,7 +949,7 @@ exports[`shows more of this conversation 1`] = `
                             >
                               <button
                                 aria-controls="username-popover-comment-from-staff-0"
-                                className="BaseButton-root coral coral-username coral-comment-username"
+                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onFocus={[Function]}
@@ -1233,7 +1233,7 @@ exports[`shows more of this conversation 1`] = `
                           >
                             <button
                               aria-controls="username-popover-comment-0"
-                              className="BaseButton-root coral coral-username coral-comment-username"
+                              className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                               onBlur={[Function]}
                               onClick={[Function]}
                               onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`cancel edit 1`] = `
                   >
                     <button
                       aria-controls="username-popover-comment-with-replies"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}
@@ -1003,7 +1003,7 @@ exports[`edit a comment: render comment with edit button 1`] = `
                   >
                     <button
                       aria-controls="username-popover-comment-with-replies"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}
@@ -1296,7 +1296,7 @@ exports[`edit a comment: server response 1`] = `
                   >
                     <button
                       aria-controls="username-popover-comment-with-replies"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}
@@ -1598,7 +1598,7 @@ exports[`shows expiry message: edit form closed 1`] = `
                   >
                     <button
                       aria-controls="username-popover-comment-with-replies"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/loadMore.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/loadMore.spec.tsx.snap
@@ -63,7 +63,7 @@ exports[`renders comment stream with load more button 1`] = `
                       >
                         <button
                           aria-controls="username-popover-comment-0"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -335,7 +335,7 @@ exports[`renders comment stream with load more button 1`] = `
                       >
                         <button
                           aria-controls="username-popover-comment-1"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postComment.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`post a comment: optimistic response 1`] = `
                   >
                     <button
                       aria-controls="username-popover-uuid-0"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`post a reply: open reply form 1`] = `
                   >
                     <button
                       aria-controls="username-popover-comment-with-deepest-replies-3"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}
@@ -562,7 +562,7 @@ exports[`post a reply: optimistic response 1`] = `
                       >
                         <button
                           aria-controls="username-popover-uuid-0"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -870,7 +870,7 @@ exports[`renders comment stream 1`] = `
                       >
                         <button
                           aria-controls="username-popover-comment-with-deepest-replies"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -1147,7 +1147,7 @@ exports[`renders comment stream 1`] = `
                             >
                               <button
                                 aria-controls="username-popover-comment-with-deepest-replies-1"
-                                className="BaseButton-root coral coral-username coral-comment-username"
+                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onFocus={[Function]}
@@ -1451,7 +1451,7 @@ exports[`renders comment stream 1`] = `
                                   >
                                     <button
                                       aria-controls="username-popover-comment-with-deepest-replies-2"
-                                      className="BaseButton-root coral coral-username coral-comment-username"
+                                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onFocus={[Function]}
@@ -1755,7 +1755,7 @@ exports[`renders comment stream 1`] = `
                                         >
                                           <button
                                             aria-controls="username-popover-comment-with-deepest-replies-3"
-                                            className="BaseButton-root coral coral-username coral-comment-username"
+                                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                             onBlur={[Function]}
                                             onClick={[Function]}
                                             onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`post a reply: open reply form 1`] = `
                   >
                     <button
                       aria-controls="username-popover-comment-0"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}
@@ -519,7 +519,7 @@ exports[`post a reply: optimistic response 1`] = `
                       >
                         <button
                           aria-controls="username-popover-uuid-0"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderCommunityGuidelines.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderCommunityGuidelines.spec.tsx.snap
@@ -376,7 +376,7 @@ exports[`renders comment stream with community guidelines 1`] = `
                               >
                                 <button
                                   aria-controls="username-popover-comment-0"
-                                  className="BaseButton-root coral coral-username coral-comment-username"
+                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}
@@ -648,7 +648,7 @@ exports[`renders comment stream with community guidelines 1`] = `
                               >
                                 <button
                                   aria-controls="username-popover-comment-1"
-                                  className="BaseButton-root coral coral-username coral-comment-username"
+                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
@@ -62,7 +62,7 @@ exports[`renders reply list 1`] = `
                       >
                         <button
                           aria-controls="username-popover-comment-with-replies"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -366,7 +366,7 @@ exports[`renders reply list 1`] = `
                             >
                               <button
                                 aria-controls="username-popover-comment-3"
-                                className="BaseButton-root coral coral-username coral-comment-username"
+                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onFocus={[Function]}
@@ -665,7 +665,7 @@ exports[`renders reply list 1`] = `
                             >
                               <button
                                 aria-controls="username-popover-comment-4"
-                                className="BaseButton-root coral coral-username coral-comment-username"
+                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onFocus={[Function]}
@@ -967,7 +967,7 @@ exports[`renders reply list 1`] = `
                       >
                         <button
                           aria-controls="username-popover-comment-5"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderStream.spec.tsx.snap
@@ -414,7 +414,7 @@ exports[`renders comment stream 1`] = `
                                   >
                                     <button
                                       aria-controls="username-popover-comment-0"
-                                      className="BaseButton-root coral coral-username coral-comment-username"
+                                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onFocus={[Function]}
@@ -686,7 +686,7 @@ exports[`renders comment stream 1`] = `
                                   >
                                     <button
                                       aria-controls="username-popover-comment-from-staff-0"
-                                      className="BaseButton-root coral coral-username coral-comment-username"
+                                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                       onBlur={[Function]}
                                       onClick={[Function]}
                                       onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
@@ -497,7 +497,7 @@ exports[`report comment as offensive 1`] = `
                   >
                     <button
                       aria-controls="username-popover-comment-0"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/showAllReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/showAllReplies.spec.tsx.snap
@@ -62,7 +62,7 @@ exports[`renders comment stream 1`] = `
                       >
                         <button
                           aria-controls="username-popover-comment-1"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/showConversation.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/showConversation.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`renders deepest comment with link 1`] = `
                   >
                     <button
                       aria-controls="username-popover-comment-with-deepest-replies-3"
-                      className="BaseButton-root coral coral-username coral-comment-username"
+                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                       onBlur={[Function]}
                       onClick={[Function]}
                       onFocus={[Function]}

--- a/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
@@ -63,7 +63,7 @@ exports[`renders app with comment stream 1`] = `
                       >
                         <button
                           aria-controls="username-popover-comment-2"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -335,7 +335,7 @@ exports[`renders app with comment stream 1`] = `
                       >
                         <button
                           aria-controls="username-popover-comment-3"
-                          className="BaseButton-root coral coral-username coral-comment-username"
+                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

Sets max-width on usernames and cuts them off with ellipses if they're too long so edit button doesn't go off screen

<img width="310" alt="Screen Shot 2020-09-02 at 9 24 01 AM" src="https://user-images.githubusercontent.com/1789029/91989967-23d1f780-ecff-11ea-8323-b2df1326caaf.png">


<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?
none
<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

create a user with a long username and view on small mobile (320px wide)
