### PR TITLE
Configure GraphQL Subscription URI

### DIFF
--- a/src/core/client/framework/lib/bootstrap/createManaged.tsx
+++ b/src/core/client/framework/lib/bootstrap/createManaged.tsx
@@ -89,11 +89,6 @@ interface CreateContextArguments {
   tokenRefreshProvider?: TokenRefreshProvider;
 }
 
-/** websocketURL points to our live graphql server */
-const websocketURL = `${location.protocol === "https:" ? "wss" : "ws"}://${
-  location.host
-}/api/graphql/live`;
-
 /**
  * timeagoFormatter integrates timeago into our translation
  * framework. It gets injected into the UIContext.
@@ -316,6 +311,18 @@ function resolveSessionStorage(pym?: PymChild): PromisifiedStorage {
   return createPromisifiedStorage(createSessionStorage());
 }
 
+function resolveGraphQLSubscriptionURI(
+  staticConfig: StaticConfig | null
+): string {
+  if (staticConfig && staticConfig.graphQLSubscriptionURI) {
+    return staticConfig.graphQLSubscriptionURI;
+  }
+
+  return `${location.protocol === "https:" ? "wss" : "ws"}://${
+    location.host
+  }/api/graphql/live`;
+}
+
 /**
  * `createManaged` establishes the dependencies of our framework
  * and returns a `ManagedCoralContextProvider` that provides the context
@@ -383,8 +390,13 @@ export default async function createManaged({
   /** clientID is sent to the server with every request */
   const clientID = uuid();
 
+  const staticConfig = getStaticConfig();
+
+  // websocketEndpoint points to our graphql server's live endpoint.
+  const graphQLSubscriptionURI = resolveGraphQLSubscriptionURI(staticConfig);
+
   const subscriptionClient = createManagedSubscriptionClient(
-    websocketURL,
+    graphQLSubscriptionURI,
     clientID,
     bundle,
     bundleConfig
@@ -426,7 +438,7 @@ export default async function createManaged({
     environment: context.relayEnvironment,
     context,
     auth,
-    staticConfig: getStaticConfig(),
+    staticConfig,
   });
 
   // Set new token for the websocket connection.

--- a/src/core/common/config.ts
+++ b/src/core/common/config.ts
@@ -30,6 +30,13 @@ export interface StaticConfig {
   reporter?: ReporterConfig;
 
   /**
+   * graphQLSubscriptionURI is the endpoint that should be used when trying to
+   * execute subscription GraphQL requests. If an empty string, the default
+   * should be used that's based on the iFrame location.
+   */
+  graphQLSubscriptionURI: string;
+
+  /**
    * featureFlags are all the feature flags currently enabled on the tenant.
    */
   featureFlags: string[];

--- a/src/core/server/app/router/index.ts
+++ b/src/core/server/app/router/index.ts
@@ -30,6 +30,7 @@ export function createRouter(app: AppOptions, options: RouterOptions) {
       // When mounting client routes, we need to provide a staticURI even when
       // not provided to the default current domain relative "/".
       staticURI: app.config.get("static_uri") || "/",
+      graphQLSubscriptionURI: app.config.get("graphql_subscription_uri") || "",
       featureFlags: [],
     };
 

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -35,9 +35,10 @@ convict.addFormat({
   },
 });
 
-// Add a custom format for the optional-url that includes a trailing slash.
+// Add a custom format for the optional-trailing-url that includes a trailing
+// slash.
 convict.addFormat({
-  name: "optional-url",
+  name: "optional-trailing-url",
   validate: (url: string) => {
     if (url) {
       Joi.assert(url, Joi.string().uri());
@@ -45,6 +46,16 @@ convict.addFormat({
   },
   // Ensure that there is an ending slash.
   coerce: (url: string) => (url ? ensureEndSlash(url) : url),
+});
+
+// Add a custom format for the optional-url.
+convict.addFormat({
+  name: "optional-url",
+  validate: (url: string) => {
+    if (url) {
+      Joi.assert(url, Joi.string().uri());
+    }
+  },
 });
 
 // Add a custom format for a list of comma seperated strings.
@@ -203,9 +214,16 @@ const config = convict({
   },
   static_uri: {
     doc: "The URL that static assets will be hosted from",
-    format: "optional-url",
+    format: "optional-trailing-url",
     default: "",
     env: "STATIC_URI",
+  },
+  graphql_subscription_uri: {
+    doc:
+      "The URL that should be used for GraphQL subscription traffic over websockets",
+    format: "optional-url",
+    default: "",
+    env: "GRAPHQL_SUBSCRIPTION_URI",
   },
   websocket_keep_alive_timeout: {
     doc:
@@ -331,7 +349,7 @@ const config = convict({
   },
   analytics_data_plane_url: {
     doc: "Analytics URL to the RudderStack data plane instance.",
-    format: "optional-url",
+    format: "optional-trailing-url",
     default: "",
     env: "ANALYTICS_DATA_PLANE_URL",
   },


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/main/CONTRIBUTING.md

-->

## What does this PR do?

Adds a `GRAPHQL_SUBSCRIPTION_URI` environment variable for customizing the endpoint that should be used for GraphQL subscription traffic. Note that this will still require integrators to send down the correct `Host` header to the upstream that matches their Coral Tenant domain when performing this proxying.

Note that the scheme on this URI must be one of `ws://` (for non-SSL) or `wss://` (for SSL).

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/main/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/main/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

Set the `GRAPHQL_SUBSCRIPTION_URI` environment variable, and see that it is used.

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->
