### PR TITLE
[CORL-2205] Instead of throwing an error on mailer timeout, log a warning

### DIFF
--- a/src/core/server/queue/Task.ts
+++ b/src/core/server/queue/Task.ts
@@ -6,6 +6,8 @@ import { createTimer } from "coral-server/helpers";
 import logger from "coral-server/logger";
 import { TenantResource } from "coral-server/models/tenant";
 
+export const MAX_JOB_ATTEMPTS = 5 as const;
+
 export type JobProcessor<T, U = void> = (job: Job<T>) => Promise<U>;
 
 interface TaskOptions<T, U = void> {
@@ -48,7 +50,7 @@ export default class Task<T extends TenantResource, U = any> {
       },
 
       // Be default, try all jobs at least 5 times.
-      attempts: 5,
+      attempts: MAX_JOB_ATTEMPTS,
     };
     this.idGenerator = jobIdGenerator;
     this.processor = jobProcessor;

--- a/src/core/server/queue/Task.ts
+++ b/src/core/server/queue/Task.ts
@@ -6,9 +6,14 @@ import { createTimer } from "coral-server/helpers";
 import logger from "coral-server/logger";
 import { TenantResource } from "coral-server/models/tenant";
 
-export const MAX_JOB_ATTEMPTS = 5 as const;
-
 export type JobProcessor<T, U = void> = (job: Job<T>) => Promise<U>;
+
+const MAX_JOB_ATTEMPTS = 5 as const;
+export const isLastAttempt = (job: Job) => {
+  // On the last attempt, the `attemptsMade` will be one less than the limit
+  // as we have already _attempted_ `limit - 1` times.
+  return job.attemptsMade >= MAX_JOB_ATTEMPTS - 1;
+};
 
 interface TaskOptions<T, U = void> {
   jobName: string;

--- a/src/core/server/queue/tasks/mailer/isLastAttempt.ts
+++ b/src/core/server/queue/tasks/mailer/isLastAttempt.ts
@@ -1,0 +1,5 @@
+export const isLastAttempt = (attemptsMade: number, limit: number) => {
+  // On the last attempt, the `attemptsMade` will be one less than the limit
+  // as we have already _attempted_ `limit - 1` times.
+  return attemptsMade >= limit - 1;
+};

--- a/src/core/server/queue/tasks/mailer/isLastAttempt.ts
+++ b/src/core/server/queue/tasks/mailer/isLastAttempt.ts
@@ -1,5 +1,0 @@
-export const isLastAttempt = (attemptsMade: number, limit: number) => {
-  // On the last attempt, the `attemptsMade` will be one less than the limit
-  // as we have already _attempted_ `limit - 1` times.
-  return attemptsMade >= limit - 1;
-};

--- a/src/core/server/queue/tasks/mailer/processor.ts
+++ b/src/core/server/queue/tasks/mailer/processor.ts
@@ -22,7 +22,7 @@ import { WrappedInternalError } from "coral-server/errors";
 import { createTimer } from "coral-server/helpers";
 import logger from "coral-server/logger";
 import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
-import { JobProcessor, MAX_JOB_ATTEMPTS } from "coral-server/queue/Task";
+import { isLastAttempt, JobProcessor } from "coral-server/queue/Task";
 import { I18n, translate } from "coral-server/services/i18n";
 import {
   TenantCache,
@@ -30,8 +30,6 @@ import {
 } from "coral-server/services/tenant/cache";
 
 import { GQLFEATURE_FLAG } from "coral-server/graph/schema/__generated__/types";
-
-import { isLastAttempt } from "./isLastAttempt";
 
 export const JOB_NAME = "mailer";
 
@@ -386,7 +384,7 @@ export const createJobProcessor = (
       sentEmailsCounter = 0;
       log.warn({ err: e }, "reset smtp transport due to a send error");
 
-      if (isLastAttempt(job.attemptsMade, MAX_JOB_ATTEMPTS)) {
+      if (isLastAttempt(job)) {
         throw new WrappedInternalError(e, "could not send email, not retrying");
       }
 

--- a/src/core/server/queue/tasks/mailer/processor.ts
+++ b/src/core/server/queue/tasks/mailer/processor.ts
@@ -31,6 +31,8 @@ import {
 
 import { GQLFEATURE_FLAG } from "coral-server/graph/schema/__generated__/types";
 
+import { isLastAttempt } from "./isLastAttempt";
+
 export const JOB_NAME = "mailer";
 
 interface TemplateMeta {
@@ -384,9 +386,7 @@ export const createJobProcessor = (
       sentEmailsCounter = 0;
       log.warn({ err: e }, "reset smtp transport due to a send error");
 
-      // On the last attempt, the `attemptsMade` will be one less than the max
-      // as we have already _attempted_ `MAX_JOB_ATTEMPTS - 1` times.
-      if (job.attemptsMade >= MAX_JOB_ATTEMPTS - 1) {
+      if (isLastAttempt(job.attemptsMade, MAX_JOB_ATTEMPTS)) {
         throw new WrappedInternalError(e, "could not send email, not retrying");
       }
 


### PR DESCRIPTION
## What does this PR do?

Instead of throwing an error on mailer timeout and causing an alert in Slack, log a warning.

This way the mailer can gracefully try and resend the email in its next mailing operation.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

It is very hard to test a mailer job timeout locally, but you can still test that this doesn't break mailing operations.

- Use https://docs.coralproject.net/development to set up the mailer testing environment with inbucket
- Create a user
- Request email notifications in the my profile configuration on stream
- Create some comments
- With another user, reply and respect some of the previous user's comments
- Wait for email summaries/notifications to show up in inbucket for the first user with notifications
 
 
## How do we deploy this PR?

Will need to update the incident reporting for mailer errors to match on this message:

```
jsonPayload.err.pvt.reason = "could not send email, not retrying"
```

instead of the previous reason/error name it was using to trigger mail failure incidents.