### PR TITLE
[CORL-1518] Show rejected comments as removed for staff in single conversation view

### DIFF
--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
@@ -16,6 +16,7 @@ import {
   useSubscription,
   withFragmentContainer,
 } from "coral-framework/lib/relay";
+import { GQLCOMMENT_STATUS } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
 import UserBoxContainer from "coral-stream/common/UserBox";
 import { ViewFullDiscussionEvent } from "coral-stream/events";
@@ -86,6 +87,10 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
     return getURLWithCommentID(url, undefined);
   }, [pym]);
 
+  const commentVisible = !!(
+    comment && comment.status !== GQLCOMMENT_STATUS.REJECTED
+  );
+
   return (
     <HorizontalGutter
       className={cn(styles.root, CLASSES.permalinkView.$root, {
@@ -125,14 +130,14 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
           </Localized>
         )}
       </Flex>
-      {!comment && (
+      {!commentVisible && (
         <CallOut>
           <Localized id="comments-permalinkView-commentRemovedOrDoesNotExist">
             This comment has been removed or does not exist.
           </Localized>
         </CallOut>
       )}
-      {comment && (
+      {comment && commentVisible && (
         <HorizontalGutter>
           <ConversationThreadContainer
             viewer={viewer}
@@ -169,6 +174,7 @@ const enhanced = withFragmentContainer<Props>({
   comment: graphql`
     fragment PermalinkViewContainer_comment on Comment {
       id
+      status
       ...ConversationThreadContainer_comment
       ...ReplyListContainer1_comment
     }

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
@@ -16,7 +16,6 @@ import {
   useSubscription,
   withFragmentContainer,
 } from "coral-framework/lib/relay";
-import { GQLCOMMENT_STATUS } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
 import UserBoxContainer from "coral-stream/common/UserBox";
 import { ViewFullDiscussionEvent } from "coral-stream/events";
@@ -30,6 +29,7 @@ import { PermalinkViewContainer_settings as SettingsData } from "coral-stream/__
 import { PermalinkViewContainer_story as StoryData } from "coral-stream/__generated__/PermalinkViewContainer_story.graphql";
 import { PermalinkViewContainer_viewer as ViewerData } from "coral-stream/__generated__/PermalinkViewContainer_viewer.graphql";
 
+import { isPublished } from "../helpers";
 import CommentEnteredSubscription from "../Stream/AllCommentsTab/CommentEnteredSubscription";
 import ConversationThreadContainer from "./ConversationThreadContainer";
 
@@ -87,9 +87,7 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
     return getURLWithCommentID(url, undefined);
   }, [pym]);
 
-  const commentVisible = !!(
-    comment && comment.status !== GQLCOMMENT_STATUS.REJECTED
-  );
+  const commentVisible = comment && isPublished(comment.status);
 
   return (
     <HorizontalGutter


### PR DESCRIPTION
## What does this PR do?

Fixes the bug where staff could still see rejected comments in the single conversation view.

Shows the callout indicated the comment is missing or removed if the comment is rejected, which is the same behaviour we see for regular users in the single conversation view.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Copy the share link to a reply comment 
- Reject the comment on the stream
- Log out
- Log in again
- Paste the link to the replied comment into your browser
- See if the comment still displays