### PR TITLE
[CORL-1411] Capture replies in slack publish events

### DIFF
--- a/src/core/server/events/listeners/slack/publishEvent.ts
+++ b/src/core/server/events/listeners/slack/publishEvent.ts
@@ -19,6 +19,7 @@ export type Trigger =
   | "pending"
   | "featured"
   | "created"
+  | "replied"
   | "staffCreated";
 
 export default class SlackPublishEvent {
@@ -66,7 +67,7 @@ export default class SlackPublishEvent {
     if (triggers.includes("staffCreated")) {
       return "This comment has been created by staff";
     }
-    if (triggers.includes("created")) {
+    if (triggers.includes("created") || triggers.includes("replied")) {
       return "This comment has been created";
     }
     if (triggers.includes("featured")) {
@@ -85,7 +86,8 @@ export default class SlackPublishEvent {
   public shouldPublishToChannel({ triggers }: GQLSlackChannel) {
     const triggerSet = this.getTriggers();
     return (
-      (triggers.allComments && triggerSet.includes("created")) ||
+      (triggers.allComments &&
+        (triggerSet.includes("created") || triggerSet.includes("replied"))) ||
       (triggers.featuredComments && triggerSet.includes("featured")) ||
       (triggers.reportedComments && triggerSet.includes("reported")) ||
       (triggers.pendingComments && triggerSet.includes("pending")) ||

--- a/src/core/server/events/listeners/slack/slack.ts
+++ b/src/core/server/events/listeners/slack/slack.ts
@@ -7,6 +7,7 @@ import {
   CommentCreatedCoralEventPayload,
   CommentEnteredModerationQueueCoralEventPayload,
   CommentFeaturedCoralEventPayload,
+  CommentReplyCreatedCoralEventPayload,
 } from "../../events";
 import {
   CoralEventListener,
@@ -18,7 +19,8 @@ import SlackPublishEvent, { Trigger } from "./publishEvent";
 type SlackCoralEventListenerPayloads =
   | CommentFeaturedCoralEventPayload
   | CommentEnteredModerationQueueCoralEventPayload
-  | CommentCreatedCoralEventPayload;
+  | CommentCreatedCoralEventPayload
+  | CommentReplyCreatedCoralEventPayload;
 
 export class SlackCoralEventListener
   implements CoralEventListener<SlackCoralEventListenerPayloads> {
@@ -27,6 +29,7 @@ export class SlackCoralEventListener
     CoralEventType.COMMENT_FEATURED,
     CoralEventType.COMMENT_ENTERED_MODERATION_QUEUE,
     CoralEventType.COMMENT_CREATED,
+    CoralEventType.COMMENT_REPLY_CREATED,
   ];
   private readonly fetch = createFetch({ name: "slack" });
 
@@ -58,6 +61,8 @@ export class SlackCoralEventListener
     switch (payload.type) {
       case CoralEventType.COMMENT_CREATED:
         return "created";
+      case CoralEventType.COMMENT_REPLY_CREATED:
+        return "replied";
       case CoralEventType.COMMENT_ENTERED_MODERATION_QUEUE:
         if (payload.data.queue === GQLMODERATION_QUEUE.REPORTED) {
           return "reported";


### PR DESCRIPTION
## What does this PR do?

Hooks in the replies to slack publish events.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Hook up a slack channel in the admin settings
- Enable all comments
- Post a comment
- Post a reply to that comment
- See that both come through on Slack
