### PR TITLE
Fix warning of unknown props when EXTERNAL_MEDIA feature flag is used

### DIFF
--- a/src/core/client/stream/tabs/Comments/RTE/RTEButton.tsx
+++ b/src/core/client/stream/tabs/Comments/RTE/RTEButton.tsx
@@ -1,3 +1,4 @@
+import { InjectedProps } from "@coralproject/rte/lib/factories/createToggle";
 import cn from "classnames";
 import React from "react";
 
@@ -7,14 +8,11 @@ import styles from "./RTEButton.css";
 
 const RTEButton = React.forwardRef<
   HTMLButtonElement,
-  React.ButtonHTMLAttributes<HTMLButtonElement>
+  React.ButtonHTMLAttributes<HTMLButtonElement> & Partial<InjectedProps>
 >(function RTEButtonForwarded(props, ref) {
+  const { ctrlKey, squire, ButtonComponent, className, ...rest } = props;
   return (
-    <BaseButton
-      {...props}
-      className={cn(styles.button, props.className)}
-      ref={ref}
-    />
+    <BaseButton {...rest} className={cn(styles.button, className)} ref={ref} />
   );
 });
 


### PR DESCRIPTION
## What does this PR do?

- Gets rid of this nasty warnings:
![image](https://user-images.githubusercontent.com/14221600/92138350-8b2a9d00-ee0e-11ea-9779-67c8887db9d5.png)
