### PR TITLE
[CORL-1763] Prevent sentry from taking over `console` during dev

### DIFF
--- a/src/core/client/framework/lib/errors/reporter/sentry/sentry.tsx
+++ b/src/core/client/framework/lib/errors/reporter/sentry/sentry.tsx
@@ -75,7 +75,16 @@ export class SentryErrorReporter implements ErrorReporter {
         return event;
       },
       integrations: [
-        ...Sentry.defaultIntegrations,
+        ...Sentry.defaultIntegrations.map((i) => {
+          if (
+            process.env.NODE_ENV !== "production" &&
+            i.name === "Breadcrumbs"
+          ) {
+            // Prevent overwriting global `console` during development and test.
+            return new Sentry.Integrations.Breadcrumbs({ console: false });
+          }
+          return i;
+        }),
         new RewriteFrames({
           iteratee: (frame) => {
             if (frame.filename) {


### PR DESCRIPTION
## What does this PR do?
- Prevents sentry from taking over `console` during development, which restores behavior of `console` commands.

## How do I test this PR?
- Any `console.log` or similar function call should retain it's correct sourcemap location.
