### PR TITLE
add prometheus buckets for 750ms and 1000ms

### DIFF
--- a/src/core/server/services/metrics/index.ts
+++ b/src/core/server/services/metrics/index.ts
@@ -19,7 +19,7 @@ export function createMetrics(): Metrics {
   const graphQLExecutionTimingsHistogram = new Histogram({
     name: "coral_executed_graph_queries_timings",
     help: "timings for execution times of GraphQL operations",
-    buckets: [0.1, 5, 15, 50, 100, 500],
+    buckets: [0.1, 5, 15, 50, 100, 500, 750, 1000],
     labelNames: ["operation_type", "operation_name"],
   });
 
@@ -32,7 +32,7 @@ export function createMetrics(): Metrics {
   const httpRequestDurationMilliseconds = new Histogram({
     name: "http_request_duration_milliseconds",
     help: "Histogram of latencies for HTTP requests.",
-    buckets: [0.1, 5, 15, 50, 100, 500],
+    buckets: [0.1, 5, 15, 50, 100, 500, 750, 1000],
     labelNames: ["method", "handler"],
   });
 


### PR DESCRIPTION
## What does this PR do?
It's very common that we have requests that take more than 500ms, sometimes 1s, especially when we have the perspective API on or in cases that we're overwhelmed. What do you think about adding two more buckets, 750 and 1000ms in prometheus metrics? 

## What changes to the GraphQL/Database Schema does this PR introduce?
None

## How do I test this PR?
Check new buckets in /metrics route.


Thanks