### PR TITLE
[CORL-1452] add fallback for when Domparser.parseFromString fails to return body

### DIFF
--- a/src/core/client/framework/lib/bootstrap/CoralContext.tsx
+++ b/src/core/client/framework/lib/bootstrap/CoralContext.tsx
@@ -95,11 +95,23 @@ export const CoralContextConsumer = CoralReactContext.Consumer;
 
 const parser = new DOMParser();
 
+function fallbackParseMarkup(str: string) {
+  const doc = document.implementation.createHTMLDocument("");
+  doc.documentElement.innerHTML = str;
+  return doc;
+}
+
 // Use this custom markup parser which works in IE11.
 function parseMarkup(str: string) {
-  const doc = parser.parseFromString(`<body>${str}</body>`, "text/html");
+  const html = `<body>${str}</body>`;
+  let doc = parser.parseFromString(html, "text/html");
+  // occasionally parser.parseFromString will not return document.body synchronously on iOS
+  if (!doc.body) {
+    doc = fallbackParseMarkup(html);
+  }
   return Array.from(doc.body.childNodes);
 }
+
 /**
  * In addition to just providing the context, CoralContextProvider also
  * renders the `LocalizationProvider` with the appropite data.


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/main/CONTRIBUTING.md

-->

## What does this PR do?

I was unable to reproduce[ this bug ](https://sentry.io/organizations/voxmedia/issues/1913993149/?project=1452040&referrer=jira_integration) so this is something of a stab in the dark, but it does sound like it is likely the same bug as reported here: https://github.com/DylanPiercey/set-dom/issues/23 (ours appears in chrome on iOS as well as UIWebView), where`DomParser.parseFromString` sometimes does not return the document body synchronously. Fix is fairly straightforward fallback to innerHTML, not sure if we should just replace with innerHTML always or if there was a reason we wanted to use DOMParser instead. 

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?
none
<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/main/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/main/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
