### PR TITLE
[CORL-1419] Count Server Caching

### DIFF
--- a/src/core/server/app/index.ts
+++ b/src/core/server/app/index.ts
@@ -111,7 +111,11 @@ export async function createApp(options: AppOptions): Promise<Express> {
   parent.use("/assets/media", cors());
 
   // Static Files
-  parent.use("/assets", cacheHeadersMiddleware("1w"), serveStatic);
+  parent.use(
+    "/assets",
+    cacheHeadersMiddleware({ cacheDuration: "1w" }),
+    serveStatic
+  );
 
   // Error Handling
   parent.use(notFoundMiddleware);

--- a/src/core/server/app/middleware/cache.ts
+++ b/src/core/server/app/middleware/cache.ts
@@ -1,0 +1,74 @@
+import { Redis } from "ioredis";
+
+import logger from "coral-server/logger";
+import { RequestHandler } from "coral-server/types/express";
+
+interface CacheEntry {
+  headers: Record<string, any>;
+  status: number;
+  body: string;
+  createdAt: number;
+}
+
+const cacheMiddleware = (redis: Redis, ttl: number): RequestHandler => async (
+  req,
+  res,
+  next
+) => {
+  // Compute the cache key.
+  const key = `rmc:${req.hostname}:${req.originalUrl}`;
+  const log = logger.child({ key }, true);
+
+  // Try to lookup the entry in the cache.
+  const value = await redis.get(key);
+  if (value) {
+    log.debug("request was in the cache");
+
+    // Found an entry! Unpack it and sent the response!
+    const entry: CacheEntry = JSON.parse(value);
+
+    // Set the headers on the request.
+    res.set({
+      ...entry.headers,
+      age: Math.floor((Date.now() - entry.createdAt) / 1000),
+    });
+
+    // Set the status on the request.
+    res.status(entry.status);
+
+    // Send the body on the request.
+    return res.send(entry.body);
+  }
+
+  log.debug("request was not in the cache");
+
+  const send = res.send.bind(res);
+  res.send = (body) => {
+    // Send the response to the client.
+    const ret = send(body);
+
+    // Create a new cache entry.
+    const entry: CacheEntry = {
+      headers: res.getHeaders(),
+      status: res.statusCode,
+      body,
+      createdAt: Date.now(),
+    };
+
+    // Add it in Redis.
+    redis
+      .set(key, JSON.stringify(entry), "PX", ttl)
+      .then(() => {
+        log.debug("request added to cache");
+      })
+      .catch((err) => {
+        log.error({ err }, "could not add request to cache");
+      });
+
+    return ret;
+  };
+
+  return next();
+};
+
+export default cacheMiddleware;

--- a/src/core/server/app/middleware/cacheHeaders.ts
+++ b/src/core/server/app/middleware/cacheHeaders.ts
@@ -4,12 +4,7 @@ import ms from "ms";
 export const noCacheMiddleware: RequestHandler = (req, res, next) => {
   // Set cache control headers to prevent browsers/cdn's from caching these
   // requests.
-  res.set({
-    "Cache-Control": "private, no-cache, no-store, must-revalidate",
-    Expires: "-1",
-    Pragma: "no-cache",
-  });
-
+  res.set("Cache-Control", "no-store");
   next();
 };
 
@@ -21,21 +16,34 @@ const parseDuration = (duration: string | number) => {
   return Math.floor(duration / 1000);
 };
 
-export const cacheHeadersMiddleware = (
-  duration?: string | false | number
-): RequestHandler => {
-  const maxAge = duration ? parseDuration(duration) : false;
+interface Options {
+  cacheDuration?: string | false | number;
+  immutable?: boolean;
+}
+
+export const cacheHeadersMiddleware = ({
+  cacheDuration = false,
+  immutable = false,
+}: Options = {}): RequestHandler => {
+  // Parse the passed duration to convert it to a max-age value.
+  const maxAge = cacheDuration ? parseDuration(cacheDuration) : false;
   if (!maxAge) {
     return noCacheMiddleware;
   }
 
-  return (req, res, next) => {
-    // Set cache control headers to encourage browsers/cdn's to cache these
-    // requests if we aren't in private mode.
-    res.set({
-      "Cache-Control": `public, max-age=${maxAge}`,
-    });
+  // Set cache control headers to encourage browsers/cdn's to cache these
+  // requests if we aren't in private mode.
+  const directives: string[] = ["public", `max-age=${maxAge}`];
 
+  if (immutable) {
+    directives.push("immutable");
+  }
+
+  // Join the directives together.
+  const value = directives.join(", ");
+
+  return (req, res, next) => {
+    res.set("Cache-Control", value);
     next();
   };
 };

--- a/src/core/server/app/middleware/cacheHeaders.ts
+++ b/src/core/server/app/middleware/cacheHeaders.ts
@@ -13,10 +13,18 @@ export const noCacheMiddleware: RequestHandler = (req, res, next) => {
   next();
 };
 
+const parseDuration = (duration: string | number) => {
+  if (typeof duration === "string") {
+    return Math.floor(ms(duration) / 1000);
+  }
+
+  return Math.floor(duration / 1000);
+};
+
 export const cacheHeadersMiddleware = (
-  duration?: string | false
+  duration?: string | false | number
 ): RequestHandler => {
-  const maxAge = duration ? Math.floor(ms(duration) / 1000) : false;
+  const maxAge = duration ? parseDuration(duration) : false;
   if (!maxAge) {
     return noCacheMiddleware;
   }

--- a/src/core/server/app/router/api/dashboard.ts
+++ b/src/core/server/app/router/api/dashboard.ts
@@ -11,7 +11,7 @@ import { userLimiterMiddleware } from "coral-server/app/middleware/userLimiter";
 import { createAPIRouter } from "./helpers";
 
 export function createDashboardRouter(app: AppOptions) {
-  const router = createAPIRouter({ cache: "30s" });
+  const router = createAPIRouter({ cacheDuration: "30s" });
 
   router.use(userLimiterMiddleware(app));
 

--- a/src/core/server/app/router/api/helpers.ts
+++ b/src/core/server/app/router/api/helpers.ts
@@ -3,7 +3,7 @@ import express from "express";
 import { cacheHeadersMiddleware } from "coral-server/app/middleware/cacheHeaders";
 
 interface Options {
-  cache?: false | string;
+  cache?: false | string | number;
 }
 
 export function createAPIRouter({ cache = false }: Options = {}) {

--- a/src/core/server/app/router/api/helpers.ts
+++ b/src/core/server/app/router/api/helpers.ts
@@ -3,14 +3,18 @@ import express from "express";
 import { cacheHeadersMiddleware } from "coral-server/app/middleware/cacheHeaders";
 
 interface Options {
-  cache?: false | string | number;
+  cacheDuration?: false | string | number;
+  immutable?: boolean;
 }
 
-export function createAPIRouter({ cache = false }: Options = {}) {
+export function createAPIRouter({
+  cacheDuration = false,
+  immutable = false,
+}: Options = {}) {
   const router = express.Router();
 
   // Add the cache headers middleware.
-  router.use(cacheHeadersMiddleware(cache));
+  router.use(cacheHeadersMiddleware({ cacheDuration, immutable }));
 
   return router;
 }

--- a/src/core/server/app/router/api/remoteMedia.ts
+++ b/src/core/server/app/router/api/remoteMedia.ts
@@ -5,7 +5,7 @@ import { createAPIRouter } from "./helpers";
 
 export function createRemoteMediaRouter(app: AppOptions) {
   // All responses from the GIF search are cached for 30 seconds on the CDN.
-  const router = createAPIRouter({ cache: "30s" });
+  const router = createAPIRouter({ cacheDuration: "30s" });
 
   router.get("/gifs", gifSearchHandler);
 

--- a/src/core/server/app/router/api/story.ts
+++ b/src/core/server/app/router/api/story.ts
@@ -5,12 +5,17 @@ import cacheMiddleware from "coral-server/app/middleware/cache";
 import { createAPIRouter } from "./helpers";
 
 export function createStoryRouter(app: AppOptions) {
-  const ttl = app.config.get("jsonp_max_age");
+  const cacheDuration = app.config.get("jsonp_cache_max_age");
+  const immutable = app.config.get("jsonp_cache_immutable");
 
-  const router = createAPIRouter({ cacheDuration: ttl, immutable: true });
+  const router = createAPIRouter({ cacheDuration, immutable });
 
-  router.get("/count.js", cacheMiddleware(app.redis, ttl), countHandler(app));
-  router.get("/active.js", cacheMiddleware(app.redis, ttl), activeHandler(app));
+  if (app.config.get("jsonp_response_cache")) {
+    router.use(cacheMiddleware(app.redis, cacheDuration));
+  }
+
+  router.get("/count.js", countHandler(app));
+  router.get("/active.js", activeHandler(app));
 
   return router;
 }

--- a/src/core/server/app/router/api/story.ts
+++ b/src/core/server/app/router/api/story.ts
@@ -1,14 +1,16 @@
 import { AppOptions } from "coral-server/app";
 import { activeHandler, countHandler } from "coral-server/app/handlers";
+import cacheMiddleware from "coral-server/app/middleware/cache";
 
 import { createAPIRouter } from "./helpers";
 
 export function createStoryRouter(app: AppOptions) {
-  // TODO: (cvle) make caching time configurable?
-  const router = createAPIRouter({ cache: "2m" });
+  const ttl = app.config.get("jsonp_max_age");
 
-  router.get("/count.js", countHandler(app));
-  router.get("/active.js", activeHandler(app));
+  const router = createAPIRouter({ cache: ttl });
+
+  router.get("/count.js", cacheMiddleware(app.redis, ttl), countHandler(app));
+  router.get("/active.js", cacheMiddleware(app.redis, ttl), activeHandler(app));
 
   return router;
 }

--- a/src/core/server/app/router/api/story.ts
+++ b/src/core/server/app/router/api/story.ts
@@ -7,7 +7,7 @@ import { createAPIRouter } from "./helpers";
 export function createStoryRouter(app: AppOptions) {
   const ttl = app.config.get("jsonp_max_age");
 
-  const router = createAPIRouter({ cache: ttl });
+  const router = createAPIRouter({ cacheDuration: ttl, immutable: true });
 
   router.get("/count.js", cacheMiddleware(app.redis, ttl), countHandler(app));
   router.get("/active.js", cacheMiddleware(app.redis, ttl), activeHandler(app));

--- a/src/core/server/app/router/client.ts
+++ b/src/core/server/app/router/client.ts
@@ -80,7 +80,7 @@ function createClientTargetRouter(options: ClientTargetHandlerOptions) {
   router.use(cspSiteMiddleware(options));
 
   // Always send the cache headers.
-  router.use(cacheHeadersMiddleware(options.cacheDuration));
+  router.use(cacheHeadersMiddleware({ cacheDuration: options.cacheDuration }));
 
   // Wildcard display all the client routes under the provided prefix.
   router.get("/*", clientHandler(options));

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -323,12 +323,25 @@ const config = convict({
     default: "",
     env: "ANALYTICS_DATA_PLANE_URL",
   },
-  jsonp_max_age: {
+  jsonp_cache_max_age: {
     doc:
       "The max age for jsonp endpoints designed to be used as embeddable scripts.",
     format: "ms",
     default: ms("2m"),
-    env: "JSONP_MAX_AGE",
+    env: "JSONP_CACHE_MAX_AGE",
+  },
+  jsonp_cache_immutable: {
+    doc:
+      "When enabled, jsonp endpoints designed to be used as embeddable scripts will have an immutable directive added to the cache control headers.",
+    format: Boolean,
+    default: false,
+    env: "JSONP_CACHE_IMMUTABLE",
+  },
+  jsonp_response_cache: {
+    doc: "When enabled, will enable caching JSONP responses in Redis.",
+    format: Boolean,
+    default: false,
+    env: "JSONP_RESPONSE_CACHE",
   },
   default_graphql_cache_max_age: {
     doc:

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -323,6 +323,13 @@ const config = convict({
     default: "",
     env: "ANALYTICS_DATA_PLANE_URL",
   },
+  jsonp_max_age: {
+    doc:
+      "The max age for jsonp endpoints designed to be used as embeddable scripts.",
+    format: "ms",
+    default: ms("2m"),
+    env: "JSONP_MAX_AGE",
+  },
   default_graphql_cache_max_age: {
     doc:
       "Specifies the max age for the GraphQL requests. Must be larger than 1 second.",


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

Caches responses for count.js and other jsonp style routes in Redis to reduce the need to contact MongoDB and perform expensive translation operations.

This also adds some more environment variables:

- `JSONP_CACHE_MAX_AGE` sets the `max-age` directive to the `Cache-Control` headers (default `2m`).
- `JSONP_CACHE_IMMUTABLE` when true, will add a `immutable` directive to the `Cache-Control` headers (default `false`).
- `JSONP_RESPONSE_CACHE` when true, will cache the responses for JSONP requests in Redis (default `false`).

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

Visit a site where the count script is loaded, wait a few seconds and reload, see that the count.js script loaded now has an `age` header with a value greater than 0, this means that it's been cached in Redis!

