### PR TITLE
[CORL-1755] Live Chat: "Go to start" scroll fix

### DIFF
--- a/src/core/client/stream/tabs/Live/LiveChatContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveChatContainer.tsx
@@ -56,6 +56,7 @@ import useConversation from "./LiveConversation/useConversation";
 import LiveEditCommentFormContainer from "./LiveEditComment/LiveEditCommentFormContainer";
 import LivePostCommentFormContainer from "./LivePostCommentFormContainer";
 import LiveSkeleton from "./LiveSkeleton";
+import { SetCursorOptions } from "./LiveTabQuery";
 
 import styles from "./LiveChatContainer.css";
 
@@ -75,7 +76,7 @@ interface Props {
   story: LiveChatContainer_story;
 
   cursor: string;
-  setCursor: (cursor: string) => void;
+  setCursor: (cursor: string, scrollToEnd?: SetCursorOptions) => void;
 }
 
 interface NewComment {
@@ -340,7 +341,7 @@ const LiveChatContainer: FunctionComponent<Props> = ({
   }, [newlyPostedComment, setNewlyPostedComment]);
 
   const handleGoToStart = useCallback(() => {
-    setCursor(new Date(0).toISOString());
+    setCursor(new Date(0).toISOString(), { scrollToEnd: false });
 
     LiveChatGoToStartEvent.emit(eventEmitter, {
       storyID: story.id,

--- a/src/core/client/stream/tabs/Live/LiveChatContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveChatContainer.tsx
@@ -56,7 +56,6 @@ import useConversation from "./LiveConversation/useConversation";
 import LiveEditCommentFormContainer from "./LiveEditComment/LiveEditCommentFormContainer";
 import LivePostCommentFormContainer from "./LivePostCommentFormContainer";
 import LiveSkeleton from "./LiveSkeleton";
-import { SetCursorOptions } from "./LiveTabQuery";
 
 import styles from "./LiveChatContainer.css";
 
@@ -76,7 +75,7 @@ interface Props {
   story: LiveChatContainer_story;
 
   cursor: string;
-  setCursor: (cursor: string, scrollToEnd?: SetCursorOptions) => void;
+  setCursor: (cursor: string) => void;
 }
 
 interface NewComment {
@@ -341,7 +340,7 @@ const LiveChatContainer: FunctionComponent<Props> = ({
   }, [newlyPostedComment, setNewlyPostedComment]);
 
   const handleGoToStart = useCallback(() => {
-    setCursor(new Date(0).toISOString(), { scrollToEnd: false });
+    setCursor(new Date(0).toISOString());
 
     LiveChatGoToStartEvent.emit(eventEmitter, {
       storyID: story.id,

--- a/src/core/client/stream/tabs/Live/LiveTabQuery.css
+++ b/src/core/client/stream/tabs/Live/LiveTabQuery.css
@@ -1,3 +1,3 @@
 .root {
-  min-height: 700px;
+  min-height: 650px;
 }

--- a/src/core/client/stream/tabs/Live/LiveTabQuery.css
+++ b/src/core/client/stream/tabs/Live/LiveTabQuery.css
@@ -1,3 +1,3 @@
 .root {
-  height: 700px;
+  min-height: 700px;
 }

--- a/src/core/client/stream/tabs/Live/LiveTabQuery.tsx
+++ b/src/core/client/stream/tabs/Live/LiveTabQuery.tsx
@@ -190,28 +190,16 @@ const LiveTabQuery: FunctionComponent = () => {
             inclusiveAfter: true,
             inclusiveBefore: false,
           });
-
-          if (options && options.scrollToEnd) {
-            window.requestAnimationFrame(() => {
-              const el = document.getElementById("live-chat-footer");
-              if (el) {
-                el.scrollIntoView();
-              }
-            });
-          }
         };
 
         return (
-          <>
-            <LiveStreamContainer
-              story={data.props.story}
-              viewer={data.props.viewer}
-              settings={data.props.settings}
-              cursor={paginationState.cursor}
-              setCursor={deleteConnectionsAndSetCursor}
-            />
-            <div id="live-chat-footer"></div>
-          </>
+          <LiveStreamContainer
+            story={data.props.story}
+            viewer={data.props.viewer}
+            settings={data.props.settings}
+            cursor={paginationState.cursor}
+            setCursor={deleteConnectionsAndSetCursor}
+          />
         );
       }}
     />

--- a/src/core/client/stream/tabs/Live/LiveTabQuery.tsx
+++ b/src/core/client/stream/tabs/Live/LiveTabQuery.tsx
@@ -30,10 +30,6 @@ interface PaginationState {
   inclusiveBefore: boolean;
 }
 
-export interface SetCursorOptions {
-  scrollToEnd?: boolean;
-}
-
 const LiveTabQuery: FunctionComponent = () => {
   const [
     {
@@ -144,10 +140,7 @@ const LiveTabQuery: FunctionComponent = () => {
         // The pagination container wouldn't allow us to start a new connection
         // by refetching with a different cursor. So we delete the connection first,
         // before starting the refetch.
-        const deleteConnectionsAndSetCursor = async (
-          s: string,
-          options: SetCursorOptions | undefined = { scrollToEnd: true }
-        ) => {
+        const deleteConnectionsAndSetCursor = async (s: string) => {
           // Setting empty cursor will trigger loading state and stops rendering any of the
           // pagination containers.
           setLocal({ liveChat: { currentCursor: "" } });

--- a/src/core/client/stream/tabs/Live/LiveTabQuery.tsx
+++ b/src/core/client/stream/tabs/Live/LiveTabQuery.tsx
@@ -30,6 +30,10 @@ interface PaginationState {
   inclusiveBefore: boolean;
 }
 
+export interface SetCursorOptions {
+  scrollToEnd?: boolean;
+}
+
 const LiveTabQuery: FunctionComponent = () => {
   const [
     {
@@ -140,7 +144,10 @@ const LiveTabQuery: FunctionComponent = () => {
         // The pagination container wouldn't allow us to start a new connection
         // by refetching with a different cursor. So we delete the connection first,
         // before starting the refetch.
-        const deleteConnectionsAndSetCursor = async (s: string) => {
+        const deleteConnectionsAndSetCursor = async (
+          s: string,
+          options: SetCursorOptions | undefined = { scrollToEnd: true }
+        ) => {
           // Setting empty cursor will trigger loading state and stops rendering any of the
           // pagination containers.
           setLocal({ liveChat: { currentCursor: "" } });
@@ -184,12 +191,14 @@ const LiveTabQuery: FunctionComponent = () => {
             inclusiveBefore: false,
           });
 
-          window.requestAnimationFrame(() => {
-            const el = document.getElementById("live-chat-footer");
-            if (el) {
-              el.scrollIntoView();
-            }
-          });
+          if (options && options.scrollToEnd) {
+            window.requestAnimationFrame(() => {
+              const el = document.getElementById("live-chat-footer");
+              if (el) {
+                el.scrollIntoView();
+              }
+            });
+          }
         };
 
         return (


### PR DESCRIPTION
## What does this PR do?

Fixes weird scrolling behaviour if you click "go to start" too many times sequentially or when you're already at the start of the stream.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Make sure you're at the bottom or a ways away from the start of the stream
- Make sure you have enough comments that scrolling and pagination are possible in stream
- Click "Go to start"
- Keep clicking "Go to start" several more times
   - Scroll around and click it some more 
- Make sure that the stream never jumps away on you or the page scrolls past the iframe
