### PR TITLE
[CORL-1440] Allow Replies to have no body

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/CreateCommentReplyMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/CreateCommentReplyMutation.ts
@@ -195,7 +195,7 @@ async function commit(
             storyID: input.storyID,
             parentID: input.parentID,
             parentRevisionID: input.parentRevisionID,
-            body: input.body,
+            body: input.body || "",
             nudge: input.nudge,
             clientMutationId: clientMutationId.toString(),
             media: input.media,
@@ -220,7 +220,7 @@ async function commit(
                   ignoreable: false,
                   avatar: viewer.avatar,
                 },
-                body: input.body,
+                body: input.body || "",
                 revision: {
                   id: uuidGenerator(),
                   media: null,


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

When enabled, comments do not need a body when it includes attached media. This fixes a bug in the frontend that previously did not default the body to an empty string. Ideally, we want to type these completely, but this is related to final form so we probably don't have the bandwidth to change that now.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

1. Post a comment with only a GIF.
2. Post a reply to that comment with only a different GIF
3. See it post!