### PR TITLE
[CORL-1693] send error payload in retry callback abort method

### DIFF
--- a/src/core/client/framework/lib/network/createNetwork.ts
+++ b/src/core/client/framework/lib/network/createNetwork.ts
@@ -81,15 +81,12 @@ export default function createNetwork(
         statusCodes: [500, 503, 504],
         beforeRetry: ({ abort, attempt, lastError }) => {
           if (attempt > 2) {
-            const payload = JSON.stringify({
-              note: "aborted in beforeRetry() callback.",
-              error: {
-                name: lastError?.name,
-                message: lastError?.message,
-                stack: lastError?.stack,
-              },
-            });
-            abort(payload);
+            let message = lastError?.message;
+            if (message && lastError?.name !== "RRNLRetryMiddlewareError") {
+              // Prefix with Error name.
+              message = `(${lastError?.name}) ${message}`;
+            }
+            abort(message);
           }
         },
       }),

--- a/src/core/client/framework/lib/network/createNetwork.ts
+++ b/src/core/client/framework/lib/network/createNetwork.ts
@@ -79,9 +79,17 @@ export default function createNetwork(
         retryDelays: (attempt: number) => Math.pow(2, attempt + 4) * 100,
         // or simple array [3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600],
         statusCodes: [500, 503, 504],
-        beforeRetry: ({ abort, attempt }) => {
+        beforeRetry: ({ abort, attempt, lastError }) => {
           if (attempt > 2) {
-            abort();
+            const payload = JSON.stringify({
+              note: "aborted in beforeRetry() callback.",
+              error: {
+                name: lastError?.name,
+                message: lastError?.message,
+                stack: lastError?.stack,
+              },
+            });
+            abort(payload);
           }
         },
       }),


### PR DESCRIPTION
## What does this PR do?

This will make the retry errors have a message that is
worth reading instead of obfuscating all these errors
with the default message of:

 "Aborted in beforeRetry() callback

This is a bit gnarly, as we're putting a stringified JSON
object into the abort message payload, but it's better than
no context coming through at all.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?
 
## How do we deploy this PR?
