### PR TITLE
Non-Fingerprinted Files Cache Fix

### DIFF
--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -448,6 +448,12 @@ const config = convict({
     default: ms("30s"),
     env: "MAILER_JOB_TIMEOUT",
   },
+  non_fingerprinted_cache_max_age: {
+    doc: "Max age for the ",
+    format: "ms",
+    default: ms("30 minutes"),
+    env: "NON_FINGERPRINTED_CACHE_MAX_AGE",
+  },
 });
 
 export type Config = typeof config;


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/main/CONTRIBUTING.md

-->

## What does this PR do?

This introduces new behaviour for non-fingerprinted files such as the `/assets/js/embed.js` and the `/assets/js/count.js` files that do not contain fingerprints in their filenames.

- Now, these will come with a `s-max-age=604800` to stay cached in the CDN for up to a week
- A new `NON_FINGERPRINTED_CACHE_MAX_AGE` environment variable has been added to control the `max-age` header sent on these non-fingerprinted files (defaults to 30 minutes)

<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/main/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/blob/main/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

```bash
$ # For the embed.js file...
$ curl -v http://localhost:3000/assets/js/embed.js 1> /dev/null
# ...
< Cache-Control: public, max-age=3600, s-max-age=604800
# ...

$ # For the a fingerprinted file...
$ curl -v http://localhost:3000/assets/media/source-sans-pro-latin-400.899c8f78ce650d4009d42443897aa723.woff2 1> /dev/null
# ...
< Cache-Control: public, max-age=604800
# ...
```