### PR TITLE
Fix restart policies in example docker-compose.yml

### DIFF
--- a/docs/source/01-01-installation.md
+++ b/docs/source/01-01-installation.md
@@ -59,10 +59,12 @@ services:
       - SIGNING_SECRET=<replace me with something secret>
   mongo:
     image: mongo:4.2
+    restart: always
     volumes:
       - ./data/mongo:/data/db
   redis:
     image: redis:3.2
+    restart: always
     volumes:
       - ./data/redis:/data
 EOF


### PR DESCRIPTION
Add restart policy for the `mongo` and `redis` containers in the example `docker-compose.yml`. Without these, if you only use `docker-compose up -d`, these dependencies will not restart on reboot, and the main container will be in an endless restart loop until you manually start the dependencies. At least this is what I am experiencing `Linux 5.11.12-arch1-1`, `community/docker 1:20.10.5-1`, and `community/docker-compose 1.29.0-1`. Adding the restart policies for the dependencies fixes the problem.