### PR TITLE
[CORL-1555] Copy Fixes

### DIFF
--- a/src/core/client/admin/routes/Configure/Link.tsx
+++ b/src/core/client/admin/routes/Configure/Link.tsx
@@ -5,7 +5,7 @@ import styles from "./Link.css";
 
 interface Props {
   className?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   to: string | LocationDescriptor;
   exact?: boolean;
 }

--- a/src/core/client/admin/routes/Configure/sections/Moderation/PreModerationConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Moderation/PreModerationConfig.tsx
@@ -3,13 +3,13 @@ import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import { formatBool, parseStringBool } from "coral-framework/lib/form";
-import { ExternalLink } from "coral-framework/lib/i18n/components";
 import {
   FieldSet,
   FormField,
   FormFieldDescription,
   Label,
 } from "coral-ui/components/v2";
+import { Link } from "coral-ui/components/v3";
 
 import ConfigBox from "../../ConfigBox";
 import Header from "../../Header";
@@ -79,11 +79,11 @@ const PreModerationConfig: FunctionComponent<Props> = ({ disabled }) => {
         </Localized>
         <Localized
           id="configure-moderation-premModeration-premodSuspectWordsDescription"
-          externalLink={<ExternalLink href="/admin/configure/wordList" />}
+          wordListLink={<Link href="/admin/configure/wordList" />}
         >
           <FormFieldDescription>
             You can view and edit your Suspect Word list{" "}
-            <ExternalLink href="/admin/configure/wordList">here</ExternalLink>
+            <Link href="/admin/configure/wordList">here</Link>
           </FormFieldDescription>
         </Localized>
         <OnOffField name="premoderateSuspectWords" disabled={disabled} />

--- a/src/core/client/admin/routes/Configure/sections/WordList/SuspectWordListConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/WordList/SuspectWordListConfig.tsx
@@ -44,7 +44,7 @@ const SuspectWordListConfig: FunctionComponent<Props> = ({
   >
     {premoderateSuspectWords ? (
       <Localized
-        id="configure-wordList-suspect-explanation"
+        id="configure-wordList-suspect-explanationSuspectWordsList "
         strong={<strong />}
       >
         <FormFieldDescription>

--- a/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/moderation.spec.tsx.snap
@@ -302,10 +302,8 @@ approved by a moderator.
                   >
                     You can view and edit your Suspect Word list 
                     <a
-                      className="ExternalLink-root"
+                      className="Link-root"
                       href="/admin/configure/wordList"
-                      rel="noopener noreferrer"
-                      target="_blank"
                     >
                       here
                     </a>

--- a/src/core/client/ui/components/v3/Link/Link.css
+++ b/src/core/client/ui/components/v3/Link/Link.css
@@ -1,0 +1,3 @@
+.root {
+  color: $colors-teal-700;
+}

--- a/src/core/client/ui/components/v3/Link/Link.tsx
+++ b/src/core/client/ui/components/v3/Link/Link.tsx
@@ -1,0 +1,16 @@
+import cn from "classnames";
+import React, { FunctionComponent } from "react";
+
+import styles from "./Link.css";
+
+const Link: FunctionComponent<{
+  href?: string;
+  children?: string;
+  className?: string;
+}> = ({ href, children, className }) => (
+  <a href={href || children} className={cn(styles.root, className)}>
+    {children}
+  </a>
+);
+
+export default Link;

--- a/src/core/client/ui/components/v3/Link/index.ts
+++ b/src/core/client/ui/components/v3/Link/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Link";

--- a/src/core/client/ui/components/v3/index.ts
+++ b/src/core/client/ui/components/v3/index.ts
@@ -5,3 +5,4 @@ export { default as StarRating } from "./StarRating";
 export { default as TextArea } from "./TextArea";
 export { default as Tombstone } from "./Tombstone";
 export { default as ValidationMessage } from "./ValidationMessage";
+export { default as Link } from "./Link";

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -715,8 +715,8 @@ configure-moderation-akismet-explanation =
 
 configure-moderation-premModeration-premodSuspectWordsEnable =
   Pre-moderate comments containing Suspect Words
-configure-moderation-premModeration-premodSuspectWordsDescription  =
-  You can view and edit your Suspect Word list <externalLink>here</externalLink>
+configure-moderation-premModeration-premodSuspectWordsDescription =
+  You can view and edit your Suspect Word list <wordListLink>here</wordListLink>
 
 #### Akismet
 configure-moderation-akismet-filter = Spam detection filter
@@ -788,6 +788,10 @@ configure-wordList-suspect-explanation =
   Comments containing a word or phrase in the Suspect Words List
   are <strong>placed into the Reported Queue for moderator review and are
   published (if comments are not pre-moderated).</strong>
+configure-wordList-suspect-explanationSuspectWordsList =
+  Comments containing a word or phrase in the Suspect Words List are
+  <strong>placed into the Pending Queue for moderator review and are not
+  published unless approved by a moderator.</strong>
 configure-wordList-suspect-wordList = Suspect word list
 configure-wordList-suspect-wordListDetailInstructions =
   Separate suspect words or phrases with a new line. Words/phrases are not case sensitive.


### PR DESCRIPTION
## What does this PR do?

- fix here link in premod suspect words
- fix description above suspect words when
premod suspect words enabled

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Enable premod with suspect words in config
- Test the `here` link and see it works in Chrome and Firefox
- Check the Suspect Word List description is correct when premod suspect words is enabled
