### PR TITLE
Exclude keyboard shortcut on input fields

### DIFF
--- a/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -103,6 +103,15 @@ const KeyboardShortcuts: FunctionComponent = ({ children }) => {
         if (typeof event === "string") {
           data = JSON.parse(event);
         } else {
+          if (event.target) {
+            const el = event.target as HTMLElement;
+            if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") {
+              return;
+            }
+            if (el.getAttribute("contenteditable") === "true") {
+              return;
+            }
+          }
           data = event;
         }
       } catch (err) {

--- a/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.tsx
@@ -1,7 +1,7 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
 import { get } from "lodash";
-import React, { FunctionComponent, KeyboardEvent } from "react";
+import React, { FunctionComponent } from "react";
 import { Field, FieldProps, Form } from "react-final-form";
 
 import { OnSubmit } from "coral-framework/lib/form";
@@ -49,19 +49,12 @@ export interface FormProps {
 }
 
 class ReportCommentForm extends React.Component<Props> {
-  // Stop keyboard shortcuts from scrolling us away
-  // if we type the C key
-  private onKeyPress(e: KeyboardEvent) {
-    e.stopPropagation();
-  }
-
   public render() {
     const { onCancel, onSubmit, id } = this.props;
     return (
       <div
         className={styles.root}
         data-testid="report-comment-form"
-        onKeyPress={this.onKeyPress}
         role="none"
       >
         <Form onSubmit={onSubmit}>

--- a/src/core/client/stream/tabs/Comments/ExternalImageInput/ExternalImageInput.tsx
+++ b/src/core/client/stream/tabs/Comments/ExternalImageInput/ExternalImageInput.tsx
@@ -38,8 +38,6 @@ const ExternalImageInput: FunctionComponent<Props> = ({ onSelect }) => {
   // This will handle when the user hits enter where we don't want to submit the
   // form.
   const onKeyPress = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-
     if (e.key !== "Enter") {
       return;
     }

--- a/src/core/client/stream/tabs/Comments/GiphyInput/GiphyInput.tsx
+++ b/src/core/client/stream/tabs/Comments/GiphyInput/GiphyInput.tsx
@@ -93,8 +93,6 @@ const GiphyInput: FunctionComponent<Props> = ({ onSelect }) => {
   }, []);
 
   const onKeyPress = useCallback((e: KeyboardEvent<HTMLInputElement>) => {
-    e.stopPropagation();
-
     if (e.key !== "Enter") {
       return;
     }

--- a/src/core/client/stream/tabs/Comments/RTE/RTE.tsx
+++ b/src/core/client/stream/tabs/Comments/RTE/RTE.tsx
@@ -13,9 +13,7 @@ import React, {
   EventHandler,
   FocusEvent,
   FunctionComponent,
-  KeyboardEvent,
   Ref,
-  useCallback,
   useMemo,
 } from "react";
 
@@ -260,14 +258,8 @@ const RTE: FunctionComponent<Props> = (props) => {
     return x;
   }, [features]);
 
-  // Stop keyboard shortcuts from scrolling us away
-  // if we type the C key
-  const onKeyPress = useCallback((e: KeyboardEvent) => {
-    e.stopPropagation();
-  }, []);
-
   return (
-    <div onKeyPress={onKeyPress} role="none">
+    <div role="none">
       <CoralRTE
         inputID={inputID}
         className={cn(CLASSES.rte.$root, className)}

--- a/src/core/client/stream/tabs/Comments/RTE/__snapshots__/RTE.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/RTE/__snapshots__/RTE.spec.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`renders correctly 1`] = `
 <div
-  onKeyPress={[Function]}
   role="none"
 >
   <RTE

--- a/src/core/client/stream/test/comments/featured/__snapshots__/renderFeaturedStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/featured/__snapshots__/renderFeaturedStream.spec.tsx.snap
@@ -121,7 +121,6 @@ exports[`renders comment stream 1`] = `
               className="PostCommentFormFake-rteContainer"
             >
               <div
-                onKeyPress={[Function]}
                 role="none"
               >
                 <div

--- a/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
@@ -353,7 +353,6 @@ exports[`edit a comment and handle server error: edit form 1`] = `
               className="CommentForm-commentFormBox coral coral-commentForm"
             >
               <div
-                onKeyPress={[Function]}
                 role="none"
               >
                 <div
@@ -575,7 +574,6 @@ exports[`edit a comment: edit form 1`] = `
               className="CommentForm-commentFormBox coral coral-commentForm"
             >
               <div
-                onKeyPress={[Function]}
                 role="none"
               >
                 <div
@@ -797,7 +795,6 @@ exports[`edit a comment: optimistic response 1`] = `
               className="CommentForm-commentFormBox coral coral-commentForm"
             >
               <div
-                onKeyPress={[Function]}
                 role="none"
               >
                 <div
@@ -1913,7 +1910,6 @@ exports[`shows expiry message: edit time expired 1`] = `
               className="CommentForm-commentFormBox coral coral-commentForm"
             >
               <div
-                onKeyPress={[Function]}
                 role="none"
               >
                 <div

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postLocalReply.spec.tsx.snap
@@ -355,7 +355,6 @@ exports[`post a reply: open reply form 1`] = `
                 className="CommentForm-commentFormBox CommentForm-noTopBorder coral coral-commentForm"
               >
                 <div
-                  onKeyPress={[Function]}
                   role="none"
                 >
                   <div

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
@@ -312,7 +312,6 @@ exports[`post a reply: open reply form 1`] = `
                 className="CommentForm-commentFormBox CommentForm-noTopBorder coral coral-commentForm"
               >
                 <div
-                  onKeyPress={[Function]}
                   role="none"
                 >
                   <div

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderCommunityGuidelines.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderCommunityGuidelines.spec.tsx.snap
@@ -83,7 +83,6 @@ exports[`renders comment stream with community guidelines 1`] = `
           className="PostCommentFormFake-rteContainer"
         >
           <div
-            onKeyPress={[Function]}
             role="none"
           >
             <div

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
@@ -356,7 +356,6 @@ exports[`renders message box when logged in 1`] = `
                 className="CommentForm-commentFormBox CommentForm-noTopBorder coral coral-commentForm"
               >
                 <div
-                  onKeyPress={[Function]}
                   role="none"
                 >
                   <div
@@ -709,7 +708,6 @@ exports[`renders message box when not logged in 1`] = `
           className="PostCommentFormFake-rteContainer"
         >
           <div
-            onKeyPress={[Function]}
             role="none"
           >
             <div

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderStream.spec.tsx.snap
@@ -121,7 +121,6 @@ exports[`renders comment stream 1`] = `
               className="PostCommentFormFake-rteContainer"
             >
               <div
-                onKeyPress={[Function]}
                 role="none"
               >
                 <div

--- a/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
@@ -4,7 +4,6 @@ exports[`render popup 1`] = `
 <div
   className="ReportCommentForm-root"
   data-testid="report-comment-form"
-  onKeyPress={[Function]}
   role="none"
 >
   <form
@@ -228,7 +227,6 @@ exports[`render popup expanded 1`] = `
 <div
   className="ReportCommentForm-root"
   data-testid="report-comment-form"
-  onKeyPress={[Function]}
   role="none"
 >
   <form


### PR DESCRIPTION
## What does this PR do?
- Instead of listening to `Keypress` events and suppress them in various places, this PR changes the behavior of the Keyboard Shortcut Handler by ignoring `Keypress` events from input fields in general.



