### PR TITLE
[CORL-1565] Optionally send Suspect to Pending instead of Premod

### DIFF
--- a/src/core/server/services/comments/pipeline/phases/wordList.ts
+++ b/src/core/server/services/comments/pipeline/phases/wordList.ts
@@ -62,7 +62,7 @@ export const wordList: IntermediateModerationPhase = ({
 
   if (tenant.premoderateSuspectWords && suspect) {
     return {
-      status: GQLCOMMENT_STATUS.PREMOD,
+      status: GQLCOMMENT_STATUS.SYSTEM_WITHHELD,
       actions: [
         {
           actionType: ACTION_TYPE.FLAG,


### PR DESCRIPTION
## What does this PR do?

When a comment is flagged as suspect, it will be withheld instead of being set to premod if the option is enabled.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

With the `Pre-moderate comments containing Suspect Words` is enabled, this will put comments that are caught as suspect into the pending queue.