### PR TITLE
[CORL-1480] Duplicate Comment Box Fix

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/AddACommentButton.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AddACommentButton.tsx
@@ -7,7 +7,11 @@ import { Button } from "coral-ui/components/v3";
 
 import styles from "./AddACommentButton.css";
 
-const AddACommentButton: FunctionComponent = () => {
+interface Props {
+  isQA?: boolean;
+}
+
+const AddACommentButton: FunctionComponent<Props> = ({ isQA = false }) => {
   const { pym } = useCoralContext();
   const onClick = useCallback(() => {
     if (!pym) {
@@ -29,7 +33,7 @@ const AddACommentButton: FunctionComponent = () => {
       >
         <Flex alignItems="center">
           <Icon className={styles.icon}>create</Icon>
-          <span>Add a Comment</span>
+          {isQA ? <span>Ask a Question</span> : <span>Add a Comment</span>}
         </Flex>
       </Button>
     </div>

--- a/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -165,7 +165,6 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
     ) &&
     local.commentsOrderBy === GQLCOMMENT_SORT.CREATED_AT_ASC &&
     local.commentsTab === "ALL_COMMENTS" &&
-    !isQA &&
     !props.story.isClosed &&
     !props.settings.disableCommenting.enabled;
 
@@ -227,7 +226,7 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
         <CommunityGuidelinesContainer settings={props.settings} />
         {showCommentForm &&
           (alternateOldestViewEnabled ? (
-            <AddACommentButton />
+            <AddACommentButton isQA={isQA} />
           ) : (
             <>
               <IntersectionProvider>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

When alternative view mode is enabled, and you are sorting the comment stream by oldest first, there should only ever be one comment box (even on Q&A stories).

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

With a story in Q&A and `ALTERNATE_OLDEST_FIRST_VIEW` enabled, view the "All" tab and see that there's no duplicate.