### PR TITLE
Fix bug leading to e-mail leak

### DIFF
--- a/graph/resolvers/util.js
+++ b/graph/resolvers/util.js
@@ -70,7 +70,7 @@ const wrapCheck = (
  * @param {Array<String>} permissions permissions that the user must have
  */
 const checkPermissions = (ctx, permissions) =>
-  ctx.user && ctx.user.can(...permissions);
+  !!(ctx.user && ctx.user.can(...permissions));
 
 /**
  * wrapCheckPermissions will wrap a specific field with a permission check.


### PR DESCRIPTION
Talk version 4 exposes private information such as e-mail addresses to unauthenticated queries because of a simple bug. This pull-request fixes the bug and thus closes the e-mail leak.