### PR TITLE
[CORL-1501] Fixed type with commentEntered event

### DIFF
--- a/src/core/server/graph/resolvers/CommentEnteredPayload.ts
+++ b/src/core/server/graph/resolvers/CommentEnteredPayload.ts
@@ -1,0 +1,9 @@
+import { GQLCommentEnteredPayloadTypeResolver } from "coral-server/graph/schema/__generated__/types";
+
+import { maybeLoadOnlyID } from "./Comment";
+import { CommentEnteredInput } from "./Subscription/commentEntered";
+
+export const CommentEnteredPayload: GQLCommentEnteredPayloadTypeResolver<CommentEnteredInput> = {
+  comment: ({ commentID }, args, ctx, info) =>
+    maybeLoadOnlyID(ctx, info, commentID),
+};

--- a/src/core/server/graph/resolvers/Subscription/commentEntered.ts
+++ b/src/core/server/graph/resolvers/Subscription/commentEntered.ts
@@ -8,6 +8,7 @@ import {
 } from "./types";
 
 export interface CommentEnteredInput extends SubscriptionPayload {
+  commentID: string;
   storyID: string;
   ancestorIDs?: string[];
 }

--- a/src/core/server/graph/resolvers/index.ts
+++ b/src/core/server/graph/resolvers/index.ts
@@ -14,6 +14,7 @@ import { Comment } from "./Comment";
 import { CommentCounts } from "./CommentCounts";
 import { CommentCreatedPayload } from "./CommentCreatedPayload";
 import { CommentEnteredModerationQueuePayload } from "./CommentEnteredModerationQueuePayload";
+import { CommentEnteredPayload } from "./CommentEnteredPayload";
 import { CommentLeftModerationQueuePayload } from "./CommentLeftModerationQueuePayload";
 import { CommentMedia } from "./CommentMedia";
 import { CommentModerationAction } from "./CommentModerationAction";
@@ -83,6 +84,7 @@ const Resolvers: GQLResolver = {
   CommentCounts,
   CommentCreatedPayload,
   CommentEnteredModerationQueuePayload,
+  CommentEnteredPayload,
   CommentLeftModerationQueuePayload,
   CommentMedia,
   CommentModerationAction,

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -8257,6 +8257,16 @@ type CommentCreatedPayload {
 }
 
 """
+CommentEnteredPayload is returned when a Comment is released on a Story.
+"""
+type CommentEnteredPayload {
+  """
+  comment is the new Comment that was released on the Story.
+  """
+  comment: Comment!
+}
+
+"""
 CommentReplyCreatedPayload is returned when a Comment is created as a reply to
 another Comment where the selected ancestor Comment is in the ancestor chain.
 """
@@ -8320,24 +8330,27 @@ type Subscription {
   """
   commentEntered returns when a Comment is created or released anywhere in the Story.
   """
-  commentEntered(storyID: ID!, ancestorID: ID): CommentCreatedPayload!
+  commentEntered(storyID: ID!, ancestorID: ID): CommentEnteredPayload!
 
   """
   commentCreated returns when a Comment is created on the top level of a Story
   that is visible.
   """
-  commentCreated(storyID: ID!): CommentCreatedPayload! @deprecated(reason: "Use commentEntered instead")
+  commentCreated(storyID: ID!): CommentCreatedPayload!
+    @deprecated(reason: "Use commentEntered instead")
 
   """
   commentReleased returns when a Comment on a premoderated stream is approved
   """
-  commentReleased(storyID: ID!): CommentReleasedPayload! @deprecated(reason: "Use commentEntered instead")
+  commentReleased(storyID: ID!): CommentReleasedPayload!
+    @deprecated(reason: "Use commentEntered instead")
 
   """
   commentReplyCreated returns when a Comment is posted in the ancestor chain of
   comments.
   """
-  commentReplyCreated(ancestorID: ID!): CommentReplyCreatedPayload! @deprecated(reason: "Use commentEntered instead")
+  commentReplyCreated(ancestorID: ID!): CommentReplyCreatedPayload!
+    @deprecated(reason: "Use commentEntered instead")
 
   """
   commentFeatured returns when a Comment is featured.

--- a/src/core/server/services/events/comments.ts
+++ b/src/core/server/services/events/comments.ts
@@ -92,10 +92,14 @@ export async function publishCommentReleased(
 
 export async function publishCommentReplyReleased(
   broker: CoralEventPublisherBroker,
-  comment: Pick<Comment, "storyID" | "parentID" | "ancestorIDs" | "status">
+  comment: Pick<
+    Comment,
+    "id" | "storyID" | "parentID" | "ancestorIDs" | "status"
+  >
 ) {
   if (getDepth(comment) > 0 && hasPublishedStatus(comment)) {
     await CommentEnteredCoralEvent.publish(broker, {
+      commentID: comment.id,
       ancestorIDs: comment.ancestorIDs,
       storyID: comment.storyID,
     });


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

Previously, the schema was re-using the `CommentCreatedPayload` type for the `commentEntered` event. This PR was fixed to instead use it's own types so that the `commentID` being used can be typed for the loader.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

- Changed `Subscription.commentEntered(storyID: ID!, ancestorID: ID): CommentCreatedPayload!` to `Subscription.commentEntered(storyID: ID!, ancestorID: ID): CommentEnteredPayload!`

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

Approve a comment with another browser watching to reproduce in the frames of the websocket connection.

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
