### PR TITLE
[CORL-1643] Subscribe to and insert new questions on unanswered tab

### DIFF
--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
@@ -21,6 +21,7 @@ import UserBoxContainer from "coral-stream/common/UserBox";
 import { ViewFullDiscussionEvent } from "coral-stream/events";
 import { SetCommentIDMutation } from "coral-stream/mutations";
 import ReplyListContainer from "coral-stream/tabs/Comments/ReplyList";
+import { CommentEnteredSubscription } from "coral-stream/tabs/Comments/Stream/Subscriptions";
 import { Flex, HorizontalGutter } from "coral-ui/components/v2";
 import { Button, CallOut } from "coral-ui/components/v3";
 
@@ -30,7 +31,6 @@ import { PermalinkViewContainer_story as StoryData } from "coral-stream/__genera
 import { PermalinkViewContainer_viewer as ViewerData } from "coral-stream/__generated__/PermalinkViewContainer_viewer.graphql";
 
 import { isPublished } from "../helpers";
-import CommentEnteredSubscription from "../Stream/AllCommentsTab/CommentEnteredSubscription";
 import ConversationThreadContainer from "./ConversationThreadContainer";
 
 import styles from "./PermalinkViewContainer.css";

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -28,6 +28,7 @@ import { PropTypesOf } from "coral-framework/types";
 import CLASSES from "coral-stream/classes";
 import { KeyboardShortcuts } from "coral-stream/common/KeyboardShortcuts";
 import { LoadMoreAllCommentsEvent } from "coral-stream/events";
+import { CommentEnteredSubscription } from "coral-stream/tabs/Comments/Stream/Subscriptions";
 import { Box, HorizontalGutter } from "coral-ui/components/v2";
 import { Button } from "coral-ui/components/v3";
 
@@ -43,7 +44,6 @@ import { PostCommentFormContainer } from "../PostCommentForm";
 import ViewersWatchingContainer from "../ViewersWatchingContainer";
 import AllCommentsTabCommentContainer from "./AllCommentsTabCommentContainer";
 import AllCommentsTabViewNewMutation from "./AllCommentsTabViewNewMutation";
-import CommentEnteredSubscription from "./CommentEnteredSubscription";
 import RatingsFilterMenu from "./RatingsFilterMenu";
 
 import styles from "./AllCommentsTabContainer.css";

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
@@ -148,17 +148,6 @@ function tagUnansweredQuestions(
       featuredTag.setValue(GQLTAG.UNANSWERED, "code");
       node.setLinkedRecords(tags.concat(featuredTag), "tags");
     }
-    const commentCountsRecord = story.getLinkedRecord("commentCounts");
-    if (!commentCountsRecord) {
-      return;
-    }
-    const tagsRecord = commentCountsRecord.getLinkedRecord("tags");
-    if (tagsRecord) {
-      tagsRecord.setValue(
-        (tagsRecord.getValue("UNANSWERED") as number) + 1,
-        "UNANSWERED"
-      );
-    }
   }
 }
 

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
@@ -11,6 +11,7 @@ import { CoralContext } from "coral-framework/lib/bootstrap";
 import {
   commitMutationPromiseNormalized,
   createMutation,
+  LOCAL_ID,
   lookup,
   MutationInput,
 } from "coral-framework/lib/relay";
@@ -147,6 +148,23 @@ function tagUnansweredQuestions(
       const featuredTag = store.create(uuidGenerator(), "Tag");
       featuredTag.setValue(GQLTAG.UNANSWERED, "code");
       node.setLinkedRecords(tags.concat(featuredTag), "tags");
+    }
+  }
+
+  // Only manually increment Unanswered count when we're not actively on
+  // the Unanswered questions tab.
+  const local = lookup(environment, LOCAL_ID);
+  if (local.commentsTab !== "UNANSWERED_COMMENTS") {
+    const commentCountsRecord = story.getLinkedRecord("commentCounts");
+    if (!commentCountsRecord) {
+      return;
+    }
+    const tagsRecord = commentCountsRecord.getLinkedRecord("tags");
+    if (tagsRecord) {
+      tagsRecord.setValue(
+        (tagsRecord.getValue("UNANSWERED") as number) + 1,
+        "UNANSWERED"
+      );
     }
   }
 }

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
@@ -36,6 +36,7 @@ export type CreateCommentInput = Omit<
 > & {
   commentsOrderBy?: COMMENT_SORT;
   tag?: GQLTAG;
+  connectionKey?: string;
 };
 
 function sharedUpdater(
@@ -91,7 +92,11 @@ function addCommentToStory(
 ) {
   // Get stream proxy.
   const streamProxy = store.get(input.storyID)!;
-  const connectionKey = "Stream_comments";
+
+  let connectionKey = "Stream_comments";
+  if (input.connectionKey) {
+    connectionKey = input.connectionKey;
+  }
 
   if (input.commentsOrderBy === "CREATED_AT_ASC") {
     const con = getConnection(streamProxy, connectionKey, {
@@ -406,11 +411,31 @@ export const CreateCommentMutation = createMutation(
             if (expectPremoderation) {
               return;
             }
-            sharedUpdater(environment, store, { ...input, tag }, uuidGenerator);
+
+            if (tag) {
+              sharedUpdater(
+                environment,
+                store,
+                { ...input, tag },
+                uuidGenerator
+              );
+            } else {
+              sharedUpdater(environment, store, input, uuidGenerator);
+            }
+
             store.get(id)!.setValue(true, "pending");
           },
           updater: (store) => {
-            sharedUpdater(environment, store, { ...input, tag }, uuidGenerator);
+            if (tag) {
+              sharedUpdater(
+                environment,
+                store,
+                { ...input, tag },
+                uuidGenerator
+              );
+            } else {
+              sharedUpdater(environment, store, input, uuidGenerator);
+            }
           },
         }
       );

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentFormContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentFormContainer.tsx
@@ -117,14 +117,21 @@ export const PostCommentFormContainer: FunctionComponent<Props> = ({
 
   const handleOnSubmit: OnSubmitHandler = async (input, form) => {
     try {
-      const response = await createComment({
+      const params: any = {
         storyID: story.id,
         nudge,
         commentsOrderBy,
         body: input.body,
         rating: input.rating,
         media: input.media,
-      });
+      };
+
+      if (tab === "UNANSWERED_COMMENTS") {
+        params.tag = GQLTAG.UNANSWERED;
+        params.connectionKey = "UnansweredStream_comments";
+      }
+
+      const response = await createComment(params);
 
       const status = getSubmitStatus(response);
 

--- a/src/core/client/stream/tabs/Comments/Stream/Subscriptions/CommentEnteredSubscription.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/Subscriptions/CommentEnteredSubscription.ts
@@ -10,7 +10,11 @@ import {
   requestSubscription,
   SubscriptionVariables,
 } from "coral-framework/lib/relay";
-import { GQLCOMMENT_SORT, GQLCOMMENT_SORT_RL } from "coral-framework/schema";
+import {
+  GQLCOMMENT_SORT,
+  GQLCOMMENT_SORT_RL,
+  GQLTAG,
+} from "coral-framework/schema";
 import { MAX_REPLY_INDENT_DEPTH } from "coral-stream/constants";
 
 import { CommentEnteredSubscription } from "coral-stream/__generated__/CommentEnteredSubscription.graphql";
@@ -209,6 +213,7 @@ const CommentEnteredSubscription = createSubscription(
         const isTopLevelComent = !parent;
         if (
           variables.tag &&
+          variables.tag !== GQLTAG.UNANSWERED &&
           isTopLevelComent &&
           comment
             .getLinkedRecords("tags")

--- a/src/core/client/stream/tabs/Comments/Stream/Subscriptions/index.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/Subscriptions/index.ts
@@ -1,0 +1,1 @@
+export { default as CommentEnteredSubscription } from "./CommentEnteredSubscription";

--- a/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabContainer.tsx
@@ -15,6 +15,7 @@ import { GQLCOMMENT_SORT, GQLTAG } from "coral-framework/schema";
 import { PropTypesOf } from "coral-framework/types";
 import CLASSES from "coral-stream/classes";
 import { LoadMoreAllCommentsEvent } from "coral-stream/events";
+import { CommentEnteredSubscription } from "coral-stream/tabs/Comments/Stream/Subscriptions";
 import { Box, HorizontalGutter } from "coral-ui/components/v2";
 import { Button } from "coral-ui/components/v3";
 
@@ -24,7 +25,6 @@ import { UnansweredCommentsTabContainer_viewer } from "coral-stream/__generated_
 import { UnansweredCommentsTabContainerLocal } from "coral-stream/__generated__/UnansweredCommentsTabContainerLocal.graphql";
 import { UnansweredCommentsTabContainerPaginationQueryVariables } from "coral-stream/__generated__/UnansweredCommentsTabContainerPaginationQuery.graphql";
 
-import CommentEnteredSubscription from "../AllCommentsTab/CommentEnteredSubscription";
 import NoComments from "../NoComments";
 import UnansweredCommentsTabCommentContainer from "./UnansweredCommentsTabCommentContainer";
 import UnansweredCommentsTabViewNewMutation from "./UnansweredCommentsTabViewNewMutation";


### PR DESCRIPTION
## What does this PR do?

Allow "View new comments" and newly posted comments to show when using the "Unanswered" tab in a Q&A conversation.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Enable Q&A
- Set stream to Q&A mode
- Set yourself as an expert
- Switch to Unanswered stream tab with expert user
- Open another browser tab as commenter
- Go to Unanswered with commenter
- Post a question while viewing the Unanswered tab in commenter browser tab
- See that the comment is inserted into the Unanswered stream on commenter browser tab
- Switch to the expert's browser tab
- See that there is a view new comments button available, click it and ensure the new unanswered comment shows up in the Unanswered tab
