### PR TITLE
[CORL-1433] Connected Websocket Metric

### DIFF
--- a/src/core/server/services/metrics/index.ts
+++ b/src/core/server/services/metrics/index.ts
@@ -1,10 +1,11 @@
-import { Counter, Histogram } from "prom-client";
+import { Counter, Gauge, Histogram } from "prom-client";
 
 export interface Metrics {
   executedGraphQueriesTotalCounter: Counter<string>;
   graphQLExecutionTimingsHistogram: Histogram<string>;
   httpRequestsTotal: Counter<string>;
   httpRequestDurationMilliseconds: Histogram<string>;
+  connectedWebsocketsTotalGauge: Gauge<string>;
 }
 
 export function createMetrics(): Metrics {
@@ -35,10 +36,18 @@ export function createMetrics(): Metrics {
     labelNames: ["method", "handler"],
   });
 
+  const connectedWebsocketsTotalGauge = new Gauge({
+    name: "coral_connected_websockets_total",
+    help: "number of websocket connections being handled",
+  });
+
+  connectedWebsocketsTotalGauge.set(0);
+
   return {
     executedGraphQueriesTotalCounter,
     graphQLExecutionTimingsHistogram,
     httpRequestsTotal,
     httpRequestDurationMilliseconds,
+    connectedWebsocketsTotalGauge,
   };
 }


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

Export a new `coral_connected_websockets_total` metric that represents the number of connected websockets that a given application is handling.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

When at least one websocket connected (logged in admin user), visit http://localhost:9000/metrics to see the new metric at the bottom.