### PR TITLE
[CORL-1627] Show "new commenter" flags even when site wide premod is enabled

### DIFF
--- a/src/core/server/services/comments/pipeline/phases/index.ts
+++ b/src/core/server/services/comments/pipeline/phases/index.ts
@@ -61,9 +61,9 @@ export const moderationPhases: IntermediateModerationPhase[] = [
   detectLinks,
 
   // Apply any pre-existing conditions to these comments.
+  statusPreModerateNewCommenter,
   statusPreModerate,
   statusPreModerateUser,
-  statusPreModerateNewCommenter,
 
   // Run any external moderation phase that missed other filters.
   external,


### PR DESCRIPTION
## What does this PR do?

Move up the new-user premod check in pipeline

This allows the new user pre-mod filter to run
before it tries to block via a site wide pre-mod
filter. This lets the "new commenter" tag show
even if site wide pre-mod is turned on.

Otherwise, premod behaves as normally expected.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Enable site wide premod
- Enable new commenter premod
- Make comments with new commenter
- See that they are marked with 'new commenter' in moderation
- Make comments with non-new commenter
- See that they are pre-modded because of site wide premod
- Turn site wide pre-mod off
- Make more comments with non-new commenter
- See that they are not pre-modded
- Approve the new commenter's comments so they are no longer a new commenter
- Make more comments with the formerly "new commenter"
- See that their comments are no longer pre-modded
- Turn off the new commenter pre-mod option
- Make yet another new commenter
- Make comments with this new commenter
- Make sure the comments are not pre-modded
