### PR TITLE
Protect media text inputs from triggering keyboard shortcuts

### DIFF
--- a/src/core/client/stream/tabs/Comments/ExternalImageInput/ExternalImageInput.tsx
+++ b/src/core/client/stream/tabs/Comments/ExternalImageInput/ExternalImageInput.tsx
@@ -38,6 +38,8 @@ const ExternalImageInput: FunctionComponent<Props> = ({ onSelect }) => {
   // This will handle when the user hits enter where we don't want to submit the
   // form.
   const onKeyPress = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+
     if (e.key !== "Enter") {
       return;
     }

--- a/src/core/client/stream/tabs/Comments/GiphyInput/GiphyInput.tsx
+++ b/src/core/client/stream/tabs/Comments/GiphyInput/GiphyInput.tsx
@@ -93,6 +93,8 @@ const GiphyInput: FunctionComponent<Props> = ({ onSelect }) => {
   }, []);
 
   const onKeyPress = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
+    e.stopPropagation();
+
     if (e.key !== "Enter") {
       return;
     }


### PR DESCRIPTION
## What does this PR do?

Stops propagation of keyboard keypress events on the `ExternalImageInput` and the `GiphyInput`.

This prevents the C key from jumping the stream around when you are typing to search for a Gif or when entering a URL into the external media field.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Press the C key while typing in the Giphy or External Media text inputs
- See that the stream doesn't scroll around
