### PR TITLE
Live Chat: Allow external media embeds in the stream

### DIFF
--- a/src/core/client/framework/components/Frame.tsx
+++ b/src/core/client/framework/components/Frame.tsx
@@ -8,9 +8,10 @@ interface Props {
   id?: string;
   src: string;
   sandbox?: boolean;
+  className?: string;
 }
 
-const Frame: FunctionComponent<Props> = ({ id, src, sandbox }) => {
+const Frame: FunctionComponent<Props> = ({ id, src, sandbox, className }) => {
   const containerID = useMemo(
     () => (id ? `frame-id-${id}-${uuid()}` : `frame-uuid-${uuid()}`),
     [id]
@@ -37,7 +38,7 @@ const Frame: FunctionComponent<Props> = ({ id, src, sandbox }) => {
   }, [containerID, sandbox, src]);
 
   return (
-    <div id={containerID}>
+    <div id={containerID} className={className}>
       {/* pym will replace the spinner with the iframe when it loads up */}
       <Spinner />
     </div>

--- a/src/core/client/stream/common/Media/ExternalMedia.tsx
+++ b/src/core/client/stream/common/Media/ExternalMedia.tsx
@@ -6,15 +6,23 @@ interface Props {
   id?: string;
   url: string;
   siteID: string;
+  className?: string;
 }
 
-const ExternalMedia: FunctionComponent<Props> = ({ id, url, siteID }) => {
+const ExternalMedia: FunctionComponent<Props> = ({
+  id,
+  url,
+  siteID,
+  className,
+}) => {
   const component = encodeURIComponent(url);
+
   return (
     <Frame
       id={id}
       src={`/api/external-media?url=${component}&siteID=${siteID}`}
       sandbox
+      className={className}
     />
   );
 };

--- a/src/core/client/stream/tabs/Comments/Comment/MediaConfirmation/MediaPreview.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MediaConfirmation/MediaPreview.tsx
@@ -1,4 +1,5 @@
 import { Localized } from "@fluent/react/compat";
+import cn from "classnames";
 import React, { FunctionComponent } from "react";
 
 import { MediaLink } from "coral-common/helpers/findMediaLinks";
@@ -23,6 +24,7 @@ interface Props {
   media: MediaLink;
   onRemove: () => void;
   siteID: string;
+  mode?: "rating" | "comment" | "chat";
 }
 
 const RemoveButton: FunctionComponent<Pick<Props, "onRemove">> = ({
@@ -45,6 +47,7 @@ const MediaPreview: FunctionComponent<Props> = ({
   media,
   onRemove,
   siteID,
+  mode,
 }) => {
   return (
     <MatchMedia gteWidth="xs">
@@ -67,7 +70,11 @@ const MediaPreview: FunctionComponent<Props> = ({
 
             {/* Show the actual media. */}
             {media.type === "external" ? (
-              <ExternalMedia url={media.url} siteID={siteID} />
+              <ExternalMedia
+                url={media.url}
+                siteID={siteID}
+                className={cn({ [styles.miniFrame]: mode === "chat" })}
+              />
             ) : media.type === "twitter" ? (
               <TwitterMedia url={media.url} siteID={siteID} />
             ) : media.type === "youtube" ? (

--- a/src/core/client/stream/tabs/Comments/Stream/CommentForm/CommentForm.css
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentForm/CommentForm.css
@@ -41,16 +41,12 @@ $rteButtonActive: #ddd;
 .chatSubmitButton {
   position: absolute;
   z-index: 1;
-  bottom: 10px;
+  top: 10px;
   right: 8px;
   padding-left: var(--spacing-1);
   padding-right: var(--spacing-1);
   padding-top: var(--spacing-1);
   padding-bottom: var(--spacing-1);
-}
-
-.chatSubmitButtonWithToolbar {
-  bottom: 46px;
 }
 
 .expiredTime {}

--- a/src/core/client/stream/tabs/Comments/Stream/CommentForm/CommentForm.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentForm/CommentForm.tsx
@@ -481,6 +481,7 @@ const CommentForm: FunctionComponent<Props> = ({
                 setPastedMedia={setPastedMedia}
                 siteID={siteID}
                 giphyConfig={mediaConfig.giphy}
+                mode={mode}
               />
             </div>
           );
@@ -495,9 +496,7 @@ const CommentForm: FunctionComponent<Props> = ({
                 (noSubmitWhenPristine && pristine)
               }
               type="submit"
-              className={cn(css.chatSubmitButton, {
-                [css.chatSubmitButtonWithToolbar]: showToolbar,
-              })}
+              className={css.chatSubmitButton}
               title={submitButtonTitle}
             >
               <Icon>send</Icon>

--- a/src/core/client/stream/tabs/Comments/Stream/CommentForm/MediaField.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentForm/MediaField.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent, useCallback, useEffect } from "react";
 import { useField } from "react-final-form";
 
 import { isMediaLink, MediaLink } from "coral-common/helpers/findMediaLinks";
+import LiveMediaPreview from "coral-stream/tabs/Live/LiveMedia/LiveMediaPreview";
 import { Icon } from "coral-ui/components/v2";
 import { CallOut } from "coral-ui/components/v3";
 
@@ -29,6 +30,7 @@ interface Props {
   pastedMedia: MediaLink | null;
   setPastedMedia: (media: MediaLink | null) => void;
   giphyConfig: GiphyConfig;
+  mode?: "rating" | "comment" | "chat";
 }
 
 interface Media {
@@ -46,6 +48,7 @@ const MediaField: FunctionComponent<Props> = ({
   pastedMedia,
   setPastedMedia,
   giphyConfig,
+  mode = "comment",
 }) => {
   const {
     input: { value, onChange },
@@ -161,7 +164,20 @@ const MediaField: FunctionComponent<Props> = ({
       {/* If there's no widget, and we have a valid url, display preview */}
       {!widget && value?.url && valid ? (
         isMediaLink(value) ? (
-          <MediaPreview media={value} siteID={siteID} onRemove={onRemove} />
+          mode === "chat" ? (
+            <LiveMediaPreview
+              media={value}
+              siteID={siteID}
+              onRemove={onRemove}
+            />
+          ) : (
+            <MediaPreview
+              media={value}
+              siteID={siteID}
+              onRemove={onRemove}
+              mode={mode}
+            />
+          )
         ) : (
           <GifPreview url={value.url} onRemove={onRemove} />
         )

--- a/src/core/client/stream/tabs/Live/LiveComment/LiveCommentAvatarAndBodyContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveComment/LiveCommentAvatarAndBodyContainer.tsx
@@ -17,6 +17,8 @@ import { LiveCommentAvatarAndBodyContainer_settings } from "coral-stream/__gener
 import { LiveCommentAvatarAndBodyContainer_story } from "coral-stream/__generated__/LiveCommentAvatarAndBodyContainer_story.graphql";
 import { LiveCommentAvatarAndBodyContainer_viewer } from "coral-stream/__generated__/LiveCommentAvatarAndBodyContainer_viewer.graphql";
 
+import LiveMediaSectionContainer from "../LiveMedia/LiveMediaSectionContainer";
+
 import styles from "./LiveCommentAvatarAndBodyContainer.css";
 
 interface Props {
@@ -125,6 +127,11 @@ const LiveCommentAvatarAndBodyContainer: FunctionComponent<Props> = ({
           <HTMLContent className={cn(styles.body, CLASSES.comment.content)}>
             {comment.body || ""}
           </HTMLContent>
+          <LiveMediaSectionContainer
+            comment={comment}
+            settings={settings}
+            defaultExpanded={true}
+          />
         </div>
       </div>
     </Flex>
@@ -160,7 +167,7 @@ const enhanced = withFragmentContainer<Props>({
       }
       ...UsernameWithPopoverContainer_comment
       ...UserTagsContainer_comment
-      ...MediaSectionContainer_comment
+      ...LiveMediaSectionContainer_comment
     }
   `,
   settings: graphql`
@@ -169,7 +176,7 @@ const enhanced = withFragmentContainer<Props>({
       ...LiveCommentActionsContainer_settings
       ...UsernameWithPopoverContainer_settings
       ...UserTagsContainer_settings
-      ...MediaSectionContainer_settings
+      ...LiveMediaSectionContainer_settings
     }
   `,
 })(LiveCommentAvatarAndBodyContainer);

--- a/src/core/client/stream/tabs/Live/LiveComment/LiveCommentAvatarAndBodyContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveComment/LiveCommentAvatarAndBodyContainer.tsx
@@ -31,6 +31,7 @@ interface Props {
   onCancel?: () => void;
 
   truncateBody?: boolean;
+  mediaMode?: "default" | "mini";
 }
 
 const LiveCommentAvatarAndBodyContainer: FunctionComponent<Props> = ({
@@ -41,6 +42,7 @@ const LiveCommentAvatarAndBodyContainer: FunctionComponent<Props> = ({
   containerClassName,
   onCancel,
   truncateBody,
+  mediaMode = "default",
 }) => {
   return (
     <Flex justifyContent="flex-start" alignItems="flex-start">
@@ -131,6 +133,7 @@ const LiveCommentAvatarAndBodyContainer: FunctionComponent<Props> = ({
             comment={comment}
             settings={settings}
             defaultExpanded={true}
+            mode={mediaMode}
           />
         </div>
       </div>

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveConversationContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveConversationContainer.tsx
@@ -368,6 +368,7 @@ const LiveConversationContainer: FunctionComponent<Props> = ({
                   settings={settings}
                   onInView={handleCommentInView}
                   truncateBody
+                  mediaMode="mini"
                 />
               </div>
               <Virtuoso

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveReplyCommentForm.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveReplyCommentForm.tsx
@@ -54,9 +54,7 @@ const LiveCommentForm: FunctionComponent<LiveCommentFormProps> = (props) => {
 
   // TODO @nick-funk, hook up media config when we have designs
   const mediaConfig = {
-    external: {
-      enabled: false,
-    },
+    external: props.mediaConfig.external,
     youtube: {
       enabled: false,
     },

--- a/src/core/client/stream/tabs/Live/LiveConversation/LiveReplyContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveConversation/LiveReplyContainer.tsx
@@ -34,6 +34,7 @@ interface Props {
 
   truncateBody?: boolean;
   highlight?: boolean;
+  mediaMode?: "default" | "mini";
 }
 
 const LiveReplyContainer: FunctionComponent<Props> = ({
@@ -47,6 +48,7 @@ const LiveReplyContainer: FunctionComponent<Props> = ({
   onCancelEditing,
   truncateBody,
   highlight,
+  mediaMode = "default",
 }) => {
   const [showReportFlow, , toggleShowReportFlow] = useToggleState(false);
 
@@ -127,6 +129,7 @@ const LiveReplyContainer: FunctionComponent<Props> = ({
           })}
           onCancel={editing ? onCancelEditing : undefined}
           truncateBody={truncateBody}
+          mediaMode={mediaMode}
         />
 
         <div id={`reply-${comment.id}`}>

--- a/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaPreview.css
+++ b/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaPreview.css
@@ -29,4 +29,6 @@
 
 .miniFrame {
   width: 80px;
+  max-height: 165px;
+  overflow: hidden;
 }

--- a/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaPreview.css
+++ b/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaPreview.css
@@ -19,6 +19,7 @@
 
 .link {
   overflow: hidden;
+  margin-left: var(--spacing-2);
 }
 
 .removeButton {

--- a/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaPreview.tsx
+++ b/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaPreview.tsx
@@ -1,0 +1,100 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent } from "react";
+
+import { MediaLink } from "coral-common/helpers/findMediaLinks";
+import {
+  ExternalMedia,
+  TwitterMedia,
+  YouTubeMedia,
+} from "coral-stream/common/Media";
+import MediaConfirmationIcon from "coral-stream/tabs/Comments/Comment/MediaConfirmation/MediaConfirmationIcon";
+import {
+  Flex,
+  HorizontalGutter,
+  Icon,
+  MatchMedia,
+} from "coral-ui/components/v2";
+import { Button } from "coral-ui/components/v3";
+
+import styles from "./LiveMediaPreview.css";
+
+interface Props {
+  media: MediaLink;
+  onRemove: () => void;
+  siteID: string;
+}
+
+const RemoveButton: FunctionComponent<Pick<Props, "onRemove">> = ({
+  onRemove,
+}) => (
+  <Button
+    onClick={onRemove}
+    color="secondary"
+    variant="flat"
+    paddingSize="extraSmall"
+  >
+    <Icon size="sm">close</Icon>
+    <Localized id="comments-postComment-confirmMedia-remove">
+      <span>Remove</span>
+    </Localized>
+  </Button>
+);
+
+const LiveMediaPreview: FunctionComponent<Props> = ({
+  media,
+  onRemove,
+  siteID,
+}) => {
+  return (
+    <MatchMedia gteWidth="xs">
+      {(matches) => (
+        <>
+          <HorizontalGutter spacing={3} className={styles.root}>
+            <Flex alignItems="center">
+              <>
+                {/* Show the actual media. */}
+                {media.type === "external" ? (
+                  <ExternalMedia
+                    url={media.url}
+                    siteID={siteID}
+                    className={styles.miniFrame}
+                  />
+                ) : media.type === "twitter" ? (
+                  <TwitterMedia url={media.url} siteID={siteID} />
+                ) : media.type === "youtube" ? (
+                  <YouTubeMedia url={media.url} siteID={siteID} />
+                ) : null}
+              </>
+              <div>
+                <Flex spacing={2} alignItems="baseline" className={styles.link}>
+                  <div>
+                    <MediaConfirmationIcon media={media} />
+                  </div>
+                  <div className={styles.url}>
+                    <a
+                      href={media.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {media.url}
+                    </a>
+                  </div>
+                </Flex>
+                {matches && <RemoveButton onRemove={onRemove} />}
+              </div>
+            </Flex>
+          </HorizontalGutter>
+
+          {/* On extra small screens, move the remove button to the bottom! */}
+          {!matches && (
+            <Flex justifyContent="center" className={styles.removeButton}>
+              <RemoveButton onRemove={onRemove} />
+            </Flex>
+          )}
+        </>
+      )}
+    </MatchMedia>
+  );
+};
+
+export default LiveMediaPreview;

--- a/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.css
+++ b/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.css
@@ -1,0 +1,7 @@
+.button {
+  background-color: transparent;
+}
+
+.miniFrame {
+  width: 80px;
+}

--- a/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.css
+++ b/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.css
@@ -4,4 +4,12 @@
 
 .miniFrame {
   width: 80px;
+  max-height: 165px;
+  overflow: hidden;
+}
+
+.frameLimits {
+  max-width: 350px;
+  max-height: 725px;
+  overflow: hidden;
 }

--- a/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.tsx
@@ -1,0 +1,211 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent, useCallback, useState } from "react";
+import { graphql } from "react-relay";
+
+import { withFragmentContainer } from "coral-framework/lib/relay";
+import {
+  ExternalMedia,
+  GiphyMedia,
+  TwitterMedia,
+  YouTubeMedia,
+} from "coral-stream/common/Media";
+import { Button, ButtonIcon, HorizontalGutter } from "coral-ui/components/v2";
+
+import { LiveMediaSectionContainer_comment } from "coral-stream/__generated__/LiveMediaSectionContainer_comment.graphql";
+import { LiveMediaSectionContainer_settings } from "coral-stream/__generated__/LiveMediaSectionContainer_settings.graphql";
+
+import styles from "./LiveMediaSectionContainer.css";
+
+interface Props {
+  comment: LiveMediaSectionContainer_comment;
+  settings: LiveMediaSectionContainer_settings;
+  defaultExpanded?: boolean;
+}
+
+const LiveMediaSectionContainer: FunctionComponent<Props> = ({
+  comment,
+  settings,
+  defaultExpanded = false,
+}) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const onToggleExpand = useCallback(() => {
+    setExpanded((v) => !v);
+  }, []);
+
+  const media = comment.revision?.media;
+  if (!media) {
+    return null;
+  }
+
+  if (
+    (media.__typename === "TwitterMedia" && !settings.media.twitter.enabled) ||
+    (media.__typename === "YouTubeMedia" && !settings.media.youtube.enabled) ||
+    (media.__typename === "GiphyMedia" && !settings.media.giphy.enabled) ||
+    (media.__typename === "ExternalMedia" && !settings.media.external.enabled)
+  ) {
+    return null;
+  }
+
+  if (!expanded) {
+    return (
+      <Button
+        iconLeft
+        variant="outlined"
+        color="stream"
+        onClick={onToggleExpand}
+        size="small"
+        className={styles.button}
+      >
+        {media.__typename === "ExternalMedia" && (
+          <ExternalMedia
+            id={comment.id}
+            url={media.url}
+            siteID={comment.site.id}
+            className={styles.miniFrame}
+          />
+        )}
+
+        <ButtonIcon>add</ButtonIcon>
+        {media.__typename === "TwitterMedia" && (
+          <Localized id="comments-embedLinks-show-twitter">
+            Show Tweet
+          </Localized>
+        )}
+        {media.__typename === "YouTubeMedia" && (
+          <Localized id="comments-embedLinks-show-youtube">
+            Show video
+          </Localized>
+        )}
+        {media.__typename === "ExternalMedia" && (
+          <Localized id="comments-embedLinks-show-external">
+            Show image
+          </Localized>
+        )}
+        {media.__typename === "GiphyMedia" && (
+          <Localized id="comments-embedLinks-show-giphy">Show GIF</Localized>
+        )}
+      </Button>
+    );
+  }
+
+  return (
+    <HorizontalGutter>
+      <div>
+        <Button
+          variant="outlined"
+          color="stream"
+          onClick={onToggleExpand}
+          size="small"
+          iconLeft
+          className={styles.button}
+        >
+          <ButtonIcon>remove</ButtonIcon>
+          {media.__typename === "TwitterMedia" && (
+            <Localized id="comments-embedLinks-hide-twitter">
+              Hide Tweet
+            </Localized>
+          )}
+          {media.__typename === "GiphyMedia" && (
+            <Localized id="comments-embedLinks-hide-giphy">Hide GIF</Localized>
+          )}
+          {media.__typename === "YouTubeMedia" && (
+            <Localized id="comments-embedLinks-hide-youtube">
+              Hide video
+            </Localized>
+          )}
+          {media.__typename === "ExternalMedia" && (
+            <Localized id="comments-embedLinks-hide-external">
+              Hide image
+            </Localized>
+          )}
+        </Button>
+      </div>
+      {media.__typename === "ExternalMedia" && (
+        <ExternalMedia
+          id={comment.id}
+          url={media.url}
+          siteID={comment.site.id}
+        />
+      )}
+      {media.__typename === "TwitterMedia" && (
+        <TwitterMedia
+          id={comment.id}
+          url={media.url}
+          siteID={comment.site.id}
+        />
+      )}
+      {media.__typename === "YouTubeMedia" && (
+        <YouTubeMedia
+          id={comment.id}
+          url={media.url}
+          siteID={comment.site.id}
+        />
+      )}
+      {media.__typename === "GiphyMedia" && (
+        <GiphyMedia
+          url={media.url}
+          width={media.width}
+          height={media.height}
+          title={media.title}
+          video={media.video}
+        />
+      )}
+    </HorizontalGutter>
+  );
+};
+
+const enhanced = withFragmentContainer<Props>({
+  comment: graphql`
+    fragment LiveMediaSectionContainer_comment on Comment {
+      id
+      site {
+        id
+      }
+      revision {
+        media {
+          __typename
+          ... on GiphyMedia {
+            url
+            title
+            width
+            height
+            still
+            video
+          }
+          ... on TwitterMedia {
+            url
+            width
+          }
+          ... on YouTubeMedia {
+            url
+            width
+            height
+          }
+          ... on ExternalMedia {
+            url
+          }
+        }
+      }
+    }
+  `,
+  settings: graphql`
+    fragment LiveMediaSectionContainer_settings on Settings {
+      media {
+        twitter {
+          enabled
+        }
+        youtube {
+          enabled
+        }
+        giphy {
+          enabled
+        }
+        external {
+          enabled
+        }
+      }
+    }
+  `,
+})(LiveMediaSectionContainer);
+
+export default enhanced;

--- a/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.tsx
@@ -133,6 +133,7 @@ const LiveMediaSectionContainer: FunctionComponent<Props> = ({
           id={comment.id}
           url={media.url}
           siteID={comment.site.id}
+          className={styles.frameLimits}
         />
       )}
       {media.__typename === "TwitterMedia" && (

--- a/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.tsx
+++ b/src/core/client/stream/tabs/Live/LiveMedia/LiveMediaSectionContainer.tsx
@@ -20,12 +20,14 @@ interface Props {
   comment: LiveMediaSectionContainer_comment;
   settings: LiveMediaSectionContainer_settings;
   defaultExpanded?: boolean;
+  mode?: "default" | "mini";
 }
 
 const LiveMediaSectionContainer: FunctionComponent<Props> = ({
   comment,
   settings,
   defaultExpanded = false,
+  mode = "default",
 }) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const onToggleExpand = useCallback(() => {
@@ -46,7 +48,7 @@ const LiveMediaSectionContainer: FunctionComponent<Props> = ({
     return null;
   }
 
-  if (!expanded) {
+  if (!expanded || mode === "mini") {
     return (
       <Button
         iconLeft
@@ -65,24 +67,30 @@ const LiveMediaSectionContainer: FunctionComponent<Props> = ({
           />
         )}
 
-        <ButtonIcon>add</ButtonIcon>
-        {media.__typename === "TwitterMedia" && (
-          <Localized id="comments-embedLinks-show-twitter">
-            Show Tweet
-          </Localized>
-        )}
-        {media.__typename === "YouTubeMedia" && (
-          <Localized id="comments-embedLinks-show-youtube">
-            Show video
-          </Localized>
-        )}
-        {media.__typename === "ExternalMedia" && (
-          <Localized id="comments-embedLinks-show-external">
-            Show image
-          </Localized>
-        )}
-        {media.__typename === "GiphyMedia" && (
-          <Localized id="comments-embedLinks-show-giphy">Show GIF</Localized>
+        {mode !== "mini" && (
+          <>
+            <ButtonIcon>add</ButtonIcon>
+            {media.__typename === "TwitterMedia" && (
+              <Localized id="comments-embedLinks-show-twitter">
+                Show Tweet
+              </Localized>
+            )}
+            {media.__typename === "YouTubeMedia" && (
+              <Localized id="comments-embedLinks-show-youtube">
+                Show video
+              </Localized>
+            )}
+            {media.__typename === "ExternalMedia" && (
+              <Localized id="comments-embedLinks-show-external">
+                Show image
+              </Localized>
+            )}
+            {media.__typename === "GiphyMedia" && (
+              <Localized id="comments-embedLinks-show-giphy">
+                Show GIF
+              </Localized>
+            )}
+          </>
         )}
       </Button>
     );

--- a/src/core/client/stream/tabs/Live/LivePostCommentForm.tsx
+++ b/src/core/client/stream/tabs/Live/LivePostCommentForm.tsx
@@ -53,9 +53,7 @@ const LiveCommentForm: FunctionComponent<LiveCommentFormProps> = (props) => {
 
   // TODO @nick-funk, hook up media config when we have designs
   const mediaConfig = {
-    external: {
-      enabled: true,
-    },
+    external: props.mediaConfig.external,
     youtube: {
       enabled: false,
     },

--- a/src/core/client/stream/tabs/Live/LivePostCommentForm.tsx
+++ b/src/core/client/stream/tabs/Live/LivePostCommentForm.tsx
@@ -54,7 +54,7 @@ const LiveCommentForm: FunctionComponent<LiveCommentFormProps> = (props) => {
   // TODO @nick-funk, hook up media config when we have designs
   const mediaConfig = {
     external: {
-      enabled: false,
+      enabled: true,
     },
     youtube: {
       enabled: false,


### PR DESCRIPTION
## What does this PR do?

Allow users to enable and use external media in the live chat stream.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Enable external media
- Go to live chat
- Make comments with external media embeds added
- See the glorious media appear in the stream
- Check both main stream and the conversation stream
