### PR TITLE
[CORL-1385] Fix translation general-userBoxAuthenticated-signedIn

### DIFF
--- a/src/locales/da/stream.ftl
+++ b/src/locales/da/stream.ftl
@@ -6,8 +6,8 @@ general-userBoxUnauthenticated-joinTheConversation = Deltag i samtalen
 general-userBoxUnauthenticated-signIn = Log ind
 general-userBoxUnauthenticated-register = Registrer
 
-general-userBoxAuthenticated-signedInAs =
-  Logget ind som <Username></Username>.
+general-userBoxAuthenticated-signedIn =
+  Logget ind som
 
 general-userBoxAuthenticated-notYou =
   Er det ikke dig? <button>Log ud</button>

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -8,7 +8,6 @@ general-userBoxUnauthenticated-joinTheConversation = Join the conversation
 general-userBoxUnauthenticated-signIn = Sign in
 general-userBoxUnauthenticated-register = Register
 
-general-userBoxAuthenticated-signedInAs =
 general-userBoxAuthenticated-signedIn =
   Signed in as
 general-userBoxAuthenticated-notYou =

--- a/src/locales/es/stream.ftl
+++ b/src/locales/es/stream.ftl
@@ -8,9 +8,6 @@ general-userBoxUnauthenticated-joinTheConversation = Unirse a la conversación
 general-userBoxUnauthenticated-signIn = Iniciar sesión
 general-userBoxUnauthenticated-register = Registrarse
 
-general-userBoxAuthenticated-signedInAs =
-  Registrado como <Username></Username>.
-
 general-userBoxAuthenticated-signedIn =
   Sesión iniciada como
 
@@ -246,16 +243,16 @@ profile-preferences-mediaPreferences-update = Actualizar
 
 ### Account
 profile-account-ignoredCommenters-description =
-  Tu puedes ignorar otros comentaristas haciendo clic en su nombre de usuario 
-  y seleccionando Ignorar. Cuando tu ignoras a alguien, todos sus comentarios 
-  estarán ocultos para ti. Los comentaristas que tu ignores todavía serán 
+  Tu puedes ignorar otros comentaristas haciendo clic en su nombre de usuario
+  y seleccionando Ignorar. Cuando tu ignoras a alguien, todos sus comentarios
+  estarán ocultos para ti. Los comentaristas que tu ignores todavía serán
   capaces de ver tus comentarios.
 profile-account-ignoredCommenters-manage = Manejar
 
 
 profile-account-download-comments-title = Descargar mi historial de comentarios
 profile-account-download-comments-description =
-  Recibirá un correo electrónico con un enlace para descargar su historial de comentarios. 
+  Recibirá un correo electrónico con un enlace para descargar su historial de comentarios.
   <strong>Puede realizar una solicitud de descarga cada 14 días.</strong>
 profile-account-download-comments-request =
   Solicitar su historial de comentarios
@@ -372,8 +369,8 @@ configure-openStream-openStream = Abrir los comentarios
 
 comments-tombstone-ignore = Este comentario está oculto porque ignoraste a {$username}
 
-configure-enableQA-title = 
-configure-enableQA-switchToQA = 
+configure-enableQA-title =
+configure-enableQA-switchToQA =
   Cambiar a Q&A
 configure-enableQA-description =
   El formato de Q&A permite a los miembros de la comunidad enviar preguntas para que las respondan los expertos elegidos.
@@ -396,7 +393,7 @@ configure-experts-filter-searchButton =
   .aria-label = Buscar
 configure-experts-filter-description =
   Agregar una insignia de experto a los comentarios de los usuarios registrados, solamente en esta página. Los nuevos usuarios primero deben registrarse y abrir los comentarios en una página para crear su cuenta.
-  page. 
+  page.
 configure-experts-search-none-found = No se encuentra ningún usario con este email o nombre de usario
 configure-experts-
 configure-experts-remove-button = Eliminar

--- a/src/locales/fi-FI/stream.ftl
+++ b/src/locales/fi-FI/stream.ftl
@@ -8,7 +8,6 @@ general-userBoxUnauthenticated-joinTheConversation = Liity keskusteluun
 general-userBoxUnauthenticated-signIn = Kirjaudu
 general-userBoxUnauthenticated-register = Rekisteröidy
 
-general-userBoxAuthenticated-signedInAs =
 general-userBoxAuthenticated-signedIn =
   Kirjoitat nimellä
 general-userBoxAuthenticated-notYou =
@@ -62,7 +61,7 @@ comments-featuredCommentTooltip-toggleButton =
 
 comments-collapse-toggle =
   .aria-label = Pienennä keskusteluketju
-comments-bannedInfo-bannedFromCommenting = Olemme asettaneet sinut kirjoituskieltoon. 
+comments-bannedInfo-bannedFromCommenting = Olemme asettaneet sinut kirjoituskieltoon.
 comments-bannedInfo-violatedCommunityGuidelines =
   Olemme asettaneet sinut kirjoituskieltoon, koska olet rikkonut kommentoinnin sääntöjä. Jos kielto on mielestäsi aiheeton, ota yhteyttä ylläpitoon.
 
@@ -106,7 +105,7 @@ comments-viewNew =
 comments-loadMore = Näytä lisää
 
 comments-permalinkPopover =
-  .description = Ikkuna jossa on linkki kommenttiin 
+  .description = Ikkuna jossa on linkki kommenttiin
 comments-permalinkPopover-permalinkToComment =
   .aria-label = Linkki kommenttiin
 comments-permalinkButton-share = Jaa
@@ -208,7 +207,7 @@ comments-userPopover-ignore = Hiljennä
 
 comments-userIgnorePopover-ignoreUser = Hiljennetäänkö {$username}?
 comments-userIgnorePopover-description =
-  Et enää näe hiljentämäsi kirjoittajan kommentteja. 
+  Et enää näe hiljentämäsi kirjoittajan kommentteja.
   Voit perua hiljentämisen Omat tiedot -sivulla.
 
 comments-userIgnorePopover-ignore = Hiljennä
@@ -216,8 +215,8 @@ comments-userIgnorePopover-cancel = Peruuta
 
 comments-userBanPopover-title = Asetetaanko {$username} kirjoituskieltoon?
 comments-userBanPopover-description =
-  Kirjoituskiellossa oleva käyttäjä ei voi enää kirjoittaa kommentteja, 
-  reagoida niihin tai ilmoittaa muiden kommentteja asiattomiksi. 
+  Kirjoituskiellossa oleva käyttäjä ei voi enää kirjoittaa kommentteja,
+  reagoida niihin tai ilmoittaa muiden kommentteja asiattomiksi.
   Myös tämä kommentti hylätään.
 comments-userBanPopover-cancel = Peruuta
 comments-userBanPopover-ban = Aseta kirjoituskieltoon
@@ -232,7 +231,7 @@ comments-moderationDropdown-reject = Hylkää
 comments-moderationDropdown-rejected = Hylätty
 comments-moderationDropdown-ban = Aseta kirjoituskieltoon
 comments-moderationDropdown-banned = Kirjoituskiellossa
-comments-moderationDropdown-goToModerate = 
+comments-moderationDropdown-goToModerate =
 comments-moderationDropdown-moderationView = Moderoi
 comments-moderationDropdown-moderateStory = Moderoi juttu
 comments-moderationDropdown-caretButton =
@@ -319,7 +318,7 @@ comments-stream-deleteAccount-callOut-receivedDesc =
   Olemme vastaanottaneet pyyntösi kirjoittajatilisi poistamiseksi { $date }.
 comments-stream-deleteAccount-callOut-cancelDesc =
   Jos haluat jatkaa kirjoittamista, voit peruuttaa poistopyyntösi { $date } asti.
- 
+
 comments-stream-deleteAccount-callOut-cancel =
   Peruuta kirjoittajatilin poistopyyntö
 comments-stream-deleteAccount-callOut-cancelAccountDeletion =
@@ -387,10 +386,10 @@ profile-preferences-mediaPreferences-preferencesUpdated =
 ### Account
 profile-account-ignoredCommenters = Hiljennetyt kirjoittajat
 profile-account-ignoredCommenters-description =
-  Voit hiljentää haluamiesi kirjoittajien kommentit painamalla heidän nimeään ja valitsemalla Hiljennä. 
+  Voit hiljentää haluamiesi kirjoittajien kommentit painamalla heidän nimeään ja valitsemalla Hiljennä.
   Et enää näe hiljentämiesi kirjoittajien kommentteja, mutta he näkevät edelleen sinun kirjoittamasi kommentit.
-  
-  
+
+
 profile-account-ignoredCommenters-empty = Et ole hiljentänyt ketään
 profile-account-ignoredCommenters-stopIgnoring = Peru hiljentäminen
 profile-account-ignoredCommenters-youAreNoLonger =
@@ -411,7 +410,7 @@ profile-account-changePassword-password = Salasana
 
 profile-account-download-comments-title = Lataa kommenttihistoriasi
 profile-account-download-comments-description =
-  Saat sähköpostin, jossa on linkki kommenttihistoriasi lataamista varten. 
+  Saat sähköpostin, jossa on linkki kommenttihistoriasi lataamista varten.
   Voit tehdä latauspyynnön 14 vuorokauden välein.
 profile-account-download-comments-request =
   Lataa kommenttihistoria
@@ -420,12 +419,12 @@ profile-account-download-comments-request-icon =
 profile-account-download-comments-recentRequest =
   Viimeisin latauspyyntösi: { $timeStamp }
 profile-account-download-comments-yourMostRecentRequest =
-  Viimeisin latauspyyntösi on kuluvan 14 vuorokauden ajalta. 
+  Viimeisin latauspyyntösi on kuluvan 14 vuorokauden ajalta.
   Voit tehdä seuraavan latauspyynnön { $timeStamp }
 profile-account-download-comments-requested =
   Pyyntö lähetetty. Seuraavaan mahdolliseen latauspyyntöön on aikaa { framework-timeago-time }
 profile-account-download-comments-requestSubmitted =
-  Latauspyyntösi on lähetetty onnistuneesti. 
+  Latauspyyntösi on lähetetty onnistuneesti.
   Seuraavaan latauspyyntöön on aikaa { framework-timeago-time }.
 profile-account-download-comments-error =
   Latauspyynnön suorittaminen ei onnistunut.
@@ -437,12 +436,12 @@ profile-account-deleteAccount-title = Poista kirjoittajatilisi
 profile-account-deleteAccount-deleteMyAccount = Poista kirjoittajatilisi
 profile-account-deleteAccount-description =
   Kirjoittajatilin poistaminen poistaa pysyvästi kaikki kirjoittamasi kommentit.
-  
+
 profile-account-deleteAccount-requestDelete = Pyydä kirjoittajatilin poistoa
 
 profile-account-deleteAccount-cancelDelete-description =
-  Olet pyytänyt kirjoittajatilisi poistoa. 
-  Tilisi poistetaan { $date }. 
+  Olet pyytänyt kirjoittajatilisi poistoa.
+  Tilisi poistetaan { $date }.
   Siihen asti voit perua pyyntösi.
 profile-account-deleteAccount-cancelDelete = Peru poistopyyntö
 
@@ -476,15 +475,15 @@ profile-account-deleteAccount-pages-whenSec1Content =
 profile-account-deleteAccount-pages-whenSec2Header =
   Voinko jatkaa kirjoittamista tilin poistoon asti?
 profile-account-deleteAccount-pages-whenSec2Content =
-  Poistumassa olevalla kirjoittajatilillä et voi enää kirjoittaa kommentteja 
+  Poistumassa olevalla kirjoittajatilillä et voi enää kirjoittaa kommentteja
   tai tehdä muitakaan kommentteihin liittyviä asioita.
 
 profile-account-deleteAccount-pages-downloadCommentHeader = Lataa kommenttisi?
 profile-account-deleteAccount-pages-downloadSubHeader = Lataa kommenttisi
 profile-account-deleteAccount-pages-downloadCommentsDesc =
-  Suosittelemme, että lataat kommenttihistoriasi itsellesi ennen kirjoittajatilisi poistamista. 
+  Suosittelemme, että lataat kommenttihistoriasi itsellesi ennen kirjoittajatilisi poistamista.
   Kun tilisi on poistettu, et voi enää ladata kommenttihistoriaasi.
-  
+
 profile-account-deleteAccount-pages-downloadCommentsPath =
   Omat tiedot > Lataa kommenttihistoriasi
 
@@ -494,7 +493,7 @@ profile-account-deleteAccount-pages-confirmDescHeader =
   Oletko varma, että haluat poistaa kirjoittajatilisi?
 profile-account-deleteAccount-confirmDescContent =
   Poistopyynnön vahvistamiseksi kirjoita seuraava teksti alla olevaan laatikkoon:
-  
+
 profile-account-deleteAccount-pages-confirmPhraseLabel =
   Vahvista kirjoittamalla teksti:
 profile-account-deleteAccount-pages-confirmPasswordLabel =
@@ -513,7 +512,7 @@ profile-account-deleteAccount-pages-completeSignIntoYourAccount =
   <strong>Peru poistopyyntö</strong>.
 profile-account-deleteAccount-pages-completeTellUsWhy = Kerro meille miksi.
 profile-account-deleteAccount-pages-completeWhyDeleteAccount =
-  Haluaisimme tietää, miksi olet poistamassa kirjoittajatiliäsi. 
+  Haluaisimme tietää, miksi olet poistamassa kirjoittajatiliäsi.
   Voit lähettää meille palautetta osoitteeseen { $email }.
 profile-account-changePassword-edit = Muokkaa
 profile-account-changePassword-change = Vaihda
@@ -582,7 +581,7 @@ profile-changeUsername-edit = Muokkaa
 profile-changeUsername-change = Vaihda
 profile-changeUsername-heading = Muokkaa nimeäsi
 profile-changeUsername-heading-changeYourUsername = Vaihda nimesi
-profile-changeUsername-desc = Vaihda nimi, joka näkyy kaikissa vanhoissa ja uusissa kommenteissasi. <strong>Nimen voi vaihtaa kerran per { framework-timeago-time }.</strong> 
+profile-changeUsername-desc = Vaihda nimi, joka näkyy kaikissa vanhoissa ja uusissa kommenteissasi. <strong>Nimen voi vaihtaa kerran per { framework-timeago-time }.</strong>
 profile-changeUsername-desc-text = Vaihda nimi, joka näkyy kaikissa vanhoissa ja uusissa kommenteissasi. <strong>Nimen voi vaihtaa kerran per { framework-timeago-time }.</strong>
 profile-changeUsername-current = Nykyinen nimi
 profile-changeUsername-newUsername-label = Uusi nimi
@@ -592,7 +591,7 @@ profile-changeUsername-save = Tallenna
 profile-changeUsername-saveChanges = Tallenna muutokset
 profile-changeUsername-recentChange = Nimesi on vaihdettu kuluneen { framework-timeago-time } aikana. Voit vaihtaa nimesi uudelleen { $nextUpdate }.
 profile-changeUsername-youChangedYourUsernameWithin =
-  Vaihdoit nimesi kuluneen { framework-timeago-time } aikana. Voit vaihtaa nimesi uudelleen { $nextUpdate }.  
+  Vaihdoit nimesi kuluneen { framework-timeago-time } aikana. Voit vaihtaa nimesi uudelleen { $nextUpdate }.
 profile-changeUsername-close = Sulje
 
 ## Discussions tab
@@ -607,40 +606,40 @@ discussions-discussionsQuery-errorLoadingProfile = Tietojen lataaminen epäonnis
 discussions-discussionsQuery-storyNotFound = Juttua ei löytynyt
 
 ## Comment Stream
-configure-stream-title = 
+configure-stream-title =
 configure-stream-title-configureThisStream =
   Muokkaa tämän kommenttiketjun asetuksia
-configure-stream-apply = 
+configure-stream-apply =
 configure-stream-update = Tallenna
 configure-stream-streamHasBeenUpdated =
   Kommenttiketju päivitettiin
 
-configure-premod-title = 
+configure-premod-title =
 configure-premod-premoderateAllComments = Kommenttien ennakkotarkastus
 configure-premod-description =
   Ylläpidon on hyväksyttävä kommentti ennen kuin se julkaistaan.
 
-configure-premodLink-title = 
+configure-premodLink-title =
 configure-premodLink-commentsContainingLinks =
   Linkkejä sisältävien kommenttien ennakkotarkastus
 configure-premodLink-description =
   Ylläpidon on hyväksyttävä linkkejä sisältävä kommentti ennen kuin se julkaistaan.
 
-configure-liveUpdates-title = 
-configure-enableLiveUpdates-title = Reaaliaikainen päivitys käytössä  
+configure-liveUpdates-title =
+configure-enableLiveUpdates-title = Reaaliaikainen päivitys käytössä
 configure-liveUpdates-description =
 configure-enableLiveUpdates-description =
-  Kun reaaliaikainen päivitys on käytössä, uusien kommenttien ja 
-  vastausten näkyminen ei vaadi sivulatausta, vaan tiedot päivittyvät välittömästi. 
-  Voit poistaa ominaisuuden käytöstä, jos se aiheuttaa kommenttien latautumisen 
+  Kun reaaliaikainen päivitys on käytössä, uusien kommenttien ja
+  vastausten näkyminen ei vaadi sivulatausta, vaan tiedot päivittyvät välittömästi.
+  Voit poistaa ominaisuuden käytöstä, jos se aiheuttaa kommenttien latautumisen
   hitautta poikkeuksellisen suosituissa jutuissa.
 configure-enableLiveUpdates-enable = Ota käyttöön
 
 configure-disableLiveUpdates-title = Poista reaaliaikainen päivitys käytöstä
 configure-disableLiveUpdates-description =
-  Kun reaaliaikainen päivitys ei ole käytössä, uudet kommentit ja vastaukset eivät enää 
-  päivity välittömästi. Uusien kommenttien näkymiseksi kommentoijien on päivitettävä sivu manuaalisesti. 
-  Reaaliaikainen päivitys on suositeltua poistaa käytöstä jos se aiheuttaa kommenttien latautumisen 
+  Kun reaaliaikainen päivitys ei ole käytössä, uudet kommentit ja vastaukset eivät enää
+  päivity välittömästi. Uusien kommenttien näkymiseksi kommentoijien on päivitettävä sivu manuaalisesti.
+  Reaaliaikainen päivitys on suositeltua poistaa käytöstä jos se aiheuttaa kommenttien latautumisen
   hitautta poikkeuksellisen suosituissa jutuissa.
 configure-disableLiveUpdates-disable = Poista käytöstä
 
@@ -653,8 +652,8 @@ configure-addMessage-title =
 configure-messageBox-description =
 configure-addMessage-description =
   Lisää viesti kommentointilaatikon yläpuolella.
-  Voit käyttää viestilaatikkoa esimerkiksi keskustelun ohjaamiseen tai 
-  kysymyksen tai juttuun liittyvän ilmoituksen tekemiseen.  
+  Voit käyttää viestilaatikkoa esimerkiksi keskustelun ohjaamiseen tai
+  kysymyksen tai juttuun liittyvän ilmoituksen tekemiseen.
 configure-addMessage-addMessage = Lisää viesti
 configure-addMessage-removed = Viesti on poistettu
 config-addMessage-messageHasBeenAdded =
@@ -674,42 +673,42 @@ configure-messageBox-iconChatBubble = Puhekupla
 configure-messageBox-noIcon = Ei kuvaketta
 configure-messageBox-writeAMessage = Kirjoita viesti
 
-configure-closeStream-title = 
+configure-closeStream-title =
 configure-closeStream-closeCommentStream =
   Sulje keskustelu
 configure-closeStream-description =
-  Keskustelu on tällä hetkellä avoinna. 
-  Suljettuun keskusteluun ei voi kirjoittaa uusia kommentteja, 
+  Keskustelu on tällä hetkellä avoinna.
+  Suljettuun keskusteluun ei voi kirjoittaa uusia kommentteja,
   mutta vanhat kommentit jäävät näkyville.
 configure-closeStream-closeStream = Sulje keskustelu
 configure-closeStream-theStreamIsNowOpen = Keskustelu on nyt avattu
 
 configure-openStream-title = Avaa keskustelu
 configure-openStream-description =
-  Keskustelu on tällä hetkellä suljettu. 
+  Keskustelu on tällä hetkellä suljettu.
   Avattuun keskusteluun voi jälleen kirjoittaa kommentteja.
 configure-openStream-openStream = Avaa keskustelu
 configure-openStream-theStreamIsNowClosed = Keskustelu on nyt suljettu
 
-configure-moderateThisStream = 
+configure-moderateThisStream =
 
 qa-experimental-tag-tooltip-content =
-  K&V toiminnallisuutta kehitetään aktiivisesti. 
+  K&V toiminnallisuutta kehitetään aktiivisesti.
   Ota yhteyttä jos haluat antaa palautetta tai kehitysehdotuksia.
 
 configure-enableQA-title =
 configure-enableQA-switchToQA =
   Vaihda K&V muotoon
 configure-enableQA-description =
-  K&V muodossa kommentoijat voivat jättää kysymyksiä erikseen valittujen 
+  K&V muodossa kommentoijat voivat jättää kysymyksiä erikseen valittujen
   asiantuntijoiden vastattavaksi.
 configure-enableQA-enableQA = Vaihda K&V muotoon
 configure-enableQA-streamIsNowComments =
-  Ketju on nyt kommentointimuodossa  
+  Ketju on nyt kommentointimuodossa
 
 configure-disableQA-title = K&V asetukset
 configure-disableQA-description =
-  K&V muodossa kommentoijat voivat jättää kysymyksiä erikseen valittujen 
+  K&V muodossa kommentoijat voivat jättää kysymyksiä erikseen valittujen
   asiantuntijoiden vastattavaksi.
 configure-disableQA-disableQA = Vaihda kommentointimuotoon
 configure-disableQA-streamIsNowQA =
@@ -723,31 +722,31 @@ configure-experts-filter-searchButton =
   .aria-label = Hae
 configure-experts-filter-description =
   Lisää Asiantuntija -leiman valituille käyttäjille vain tällä sivulla.
-  Uusien käyttäjien on ensin luotava kirjoittajatili ja 
+  Uusien käyttäjien on ensin luotava kirjoittajatili ja
   vierailtava kommenttisivulla.
 configure-experts-search-none-found = No users were found with that email or username
 configure-experts-
 configure-experts-remove-button = Poista
 configure-experts-load-more = Lataa lisää
-configure-experts-none-yet = Tälle K&V ketjulle ei ole vielä lisätty asiantuntijoita 
+configure-experts-none-yet = Tälle K&V ketjulle ei ole vielä lisätty asiantuntijoita
 configure-experts-search-title = Hae asiantuntijaa
 configure-experts-assigned-title = Asiantuntijat
 configure-experts-noLongerAnExpert = ei ole enää asiantuntija
-comments-tombstone-ignore = Kommentti ei näy, koska olet hiljentänyt kirjoittajan {$username} 
+comments-tombstone-ignore = Kommentti ei näy, koska olet hiljentänyt kirjoittajan {$username}
 comments-tombstone-showComment = Näytä kommentti
 comments-tombstone-deleted =
   Kommentti on poistettu, koska sen kirjoittaja on poistanut kirjoittajatilinsä.
 
-suspendInfo-heading = 
+suspendInfo-heading =
 suspendInfo-heading-yourAccountHasBeen =
-  Olemme asettaneet sinut määräaikaiseen kirjoituskieltoon. 
+  Olemme asettaneet sinut määräaikaiseen kirjoituskieltoon.
 suspendInfo-info =
 suspendInfo-description-inAccordanceWith =
-  Et saa kirjoittaa kommentteja, koska olet rikkonut kommentoinnin sääntöjä. 
-  Kirjoituskiellon aikana et voi myöskään reagoida toisten kommentteihin tai 
-  ilmoittaa niitä asiattomiksi. 
+  Et saa kirjoittaa kommentteja, koska olet rikkonut kommentoinnin sääntöjä.
+  Kirjoituskiellon aikana et voi myöskään reagoida toisten kommentteihin tai
+  ilmoittaa niitä asiattomiksi.
 suspendInfo-until-pleaseRejoinThe =
-  Kirjoituskieltosi päättyy { $until }. 
+  Kirjoituskieltosi päättyy { $until }.
 
 warning-heading = Kirjoittajatilillesi on annettu varoitus
 warning-explanation =
@@ -765,13 +764,13 @@ profile-changeEmail-change = Vaihda
 profile-changeEmail-please-verify = Vahvista sähköpostiosoitteesi
 profile-changeEmail-please-verify-details =
   Vahvistusviesti on lähetetty sähköpostiosoitteeseesi { $email }.
-  Sinun tulee vahvistaa uusi sähköpostiosoitteesi ennen kuin voit 
+  Sinun tulee vahvistaa uusi sähköpostiosoitteesi ennen kuin voit
   käyttää sitä kirjautumiseen tai ilmoitusten vastaanottamiseen.
 profile-changeEmail-resend = Lähetä vahvistusviesti uudelleen
 profile-changeEmail-heading = Muokkaa sähköpostiosoitettasi
 profile-changeEmail-changeYourEmailAddress =
   Vaihda sähköpostiosoitteesi
-profile-changeEmail-desc = Vaihda sähköpostiosoite, jota käytät kirjautumiseen ja johon saat kirjoittajatiliisi liittyviä viestejä. 
+profile-changeEmail-desc = Vaihda sähköpostiosoite, jota käytät kirjautumiseen ja johon saat kirjoittajatiliisi liittyviä viestejä.
 profile-changeEmail-newEmail-label = Uusi sähköpostiosoite
 profile-changeEmail-password = Salasana
 profile-changeEmail-password-input =

--- a/src/locales/fr-FR/stream.ftl
+++ b/src/locales/fr-FR/stream.ftl
@@ -8,9 +8,8 @@ general-userBoxUnauthenticated-joinTheConversation = Réagir
 general-userBoxUnauthenticated-signIn = Se connecter
 general-userBoxUnauthenticated-register = S'enregistrer
 
-general-userBoxAuthenticated-signedInAs =
 general-userBoxAuthenticated-signedIn =
-  Connecté en tant que <Username></Username>.
+  Connecté en tant que
 general-userBoxAuthenticated-notYou =
   Ce n'est pas vous ?<button>Se déconnecter</button>
 

--- a/src/locales/nl-NL/stream.ftl
+++ b/src/locales/nl-NL/stream.ftl
@@ -6,8 +6,8 @@ general-userBoxUnauthenticated-joinTheConversation = Meld je aan of Registreer j
 general-userBoxUnauthenticated-signIn = Aanmelden
 general-userBoxUnauthenticated-register = Registreren
 
-general-userBoxAuthenticated-signedInAs =
-  Aangemeld als <Username></Username>.
+general-userBoxAuthenticated-signedIn =
+  Aangemeld als
 
 general-userBoxAuthenticated-notYou =
   Bent u dit niet? <button>Uitloggen</button>
@@ -37,7 +37,7 @@ comments-featuredCommentTooltip-toggleButton =
 comments-bannedInfo-bannedFromCommenting = Uw account is beblokkeerd voor het geven van reacties.
 comments-bannedInfo-violatedCommunityGuidelines =
   Iemand die toegang heeft tot uw account heeft onze spelregels geschonden.
-  Als gevolg daarvan is uw account geblokkeerd. U zult niet langer 
+  Als gevolg daarvan is uw account geblokkeerd. U zult niet langer
   in staat zijn om reacties te plaatsen. Als u denkt dat
   dit is foutief gebeurd is, neem dan contact op met onze moderator.
 
@@ -203,7 +203,7 @@ profile-accountDeletion-cancelDeletion =
 ### Comment History
 profile-historyComment-viewConversation = Bekijk discussie
 profile-historyComment-replies = Antwoorden {$replyCount}
-profile-historyComment-commentHistory = Voorbije reacties 
+profile-historyComment-commentHistory = Voorbije reacties
 profile-historyComment-story = Bericht: {$title}
 profile-historyComment-comment-on = Reageer op:
 profile-profileQuery-errorLoadingProfile = Profiel kan niet ingeladen worden
@@ -448,7 +448,7 @@ comments-tombstone-deleted =
 suspendInfo-heading = Uw account is tijdelijk geschorst voor reacties.
 suspendInfo-info =
   In overeenstemming met de spelregels van  { $organization } is uw
-  account tijdelijk geblokkeerd. Intussen zult U geen reacties 
+  account tijdelijk geblokkeerd. Intussen zult U geen reacties
   meer kunnen plaatsen. U kunt terug deelnemen
   aan de discussie op { $until }
 

--- a/src/locales/pl/stream.ftl
+++ b/src/locales/pl/stream.ftl
@@ -6,8 +6,8 @@ general-userBoxUnauthenticated-joinTheConversation = Dołącz do rozmowy
 general-userBoxUnauthenticated-signIn = Zaloguj się
 general-userBoxUnauthenticated-register = Rejestracja
 
-general-userBoxAuthenticated-signedInAs =
-  Twój login to <Username></Username>.
+general-userBoxAuthenticated-signedIn =
+  Twój login to
 
 general-userBoxAuthenticated-notYou =
   To nie Ty? <button>Wyloguj</button>
@@ -39,8 +39,8 @@ comments-featuredCommentTooltip-toggleButton =
 comments-bannedInfo-bannedFromCommenting = Twoje konto zostało zablokowane i nie możesz komentować.
 comments-bannedInfo-violatedCommunityGuidelines =
   Ktoś z dostępem do Twojego konta złamał zasady obowiązujące w
-  naszej społeczności. W rezultacie tych działań, Twoje konto 
-  zostało zbanowane. Nie masz już więcej możliwości komentowania, 
+  naszej społeczności. W rezultacie tych działań, Twoje konto
+  zostało zbanowane. Nie masz już więcej możliwości komentowania,
   ocenienia albo zgłaszania komentarzy. Jeśli uważasz, że stało się
   to w wyniku błędu, skontaktuj się z naszym zespołem.
 
@@ -138,7 +138,7 @@ comments-userPopover-ignore = Ignoruj
 
 comments-userIgnorePopover-ignoreUser = Ignorować {$username}?
 comments-userIgnorePopover-description =
-  Kiedy ignorujesz użytkownika, wszystkie jej/jego komentarze 
+  Kiedy ignorujesz użytkownika, wszystkie jej/jego komentarze
   będą przed Tobą ukryte. Możesz później cofnąć tę operację
   w swoim Profilu.
 comments-userIgnorePopover-ignore = Ignoruj
@@ -146,9 +146,9 @@ comments-userIgnorePopover-cancel = Anuluj
 
 comments-userBanPopover-title = Zbanować {$username}?
 comments-userBanPopover-description =
-  Po zbanowaniu, nie będzie już mógł/mogła 
+  Po zbanowaniu, nie będzie już mógł/mogła
   komentować, reagować, zgłaszać komentarzy.
-  Ten komentarz zostanie usunięty. 
+  Ten komentarz zostanie usunięty.
 comments-userBanPopover-cancel = Anuluj
 comments-userBanPopover-ban = Banuj
 
@@ -222,7 +222,7 @@ comments-stream-deleteAccount-callOut-title =
 comments-stream-deleteAccount-callOut-receivedDesc =
   Twoja prośba o usunięcie konta została przyjęta { $date }.
 comments-stream-deleteAccount-callOut-cancelDesc =
-  Jeśli chcesz nadal publikować komentarze, odpowiadać na nie lub reagować, 
+  Jeśli chcesz nadal publikować komentarze, odpowiadać na nie lub reagować,
   możesz anulować swoją prośbę o usunięcie konta przed { $date }.
 comments-stream-deleteAccount-callOut-cancel =
   Anuluj prośbę o usunięcie konta
@@ -263,8 +263,8 @@ profile-commentHistory-empty-subheading = Tutaj pojawi się lista napisanych prz
 profile-account-ignoredCommenters = Ignorowani komentatorzy
 profile-account-ignoredCommenters-description =
   Możesz ignorować innych po kliknięciu w ich profil
-  i wybraniu opcji Ignoruj. Kiedy kogoś ignorujesz, 
-  jej/jego komentarze są ukryte przed Tobą. Ale Twoje 
+  i wybraniu opcji Ignoruj. Kiedy kogoś ignorujesz,
+  jej/jego komentarze są ukryte przed Tobą. Ale Twoje
   komentarze nadal są dla nich widoczne.
 profile-account-ignoredCommenters-empty = Nie ignorujesz nikogo
 profile-account-ignoredCommenters-stopIgnoring = Przestań ignorować
@@ -304,7 +304,7 @@ profile-account-deleteAccount-description =
 profile-account-deleteAccount-requestDelete = Wyślij prośbę o usunięcie konta
 
 profile-account-deleteAccount-cancelDelete-description =
-  Wysłałaś/eś już prośbę o usunięcie konta. 
+  Wysłałaś/eś już prośbę o usunięcie konta.
   Konto zostanie usunięte { $date }.
   Do tego czasu możesz jeszcze anulować ten proces.
 profile-account-deleteAccount-cancelDelete = Anuluj usunięcie konta
@@ -342,8 +342,8 @@ profile-account-deleteAccount-pages-whenSec2Content =
 profile-account-deleteAccount-pages-downloadCommentHeader = Pobrać moje komentarze?
 profile-account-deleteAccount-pages-downloadCommentsDesc =
   Zanim Twoje konto zostanie usunięte, polecamy skorzystanie z opcji
-  pobrania historii Twoich komentarzy. Nie będzie to możliwe 
-  po usunięciu konta. 
+  pobrania historii Twoich komentarzy. Nie będzie to możliwe
+  po usunięciu konta.
 profile-account-deleteAccount-pages-downloadCommentsPath =
   Mój profil > Pobierz historię moich komentarzy
 
@@ -361,7 +361,7 @@ profile-account-deleteAccount-pages-confirmPasswordLabel =
 profile-account-deleteAccount-pages-completeHeader = Zażądano usunięcie konta
 profile-account-deleteAccount-pages-completeDescript =
   Twoje życzenie zostało wysłane i na adres email powiązany z Twoim kontem
-  wysłaliśmy link do potwierdzenia. 
+  wysłaliśmy link do potwierdzenia.
 profile-account-deleteAccount-pages-completeTimeHeader =
   Twoje konto zostanie usunięte: { $date }
 profile-account-deleteAccount-pages-completeChangeYourMindHeader = Zmiana decyzji?
@@ -457,12 +457,12 @@ configure-premodLink-description =
 
 configure-liveUpdates-title = Włącz Aktualizację Na Żywo dla tego artykułu
 configure-liveUpdates-description =
-  Kiedy włączysz tę opcję, komentarze będą aktualizowane 
+  Kiedy włączysz tę opcję, komentarze będą aktualizowane
   od razu po wysłaniu, bez czekania na przeładowanie strony.
-  Możesz wyłączyć tę opcję, w rzadko spotykanej sytuacji, gdy 
+  Możesz wyłączyć tę opcję, w rzadko spotykanej sytuacji, gdy
   artykuł ma tak dużo odwiedzin, że komentarze ładują się
-  zbyt wolno. 
-  
+  zbyt wolno.
+
 configure-messageBox-title = Włącz Boks Wiadomości dla tego artykułu
 configure-messageBox-description =
   Dodaj wiadomość na górze pola komentarzy dla Twoich użytkowników.
@@ -528,7 +528,7 @@ suspendInfo-heading = Twoje konto zostało chwilowo zawieszone i na razie nie mo
 suspendInfo-info =
   Zgodnie z regulaminem społeczności { $organization } Twoje
   konto zostało chwilowo zawieszone. Dopóki jest zawieszone nie
-  możesz komentować, reagować ani zgłaszać innych komentarzy. 
+  możesz komentować, reagować ani zgłaszać innych komentarzy.
   Wróc do nas { $until }
 
 profile-changeEmail-unverified = (Niepotwierdzone)
@@ -537,7 +537,7 @@ profile-changeEmail-please-verify = Potwierdź swój email
 profile-changeEmail-please-verify-details =
   Email do weryfikacji konta został wysłany na { $email }.
   Musisz potwierdzić swoje konto, zanim będzie można się
-  zalogować i otrzymywać powiadomienia. 
+  zalogować i otrzymywać powiadomienia.
 profile-changeEmail-resend = Ponowna weryfikacja
 profile-changeEmail-heading = Zmień email
 profile-changeEmail-desc = Zmień adres email używany do logowania i otrzymywania powiadomień.

--- a/src/locales/pt-BR/stream.ftl
+++ b/src/locales/pt-BR/stream.ftl
@@ -8,7 +8,6 @@ general-userBoxUnauthenticated-joinTheConversation = Participe da conversa
 general-userBoxUnauthenticated-signIn = Entrar
 general-userBoxUnauthenticated-register = Cadastre-se
 
-general-userBoxAuthenticated-signedInAs =
 general-userBoxAuthenticated-signedIn =
   Logado como
 general-userBoxAuthenticated-notYou =

--- a/src/locales/ro/stream.ftl
+++ b/src/locales/ro/stream.ftl
@@ -6,8 +6,8 @@ general-userBoxUnauthenticated-joinTheConversation = Alaturâ-te conversației
 general-userBoxUnauthenticated-signIn = Intră în cont
 general-userBoxUnauthenticated-register = Înregistrează-te
 
-general-userBoxAuthenticated-signedInAs =
-  Înregistrat ca <Username></Username>.
+general-userBoxAuthenticated-signedIn =
+  Înregistrat ca
 
 general-userBoxAuthenticated-notYou =
   Nu ești tu? <button>Ieși din cont</button>;

--- a/src/locales/sv/stream.ftl
+++ b/src/locales/sv/stream.ftl
@@ -6,8 +6,8 @@ general-userBoxUnauthenticated-joinTheConversation = Delta i diskussionen
 general-userBoxUnauthenticated-signIn = Logga in
 general-userBoxUnauthenticated-register = Registrera dig
 
-general-userBoxAuthenticated-signedInAs =
-  Inloggad som <Username></Username>.
+general-userBoxAuthenticated-signedIn =
+  Inloggad som
 
 general-userBoxAuthenticated-notYou =
   Inte du? <button>Logga ut</button>
@@ -36,8 +36,8 @@ comments-featuredCommentTooltip-toggleButton =
 
 comments-bannedInfo-bannedFromCommenting = Ditt konto har blivit avstängt från att kommentera.
 comments-bannedInfo-violatedCommunityGuidelines =
-  Någon med access till ditt konto har brutit mot våra regler. 
-  Ditt konto har därför blivit avstängt och du kommer inte kunna 
+  Någon med access till ditt konto har brutit mot våra regler.
+  Ditt konto har därför blivit avstängt och du kommer inte kunna
   kommentera längre. Om du tycker detta är fel, vänligen kontakta oss.
 
 comments-noCommentsYet = Det finns inga kommentarer ännu. Varför inte skriva en?
@@ -85,7 +85,7 @@ comments-postCommentFormFake-rte =
   .placeholder = { comments-postCommentForm-rteLabel }
 
 comments-postCommentForm-userScheduledForDeletion-warning =
-  Du kan inte kommentera när ditt konto är på väg att raderas. 
+  Du kan inte kommentera när ditt konto är på väg att raderas.
 
 comments-replyButton-reply = Svara
 
@@ -106,7 +106,7 @@ comments-editCommentForm-rteLabel = Redigera kommentar
 comments-editCommentForm-rte =
   .placeholder = { comments-editCommentForm-rteLabel }
 comments-editCommentForm-editRemainingTime = Redigering: <time></time> kvar
-comments-editCommentForm-editTimeExpired = Tiden för att redigera har gått ut. Du kan inte längre redigera den här kommentaren. Varför inte skriva en till? 
+comments-editCommentForm-editTimeExpired = Tiden för att redigera har gått ut. Du kan inte längre redigera den här kommentaren. Varför inte skriva en till?
 comments-editedMarker-edited = Redigerad
 comments-showConversationLink-readMore = Läs mer av den här diskussionen >
 comments-conversationThread-showMoreOfThisConversation =
@@ -227,7 +227,7 @@ profile-account-changePassword-password = Lösenord
 
 profile-account-download-comments-title = Ladda ner min kommentarshistorik
 profile-account-download-comments-description =
-  Du kommer få ett mejl med en länk till att ladda ner din kommentarshistorik. 
+  Du kommer få ett mejl med en länk till att ladda ner din kommentarshistorik.
   Du kan göra <strong>en begäran om nedladdning var 14:e dag</strong>
 profile-account-download-comments-request =
   Begär kommentarshistorik
@@ -236,7 +236,7 @@ profile-account-download-comments-request-icon =
 profile-account-download-comments-recentRequest =
   Din senaste begäran: { $timeStamp }
 profile-account-download-comments-requested =
-  Nedladdning begärd. Du kan begära en ny nedladdning om { framework-timeago-time }.  
+  Nedladdning begärd. Du kan begära en ny nedladdning om { framework-timeago-time }.
 profile-account-download-comments-request-button = Begäran
 
 ## Delete Account
@@ -385,9 +385,9 @@ configure-stream-apply = Applicera
 
 configure-premod-title = Använd förhandsmoderering
 configure-premod-description =
-  Moderatorer måste godkänna varje kommentar innan den publiceras vid den här artikeln. 
+  Moderatorer måste godkänna varje kommentar innan den publiceras vid den här artikeln.
 
-configure-premodLink-title = Förhandsmoderera kommentarer som innehåller länkar 
+configure-premodLink-title = Förhandsmoderera kommentarer som innehåller länkar
 configure-premodLink-description =
   Moderatorer måste godkänna varje kommentar som innehåller en länk innan den publiceras vid den här artikeln.
 


### PR DESCRIPTION
## What does this PR do?

- Translation `general-userBoxAuthenticated-signedInAs` has moved to `general-userBoxAuthenticated-signed`
- Port all other translations.