### PR TITLE
[CORL-1466] NodeJS Timeouts

### DIFF
--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -363,6 +363,20 @@ const config = convict({
     default: false,
     env: "GRAPHQL_CACHE_HEADERS",
   },
+  nodejs_keep_alive_timeout: {
+    doc:
+      "Specifies the keep alive timeout to set for the HTTP server used by Coral.",
+    format: "ms",
+    default: ms("5s"),
+    env: "NODEJS_KEEP_ALIVE_TIMEOUT",
+  },
+  nodejs_headers_timeout: {
+    doc:
+      "Specifies the headers timeout to set for the HTTP server used by Coral.",
+    format: "ms",
+    default: ms("1m"),
+    env: "NODEJS_HEADERS_TIMEOUT",
+  },
 });
 
 export type Config = typeof config;


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

In order to rectify some error's we're seeing during high load periods, we wanted to expose the following environment variables:

- `NODEJS_KEEP_ALIVE_TIMEOUT` - Specifies the keep alive timeout to set for the HTTP server used by Coral (Default `5s`)
  - See [`server.keepAliveTimeout`](https://nodejs.org/api/http.html#http_server_keepalivetimeout)
- `NODEJS_HEADERS_TIMEOUT` - Specifies the headers timeout to set for the HTTP server used by Coral (Default `1m`)
  - See [`server.headersTimeout`](https://nodejs.org/api/http.html#http_server_headerstimeout)

Note that the `NODEJS_HEADERS_TIMEOUT` must always be greater than the `NODEJS_KEEP_ALIVE_TIMEOUT`.

Related:

- https://shuheikagawa.com/blog/2019/04/25/keep-alive-timeout/
- https://amoss.me/2019/01/debugging-http-502-errors-on-google-kubernetes-engine/

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

Set the parameters, and try to set `NODEJS_HEADERS_TIMEOUT` less than `NODEJS_KEEP_ALIVE_TIMEOUT` and see the error the application produces!