### PR TITLE
[CORL-1378] ip based spam detection option

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Moderation/AkismetConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Moderation/AkismetConfig.tsx
@@ -32,6 +32,7 @@ graphql`
     integrations {
       akismet {
         enabled
+        ipBased
         key
         site
       }
@@ -77,6 +78,12 @@ const AkismetConfig: FunctionComponent<Props> = ({ disabled }) => {
           <Label component="legend">Spam detection filter</Label>
         </Localized>
         <OnOffField name="integrations.akismet.enabled" disabled={disabled} />
+      </FormField>
+      <FormField container={<FieldSet />}>
+        <Localized id="configure-moderation-akismet-ipBased">
+          <Label component="legend">IP-based spam detection</Label>
+        </Localized>
+        <OnOffField name="integrations.akismet.ipBased" disabled={disabled} />
       </FormField>
       <HorizontalGutter spacing={3}>
         <Localized id="configure-configurationSubHeader" strong={<strong />}>

--- a/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
@@ -1155,6 +1155,65 @@ If approved by a moderator, the comment will be published.
                     </div>
                   </div>
                 </fieldset>
+                <fieldset
+                  className="FieldSet-root Box-root HorizontalGutter-root FormField-root HorizontalGutter-spacing-2"
+                >
+                  <legend
+                    className="Label-root"
+                  >
+                    IP-based spam detection
+                  </legend>
+                  <div>
+                    <div
+                      className="Box-root Flex-root RadioButton-root Flex-flex Flex-alignCenter"
+                    >
+                      <input
+                        checked={false}
+                        className="RadioButton-input"
+                        disabled={false}
+                        id="integrations.akismet.ipBased-true"
+                        name="integrations.akismet.ipBased"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        type="radio"
+                        value="true"
+                      />
+                      <label
+                        className="RadioButton-label"
+                        htmlFor="integrations.akismet.ipBased-true"
+                      >
+                        <span>
+                          On
+                        </span>
+                      </label>
+                    </div>
+                    <div
+                      className="Box-root Flex-root RadioButton-root Flex-flex Flex-alignCenter"
+                    >
+                      <input
+                        checked={true}
+                        className="RadioButton-input"
+                        disabled={false}
+                        id="integrations.akismet.ipBased-false"
+                        name="integrations.akismet.ipBased"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        type="radio"
+                        value="false"
+                      />
+                      <label
+                        className="RadioButton-label RadioButton-labelChecked"
+                        htmlFor="integrations.akismet.ipBased-false"
+                      >
+                        <span>
+                          Off
+                        </span>
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
                 <div
                   className="Box-root HorizontalGutter-root HorizontalGutter-spacing-3"
                 >

--- a/src/core/client/admin/test/configure/moderation.spec.tsx
+++ b/src/core/client/admin/test/configure/moderation.spec.tsx
@@ -166,6 +166,7 @@ it("change akismet settings", async () => {
       updateSettings: ({ variables }) => {
         expectAndFail(variables.settings.integrations!.akismet).toEqual({
           enabled: true,
+          ipBased: false,
           key: "my api key",
           site: "https://coralproject.net",
         });
@@ -183,7 +184,13 @@ it("change akismet settings", async () => {
     "akismet-config"
   );
 
-  const onField = within(akismetContainer).getByLabelText("On");
+  const spamDetectionFieldset = within(akismetContainer).getAllByText(
+    "Spam detection filter",
+    {
+      selector: "fieldset",
+    }
+  )[1];
+  const onField = within(spamDetectionFieldset).getByLabelText("On");
   const keyField = within(akismetContainer).getByLabelText("API key");
   const siteField = within(akismetContainer).getByLabelText("Site URL");
   const form = findParentWithType(akismetContainer, "form")!;

--- a/src/core/client/admin/test/fixtures.ts
+++ b/src/core/client/admin/test/fixtures.ts
@@ -94,6 +94,7 @@ export const settings = createFixture<GQLSettings>({
   integrations: {
     akismet: {
       enabled: false,
+      ipBased: false,
     },
     perspective: {
       enabled: false,

--- a/src/core/client/test/helpers/fixture.ts
+++ b/src/core/client/test/helpers/fixture.ts
@@ -348,6 +348,7 @@ export function createSettings() {
     integrations: {
       akismet: {
         enabled: false,
+        ipBased: false,
       },
       perspective: {
         enabled: false,

--- a/src/core/server/graph/resolvers/AkismetExternalIntegration.ts
+++ b/src/core/server/graph/resolvers/AkismetExternalIntegration.ts
@@ -1,0 +1,7 @@
+import * as settings from "coral-server/models/settings";
+
+import { GQLAkismetExternalIntegrationTypeResolver } from "coral-server/graph/schema/__generated__/types";
+
+export const AkismetExternalIntegration: GQLAkismetExternalIntegrationTypeResolver<settings.AkismetExternalIntegration> = {
+  ipBased: ({ ipBased = true }) => ipBased,
+};

--- a/src/core/server/graph/resolvers/index.ts
+++ b/src/core/server/graph/resolvers/index.ts
@@ -4,6 +4,7 @@ import Time from "coral-server/graph/scalars/time";
 
 import { GQLResolver } from "coral-server/graph/schema/__generated__/types";
 
+import { AkismetExternalIntegration } from "./AkismetExternalIntegration";
 import { ApproveCommentPayload } from "./ApproveCommentPayload";
 import { AuthIntegrations } from "./AuthIntegrations";
 import { BanStatus } from "./BanStatus";
@@ -71,6 +72,7 @@ import { WebhookEndpoint } from "./WebhookEndpoint";
 import { YouTubeMediaConfiguration } from "./YouTubeMediaConfiguration";
 
 const Resolvers: GQLResolver = {
+  AkismetExternalIntegration,
   ApproveCommentPayload,
   StaffConfiguration,
   AuthIntegrations,

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -969,6 +969,11 @@ type AkismetExternalIntegration {
   enabled: Boolean!
 
   """
+  ipBased when True will enable IP-based spam detection.
+  """
+  ipBased: Boolean!
+
+  """
   The key for the Akismet integration.
   """
   key: String
@@ -4383,6 +4388,11 @@ input SettingsAkismetExternalIntegrationInput {
   enabled when True will enable the integration.
   """
   enabled: Boolean
+
+  """
+  ipBased when True will enable IP-based spam detection.
+  """
+  ipBased: Boolean
 
   """
   The key for the Akismet integration.

--- a/src/core/server/models/settings/settings.ts
+++ b/src/core/server/models/settings/settings.ts
@@ -1,5 +1,4 @@
 import {
-  GQLAkismetExternalIntegration,
   GQLAuth,
   GQLAuthenticationTargetFilter,
   GQLCOMMENT_BODY_FORMAT,
@@ -142,11 +141,33 @@ export interface ExternalModerationExternalIntegration {
   phases: ExternalModerationPhase[];
 }
 
+export interface AkismetExternalIntegration {
+  /**
+   * enabled when True will enable the integration.
+   */
+  enabled: boolean;
+
+  /**
+   * ipBased when true will enable IP-based spam detection.
+   */
+  ipBased?: boolean;
+
+  /**
+   * The key for the Akismet integration.
+   */
+  key?: string;
+
+  /**
+   * The site (blog) for the Akismet integration.
+   */
+  site?: string;
+}
+
 export interface ExternalIntegrations {
   /**
    * akismet provides integration with the Akismet Spam detection service.
    */
-  akismet: GQLAkismetExternalIntegration;
+  akismet: AkismetExternalIntegration;
 
   /**
    * perspective provides integration with the Perspective API comment analysis

--- a/src/core/server/models/tenant/tenant.ts
+++ b/src/core/server/models/tenant/tenant.ts
@@ -236,6 +236,7 @@ export async function createTenant(
     integrations: {
       akismet: {
         enabled: false,
+        ipBased: false,
       },
       perspective: {
         enabled: false,

--- a/src/core/server/services/comments/pipeline/phases/spam.ts
+++ b/src/core/server/services/comments/pipeline/phases/spam.ts
@@ -61,10 +61,17 @@ export const spam: IntermediateModerationPhase = async ({
   });
 
   // Grab the properties we need.
-  const userIP = req.ip;
-  if (!userIP) {
-    log.debug("request did not contain ip address, aborting spam check");
-    return;
+
+  let userIP = "";
+  // Only use the ip address if ipBased is enabled.
+  if (integration.ipBased) {
+    if (req.ip) {
+      userIP = req.ip;
+    } else {
+      log.debug(
+        "request did not contain ip address, continue spam check with empty ip address"
+      );
+    }
   }
 
   const userAgent = req.get("User-Agent");

--- a/src/core/server/services/comments/pipeline/phases/spam.ts
+++ b/src/core/server/services/comments/pipeline/phases/spam.ts
@@ -61,10 +61,12 @@ export const spam: IntermediateModerationPhase = async ({
   });
 
   // Grab the properties we need.
-
   let userIP = "";
-  // Only use the ip address if ipBased is enabled.
-  if (integration.ipBased) {
+
+  // Only use the ip address if ipBased is enabled. This property is by default
+  // not set, that's why we're explicitly checking if it is false before using
+  // it.
+  if (integration.ipBased !== false) {
     if (req.ip) {
       userIP = req.ip;
     } else {
@@ -72,6 +74,8 @@ export const spam: IntermediateModerationPhase = async ({
         "request did not contain ip address, continue spam check with empty ip address"
       );
     }
+  } else {
+    log.trace("not adding ip address to request due to configuration");
   }
 
   const userAgent = req.get("User-Agent");

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -715,6 +715,7 @@ configure-moderation-akismet-explanation =
 
 #### Akismet
 configure-moderation-akismet-filter = Spam detection filter
+configure-moderation-akismet-ipBased = IP-based spam detection
 configure-moderation-akismet-accountNote =
   Note: You must add your active domain(s)
   in your Akismet account: <externalLink>https://akismet.com/account/</externalLink>


### PR DESCRIPTION
## What does this PR do?
- Introduce `akismet.ipBased` option that defaults to `false`.
- if `akismet.ipBased` is `true` use user ip in spam detection otherwise leave it out.