### PR TITLE
[CORL-1596] Move deleted comments into approve/rejected queues

### DIFF
--- a/src/core/server/cron/accountDeletion.ts
+++ b/src/core/server/cron/accountDeletion.ts
@@ -2,6 +2,7 @@ import { Db } from "mongodb";
 
 import { retrieveUserScheduledForDeletion } from "coral-server/models/user";
 import { MailerQueue } from "coral-server/queue/tasks/mailer";
+import { AugmentedRedis } from "coral-server/services/redis";
 import { TenantCache } from "coral-server/services/tenant/cache";
 import { deleteUser } from "coral-server/services/users/delete";
 
@@ -13,6 +14,7 @@ import {
 
 interface Options {
   mongo: Db;
+  redis: AugmentedRedis;
   mailerQueue: MailerQueue;
   tenantCache: TenantCache;
 }
@@ -34,6 +36,7 @@ export function registerAccountDeletion(
 const deleteScheduledAccounts: ScheduledJobCommand<Options> = async ({
   log,
   mongo,
+  redis,
   mailerQueue,
   tenantCache,
 }) => {
@@ -59,7 +62,7 @@ const deleteScheduledAccounts: ScheduledJobCommand<Options> = async ({
 
       log.info({ userID: user.id }, "deleting user");
 
-      await deleteUser(mongo, user.id, tenant.id, now);
+      await deleteUser(mongo, redis, user.id, tenant.id, now);
 
       // If the user has an email, then send them a confirmation that their account
       // was deleted.

--- a/src/core/server/cron/index.ts
+++ b/src/core/server/cron/index.ts
@@ -3,6 +3,7 @@ import { Db } from "mongodb";
 import { Config } from "coral-server/config";
 import { MailerQueue } from "coral-server/queue/tasks/mailer";
 import { JWTSigningConfig } from "coral-server/services/jwt";
+import { AugmentedRedis } from "coral-server/services/redis";
 import { TenantCache } from "coral-server/services/tenant/cache";
 
 import { registerAccountDeletion } from "./accountDeletion";
@@ -15,6 +16,7 @@ export interface ScheduledJobGroups {
 
 interface Options {
   mongo: Db;
+  redis: AugmentedRedis;
   config: Config;
   mailerQueue: MailerQueue;
   signingConfig: JWTSigningConfig;

--- a/src/core/server/graph/mutators/Users.ts
+++ b/src/core/server/graph/mutators/Users.ts
@@ -168,7 +168,13 @@ export const Users = (ctx: GraphContext) => ({
       throw new Error("cannot delete self immediately");
     }
 
-    return deleteUser(ctx.mongo, input.userID, ctx.tenant.id, ctx.now);
+    return deleteUser(
+      ctx.mongo,
+      ctx.redis,
+      input.userID,
+      ctx.tenant.id,
+      ctx.now
+    );
   },
   cancelAccountDeletion: async (
     input: GQLCancelAccountDeletionInput

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -318,6 +318,7 @@ class Server {
     // Start up the cron job processors.
     this.scheduledTasks = startScheduledTasks({
       mongo: this.mongo,
+      redis: this.redis,
       config: this.config,
       mailerQueue: this.tasks.mailer,
       tenantCache: this.tenantCache,

--- a/src/core/server/services/users/delete.ts
+++ b/src/core/server/services/users/delete.ts
@@ -124,7 +124,7 @@ async function moderateComments(
 
   const comments = collections.comments(mongo).find(filter);
 
-  while (comments.hasNext()) {
+  while (await comments.hasNext()) {
     const comment = await comments.next();
     if (!comment) {
       continue;

--- a/src/core/server/services/users/delete.ts
+++ b/src/core/server/services/users/delete.ts
@@ -1,4 +1,4 @@
-import { Collection, Db } from "mongodb";
+import { Collection, Db, FilterQuery } from "mongodb";
 
 import { ACTION_TYPE } from "coral-server/models/action/comment";
 import { getLatestRevision } from "coral-server/models/comment";
@@ -113,7 +113,7 @@ async function moderateComments(
   mongo: Db,
   redis: AugmentedRedis,
   tenantID: string,
-  filter: any,
+  filter: FilterQuery<Comment>,
   targetStatus: GQLCOMMENT_STATUS,
   now: Date
 ) {

--- a/src/core/server/services/users/delete.ts
+++ b/src/core/server/services/users/delete.ts
@@ -1,7 +1,7 @@
 import { Collection, Db, FilterQuery } from "mongodb";
 
 import { ACTION_TYPE } from "coral-server/models/action/comment";
-import { getLatestRevision } from "coral-server/models/comment";
+import { Comment, getLatestRevision } from "coral-server/models/comment";
 import { Story } from "coral-server/models/story";
 import { retrieveTenant } from "coral-server/models/tenant";
 import collections from "coral-server/services/mongodb/collections";


### PR DESCRIPTION
## What does this PR do?

When a user is deleted, the comments for that user are approved and rejected accordingly depending on whether they have replies or not.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Create a user
- Create some comments for them
- Get some of the comments to be reported
- Ensure that several of the comments have replies from another commenter too
- Use the following mutation or set the account for deletion and delete the user

```
mutation ($userID: ID!, $clientMutationId: String!) {
  deleteUserAccount(input: {
    userID: $userID,
    clientMutationId: $clientMutationId
  }) {
    user {
      id
    }
  }
}
```

- Make sure the deletion mutation returns successfully
- Check the comment streams and queues
- The comments should either be deleted (no replies) or show a tombstone (has replies)
- The comments should be in the rejected queue (no replies) or in the approved queue (has replies)
