### PR TITLE
[CORL-1765] Fix: change abusive translation in report

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.tsx
@@ -100,7 +100,7 @@ class ReportCommentForm extends React.Component<Props> {
                         value="COMMENT_REPORTED_ABUSIVE"
                         disabled={submitting}
                       >
-                        This is abusive behaviour
+                        This commenter is being abusive
                       </RadioField>
                     </Localized>
                   </li>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
@@ -70,7 +70,7 @@ exports[`render popup 1`] = `
               className="RadioButton-label"
               htmlFor="reportComment-popover--reason-COMMENT_REPORTED_ABUSIVE"
             >
-              This is abusive behaviour
+              This commenter is being abusive
             </label>
           </div>
         </li>
@@ -293,7 +293,7 @@ exports[`render popup expanded 1`] = `
               className="RadioButton-label"
               htmlFor="reportComment-popover--reason-COMMENT_REPORTED_ABUSIVE"
             >
-              This is abusive behaviour
+              This commenter is being abusive
             </label>
           </div>
         </li>

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -566,7 +566,7 @@ comments-reportPopover-reportThisComment = Report This Comment
 comments-reportPopover-whyAreYouReporting = Why are you reporting this comment?
 
 comments-reportPopover-reasonOffensive = This comment is offensive
-comments-reportPopover-reasonAbusive = This is abusive behaviour
+comments-reportPopover-reasonAbusive = This commenter is being abusive
 comments-reportPopover-reasonIDisagree = I disagree with this comment
 comments-reportPopover-reasonSpam = This looks like an ad or marketing
 comments-reportPopover-reasonOther = Other


### PR DESCRIPTION
## What does this PR do?
- The spelling of 'behaviour' is British spelling currently, we are changing it to something that works across different versions of English.