### PR TITLE
[CORL-1460/CORL-1504] Fix slack configuration UI issues

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/Slack/SlackChannel.css
+++ b/src/core/client/admin/routes/Configure/sections/Slack/SlackChannel.css
@@ -30,7 +30,7 @@
 }
 
 .content {
-  padding: var(--spacing-3) var(--spacing-2) 0 var(--spacing-2);
+  padding: 0 var(--spacing-2);
 }
 
 .textField {

--- a/src/core/client/admin/routes/Configure/sections/Slack/SlackChannel.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Slack/SlackChannel.tsx
@@ -1,7 +1,7 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
 import { FormApi } from "final-form";
-import React, { FunctionComponent, useCallback, useMemo } from "react";
+import React, { FunctionComponent, Ref, useCallback, useMemo } from "react";
 import { Field, useFormState } from "react-final-form";
 
 import { parseBool } from "coral-framework/lib/form";
@@ -18,6 +18,7 @@ import {
   Label,
   TextField,
 } from "coral-ui/components/v2";
+import { withForwardRef } from "coral-ui/hocs";
 
 import Subheader from "../../Subheader";
 import TextFieldWithValidation from "../../TextFieldWithValidation";
@@ -30,6 +31,7 @@ interface Props {
   index: number;
   onRemoveClicked: (index: number) => void;
   form: FormApi;
+  forwardRef?: Ref<HTMLInputElement>;
 }
 
 const SlackChannel: FunctionComponent<Props> = ({
@@ -38,6 +40,7 @@ const SlackChannel: FunctionComponent<Props> = ({
   index,
   onRemoveClicked,
   form,
+  forwardRef,
 }) => {
   const onRemove = useCallback(() => {
     onRemoveClicked(index);
@@ -126,6 +129,7 @@ const SlackChannel: FunctionComponent<Props> = ({
                       spellCheck={false}
                       fullWidth
                       className={styles.textField}
+                      ref={forwardRef}
                       {...input}
                     />
                   </>
@@ -296,4 +300,4 @@ const SlackChannel: FunctionComponent<Props> = ({
   );
 };
 
-export default SlackChannel;
+export default withForwardRef(SlackChannel);

--- a/src/core/client/admin/routes/Configure/sections/Slack/SlackChannel.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Slack/SlackChannel.tsx
@@ -1,7 +1,8 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
-import React, { FunctionComponent, useCallback } from "react";
-import { Field } from "react-final-form";
+import { FormApi } from "final-form";
+import React, { FunctionComponent, useCallback, useMemo } from "react";
+import { Field, useFormState } from "react-final-form";
 
 import { parseBool } from "coral-framework/lib/form";
 import { ExternalLink } from "coral-framework/lib/i18n/components";
@@ -28,6 +29,7 @@ interface Props {
   disabled: boolean;
   index: number;
   onRemoveClicked: (index: number) => void;
+  form: FormApi;
 }
 
 const SlackChannel: FunctionComponent<Props> = ({
@@ -35,10 +37,29 @@ const SlackChannel: FunctionComponent<Props> = ({
   disabled,
   index,
   onRemoveClicked,
+  form,
 }) => {
   const onRemove = useCallback(() => {
     onRemoveClicked(index);
   }, [index, onRemoveClicked]);
+
+  const formState = useFormState();
+
+  const allSelected = useMemo(() => {
+    return formState.values.slack.channels[index].triggers.allComments;
+  }, [formState, index]);
+
+  const onAllSelected = useCallback(
+    (checked: boolean | undefined) => {
+      if (!checked) {
+        form.change(`${channel}.triggers.staffComments`, false);
+        form.change(`${channel}.triggers.reportedComments`, false);
+        form.change(`${channel}.triggers.pendingComments`, false);
+        form.change(`${channel}.triggers.featuredComments`, false);
+      }
+    },
+    [form, channel]
+  );
 
   return (
     <>
@@ -165,6 +186,10 @@ const SlackChannel: FunctionComponent<Props> = ({
                         id={`configure-slack-channel-triggers-allComments-${input.name}`}
                         disabled={disabled || !channelEnabled}
                         {...input}
+                        onChange={(event) => {
+                          onAllSelected(input.checked);
+                          input.onChange(event);
+                        }}
                       >
                         <Localized id="configure-slack-channel-triggers-allComments">
                           All Comments
@@ -187,7 +212,7 @@ const SlackChannel: FunctionComponent<Props> = ({
                   {({ input }) => (
                     <CheckBox
                       id={`configure-slack-channel-triggers-staffComments-${input.name}`}
-                      disabled={disabled || !channelEnabled}
+                      disabled={disabled || !channelEnabled || allSelected}
                       className={styles.trigger}
                       {...input}
                     >
@@ -205,7 +230,7 @@ const SlackChannel: FunctionComponent<Props> = ({
                   {({ input }) => (
                     <CheckBox
                       id={`configure-slack-channel-triggers-reportedComments-${input.name}`}
-                      disabled={disabled || !channelEnabled}
+                      disabled={disabled || !channelEnabled || allSelected}
                       className={styles.trigger}
                       {...input}
                     >
@@ -223,7 +248,7 @@ const SlackChannel: FunctionComponent<Props> = ({
                   {({ input }) => (
                     <CheckBox
                       id={`configure-slack-channel-triggers-pendingComments-${input.name}`}
-                      disabled={disabled || !channelEnabled}
+                      disabled={disabled || !channelEnabled || allSelected}
                       className={styles.trigger}
                       {...input}
                     >
@@ -241,7 +266,7 @@ const SlackChannel: FunctionComponent<Props> = ({
                   {({ input }) => (
                     <CheckBox
                       id={`configure-slack-channel-triggers-featuredComments-${input.name}`}
-                      disabled={disabled || !channelEnabled}
+                      disabled={disabled || !channelEnabled || allSelected}
                       className={styles.trigger}
                       {...input}
                     >

--- a/src/core/client/admin/routes/Configure/sections/Slack/SlackConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Slack/SlackConfigContainer.tsx
@@ -1,6 +1,6 @@
 import { Localized } from "@fluent/react/compat";
 import { FormApi } from "final-form";
-import React, { FunctionComponent, useCallback, useMemo } from "react";
+import React, { FunctionComponent, useCallback, useMemo, useRef } from "react";
 import { FieldArray } from "react-final-form-arrays";
 import { graphql } from "react-relay";
 
@@ -29,6 +29,8 @@ interface Props {
 }
 
 const SlackConfigContainer: FunctionComponent<Props> = ({ form, settings }) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const onAddChannel = useCallback(() => {
     // We use push here because final form still has issues tracking new items
     // being inserted at the old array index.
@@ -47,6 +49,11 @@ const SlackConfigContainer: FunctionComponent<Props> = ({ form, settings }) => {
         staffComments: false,
       },
     });
+    setTimeout(() => {
+      if (inputRef && inputRef.current) {
+        inputRef.current.focus();
+      }
+    }, 0);
   }, [form]);
 
   const onRemoveChannel = useCallback(
@@ -115,9 +122,9 @@ const SlackConfigContainer: FunctionComponent<Props> = ({ form, settings }) => {
           <Localized id="configure-slack-addChannel">Add Channel</Localized>
         </Button>
         <FieldArray name="slack.channels">
-          {({ fields }) =>
-            fields
-              .map((channel: any, index: number) => (
+          {({ fields, meta }) =>
+            fields.map((channel: any, index: number) => (
+              <>
                 <SlackChannel
                   key={index}
                   channel={channel}
@@ -125,12 +132,14 @@ const SlackConfigContainer: FunctionComponent<Props> = ({ form, settings }) => {
                   index={index}
                   onRemoveClicked={onRemoveChannel}
                   form={form}
+                  ref={
+                    fields.length && fields.length - 1 === index
+                      ? inputRef
+                      : null
+                  }
                 />
-              ))
-              // We're reversing here because we wanted the order of new items
-              // added to be at the front, and we can only use `.push` and not
-              // `.insert` or `.unshift`.
-              .reverse()
+              </>
+            ))
           }
         </FieldArray>
       </ConfigBox>

--- a/src/core/client/admin/routes/Configure/sections/Slack/SlackConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Slack/SlackConfigContainer.tsx
@@ -124,6 +124,7 @@ const SlackConfigContainer: FunctionComponent<Props> = ({ form, settings }) => {
                   disabled={false}
                   index={index}
                   onRemoveClicked={onRemoveChannel}
+                  form={form}
                 />
               ))
               // We're reversing here because we wanted the order of new items

--- a/src/core/client/admin/routes/Configure/sections/Slack/SlackConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Slack/SlackConfigContainer.tsx
@@ -122,23 +122,19 @@ const SlackConfigContainer: FunctionComponent<Props> = ({ form, settings }) => {
           <Localized id="configure-slack-addChannel">Add Channel</Localized>
         </Button>
         <FieldArray name="slack.channels">
-          {({ fields, meta }) =>
+          {({ fields }) =>
             fields.map((channel: any, index: number) => (
-              <>
-                <SlackChannel
-                  key={index}
-                  channel={channel}
-                  disabled={false}
-                  index={index}
-                  onRemoveClicked={onRemoveChannel}
-                  form={form}
-                  ref={
-                    fields.length && fields.length - 1 === index
-                      ? inputRef
-                      : null
-                  }
-                />
-              </>
+              <SlackChannel
+                key={index}
+                channel={channel}
+                disabled={false}
+                index={index}
+                onRemoveClicked={onRemoveChannel}
+                form={form}
+                ref={
+                  fields.length && fields.length - 1 === index ? inputRef : null
+                }
+              />
             ))
           }
         </FieldArray>


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/master/CONTRIBUTING.md

-->

## What does this PR do?

Fixes two issues with slack config UI:
1. Disables and un-checks other trigger options when "all comments" trigger is selected
2. Fixes a bug where "remove channel" would remove the wrong channel. The solution is hacky because we need to work around a bug (or 2 bugs?) in react-final-form-arrays. The array of channels is no longer reversed, and new channels are added to the end of the list. When a new channel is added, the input field is focused so the user doesn't have to scroll down manually.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?
none
<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/master/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/master/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

Try adding/removing slack channels and changing the triggers between all and the other options

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
