### PR TITLE
[CORL-1425] Cache Defaults + Config

### DIFF
--- a/src/core/server/app/middleware/graphql/apolloServer.ts
+++ b/src/core/server/app/middleware/graphql/apolloServer.ts
@@ -60,7 +60,7 @@ export const apolloGraphQLMiddleware = ({
         defaultMaxAge: number;
       }
     | boolean = false;
-  if (!options.config.get("disable_graphql_cache_headers")) {
+  if (options.config.get("graphql_cache_headers")) {
     cacheControl = {
       defaultMaxAge: Math.floor(
         options.config.get("default_graphql_cache_max_age") / 1000
@@ -77,8 +77,8 @@ export const apolloGraphQLMiddleware = ({
   // Optionally cache GraphQL responses in Redis. Will only enable if headers
   // are also enabled.
   if (
-    !options.config.get("disable_graphql_response_cache") &&
-    !options.config.get("disable_graphql_cache_headers")
+    options.config.get("graphql_response_cache") &&
+    options.config.get("graphql_cache_headers")
   ) {
     plugins.push(
       ResponseCachePlugin({

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -330,18 +330,18 @@ const config = convict({
     default: ms("30 seconds"),
     env: "DEFAULT_GRAPHQL_CACHE_MAX_AGE",
   },
-  disable_graphql_response_cache: {
-    doc: "When enabled, will disable caching GraphQL requests.",
+  graphql_response_cache: {
+    doc: "When enabled, will enable caching GraphQL responses in Redis.",
     format: Boolean,
     default: false,
-    env: "DISABLE_GRAPHQL_RESPONSE_CACHE",
+    env: "GRAPHQL_RESPONSE_CACHE",
   },
-  disable_graphql_cache_headers: {
+  graphql_cache_headers: {
     doc:
-      "When enabled, will disable sending GraphQL Cache-Control headers along with requests. This will also disable the response cache.",
+      "When enabled, Coral will send Cache-Control headers along with GraphQL requests. If this is not enabled, the response cache is also not enabled.",
     format: Boolean,
     default: false,
-    env: "DISABLE_GRAPHQL_CACHE_HEADERS",
+    env: "GRAPHQL_CACHE_HEADERS",
   },
 });
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

While we work out issues with CDN + Cache headers, this PR will change the default behaviour of GraphQL requests to non-cached. This also changes the configuration variables to reflect the change:

- `GRAPHQL_CACHE_HEADERS`: When enabled, Coral will send Cache-Control headers along with GraphQL requests. If this is not enabled, the response cache is also not enabled. (default `false`)
- `GRAPHQL_RESPONSE_CACHE`: When enabled, will enable caching GraphQL responses in Redis. (default `false`)

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

Start the server without any environment variables referencing the caching system and notice that all GraphQL requests do not send cache control headers.

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
