### PR TITLE
Auto focus first input field on Sign In and Sign Up popups

### DIFF
--- a/src/core/client/auth/components/EmailField.tsx
+++ b/src/core/client/auth/components/EmailField.tsx
@@ -1,5 +1,5 @@
 import { Localized } from "@fluent/react/compat";
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useEffect } from "react";
 import { Field } from "react-final-form";
 
 import { streamColorFromMeta } from "coral-framework/lib/form";
@@ -13,33 +13,49 @@ import { ValidationMessage } from "coral-ui/components/v3";
 
 interface Props {
   disabled: boolean;
+  focus?: boolean;
 }
 
-const EmailField: FunctionComponent<Props> = (props) => (
-  <Field name="email" validate={composeValidators(required, validateEmail)}>
-    {({ input, meta }) => (
-      <FormField>
-        <Localized id="general-emailAddressLabel">
-          <InputLabel htmlFor={input.name}>Email Address</InputLabel>
-        </Localized>
-        <Localized
-          id="general-emailAddressTextField"
-          attrs={{ placeholder: true }}
-        >
-          <TextField
-            {...input}
-            id={input.name}
-            placeholder="Email Address"
-            type="email"
-            color={streamColorFromMeta(meta)}
-            disabled={props.disabled}
-            fullWidth
-          />
-        </Localized>
-        <ValidationMessage meta={meta} />
-      </FormField>
-    )}
-  </Field>
-);
+const EmailField: FunctionComponent<Props> = (props) => {
+  let inputRef: HTMLInputElement | null = null;
+  useEffect(() => {
+    if (props.focus) {
+      // eslint-disable-next-line no-unused-expressions
+      inputRef?.focus();
+    }
+  }, [inputRef, props.focus]);
+
+  return (
+    <Field name="email" validate={composeValidators(required, validateEmail)}>
+      {({ input, meta }) => (
+        <FormField>
+          <Localized id="general-emailAddressLabel">
+            <InputLabel htmlFor={input.name}>Email Address</InputLabel>
+          </Localized>
+          <Localized
+            id="general-emailAddressTextField"
+            attrs={{ placeholder: true }}
+          >
+            <TextField
+              {...input}
+              id={input.name}
+              placeholder="Email Address"
+              type="email"
+              color={streamColorFromMeta(meta)}
+              disabled={props.disabled}
+              fullWidth
+              ref={(field) => {
+                if (props.focus) {
+                  inputRef = field;
+                }
+              }}
+            />
+          </Localized>
+          <ValidationMessage meta={meta} />
+        </FormField>
+      )}
+    </Field>
+  );
+};
 
 export default EmailField;

--- a/src/core/client/auth/components/EmailField.tsx
+++ b/src/core/client/auth/components/EmailField.tsx
@@ -1,5 +1,5 @@
 import { Localized } from "@fluent/react/compat";
-import React, { FunctionComponent, useEffect } from "react";
+import React, { FunctionComponent, useCallback } from "react";
 import { Field } from "react-final-form";
 
 import { streamColorFromMeta } from "coral-framework/lib/form";
@@ -13,17 +13,18 @@ import { ValidationMessage } from "coral-ui/components/v3";
 
 interface Props {
   disabled: boolean;
-  focus?: boolean;
+  autofocus?: boolean;
 }
 
 const EmailField: FunctionComponent<Props> = (props) => {
-  let inputRef: HTMLInputElement | null = null;
-  useEffect(() => {
-    if (props.focus) {
-      // eslint-disable-next-line no-unused-expressions
-      inputRef?.focus();
-    }
-  }, [inputRef, props.focus]);
+  const handleRef = useCallback(
+    (ref: HTMLInputElement | null) => {
+      if (props.autofocus && ref) {
+        ref.focus();
+      }
+    },
+    [props.autofocus]
+  );
 
   return (
     <Field name="email" validate={composeValidators(required, validateEmail)}>
@@ -44,11 +45,7 @@ const EmailField: FunctionComponent<Props> = (props) => {
               color={streamColorFromMeta(meta)}
               disabled={props.disabled}
               fullWidth
-              ref={(field) => {
-                if (props.focus) {
-                  inputRef = field;
-                }
-              }}
+              ref={handleRef}
             />
           </Localized>
           <ValidationMessage meta={meta} />

--- a/src/core/client/auth/views/SignIn/SignInWithEmail.tsx
+++ b/src/core/client/auth/views/SignIn/SignInWithEmail.tsx
@@ -50,7 +50,7 @@ const SignInWithEmail: FunctionComponent<SignInWithEmailForm> = (props) => {
               />
             )}
             <div className={cn(CLASSES.login.field, styles.field)}>
-              <EmailField disabled={submitting} focus />
+              <EmailField disabled={submitting} autofocus />
             </div>
             <div className={cn(CLASSES.login.field, styles.field)}>
               <Field name="password" validate={composeValidators(required)}>

--- a/src/core/client/auth/views/SignIn/SignInWithEmail.tsx
+++ b/src/core/client/auth/views/SignIn/SignInWithEmail.tsx
@@ -50,7 +50,7 @@ const SignInWithEmail: FunctionComponent<SignInWithEmailForm> = (props) => {
               />
             )}
             <div className={cn(CLASSES.login.field, styles.field)}>
-              <EmailField disabled={submitting} />
+              <EmailField disabled={submitting} focus />
             </div>
             <div className={cn(CLASSES.login.field, styles.field)}>
               <Field name="password" validate={composeValidators(required)}>

--- a/src/core/client/auth/views/SignUp/SignUpWithEmail.tsx
+++ b/src/core/client/auth/views/SignUp/SignUpWithEmail.tsx
@@ -31,7 +31,7 @@ const SignUp: FunctionComponent<Props> = (props) => {
         <form autoComplete="off" onSubmit={handleSubmit}>
           {submitError && <CallOut color="error" title={submitError} />}
           <div className={styles.field}>
-            <EmailField disabled={submitting} />
+            <EmailField disabled={submitting} focus />
           </div>
           <div className={styles.field}>
             <UsernameField disabled={submitting} />

--- a/src/core/client/auth/views/SignUp/SignUpWithEmail.tsx
+++ b/src/core/client/auth/views/SignUp/SignUpWithEmail.tsx
@@ -31,7 +31,7 @@ const SignUp: FunctionComponent<Props> = (props) => {
         <form autoComplete="off" onSubmit={handleSubmit}>
           {submitError && <CallOut color="error" title={submitError} />}
           <div className={styles.field}>
-            <EmailField disabled={submitting} focus />
+            <EmailField disabled={submitting} autofocus />
           </div>
           <div className={styles.field}>
             <UsernameField disabled={submitting} />


### PR DESCRIPTION
## What does this PR do?

Auto focuses the first input field (the email field) on Sign In and Sign Up popups.

It was really starting to bug me that this was not the first focused element.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Go to stream
- Click `Register` or `Sign In`
- Notice that the first field (email field) is focused and you can immediately start typing into it
