### PR TITLE
CORL-1738: Posting Comment and Replying appear out of order

### DIFF
--- a/src/core/client/stream/local/local.graphql
+++ b/src/core/client/stream/local/local.graphql
@@ -43,6 +43,12 @@ type AuthPopup {
   view: VIEW
 }
 
+extend type PageInfo {
+  # This can be set to true, if "hasNextPage" in the connection was set through
+  # a locally ran mutation.
+  hasNextPageFromMutation: Boolean
+}
+
 type LiveChatState {
   tailing: Boolean
   tailingConversation: Boolean

--- a/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/CreateCommentReplyMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/CreateCommentReplyMutation.ts
@@ -234,12 +234,6 @@ graphql`
     role
     badges
     createdAt
-    status {
-      current
-      ban {
-        active
-      }
-    }
   }
 `;
 /** end */

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/CreateCommentMutation.ts
@@ -168,12 +168,6 @@ graphql`
     createdAt
     role
     username
-    status {
-      current
-      ban {
-        active
-      }
-    }
   }
 `;
 

--- a/src/core/client/stream/tabs/Live/LiveCommentEnteredSubscription.tsx
+++ b/src/core/client/stream/tabs/Live/LiveCommentEnteredSubscription.tsx
@@ -1,10 +1,5 @@
 import { graphql } from "react-relay";
-import {
-  ConnectionHandler,
-  Environment,
-  RecordProxy,
-  RecordSourceSelectorProxy,
-} from "relay-runtime";
+import { Environment } from "relay-runtime";
 
 import {
   createSubscription,
@@ -17,54 +12,12 @@ import {
 import { LiveCommentEnteredSubscription } from "coral-stream/__generated__/LiveCommentEnteredSubscription.graphql";
 
 import { isPublished } from "../shared/helpers";
+import insertCommentToStory from "./helpers/insertCommentToStory";
 
 function liveInsertionEnabled(environment: Environment): boolean {
   const liveChat = lookup(environment, LOCAL_ID).liveChat;
 
   return liveChat.tailing;
-}
-
-function insertComment(
-  environment: Environment,
-  store: RecordSourceSelectorProxy<unknown>,
-  storyID: string,
-  comment: RecordProxy
-) {
-  const story = store.get(storyID)!;
-  const afterConnection = ConnectionHandler.getConnection(story, "Chat_after");
-  if (!afterConnection) {
-    return;
-  }
-
-  const beforeConnection = ConnectionHandler.getConnection(
-    story,
-    "Chat_before"
-  );
-
-  const liveInsertion = liveInsertionEnabled(environment);
-
-  if (liveInsertion) {
-    const edge = ConnectionHandler.createEdge(store, comment, comment, "");
-    edge.setValue(comment.getValue("createdAt"), "cursor");
-
-    ConnectionHandler.insertEdgeAfter(afterConnection, edge);
-  } else {
-    const pageInfoAfter = afterConnection.getLinkedRecord("pageInfo")!;
-    // Should not be falsy because Relay uses this information to determine
-    // whether or not new data is available to load.
-    if (!pageInfoAfter.getValue("endCursor")) {
-      const beforeEdges = beforeConnection
-        ? beforeConnection.getLinkedRecords("edges")!
-        : [];
-      const endCursor =
-        beforeEdges.length > 0
-          ? beforeEdges[0].getValue("cursor")
-          : new Date(0).toISOString();
-      // Set cursor to oldest date, to load from the beginning.
-      pageInfoAfter.setValue(endCursor, "endCursor");
-    }
-    pageInfoAfter.setValue(true, "hasNextPage");
-  }
 }
 
 type CommentEnteredVariables = Omit<
@@ -77,11 +30,8 @@ const LiveCommentEnteredSubscription = createSubscription(
   (environment: Environment, variables: CommentEnteredVariables) => {
     return requestSubscription(environment, {
       subscription: graphql`
-        subscription LiveCommentEnteredSubscription(
-          $storyID: ID!
-          $ancestorID: ID
-        ) {
-          commentEntered(storyID: $storyID, ancestorID: $ancestorID) {
+        subscription LiveCommentEnteredSubscription($storyID: ID!) {
+          commentEntered(storyID: $storyID) {
             comment {
               id
               createdAt
@@ -99,7 +49,6 @@ const LiveCommentEnteredSubscription = createSubscription(
       `,
       variables: {
         storyID: variables.storyID,
-        ancestorID: variables.ancestorID,
       },
       updater: (store) => {
         const rootField = store.getRootField("commentEntered");
@@ -127,7 +76,10 @@ const LiveCommentEnteredSubscription = createSubscription(
         }
 
         comment.setValue(true, "enteredLive");
-        insertComment(environment, store, variables.storyID, comment);
+        insertCommentToStory(store, variables.storyID, comment, {
+          liveInsertion: liveInsertionEnabled(environment),
+          fromMutation: false,
+        });
       },
     });
   }

--- a/src/core/client/stream/tabs/Live/LiveCommentsAfterContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveCommentsAfterContainer.tsx
@@ -21,6 +21,7 @@ interface RenderProps {
     >;
   }>;
   afterHasMore: boolean;
+  afterHasMoreFromMutation: boolean;
   loadMoreAfter: () => Promise<void>;
   isLoadingMoreAfter: boolean;
 }
@@ -63,6 +64,11 @@ const LiveCommentsAfterContainer: FunctionComponent<Props> = ({
     story.after && story.after.pageInfo
       ? story.after.pageInfo.hasNextPage
       : false;
+  const afterHasMoreFromMutation = Boolean(
+    story.after && story.after.pageInfo
+      ? story.after.pageInfo.hasNextPageFromMutation
+      : false
+  );
 
   const initialIgnoredUsers = useMemo(
     () => (viewer ? viewer.ignoredUsers.map((u) => u.id) : []),
@@ -81,6 +87,7 @@ const LiveCommentsAfterContainer: FunctionComponent<Props> = ({
   return children({
     afterComments: filtered,
     afterHasMore,
+    afterHasMoreFromMutation,
     loadMoreAfter: loadMore,
     isLoadingMoreAfter: isLoadingMore,
   });
@@ -122,6 +129,7 @@ const enhanced = withPaginationContainer<
           }
           pageInfo {
             hasNextPage
+            hasNextPageFromMutation
           }
         }
       }

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveCommentRepliesAfterContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveCommentRepliesAfterContainer.tsx
@@ -15,6 +15,7 @@ import filterIgnoredComments from "../../helpers/filterIgnoredComments";
 interface RenderProps {
   afterComments: LiveCommentRepliesAfterContainer_comment["after"]["edges"];
   afterHasMore: boolean;
+  afterHasMoreFromMutation: boolean;
   loadMoreAfter: () => Promise<void>;
   isLoadingMoreAfter: boolean;
 }
@@ -41,6 +42,11 @@ const LiveCommentRepliesAfterContainer: FunctionComponent<Props> = ({
     comment.after && comment.after.pageInfo
       ? comment.after.pageInfo.hasNextPage
       : false;
+  const afterHasMoreFromMutation = Boolean(
+    comment.after && comment.after.pageInfo
+      ? comment.after.pageInfo.hasNextPageFromMutation
+      : false
+  );
 
   const initialIgnoredUsers = useMemo(
     () => (viewer ? viewer.ignoredUsers.map((u) => u.id) : []),
@@ -59,6 +65,7 @@ const LiveCommentRepliesAfterContainer: FunctionComponent<Props> = ({
   return children({
     afterComments: filtered,
     afterHasMore,
+    afterHasMoreFromMutation,
     loadMoreAfter: loadMore,
     isLoadingMoreAfter: isLoadingMore,
   });
@@ -98,6 +105,7 @@ const enhanced = withPaginationContainer<
           }
           pageInfo {
             hasNextPage
+            hasNextPageFromMutation
           }
         }
       }

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveCommentRepliesStreamContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveCommentRepliesStreamContainer.tsx
@@ -39,8 +39,6 @@ const LiveCommentRepliesStreamContainer: FunctionComponent<Props> = ({
   viewer,
   settings,
   cursor,
-  tailing,
-  setTailing,
   onCommentInView,
   onEdit,
   onCancelEdit,
@@ -68,6 +66,7 @@ const LiveCommentRepliesStreamContainer: FunctionComponent<Props> = ({
           {({
             afterComments,
             afterHasMore,
+            afterHasMoreFromMutation,
             loadMoreAfter,
             isLoadingMoreAfter,
           }) => (
@@ -78,14 +77,13 @@ const LiveCommentRepliesStreamContainer: FunctionComponent<Props> = ({
               isLoadingMoreBefore={isLoadingMoreBefore}
               afterComments={afterComments}
               afterHasMore={afterHasMore}
+              afterHasMoreFromMutation={afterHasMoreFromMutation}
               loadMoreAfter={loadMoreAfter}
               isLoadingMoreAfter={isLoadingMoreAfter}
               comment={comment}
               viewer={viewer}
               settings={settings}
               story={story}
-              tailing={tailing}
-              setTailing={setTailing}
               onCommentInView={onCommentInView}
               onEdit={onEdit}
               onCancelEdit={onCancelEdit}

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveReplyCommentEnteredSubscription.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveReplyCommentEnteredSubscription.tsx
@@ -1,10 +1,5 @@
 import { graphql } from "react-relay";
-import {
-  ConnectionHandler,
-  Environment,
-  RecordProxy,
-  RecordSourceSelectorProxy,
-} from "relay-runtime";
+import { Environment } from "relay-runtime";
 
 import {
   createSubscription,
@@ -13,13 +8,10 @@ import {
   requestSubscription,
   SubscriptionVariables,
 } from "coral-framework/lib/relay";
-import { GQLCOMMENT_SORT_RL } from "coral-framework/schema";
-import {
-  determineDepthTillAncestor,
-  isPublished,
-} from "coral-stream/tabs/shared/helpers";
+import { isPublished } from "coral-stream/tabs/shared/helpers";
 
 import { LiveReplyCommentEnteredSubscription } from "coral-stream/__generated__/LiveReplyCommentEnteredSubscription.graphql";
+import insertReplyToAncestor from "../../helpers/insertReplyToAncestor";
 
 function liveInsertionEnabled(environment: Environment): boolean {
   const liveChat = lookup(environment, LOCAL_ID).liveChat;
@@ -27,82 +19,10 @@ function liveInsertionEnabled(environment: Environment): boolean {
   return liveChat.tailingConversation;
 }
 
-function insertComment(
-  environment: Environment,
-  store: RecordSourceSelectorProxy<unknown>,
-  parentID: string,
-  parent: RecordProxy | null,
-  comment: RecordProxy
-) {
-  if (!parent) {
-    return;
-  }
-
-  const pID = parent.getValue("id")! as string;
-  // Wrong reply stream, bail out
-  if (parentID !== pID) {
-    return;
-  }
-
-  const depth = determineDepthTillAncestor(comment, parentID);
-  if (depth && depth > 1) {
-    return;
-  }
-
-  const afterConnection = ConnectionHandler.getConnection(
-    parent,
-    "Replies_after"
-  );
-  if (!afterConnection) {
-    return;
-  }
-
-  const beforeConnection = ConnectionHandler.getConnection(
-    parent,
-    "Replies_before"
-  );
-
-  const liveInsertion = liveInsertionEnabled(environment);
-
-  if (liveInsertion) {
-    const edge = ConnectionHandler.createEdge(store, comment, comment, "");
-    edge.setValue(comment.getValue("createdAt"), "cursor");
-
-    ConnectionHandler.insertEdgeAfter(afterConnection, edge);
-  } else {
-    const pageInfoAfter = afterConnection.getLinkedRecord("pageInfo")!;
-    // Should not be falsy because Relay uses this information to determine
-    // whether or not new data is available to load.
-    if (!pageInfoAfter.getValue("endCursor")) {
-      const beforeEdges = beforeConnection
-        ? beforeConnection.getLinkedRecords("edges")!
-        : [];
-      const endCursor =
-        beforeEdges.length > 0
-          ? beforeEdges[0].getValue("cursor")
-          : new Date(0).toISOString();
-      // Set cursor to oldest date, to load from the beginning.
-      pageInfoAfter.setValue(endCursor, "endCursor");
-    }
-    pageInfoAfter.setValue(true, "hasNextPage");
-  }
-}
-
 type CommentEnteredVariables = Omit<
   SubscriptionVariables<LiveReplyCommentEnteredSubscription>,
   "flattenReplies"
-> & {
-  /** orderBy that was supplied to the `comments` connection on Story */
-  orderBy?: GQLCOMMENT_SORT_RL;
-  /** Tag that was supplied to the `comments` connection on Story */
-  tag?: string;
-  /** If set together with ancestorID, direct replies to the ancestor will immediately displayed */
-  liveDirectRepliesInsertion?: boolean;
-  /** The relay connection key to find the commments on the story */
-  connectionKey: string;
-  /** The parent ID we are listening to replies for */
-  parentID: string;
-};
+>;
 
 const LiveReplyCommentEnteredSubscription = createSubscription(
   "subscribeToCommentEntered",
@@ -111,7 +31,7 @@ const LiveReplyCommentEnteredSubscription = createSubscription(
       subscription: graphql`
         subscription LiveReplyCommentEnteredSubscription(
           $storyID: ID!
-          $ancestorID: ID
+          $ancestorID: ID!
         ) {
           commentEntered(storyID: $storyID, ancestorID: $ancestorID) {
             comment {
@@ -146,23 +66,12 @@ const LiveReplyCommentEnteredSubscription = createSubscription(
         if (!isPublished(status)) {
           return;
         }
+        comment.setValue(true, "enteredLive");
 
-        const parent = comment.getLinkedRecord("parent");
-        const isTopLevelComent = !parent;
-
-        if (isTopLevelComent) {
-          // we only do replies here
-          return;
-        } else {
-          comment.setValue(true, "enteredLive");
-          insertComment(
-            environment,
-            store,
-            variables.parentID,
-            parent,
-            comment
-          );
-        }
+        insertReplyToAncestor(store, variables.ancestorID, comment, {
+          liveInsertion: liveInsertionEnabled(environment),
+          fromMutation: false,
+        });
       },
     });
   }

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveConversationContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveConversationContainer.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FunctionComponent,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import React, { FunctionComponent, useCallback, useState } from "react";
 import { commitLocalUpdate, graphql } from "react-relay";
 import { ConnectionHandler } from "relay-runtime";
 
@@ -82,10 +77,6 @@ const LiveConversationContainer: FunctionComponent<Props> = ({
     },
     [setLocal]
   );
-  // Initialize tailing on open, runs only once
-  useEffect(() => {
-    setTailing(false);
-  }, [setTailing]);
 
   const banned = !!viewer?.status.current.includes(GQLUSER_STATUS.BANNED);
   const suspended = !!viewer?.status.current.includes(GQLUSER_STATUS.SUSPENDED);

--- a/src/core/client/stream/tabs/Live/LivePostCommentFormContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LivePostCommentFormContainer.tsx
@@ -48,7 +48,6 @@ import {
 import { LivePostCommentFormContainer_settings } from "coral-stream/__generated__/LivePostCommentFormContainer_settings.graphql";
 import { LivePostCommentFormContainer_story } from "coral-stream/__generated__/LivePostCommentFormContainer_story.graphql";
 import { LivePostCommentFormContainer_viewer } from "coral-stream/__generated__/LivePostCommentFormContainer_viewer.graphql";
-import { COMMENT_SORT } from "coral-stream/__generated__/StreamContainerLocal.graphql";
 
 import { LiveCreateCommentMutation } from "./LiveCreateCommentMutation";
 import LivePostCommentForm from "./LivePostCommentForm";
@@ -58,7 +57,6 @@ interface Props {
   settings: LivePostCommentFormContainer_settings;
   viewer: LivePostCommentFormContainer_viewer | null;
   story: LivePostCommentFormContainer_story;
-  commentsOrderBy?: COMMENT_SORT;
 
   onSubmitted: (commentID: string | undefined, cursor: string) => void;
 }
@@ -67,7 +65,6 @@ export const LivePostCommentFormContainer: FunctionComponent<Props> = ({
   settings,
   viewer,
   story,
-  commentsOrderBy,
   onSubmitted,
 }) => {
   const rteRef = useRef<CoralRTE | null>(null);
@@ -112,7 +109,6 @@ export const LivePostCommentFormContainer: FunctionComponent<Props> = ({
         const response = await createComment({
           storyID: story.id,
           nudge,
-          commentsOrderBy,
           body: input.body,
           media: input.media,
         });
@@ -175,7 +171,6 @@ export const LivePostCommentFormContainer: FunctionComponent<Props> = ({
       return;
     },
     [
-      commentsOrderBy,
       createComment,
       nudge,
       onSubmitted,

--- a/src/core/client/stream/tabs/Live/LiveStreamContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveStreamContainer.tsx
@@ -60,6 +60,7 @@ const LiveStreamContainer: FunctionComponent<Props> = ({
             {({
               afterComments,
               afterHasMore,
+              afterHasMoreFromMutation,
               loadMoreAfter,
               isLoadingMoreAfter,
             }) => (
@@ -70,6 +71,7 @@ const LiveStreamContainer: FunctionComponent<Props> = ({
                 isLoadingMoreBefore={isLoadingMoreBefore}
                 afterComments={afterComments}
                 afterHasMore={afterHasMore}
+                afterHasMoreFromMutation={afterHasMoreFromMutation}
                 loadMoreAfter={loadMoreAfter}
                 isLoadingMoreAfter={isLoadingMoreAfter}
                 viewer={viewer}

--- a/src/core/client/stream/tabs/Live/helpers/insertComment.ts
+++ b/src/core/client/stream/tabs/Live/helpers/insertComment.ts
@@ -1,0 +1,16 @@
+import {
+  ConnectionHandler,
+  RecordProxy,
+  RecordSourceSelectorProxy,
+} from "relay-runtime";
+
+export default function insertComment(
+  store: RecordSourceSelectorProxy<unknown>,
+  comment: RecordProxy,
+  afterConnection: RecordProxy
+) {
+  const edge = ConnectionHandler.createEdge(store, comment, comment, "");
+  edge.setValue(comment.getValue("createdAt"), "cursor");
+
+  ConnectionHandler.insertEdgeAfter(afterConnection, edge);
+}

--- a/src/core/client/stream/tabs/Live/helpers/insertCommentToStory.ts
+++ b/src/core/client/stream/tabs/Live/helpers/insertCommentToStory.ts
@@ -1,0 +1,37 @@
+import {
+  ConnectionHandler,
+  RecordProxy,
+  RecordSourceSelectorProxy,
+} from "relay-runtime";
+
+import insertComment from "./insertComment";
+import markHasNextPage from "./markHasNextPage";
+
+export default function insertCommentToStory(
+  store: RecordSourceSelectorProxy<unknown>,
+  storyID: string,
+  comment: RecordProxy,
+  options: {
+    liveInsertion?: boolean;
+    fromMutation?: boolean;
+  } = {}
+) {
+  const story = store.get(storyID)!;
+  const afterConnection = ConnectionHandler.getConnection(story, "Chat_after");
+  if (!afterConnection) {
+    return;
+  }
+  const beforeConnection = ConnectionHandler.getConnection(
+    story,
+    "Chat_before"
+  );
+  if (options.liveInsertion) {
+    insertComment(store, comment, afterConnection);
+  } else {
+    markHasNextPage(
+      afterConnection,
+      beforeConnection,
+      Boolean(options.fromMutation)
+    );
+  }
+}

--- a/src/core/client/stream/tabs/Live/helpers/insertReplyToAncestor.ts
+++ b/src/core/client/stream/tabs/Live/helpers/insertReplyToAncestor.ts
@@ -1,0 +1,59 @@
+import {
+  ConnectionHandler,
+  RecordProxy,
+  RecordSourceSelectorProxy,
+} from "relay-runtime";
+
+import determineDepthTillAncestor from "coral-stream/tabs/shared/helpers/determineDepthTillAncestor";
+
+import insertComment from "./insertComment";
+import markHasNextPage from "./markHasNextPage";
+
+export default function insertReplyToAncestor(
+  store: RecordSourceSelectorProxy<unknown>,
+  ancestorID: string,
+  comment: RecordProxy,
+  options: {
+    liveInsertion?: boolean;
+    fromMutation?: boolean;
+  } = {}
+) {
+  const parent = comment.getLinkedRecord("parent");
+  if (!parent) {
+    return;
+  }
+
+  const pID = parent.getValue("id")! as string;
+  // Wrong reply stream, bail out
+  if (ancestorID !== pID) {
+    return;
+  }
+
+  const depth = determineDepthTillAncestor(comment, ancestorID);
+  if (depth && depth > 1) {
+    return;
+  }
+
+  const afterConnection = ConnectionHandler.getConnection(
+    parent,
+    "Replies_after"
+  );
+  if (!afterConnection) {
+    return;
+  }
+
+  const beforeConnection = ConnectionHandler.getConnection(
+    parent,
+    "Replies_before"
+  );
+
+  if (options.liveInsertion) {
+    insertComment(store, comment, afterConnection);
+  } else {
+    markHasNextPage(
+      afterConnection,
+      beforeConnection,
+      Boolean(options.fromMutation)
+    );
+  }
+}

--- a/src/core/client/stream/tabs/Live/helpers/markHasNextPage.ts
+++ b/src/core/client/stream/tabs/Live/helpers/markHasNextPage.ts
@@ -1,0 +1,24 @@
+import { RecordProxy } from "relay-runtime";
+
+export default function markHasNextPage(
+  afterConnection: RecordProxy,
+  beforeConnection: RecordProxy | null | undefined,
+  fromMutation: boolean
+) {
+  const pageInfoAfter = afterConnection.getLinkedRecord("pageInfo")!;
+  // Should not be falsy because Relay uses this information to determine
+  // whether or not new data is available to load.
+  if (!pageInfoAfter.getValue("endCursor")) {
+    const beforeEdges = beforeConnection
+      ? beforeConnection.getLinkedRecords("edges")!
+      : [];
+    const endCursor =
+      beforeEdges.length > 0
+        ? beforeEdges[0].getValue("cursor")
+        : new Date(0).toISOString();
+    // Set cursor to oldest date, to load from the beginning.
+    pageInfoAfter.setValue(endCursor, "endCursor");
+  }
+  pageInfoAfter.setValue(true, "hasNextPage");
+  pageInfoAfter.setValue(fromMutation, "hasNextPageFromMutation");
+}

--- a/src/core/client/stream/tabs/Live/helpers/useColdStart.ts
+++ b/src/core/client/stream/tabs/Live/helpers/useColdStart.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export default function useColdStart(period = 1000) {
+  // We define a period at the beginning as cold start, where
+  // different state might not yet be stable.
+  const [coldStart, setColdStart] = useState(true);
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setColdStart(false);
+    }, period);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, []);
+  return coldStart;
+}


### PR DESCRIPTION
## What does this PR do?

- Fixes an issue were posting or replying would create a comment out of chronological order
- Refactor and smaller improvements

## How do I test this PR?
- Scroll until you're not tailing
- Now in another window post new comments
- Back to the original window, without scrolling down, post comment
- Scroll down and see your comment appear in correct order
- repeat for conversation view