### PR TITLE
[CORL-1625] Add permalink translation keys

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/PermalinkButton/PermalinkPopover.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/PermalinkButton/PermalinkPopover.tsx
@@ -80,7 +80,7 @@ const PermalinkPopover: FunctionComponent<Props> = ({
               <Icon size="sm" className={styles.icon}>
                 check_circle_outline
               </Icon>
-              <Localized id="comments-permalink-copyLink">
+              <Localized id="comments-permalink-linkCopied">
                 <span>Link copied</span>
               </Localized>
             </Flex>

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -334,6 +334,9 @@ comments-stream-deleteAccount-callOut-cancel =
 comments-stream-deleteAccount-callOut-cancelAccountDeletion =
   Cancel account deletion
 
+comments-permalink-copyLink = Copy link
+comments-permalink-linkCopied = Link copied
+
 ### Embed Links
 
 comments-embedLinks-showEmbeds = Show embeds

--- a/src/locales/fr-FR/stream.ftl
+++ b/src/locales/fr-FR/stream.ftl
@@ -255,6 +255,9 @@ comments-reacted =
     *[other] {$reaction} ({$count}) commentaire de {$username}
   }
 
+comments-permalink-copyLink = Copier le lien
+comments-permalink-linkCopied = Lien copié
+
 ### Q&A
 
 general-tabBar-qaTab = Q&R


### PR DESCRIPTION
## What does this PR do?

Add permalink copy link and link copied translation keys for `en-US` and `fr-FR`.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

Check translations for permalink are visible.
