### PR TITLE
[CORL-1409] prevent long usernames and badges from being cut off on mobile

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -359,7 +359,7 @@ export const CommentContainer: FunctionComponent<Props> = ({
             parentAuthorName={comment.parent?.author?.username}
             staticUsername={
               comment.author && (
-                <Flex direction="row" alignItems="center">
+                <Flex direction="row" alignItems="center" wrap>
                   <UsernameContainer
                     className={cn(
                       styles.staticUsername,

--- a/src/core/client/stream/tabs/Comments/Comment/CommentToggle.css
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentToggle.css
@@ -11,6 +11,7 @@
 
 .icon {
   color: var(--palette-grey-500);
+  padding-top: 3px;
 }
 
 .timestamp {

--- a/src/core/client/stream/tabs/Comments/Comment/CommentToggle.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentToggle.tsx
@@ -29,7 +29,7 @@ const CommentToggle: FunctionComponent<Props> = (props) => {
       onClick={props.toggleCollapsed}
       className={cn(styles.root, CLASSES.comment.collapseToggle.$root)}
     >
-      <Flex alignItems="center" spacing={1}>
+      <Flex alignItems="flex-start" spacing={1}>
         <Icon className={cn(styles.icon, CLASSES.comment.collapseToggle.icon)}>
           add
         </Icon>
@@ -38,11 +38,13 @@ const CommentToggle: FunctionComponent<Props> = (props) => {
           justifyContent="space-between"
           alignItems="center"
           className={cn(styles.inner, CLASSES.comment.topBar.$root)}
+          wrap
         >
           <Flex
             direction="row"
             alignItems="center"
             justifyContent="space-between"
+            wrap
           >
             <Flex
               className={styles.username}

--- a/src/core/client/stream/tabs/Comments/Comment/__snapshots__/CommentContainer.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/Comment/__snapshots__/CommentContainer.spec.tsx.snap
@@ -178,6 +178,7 @@ exports[`hide reply button 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
           direction="row"
+          wrap={true}
         >
           <Relay(UsernameContainer)
             className="CommentContainer-staticUsername coral coral-username coral-comment-username"
@@ -517,6 +518,7 @@ exports[`renders body only 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
           direction="row"
+          wrap={true}
         >
           <Relay(UsernameContainer)
             className="CommentContainer-staticUsername coral coral-username coral-comment-username"
@@ -856,6 +858,7 @@ exports[`renders disabled reply when commenting has been disabled 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
           direction="row"
+          wrap={true}
         >
           <Relay(UsernameContainer)
             className="CommentContainer-staticUsername coral coral-username coral-comment-username"
@@ -1195,6 +1198,7 @@ exports[`renders disabled reply when story is closed 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
           direction="row"
+          wrap={true}
         >
           <Relay(UsernameContainer)
             className="CommentContainer-staticUsername coral coral-username coral-comment-username"
@@ -1547,6 +1551,7 @@ exports[`renders in reply to 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
           direction="row"
+          wrap={true}
         >
           <Relay(UsernameContainer)
             className="CommentContainer-staticUsername coral coral-username coral-comment-username"
@@ -1898,6 +1903,7 @@ exports[`renders username and body 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
           direction="row"
+          wrap={true}
         >
           <Relay(UsernameContainer)
             className="CommentContainer-staticUsername coral coral-username coral-comment-username"
@@ -2254,6 +2260,7 @@ exports[`shows conversation link 1`] = `
         <ForwardRef(forwardRef)
           alignItems="center"
           direction="row"
+          wrap={true}
         >
           <Relay(UsernameContainer)
             className="CommentContainer-staticUsername coral coral-username coral-comment-username"


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

forces some line breaks on mobile for long usernames and badges when comments are collapsed

before:
<img width="341" alt="Screen Shot 2020-10-27 at 9 46 50 AM" src="https://user-images.githubusercontent.com/1789029/97324582-5eac6380-1848-11eb-90dd-20c64c83d360.png">

after:

<img width="351" alt="Screen Shot 2020-10-27 at 11 35 21 AM" src="https://user-images.githubusercontent.com/1789029/97324704-87ccf400-1848-11eb-84cf-0b5b225bdea3.png">

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?
none
<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

create a user with a long username and update staff/admin badge to be long, make a comment, then view stream on mobile. toggle comment open and closed.


<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
