### PR TITLE
Remove `latestCursor` from Local relay cache

### DIFF
--- a/src/core/client/stream/local/initLocalState.ts
+++ b/src/core/client/stream/local/initLocalState.ts
@@ -12,7 +12,7 @@ import {
   initLocalBaseState,
 } from "coral-framework/lib/relay";
 import { GQLFEATURE_FLAG, GQLSTORY_MODE } from "coral-framework/schema";
-import { getLatestCursor } from "coral-stream/tabs/Live/cursorState";
+import { getLatestCursorState } from "coral-stream/tabs/Live/cursorState";
 
 import { initLocalStateQuery } from "coral-stream/__generated__/initLocalStateQuery.graphql";
 
@@ -90,7 +90,7 @@ const initLocalState: InitLocalState = async ({
   // Parse query params
   const query = parseQuery(location.search);
 
-  const currentCursor = await getLatestCursor(
+  const latestCursorState = await getLatestCursorState(
     context.localStorage,
     query.storyID,
     query.storyURL
@@ -161,8 +161,8 @@ const initLocalState: InitLocalState = async ({
     );
     liveChatState.setValue(false, "tailing");
     liveChatState.setValue(false, "tailingConversation");
-    if (currentCursor && currentCursor.cursor) {
-      liveChatState.setValue(currentCursor.cursor, "currentCursor");
+    if (latestCursorState && latestCursorState.cursor) {
+      liveChatState.setValue(latestCursorState.cursor, "currentCursor");
     }
     localRecord.setLinkedRecord(liveChatState, "liveChat");
   });

--- a/src/core/client/stream/local/local.graphql
+++ b/src/core/client/stream/local/local.graphql
@@ -50,10 +50,6 @@ type LiveChatState {
   # The current cursor that is shown at the "New" divider
   # in the live chat.
   currentCursor: String
-
-  # The latest comment cursor that the player has read
-  # in the live chat stream.
-  latestCursor: String
 }
 
 extend type Comment {

--- a/src/core/client/stream/tabs/Live/LiveChatContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveChatContainer.tsx
@@ -50,7 +50,7 @@ import { LiveChatContainerBeforeCommentEdge } from "coral-stream/__generated__/L
 import { LiveChatContainerLocal } from "coral-stream/__generated__/LiveChatContainerLocal.graphql";
 import { LiveCommentContainer_comment } from "coral-stream/__generated__/LiveCommentContainer_comment.graphql";
 
-import { getLatestCursor, persistLatestCursor } from "./cursorState";
+import { getLatestCursorState, persistLatestCursorState } from "./cursorState";
 import InView from "./InView";
 import JumpToButton from "./JumpToButton";
 import LiveCommentContainer from "./LiveComment";
@@ -234,20 +234,20 @@ const LiveChatContainer: FunctionComponent<Props> = ({
         return;
       }
 
-      const latestCursor = await getLatestCursor(
+      const latestCursorState = await getLatestCursorState(
         localStorage,
         storyID,
         storyURL
       );
 
       if (
-        !latestCursor ||
-        !latestCursor.cursor ||
-        (latestCursor &&
-          latestCursor.cursor &&
-          new Date(createdAt) > new Date(latestCursor.cursor))
+        !latestCursorState ||
+        !latestCursorState.cursor ||
+        (latestCursorState &&
+          latestCursorState.cursor &&
+          new Date(createdAt) > new Date(latestCursorState.cursor))
       ) {
-        await persistLatestCursor(localStorage, storyID, storyURL, {
+        await persistLatestCursorState(localStorage, storyID, storyURL, {
           cursor,
           createdAt,
         });

--- a/src/core/client/stream/tabs/Live/LiveChatContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveChatContainer.tsx
@@ -50,7 +50,7 @@ import { LiveChatContainerBeforeCommentEdge } from "coral-stream/__generated__/L
 import { LiveChatContainerLocal } from "coral-stream/__generated__/LiveChatContainerLocal.graphql";
 import { LiveCommentContainer_comment } from "coral-stream/__generated__/LiveCommentContainer_comment.graphql";
 
-import { persistCursor } from "./cursorState";
+import { getLatestCursor, persistLatestCursor } from "./cursorState";
 import InView from "./InView";
 import JumpToButton from "./JumpToButton";
 import LiveCommentContainer from "./LiveComment";
@@ -121,7 +121,7 @@ const LiveChatContainer: FunctionComponent<Props> = ({
     {
       storyID,
       storyURL,
-      liveChat: { tailing, latestCursor },
+      liveChat: { tailing },
     },
     setLocal,
   ] = useLocal<LiveChatContainerLocal>(graphql`
@@ -130,7 +130,6 @@ const LiveChatContainer: FunctionComponent<Props> = ({
       storyURL
       liveChat {
         tailing
-        latestCursor
       }
     }
   `);
@@ -235,11 +234,20 @@ const LiveChatContainer: FunctionComponent<Props> = ({
         return;
       }
 
+      const latestCursor = await getLatestCursor(
+        localStorage,
+        storyID,
+        storyURL
+      );
+
       if (
         !latestCursor ||
-        (latestCursor && new Date(createdAt) > new Date(latestCursor))
+        !latestCursor.cursor ||
+        (latestCursor &&
+          latestCursor.cursor &&
+          new Date(createdAt) > new Date(latestCursor.cursor))
       ) {
-        await persistCursor(localStorage, setLocal, storyID, storyURL, {
+        await persistLatestCursor(localStorage, storyID, storyURL, {
           cursor,
           createdAt,
         });
@@ -253,14 +261,7 @@ const LiveChatContainer: FunctionComponent<Props> = ({
         setNewlyPostedComment(null);
       }
     },
-    [
-      latestCursor,
-      localStorage,
-      newlyPostedComment,
-      setLocal,
-      storyID,
-      storyURL,
-    ]
+    [localStorage, newlyPostedComment, storyID, storyURL]
   );
 
   const showConversation = useCallback(

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveCreateCommentReplyFormContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveCreateCommentReplyFormContainer.tsx
@@ -12,7 +12,7 @@ import React, {
 import { graphql } from "react-relay";
 
 import { ERROR_CODES } from "coral-common/errors";
-import { usePersistedState } from "coral-framework/hooks";
+import { usePersistedSessionState } from "coral-framework/hooks";
 import {
   InvalidRequestError,
   ModerationNudgeError,
@@ -91,7 +91,7 @@ const LiveCreateCommentReplyFormContainer: FunctionComponent<Props> = ({
   const [nudge, setNudge] = useState(true);
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus | null>(null);
 
-  const [, setToggle] = usePersistedState<Toggle>(
+  const [, setToggle] = usePersistedSessionState<Toggle>(
     "LiveCreateCommentReplyFormContainer:toggle"
   );
 

--- a/src/core/client/stream/tabs/Live/LivePostCommentFormContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LivePostCommentFormContainer.tsx
@@ -12,7 +12,7 @@ import React, {
 import { graphql } from "react-relay";
 
 import { ERROR_CODES } from "coral-common/errors";
-import { usePersistedState } from "coral-framework/hooks";
+import { usePersistedSessionState } from "coral-framework/hooks";
 import {
   InvalidRequestError,
   ModerationNudgeError,
@@ -89,10 +89,10 @@ export const LivePostCommentFormContainer: FunctionComponent<Props> = ({
   const [nudge, setNudge] = useState(true);
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus | null>(null);
 
-  const [draft = "", setDraft, initialDraft] = usePersistedState<string>(
+  const [draft = "", setDraft, initialDraft] = usePersistedSessionState<string>(
     "LivePostCommentFormContainer:draft"
   );
-  const [, setToggle] = usePersistedState<Toggle>(
+  const [, setToggle] = usePersistedSessionState<Toggle>(
     "LivePostCommentFormContainer:toggle"
   );
 

--- a/src/core/client/stream/tabs/Live/cursorState.ts
+++ b/src/core/client/stream/tabs/Live/cursorState.ts
@@ -9,7 +9,7 @@ const computeKey = (storyID?: string | null, storyURL?: string | null) => {
   return `liveCursor:${storyID}:${storyURL}`;
 };
 
-export const getLatestCursor = async (
+export const getLatestCursorState = async (
   localStorage: PromisifiedStorage,
   storyID?: string | null,
   storyURL?: string | null
@@ -24,7 +24,7 @@ export const getLatestCursor = async (
   return currentCursor;
 };
 
-export const persistLatestCursor = async (
+export const persistLatestCursorState = async (
   localStorage: PromisifiedStorage,
   storyID: string | null,
   storyURL: string | null,

--- a/src/core/client/stream/tabs/Live/cursorState.ts
+++ b/src/core/client/stream/tabs/Live/cursorState.ts
@@ -1,40 +1,35 @@
-import { DeepPartial } from "coral-common/types";
 import { PromisifiedStorage } from "coral-framework/lib/storage";
-import { RecordProxy } from "relay-runtime";
-
-type AdvancedUpdater = (record: RecordProxy) => void;
-type LocalUpdater = DeepPartial<any> | AdvancedUpdater;
 
 export default interface CursorState {
   cursor: string;
   createdAt: string;
 }
 
-export const persistCursorToLocalStorage = async (
+const computeKey = (storyID?: string | null, storyURL?: string | null) => {
+  return `liveCursor:${storyID}:${storyURL}`;
+};
+
+export const getLatestCursor = async (
+  localStorage: PromisifiedStorage,
+  storyID?: string | null,
+  storyURL?: string | null
+): Promise<CursorState | null> => {
+  const key = computeKey(storyID, storyURL);
+  const rawValue = await localStorage.getItem(key);
+  let currentCursor: CursorState | null = null;
+  if (rawValue) {
+    currentCursor = JSON.parse(rawValue);
+  }
+
+  return currentCursor;
+};
+
+export const persistLatestCursor = async (
   localStorage: PromisifiedStorage,
   storyID: string | null,
   storyURL: string | null,
   state: CursorState
 ) => {
-  // Set the constant updating cursor
-  const key = `liveCursor:${storyID}:${storyURL}`;
+  const key = computeKey(storyID, storyURL);
   await localStorage.setItem(key, JSON.stringify(state));
-};
-
-export const persistLatestCursorToRelay = async (
-  setLocal: LocalUpdater,
-  state: CursorState
-) => {
-  setLocal({ liveChat: { latestCursor: state.cursor } });
-};
-
-export const persistCursor = async (
-  localStorage: PromisifiedStorage,
-  setLocal: LocalUpdater,
-  storyID: string | null,
-  storyURL: string | null,
-  state: CursorState
-) => {
-  await persistCursorToLocalStorage(localStorage, storyID, storyURL, state);
-  await persistLatestCursorToRelay(setLocal, state);
 };


### PR DESCRIPTION
## What does this PR do?

Removes the `latestCursor` value from the Local relay cache.

Instead uses two helper functions to retrieve and persist this constantly changing value.

This same retrieval is also used for the retrieval during `initLocalState` for the `currentCursor`.

## What changes to the GraphQL/Database Schema does this PR introduce?

None on main schema.
Removes `latestCursor` from `local.graphql` stream side.

## How do I test this PR?

Load up the stream and make sure it is properly remembering your cursor position.
