### PR TITLE
[CORL-1615] Send front end analytics to rudderstack if available

### DIFF
--- a/src/core/client/stream/App/listeners/OnEvents.tsx
+++ b/src/core/client/stream/App/listeners/OnEvents.tsx
@@ -18,6 +18,11 @@ export class OnEvents extends Component<Props> {
           value,
         })
       );
+
+      const rudder = (window as any).rudderanalytics;
+      if (rudder) {
+        rudder.track(eventName, value, () => {});
+      }
     });
   }
 


### PR DESCRIPTION
## What does this PR do?

Send front end analytics to rudderstack if available.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

1. Create a test account at: https://app.rudderstack.com
2. setup a local data plane via: https://docs.rudderstack.com/installing-and-setting-up-rudderstack/docker
3. use the API key for account in step 1 to hook up your rudderstack instance
4. Create a front end source at https://app.rudderstack.com using a javascript source type
5. Set `ANALYTICS_FRONTEND_KEY` to your source's write key in your `.env` file
6. Set `ANALYTICS_DATA_PLANE_URL` to `http://localhost:8080/` to point it to your local docker dataplane
7. Build and run a development build via `npm run build:development` and `npm run start:development`
8. Create a site that you can host externally and point to your coral instance
9. Point to your site using some external site (I recommend using the `multi-site-test`) and create a story
10. Head to the source your created in https://app.rudderstack.com and click on it
11. Select `Live Events` in the top right, continue through the prompt modal, and start watching for live events
12. Go back to your comment stream window from step 9 and login, create some comments, reply to a comment, etc
13. You should see some events streaming into https://app.rudderstack.com on the Live Events page
