### PR TITLE
[CORL-1734] Live Chat: truncate reply comment if it's too long in the conversation view

### DIFF
--- a/src/core/client/stream/tabs/Live/LiveComment/LiveCommentBodyContainer.css
+++ b/src/core/client/stream/tabs/Live/LiveComment/LiveCommentBodyContainer.css
@@ -70,6 +70,18 @@
   margin-left: var(--spacing-2);
 }
 
+.truncatedBody {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+
+  line-height: 1.3rem;
+  max-height: calc(4 * 1.3rem);
+
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+}
+
 .body {
   font-size: var(--font-size-2);
   font-family: var(--font-family-primary);

--- a/src/core/client/stream/tabs/Live/LiveComment/LiveCommentBodyContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveComment/LiveCommentBodyContainer.tsx
@@ -28,6 +28,8 @@ interface Props {
 
   containerClassName?: string;
   onCancel?: () => void;
+
+  truncateBody?: boolean;
 }
 
 const LiveCommentBodyContainer: FunctionComponent<Props> = ({
@@ -37,6 +39,7 @@ const LiveCommentBodyContainer: FunctionComponent<Props> = ({
   viewer,
   containerClassName,
   onCancel,
+  truncateBody,
 }) => {
   return (
     <Flex justifyContent="flex-start" alignItems="flex-start">
@@ -115,9 +118,15 @@ const LiveCommentBodyContainer: FunctionComponent<Props> = ({
           )}
         </div>
 
-        <HTMLContent className={cn(styles.body, CLASSES.comment.content)}>
-          {comment.body || ""}
-        </HTMLContent>
+        <div
+          className={cn({
+            [styles.truncatedBody]: truncateBody,
+          })}
+        >
+          <HTMLContent className={cn(styles.body, CLASSES.comment.content)}>
+            {comment.body || ""}
+          </HTMLContent>
+        </div>
       </div>
     </Flex>
   );

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveCommentRepliesContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveCommentRepliesContainer.tsx
@@ -240,6 +240,7 @@ const LiveCommentRepliesContainer: FunctionComponent<Props> = ({
           viewer={viewer}
           settings={settings}
           onInView={onCommentInView}
+          truncateBody
         />
       </div>
       <Virtuoso

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveReplyContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveCommentReplies/LiveReplyContainer.tsx
@@ -30,6 +30,8 @@ interface Props {
   onEdit?: (comment: LiveReplyContainer_comment) => void;
   editing?: boolean;
   onCancelEditing?: () => void;
+
+  truncateBody?: boolean;
 }
 
 const LiveReplyContainer: FunctionComponent<Props> = ({
@@ -41,6 +43,7 @@ const LiveReplyContainer: FunctionComponent<Props> = ({
   onEdit,
   editing,
   onCancelEditing,
+  truncateBody,
 }) => {
   const [showReportFlow, , toggleShowReportFlow] = useToggleState(false);
 
@@ -114,6 +117,7 @@ const LiveReplyContainer: FunctionComponent<Props> = ({
           story={story}
           containerClassName={editing ? styles.highlight : ""}
           onCancel={editing ? onCancelEditing : undefined}
+          truncateBody={truncateBody}
         />
 
         <div id={`reply-${comment.id}`}>


### PR DESCRIPTION
## What does this PR do?

Truncates with ellipsis in the reply view (conversation view) on the root reply comment if it's longer than 4 lines long.

This prevents the comment from pushing the conversation view's close button and header up so far that it is no longer click-able and users are trapped in the conversation modal.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Go to live chat
- Make a REALLY long comment (multiple lines long)
- Reply to it in conversation view
- Reply multiple times, so that the conversation modal takes up as much space as it can
- The ellipsis should show on the truncated root (parent) comment
- You can always close the conversation modal
