### PR TITLE
Job Improvements

### DIFF
--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -434,6 +434,27 @@ const config = convict({
     default: false,
     env: "MOUNT_DOCUMENTATION",
   },
+  smtp_transport_send_max: {
+    doc:
+      "Maximum number of emails that a given transport can send before it's reset.",
+    env: "SMTP_TRANSPORT_SEND_MAX",
+    format: Number,
+    default: 50,
+  },
+  smtp_transport_timeout: {
+    doc:
+      "Maximum time that the transport can take sending a Email before it aborts.",
+    format: "ms",
+    default: ms("20s"),
+    env: "SMTP_TRANSPORT_TIMEOUT",
+  },
+  mailer_job_timeout: {
+    doc:
+      "Maximum time that the mailer can take to process any mailer jobs before it aborts.",
+    format: "ms",
+    default: ms("30s"),
+    env: "MAILER_JOB_TIMEOUT",
+  },
 });
 
 export type Config = typeof config;

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -157,6 +157,15 @@ class Server {
       );
     }
 
+    if (
+      this.config.get("smtp_transport_timeout") >=
+      this.config.get("mailer_job_timeout")
+    ) {
+      throw new Error(
+        "SMTP_TRANSPORT_TIMEOUT must be less than MAILER_JOB_TIMEOUT"
+      );
+    }
+
     // Configure the error reporter.
     if (
       this.config.get("env") === "production" &&

--- a/src/core/server/queue/Task.ts
+++ b/src/core/server/queue/Task.ts
@@ -11,53 +11,48 @@ export type JobProcessor<T, U = void> = (job: Job<T>) => Promise<U>;
 interface TaskOptions<T, U = void> {
   jobName: string;
   jobProcessor: JobProcessor<T, U>;
-  jobOptions?: Queue.JobOptions;
   queue: Queue.QueueOptions;
   timeout?: number;
+  jobIdGenerator?: null | ((data: T) => number | string);
 }
 
 export default class Task<T extends TenantResource, U = any> {
-  private readonly options: Required<TaskOptions<T, U>>;
   private readonly queue: QueueType<T>;
   private readonly log: Logger;
+  private readonly options: Queue.JobOptions;
+  private readonly idGenerator: ((data: T) => number | string) | null;
+  private readonly processor: JobProcessor<T, U>;
+  private readonly timeout: number;
 
   constructor({
     jobName,
     jobProcessor,
-    jobOptions = {},
+    jobIdGenerator = null,
     queue,
     timeout = 30000,
   }: TaskOptions<T, U>) {
     this.log = logger.child({ jobName }, true);
     this.queue = new Queue(jobName, queue);
     this.options = {
-      jobName,
-      jobProcessor,
-      jobOptions: {
-        // We always remove the job when it's complete, no need to fill up Redis
-        // with completed entries if we don't need to.
-        removeOnComplete: true,
+      // We always remove the job when it's complete, no need to fill up Redis
+      // with completed entries if we don't need to.
+      removeOnComplete: true,
 
-        // Remove the job if it fails after all attempts.
-        removeOnFail: true,
+      // Remove the job if it fails after all attempts.
+      removeOnFail: true,
 
-        // By default, configure jobs to use an exponential backoff strategy.
-        backoff: {
-          type: "exponential",
-          delay: 10000,
-        },
-
-        // Be default, try all jobs at least 5 times.
-        attempts: 5,
-
-        // Add the custom job options if they exist.
-        ...jobOptions,
+      // By default, configure jobs to use an exponential backoff strategy.
+      backoff: {
+        type: "exponential",
+        delay: 10000,
       },
-      queue,
-      timeout,
-    };
 
-    // TODO: (wyattjoh) attach event handlers to the queue for metrics via: https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#events
+      // Be default, try all jobs at least 5 times.
+      attempts: 5,
+    };
+    this.idGenerator = jobIdGenerator;
+    this.processor = jobProcessor;
+    this.timeout = timeout;
   }
 
   public async counts(): Promise<JobCounts> {
@@ -71,8 +66,14 @@ export default class Task<T extends TenantResource, U = any> {
    * @param data the data for the job to add.
    */
   public async add(data: T): Promise<Queue.Job<T> | undefined> {
+    // Generate the ID if we need to.
+    const options = { ...this.options };
+    if (this.idGenerator) {
+      options.jobId = this.idGenerator(data);
+    }
+
     // Create the job.
-    const job = await this.queue.add(data, this.options.jobOptions);
+    const job = await this.queue.add(data, options);
 
     this.log.info({ jobID: job.id }, "added job to queue");
     return job;
@@ -102,8 +103,8 @@ export default class Task<T extends TenantResource, U = any> {
         // Send the job off to the job processor to be handled. If the
         // processing of the job takes too long time it out.
         const promise: U = await timeoutPromiseAfter(
-          this.options.jobProcessor(job),
-          this.options.timeout
+          this.processor(job),
+          this.timeout
         );
 
         // Log it!

--- a/src/core/server/queue/tasks/mailer/index.ts
+++ b/src/core/server/queue/tasks/mailer/index.ts
@@ -32,6 +32,9 @@ export class MailerQueue {
       jobName: JOB_NAME,
       jobProcessor: createJobProcessor(options),
       queue,
+      // Time the mailer job out after the specified timeout value has been
+      // reached.
+      timeout: options.config.get("mailer_job_timeout"),
     });
     this.content = new MailerContent(options);
     this.tenantCache = options.tenantCache;

--- a/src/core/server/queue/tasks/rejector.ts
+++ b/src/core/server/queue/tasks/rejector.ts
@@ -116,5 +116,9 @@ export function createRejectorTask(
     jobName: JOB_NAME,
     jobProcessor: createJobProcessor(options),
     queue,
+    // We will generate a stable job ID for these rejector jobs. This ensures
+    // that we cannot add multiple rejector jobs for the same user while one is
+    // already in progress.
+    jobIdGenerator: ({ tenantID, authorID }) => `${tenantID}:${authorID}`,
   });
 }

--- a/src/core/server/queue/tasks/scraper.ts
+++ b/src/core/server/queue/tasks/scraper.ts
@@ -62,5 +62,9 @@ export function createScraperTask(
     // give the scraper a chance to time itself out after the scraper fails, but
     // will catch it if the scraping takes too long.
     timeout: options.config.get("scrape_timeout") * 2,
+    // We will generate a stable job ID for these scrape jobs. This ensures that
+    // we cannot add multiple scraper jobs for the same story multiple times
+    // while one is already in progress.
+    jobIdGenerator: ({ tenantID, storyID }) => `${tenantID}:${storyID}`,
   });
 }

--- a/src/core/server/services/tenant/cache/adapter.ts
+++ b/src/core/server/services/tenant/cache/adapter.ts
@@ -46,6 +46,20 @@ export default class TenantCacheAdapter<T> {
     }
   };
 
+  /**
+   * delete the cached instance (if cached) for this Tenant. This does not call
+   * the optional deconstruction function.
+   *
+   * @param tenantID the tenantID for the cached item
+   */
+  public delete(tenantID: string) {
+    if (this.tenantCache.cachingEnabled) {
+      this.cache.delete(tenantID);
+    }
+
+    return;
+  }
+
   public subscribe() {
     if (this.tenantCache.cachingEnabled && !this.unsubscribeFn) {
       this.unsubscribeFn = this.tenantCache.subscribe(


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/main/CONTRIBUTING.md

-->

## What does this PR do?

1. Enhances the scraper and rejector jobs so that their ID's are deterministic and based on the job input. This prevents duplicate jobs from being inserted for the same task, and avoids the "thundering herd" issue with creating jobs.
2. Added more sophisticated logic around SMTP traffic to recreate the transport when a certain amount of emails have been sent (recommended by [Amazon](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/troubleshoot-smtp.html)), or an error occurs during the sending process. It does this be including three new environment variables, `SMTP_TRANSPORT_SEND_MAX`, `SMTP_TRANSPORT_TIMEOUT`, and `MAILER_JOB_TIMEOUT`.

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/main/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/main/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

We've verified that resetting the transport will repair issues with connectivity issues with the SMTP server, but validation of the thundering herd can be done by disabling job processing (with `DISABLE_JOB_PROCESSORS=true`) and visiting a URL that was not scraped before. You can then run `KEYS *` in Redis and see only a single `{queue}:scraper:${TENANT_ID}:${STORY_ID}` entry and not multiple after each refresh.