### PR TITLE
[CORL-1598] Prevent duplicate ratings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "6.6.2",
+  "version": "6.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "6.6.2",
+  "version": "6.7.0",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/src/core/common/errors.ts
+++ b/src/core/common/errors.ts
@@ -352,4 +352,10 @@ export enum ERROR_CODES {
   USER_BIO_TOO_LONG = "USER_BIO_TOO_LONG",
 
   COMMENT_EDIT_WINDOW_EXPIRED = "COMMENT_EDIT_WINDOW_EXPIRED",
+
+  /**
+   * AUTHOR_ALREADY_HAS_RATED_STORY is returned when the author has already
+   * rated a story and attempts to do so again.
+   */
+  AUTHOR_ALREADY_HAS_RATED_STORY = "AUTHOR_ALREADY_HAS_RATED_STORY",
 }

--- a/src/core/server/errors/index.ts
+++ b/src/core/server/errors/index.ts
@@ -480,6 +480,15 @@ export class CommentNotFoundError extends CoralError {
   }
 }
 
+export class AuthorAlreadyHasRatedStory extends CoralError {
+  constructor(userID: string, storyID: string) {
+    super({
+      code: ERROR_CODES.AUTHOR_ALREADY_HAS_RATED_STORY,
+      context: { pvt: { userID, storyID } },
+    });
+  }
+}
+
 export class CommentEditWindowExpiredError extends CoralError {
   constructor(commentID: string) {
     super({

--- a/src/core/server/errors/translations.ts
+++ b/src/core/server/errors/translations.ts
@@ -64,4 +64,5 @@ export const ERROR_TRANSLATIONS: Record<ERROR_CODES, string> = {
   VALIDATION: "error-validation",
   USER_BIO_TOO_LONG: "error-userBioTooLong",
   COMMENT_EDIT_WINDOW_EXPIRED: "error-commentEditWindowExpired",
+  AUTHOR_ALREADY_HAS_RATED_STORY: "error-authorAlreadyHasRatedStory",
 };

--- a/src/core/server/locales/en-US/errors.ftl
+++ b/src/core/server/locales/en-US/errors.ftl
@@ -65,3 +65,4 @@ error-duplicateSiteOrigin = Allowed domains may only be associated with a single
 error-validation = A validation error occurred.
 error-userBioTooLong = Bio exceeds maximum length.
 error-commentEditWindowExpired = Edit time has expired. You can no longer edit this comment. Why not post another one?
+error-authorAlreadyHasRatedStory = You’ve already submitted a rating on this page.

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -1125,6 +1125,30 @@ export async function retrieveOngoingDiscussions(
   return results;
 }
 
+export async function hasAuthorStoryRating(
+  mongo: Db,
+  tenantID: string,
+  storyID: string,
+  authorID: string
+): Promise<boolean> {
+  const timer = createTimer();
+
+  const comment = await collection(mongo).findOne({
+    tenantID,
+    storyID,
+    authorID,
+    parentID: null,
+    status: {
+      $ne: GQLCOMMENT_STATUS.REJECTED,
+    },
+    rating: { $gt: 0 },
+  });
+
+  logger.info({ took: timer() }, "has comment rated query");
+
+  return !!comment;
+}
+
 export async function retrieveAuthorStoryRating(
   mongo: Db,
   tenantID: string,

--- a/src/core/server/stacks/createComment.ts
+++ b/src/core/server/stacks/createComment.ts
@@ -5,6 +5,7 @@ import { Db } from "mongodb";
 import { ERROR_TYPES } from "coral-common/errors";
 import { Config } from "coral-server/config";
 import {
+  AuthorAlreadyHasRatedStory,
   CoralError,
   StoryNotFoundError,
   UserSiteBanned,
@@ -21,8 +22,8 @@ import {
   CommentMedia,
   createComment,
   CreateCommentInput,
+  hasAuthorStoryRating,
   pushChildCommentIDOntoParent,
-  retrieveAuthorStoryRating,
 } from "coral-server/models/comment";
 import { getDepth, hasAncestors } from "coral-server/models/comment/helpers";
 import { retrieveSite } from "coral-server/models/site";
@@ -149,14 +150,14 @@ const validateRating = async (
 
   // Check to see if this user has already submitted a comment with a rating
   // on this story.
-  const existing = await retrieveAuthorStoryRating(
+  const existing = await hasAuthorStoryRating(
     mongo,
     tenant.id,
     story.id,
     author.id
   );
   if (existing) {
-    throw new Error("author has already written a comment with a rating");
+    throw new AuthorAlreadyHasRatedStory(author.id, story.id);
   }
 };
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/main/CONTRIBUTING.md

-->

## What does this PR do?

Changed logic around the duplicate rating detection for new ratings. Only comments that are rejected are not considered duplicate when submitting a rating.

This also bumps to 6.7.0.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/main/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/main/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

To verify that a user can write another review after one was rejected:

1. Submit a review with a banned word.
2. Ensure you can submit another review without a banned word.

To verify that a user can not write a review when others are in premod:

1. Submit a review as a new user (with the "New commenter approval") on such that your review will be held in premod
2. Submit another review, ensure that the review is rejected with the message: "You’ve already submitted a rating on this page."