### PR TITLE
fix: pass requests with expired jwt

### DIFF
--- a/src/core/server/app/middleware/passport/strategies/jwt.ts
+++ b/src/core/server/app/middleware/passport/strategies/jwt.ts
@@ -101,7 +101,7 @@ export async function verifyAndRetrieveUser(
     // request rather than erroring out.
     if (
       err instanceof JWTRevokedError ||
-      err.jse_cause instanceof TokenExpiredError
+      err.cause() instanceof TokenExpiredError
     ) {
       return null;
     }

--- a/src/core/server/app/middleware/passport/strategies/jwt.ts
+++ b/src/core/server/app/middleware/passport/strategies/jwt.ts
@@ -1,4 +1,4 @@
-import jwt from "jsonwebtoken";
+import jwt, { TokenExpiredError } from "jsonwebtoken";
 import { Strategy } from "passport-strategy";
 
 import { AppOptions } from "coral-server/app";
@@ -99,7 +99,10 @@ export async function verifyAndRetrieveUser(
   } catch (err) {
     // When the JWT was revoked, just indicate that there is no user on the
     // request rather than erroring out.
-    if (err instanceof JWTRevokedError) {
+    if (
+      err instanceof JWTRevokedError ||
+      err.jse_cause instanceof TokenExpiredError
+    ) {
       return null;
     }
 


### PR DESCRIPTION
## What does this PR do?
This PR updates our JWTStrategy so that when a token is expired but otherwise valid, the request will be allowed to proceed as if it is an unauthenticated request (it may still later be rejected if the specific request required authorization. Essentially our auth layer punts on the issue).

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## How do I test this PR?
Let your JWT expire (I temporarily changed my tenants ttl to 10 seconds in the db) and then make a request. You should no longer receive a 401.
