### PR TITLE
Dockerfile.onbuild Permission Fix

### DIFF
--- a/Dockerfile.onbuild
+++ b/Dockerfile.onbuild
@@ -1,4 +1,7 @@
-FROM coralproject/talk:latest
+# TAG lets us override the target image that we're building the onbuild for.
+ARG TAG=latest
+
+FROM coralproject/talk:${TAG}
 
 # Setup the build arguments
 ONBUILD ARG TALK_ADDTL_COMMENTS_ON_LOAD_MORE=10
@@ -17,6 +20,9 @@ ONBUILD ARG TALK_DEFAULT_LAZY_RENDER
 # Bundle app source
 ONBUILD COPY . /usr/src/app
 
+# Revert to the root user so we can install.
+ONBUILD USER root
+
 # At this stage, we need to install the development dependencies again because
 # we need to have webpack available. We then build the new dependencies and
 # clear out the development dependencies again. After this we of course need to
@@ -25,3 +31,6 @@ ONBUILD RUN cli plugins reconcile && \
             yarn && \
             yarn build && \
             yarn cache clean
+
+# Revert to the node user for the CMD.
+ONBUILD USER node


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/main/CONTRIBUTING.md

-->

## What does this PR do?

In a recent security patch #3203 the following line was added to the `Dockerfile`:

```Dockerfile
USER node
```

This works great for the standard image, but causes issues with the image based on the `Dockerfile.onbuild` file, because it uses commands which modify files that are created by root in previous steps.

These changes change the user back to root when performing the `ONBUILD` triggers and revert back to the `node` user when finished.