### PR TITLE
[CORL-1485] Revert #3241

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

It seems like the solution introduced in #3241 via https://github.com/apollographql/graphql-subscriptions/pull/209#issuecomment-713906710 _introduced_ a memory leak:

![Memory Usage(1)](https://user-images.githubusercontent.com/633002/97737912-45ebba00-1aa3-11eb-821e-c35d5a0d278c.png)

After rolling back that change the memory slope went away:

![Memory Usage(3)](https://user-images.githubusercontent.com/633002/97740050-4c2f6580-1aa6-11eb-8316-1ec73aa4a919.png)

This is curious as we are transpiling for `ES2018` running on a NodeJS 12-alpine Docker image.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

Wait for CI to pass!

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
