### PR TITLE
fix comments:suggestscore from perspective API

### DIFF
--- a/src/core/server/services/perspective/perspective.ts
+++ b/src/core/server/services/perspective/perspective.ts
@@ -111,7 +111,7 @@ function formatBody(req: Request): object {
           ],
         },
         attributeScores: {
-          [status]: {
+          [req.body.commentStatus]: {
             summaryScore: {
               value: 1,
             },


### PR DESCRIPTION
I was testing the Talk integration with the API perspective when I came across the following error:

```
 err: {
      "message": "status is not defined",
      "name": "ReferenceError",
      "stack": "formatBody (src/core/server/services/perspective/perspective.ts:114:12)\nObject.sendToPerspective (src/core/server/services/perspective/perspective.ts:137:31)\nsrc/core/server/events/listeners/perspective.ts:87:28\nasync Promise.all (index 2)\nObject.publish (src/core/server/events/event.ts:48:7)\nObject.publishCommentStatusChanges (src/core/server/services/events/comments.ts:36:5)\nasync Promise.all (index 1)\nObject.publishChanges (src/core/server/stacks/helpers/publishChanges.ts:66:3)\nObject.rejectComment (src/core/server/stacks/rejectComment.ts:57:5)\nObject.rejectComment (src/core/server/graph/resolvers/Mutation.ts:135:14)\n"
    }

```

I solved the problem based on the code before this PR: https://github.com/coralproject/talk/pull/2866 

