### PR TITLE
[CORL-1708] Allow admins to access notifications

### DIFF
--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -2776,6 +2776,7 @@ type User {
   notifications: UserNotificationSettings!
     @auth(
       userIDField: "id"
+      roles: [ADMIN]
       permit: [SUSPENDED, BANNED, PENDING_DELETION, WARNED]
     )
 


### PR DESCRIPTION
## What does this PR do?

Allow admins to access notifications for users

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

See notes for the CORL-1708 with reproduction steps from @immber.

- Create comments from many users in a Coral stream
- Use the query in the case notes to pull notification data from the API using an ADMIN user credentials
- See that no `USER_NOT_ENTITLED` errors appear in the comment results
