### PR TITLE
[CORL-1596] Allow admins to remove deleted comments

### DIFF
--- a/src/core/client/admin/components/ModerateCard/ModerateCard.spec.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCard.spec.tsx
@@ -36,6 +36,7 @@ const baseProps: PropTypesOf<typeof ModerateCardN> = {
   onUsernameClick: noop,
   onFocusOrClick: noop,
   onConversationClick: noop,
+  onRemove: noop,
   showStory: false,
   moderatedBy: null,
 };

--- a/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
@@ -65,6 +65,7 @@ interface Props {
   onUsernameClick: (id?: string) => void;
   onConversationClick: (() => void) | null;
   onFocusOrClick: () => void;
+  onRemove: () => void;
   mini?: boolean;
   hideUsername?: boolean;
   selected?: boolean;
@@ -126,6 +127,7 @@ const ModerateCard: FunctionComponent<Props> = ({
   selectPrev,
   onBan,
   isQA,
+  onRemove,
 }) => {
   const div = useRef<HTMLDivElement>(null);
 
@@ -352,6 +354,13 @@ const ModerateCard: FunctionComponent<Props> = ({
           </Flex>
           {moderatedBy}
         </Flex>
+        {deleted && (
+          <div>
+            <Button color="alert" onClick={onRemove}>
+              Remove
+            </Button>
+          </div>
+        )}
       </Flex>
     </Card>
   );

--- a/src/core/client/admin/components/ModerateCard/ModerateCardContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCardContainer.tsx
@@ -36,6 +36,7 @@ import BanCommentUserMutation from "./BanCommentUserMutation";
 import FeatureCommentMutation from "./FeatureCommentMutation";
 import ModerateCard from "./ModerateCard";
 import ModeratedByContainer from "./ModeratedByContainer";
+import RemoveCommentMutation from "./RemoveCommentMutation";
 import UnfeatureCommentMutation from "./UnfeatureCommentMutation";
 
 interface Props {
@@ -95,6 +96,7 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
   const featureComment = useMutation(FeatureCommentMutation);
   const unfeatureComment = useMutation(UnfeatureCommentMutation);
   const banUser = useMutation(BanCommentUserMutation);
+  const removeComment = useMutation(RemoveCommentMutation);
 
   const scoped = useMemo(
     () =>
@@ -266,6 +268,10 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
     [comment, banUser, setShowBanModal]
   );
 
+  const handleRemove = useCallback(async () => {
+    await removeComment({ commentID: comment.id });
+  }, [comment.id, removeComment]);
+
   // Only highlight comments that have been flagged for containing a banned or
   // suspect word.
   const highlight = useMemo(() => {
@@ -316,6 +322,7 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
           onConversationClick={
             conversationClicked ? onConversationClicked : null
           }
+          onRemove={handleRemove}
           selected={selected}
           selectPrev={selectPrev}
           selectNext={selectNext}

--- a/src/core/client/admin/components/ModerateCard/RemoveCommentMutation.ts
+++ b/src/core/client/admin/components/ModerateCard/RemoveCommentMutation.ts
@@ -1,0 +1,93 @@
+import { graphql } from "react-relay";
+import { ConnectionHandler, Environment } from "relay-runtime";
+
+import { getQueueConnection } from "coral-admin/helpers";
+import { SectionFilter } from "coral-common/section";
+import {
+  commitMutationPromiseNormalized,
+  createMutation,
+  MutationInput,
+} from "coral-framework/lib/relay";
+
+import { RemoveCommentMutation as MutationTypes } from "coral-admin/__generated__/RemoveCommentMutation.graphql";
+
+let clientMutationId = 0;
+
+const RemoveCommentMutation = createMutation(
+  "removeComment",
+  (
+    environment: Environment,
+    input: MutationInput<MutationTypes> & {
+      storyID?: string | null;
+      siteID?: string | null;
+      section?: SectionFilter | null;
+    }
+  ) =>
+    commitMutationPromiseNormalized<MutationTypes>(environment, {
+      mutation: graphql`
+        mutation RemoveCommentMutation($input: RemoveCommentInput!) {
+          removeComment(input: $input) {
+            success
+            clientMutationId
+          }
+        }
+      `,
+      variables: {
+        input: {
+          commentID: input.commentID,
+          clientMutationId: (clientMutationId++).toString(),
+        },
+      },
+      optimisticUpdater: (store) => {
+        // const proxy = store.get(input.commentID)!;
+      },
+      updater: (store, data) => {
+        if (!data || !data.removeComment || !data.removeComment.success) {
+          return;
+        }
+
+        const connections = [
+          getQueueConnection(
+            store,
+            "REPORTED",
+            input.storyID,
+            input.siteID,
+            input.section
+          ),
+          getQueueConnection(
+            store,
+            "PENDING",
+            input.storyID,
+            input.siteID,
+            input.section
+          ),
+          getQueueConnection(
+            store,
+            "UNMODERATED",
+            input.storyID,
+            input.siteID,
+            input.section
+          ),
+          getQueueConnection(
+            store,
+            "APPROVED",
+            input.storyID,
+            input.siteID,
+            input.section
+          ),
+          getQueueConnection(
+            store,
+            "REJECTED",
+            input.storyID,
+            input.siteID,
+            input.section
+          ),
+        ].filter((c) => c);
+        connections.forEach((con) =>
+          ConnectionHandler.deleteNode(con!, input.commentID)
+        );
+      },
+    })
+);
+
+export default RemoveCommentMutation;

--- a/src/core/server/graph/mutators/Comments.ts
+++ b/src/core/server/graph/mutators/Comments.ts
@@ -3,7 +3,7 @@ import { ADDITIONAL_DETAILS_MAX_LENGTH } from "coral-common/helpers/validate";
 import GraphContext from "coral-server/graph/context";
 import { mapFieldsetToErrorCodes } from "coral-server/graph/errors";
 import { hasFeatureFlag } from "coral-server/models/tenant";
-import { addTag, removeTag } from "coral-server/services/comments";
+import { addTag, remove, removeTag } from "coral-server/services/comments";
 import {
   createDontAgree,
   createFlag,
@@ -30,6 +30,7 @@ import {
   GQLFEATURE_FLAG,
   GQLFeatureCommentInput,
   GQLRemoveCommentDontAgreeInput,
+  GQLRemoveCommentInput,
   GQLRemoveCommentReactionInput,
   GQLTAG,
   GQLUnfeatureCommentInput,
@@ -217,5 +218,8 @@ export const Comments = (ctx: GraphContext) => ({
     }
 
     return removeTag(ctx.mongo, ctx.tenant, commentID, GQLTAG.FEATURED);
+  },
+  remove: async ({ commentID }: WithoutMutationID<GQLRemoveCommentInput>) => {
+    return remove(ctx.mongo, ctx.tenant, commentID);
   },
 });

--- a/src/core/server/graph/mutators/Comments.ts
+++ b/src/core/server/graph/mutators/Comments.ts
@@ -220,6 +220,6 @@ export const Comments = (ctx: GraphContext) => ({
     return removeTag(ctx.mongo, ctx.tenant, commentID, GQLTAG.FEATURED);
   },
   remove: async ({ commentID }: WithoutMutationID<GQLRemoveCommentInput>) => {
-    return remove(ctx.mongo, ctx.tenant, commentID);
+    return remove(ctx.mongo, ctx.redis, ctx.tenant, commentID);
   },
 });

--- a/src/core/server/graph/resolvers/Mutation.ts
+++ b/src/core/server/graph/resolvers/Mutation.ts
@@ -421,4 +421,8 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     user: await ctx.mutators.Users.updateBio(input),
     clientMutationId: input.clientMutationId,
   }),
+  removeComment: async (source, { input }, ctx) => ({
+    succeeded: await ctx.mutators.Comments.remove(input),
+    clientMutationId: input.clientMutationId,
+  }),
 };

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -5951,6 +5951,34 @@ type UnfeatureCommentPayload {
 }
 
 ##################
+# removeComment
+##################
+
+input RemoveCommentInput {
+  """
+  commentID is the ID of the featured Comment that should be unfeatured.
+  """
+  commentID: ID!
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+type RemoveCommentPayload {
+  """
+  comment is the Comment that was unfeatured.
+  """
+  success: Boolean
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+##################
 # setUsername
 ##################
 
@@ -7867,6 +7895,12 @@ type Mutation {
   """
   unfeatureComment(input: UnfeatureCommentInput!): UnfeatureCommentPayload!
     @auth(roles: [ADMIN, MODERATOR])
+
+  """
+  removeComment will remove the comment.
+  """
+  removeComment(input: RemoveCommentInput!): RemoveCommentPayload!
+    @auth(roles: [ADMIN])
 
   """
   createStory will create the provided Story.

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -1292,3 +1292,17 @@ export async function retrieveFeaturedComments(
 
   return results;
 }
+
+export async function removeComment(
+  mongo: Db,
+  tenantID: string,
+  commentID: string
+): Promise<boolean> {
+  const op = await collection(mongo).deleteOne({ tenantID, id: commentID });
+
+  if (!op || !op.result) {
+    return false;
+  }
+
+  return !!op.result.ok;
+}

--- a/src/core/server/services/comments/index.ts
+++ b/src/core/server/services/comments/index.ts
@@ -3,3 +3,4 @@ export * from "./actions";
 export * from "./pipeline";
 export * from "./moderation";
 export * from "./media";
+export * from "./remove";

--- a/src/core/server/services/comments/remove.ts
+++ b/src/core/server/services/comments/remove.ts
@@ -3,14 +3,44 @@ import { Db } from "mongodb";
 import { CommentNotFoundError } from "coral-server/errors";
 import { removeComment, retrieveComment } from "coral-server/models/comment";
 import { Tenant } from "coral-server/models/tenant";
+import { AugmentedRedis } from "coral-server/services/redis";
+import { updateAllCounts } from "coral-server/stacks/helpers/updateAllCommentCounts";
 
-export async function remove(mongo: Db, tenant: Tenant, commentID: string) {
+export async function remove(
+  mongo: Db,
+  redis: AugmentedRedis,
+  tenant: Tenant,
+  commentID: string
+) {
   const comment = await retrieveComment(mongo, tenant.id, commentID);
   if (!comment) {
     throw new CommentNotFoundError(commentID);
   }
 
-  // TODO (Nick): update comment queue counts
+  const removedComment = removeComment(mongo, tenant.id, commentID);
+  if (!removedComment) {
+    throw new Error("unable to remove comment");
+  }
+
+  // Subtract from any statuses currently assigned to this
+  // comment as we have deleted it.
+  await updateAllCounts(
+    mongo,
+    redis,
+    tenant.id,
+    comment.storyID,
+    comment.siteID,
+    {
+      action: {},
+      status: {
+        [comment.status]: -1,
+      },
+      moderationQueue: {
+        [comment.status]: -1,
+      },
+    },
+    comment.authorID
+  );
 
   return removeComment(mongo, tenant.id, commentID);
 }

--- a/src/core/server/services/comments/remove.ts
+++ b/src/core/server/services/comments/remove.ts
@@ -1,0 +1,16 @@
+import { Db } from "mongodb";
+
+import { CommentNotFoundError } from "coral-server/errors";
+import { removeComment, retrieveComment } from "coral-server/models/comment";
+import { Tenant } from "coral-server/models/tenant";
+
+export async function remove(mongo: Db, tenant: Tenant, commentID: string) {
+  const comment = await retrieveComment(mongo, tenant.id, commentID);
+  if (!comment) {
+    throw new CommentNotFoundError(commentID);
+  }
+
+  // TODO (Nick): update comment queue counts
+
+  return removeComment(mongo, tenant.id, commentID);
+}


### PR DESCRIPTION
## What does this PR do?

Allow admins to remove deleted comments.

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds a `removeComment` mutation.

## How do I test this PR?

- Create a commenter
- Validate commenter email
- Create some comments
- Delete account of commenter
- Check queues for deleted account comments
- Click remove
- See comment disappear
