### PR TITLE
[CORL-2147] Track queue sort change events into metrics

### DIFF
--- a/CLIENT_EVENTS.md
+++ b/CLIENT_EVENTS.md
@@ -356,13 +356,7 @@ createComment.error
 - <a id="queueSortChanged">**queueSortChanged**</a>: This event is emitted when the viewer changes the moderation queue sort.
   ```ts
   {
-      success: {
-          sortOrder: string;
-      };
-      error: {
-          message: string;
-          code?: string | undefined;
-      };
+      sortOrder: string;
   }
   ```
 - <a id="rejectComment">**rejectComment.success**, **rejectComment.error**</a>: This event is emitted when the viewer rejects a comment.

--- a/CLIENT_EVENTS.md
+++ b/CLIENT_EVENTS.md
@@ -353,7 +353,7 @@ createComment.error
       };
   }
   ```
-- <a id="queueSortChanged">**queueSortChanged.success**, **queueSortChanged.error**</a>: This event is emitted when the viewer changes the moderation queue sort.
+- <a id="queueSortChanged">**queueSortChanged**</a>: This event is emitted when the viewer changes the moderation queue sort.
   ```ts
   {
       success: {

--- a/CLIENT_EVENTS.md
+++ b/CLIENT_EVENTS.md
@@ -100,6 +100,7 @@ createComment.error
 - <a href="#loginPrompt">loginPrompt</a>
 - <a href="#openSortMenu">openSortMenu</a>
 - <a href="#openStory">openStory</a>
+- <a href="#queueSortChanged">queueSortChanged</a>
 - <a href="#rejectComment">rejectComment</a>
 - <a href="#removeCommentReaction">removeCommentReaction</a>
 - <a href="#removeUserIgnore">removeUserIgnore</a>
@@ -346,6 +347,18 @@ createComment.error
   {
       storyID: string;
       success: {};
+      error: {
+          message: string;
+          code?: string | undefined;
+      };
+  }
+  ```
+- <a id="queueSortChanged">**queueSortChanged.success**, **queueSortChanged.error**</a>: This event is emitted when the viewer changes the moderation queue sort.
+  ```ts
+  {
+      success: {
+          sortOrder: string;
+      };
       error: {
           message: string;
           code?: string | undefined;

--- a/src/core/client/admin/routes/Moderate/Queue/QueueSort/ChangeQueueSortMutation.ts
+++ b/src/core/client/admin/routes/Moderate/Queue/QueueSort/ChangeQueueSortMutation.ts
@@ -19,8 +19,9 @@ export async function commit(
   await context.localStorage.setItem(MOD_QUEUE_SORT_ORDER, input.sortOrder);
 
   // Track event
-  const sortChangedEvent = QueueSortChangedEvent.begin(context.eventEmitter);
-  sortChangedEvent.success({ sortOrder: input.sortOrder });
+  QueueSortChangedEvent.emit(context.eventEmitter, {
+    sortOrder: input.sortOrder,
+  });
 
   // Set in Relay
   return commitLocalUpdate(environment, (store) => {

--- a/src/core/client/admin/routes/Moderate/Queue/QueueSort/ChangeQueueSortMutation.ts
+++ b/src/core/client/admin/routes/Moderate/Queue/QueueSort/ChangeQueueSortMutation.ts
@@ -4,6 +4,7 @@ import { MOD_QUEUE_SORT_ORDER } from "coral-admin/constants";
 import { CoralContext } from "coral-framework/lib/bootstrap";
 import { createMutation, LOCAL_ID } from "coral-framework/lib/relay";
 import { GQLCOMMENT_SORT_RL } from "coral-framework/schema";
+import { QueueSortChangedEvent } from "coral-stream/events";
 
 export interface Input {
   sortOrder: GQLCOMMENT_SORT_RL;
@@ -16,6 +17,10 @@ export async function commit(
 ) {
   // Set in local storage
   await context.localStorage.setItem(MOD_QUEUE_SORT_ORDER, input.sortOrder);
+
+  // Track event
+  const sortChangedEvent = QueueSortChangedEvent.begin(context.eventEmitter);
+  sortChangedEvent.success({ sortOrder: input.sortOrder });
 
   // Set in Relay
   return commitLocalUpdate(environment, (store) => {

--- a/src/core/client/stream/events.ts
+++ b/src/core/client/stream/events.ts
@@ -627,7 +627,7 @@ export const CancelAccountDeletionEvent = createViewerNetworkEvent<{
  * This event is emitted when the viewer changes the moderation
  * queue sort.
  */
-export const QueueSortChangedEvent = createViewerNetworkEvent<{
+export const QueueSortChangedEvent = createViewerEvent<{
   success: {
     sortOrder: string;
   };

--- a/src/core/client/stream/events.ts
+++ b/src/core/client/stream/events.ts
@@ -628,11 +628,5 @@ export const CancelAccountDeletionEvent = createViewerNetworkEvent<{
  * queue sort.
  */
 export const QueueSortChangedEvent = createViewerEvent<{
-  success: {
-    sortOrder: string;
-  };
-  error: {
-    message: string;
-    code?: string;
-  };
+  sortOrder: string;
 }>("queueSortChangedEvent");

--- a/src/core/client/stream/events.ts
+++ b/src/core/client/stream/events.ts
@@ -622,3 +622,17 @@ export const CancelAccountDeletionEvent = createViewerNetworkEvent<{
     code?: string;
   };
 }>("cancelAccountDeletionEvent");
+
+/**
+ * This event is emitted when the viewer changes the moderation
+ * queue sort.
+ */
+export const QueueSortChangedEvent = createViewerNetworkEvent<{
+  success: {
+    sortOrder: string;
+  };
+  error: {
+    message: string;
+    code?: string;
+  };
+}>("queueSortChangedEvent");


### PR DESCRIPTION
## What does this PR do?

When the user changes the sortedBy in the moderation queues, we fire an event with the eventEmitter that can be collected into our metrics.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Start up app
- Go to mod queues
- Change sort by back and forth
- See event emitter logs in the Coral CLI output