### PR TITLE
[CORL-2167] Disable collapsible comments on flattened replies

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.css
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.css
@@ -76,3 +76,7 @@ $commenterActionEditColorActive: var(--palette-primary-300);
 .notSeen {
   background-color: $colors-yellow-100;
 }
+
+.flattenedPadding {
+  padding-left: var(--spacing-4);
+}

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.css
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.css
@@ -78,5 +78,5 @@ $commenterActionEditColorActive: var(--palette-primary-300);
 }
 
 .flattenedPadding {
-  padding-left: var(--spacing-4);
+  padding-left: 18px;
 }

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -60,7 +60,7 @@ import ButtonsBar from "./ButtonsBar";
 import computeCommentElementID from "./computeCommentElementID";
 import EditCommentFormContainer from "./EditCommentForm";
 import FeaturedTag from "./FeaturedTag";
-import { replyIsFlattened } from "./flattenReplies";
+import { isReplyFlattened } from "./flattenReplies";
 import IndentedComment from "./IndentedComment";
 import MediaSectionContainer from "./MediaSection/MediaSectionContainer";
 import CaretContainer, {
@@ -464,7 +464,7 @@ export const CommentContainer: FunctionComponent<Props> = ({
           classNameIndented={cn({
             [styles.commentSeenEnabled]: commentSeenEnabled,
             [styles.notSeen]: shouldApplyNotSeenClass,
-            [styles.flattenedPadding]: replyIsFlattened(
+            [styles.flattenedPadding]: isReplyFlattened(
               flattenReplies,
               indentLevel
             ),

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -60,6 +60,7 @@ import ButtonsBar from "./ButtonsBar";
 import computeCommentElementID from "./computeCommentElementID";
 import EditCommentFormContainer from "./EditCommentForm";
 import FeaturedTag from "./FeaturedTag";
+import { replyIsFlattened } from "./flattenReplies";
 import IndentedComment from "./IndentedComment";
 import MediaSectionContainer from "./MediaSection/MediaSectionContainer";
 import CaretContainer, {
@@ -463,6 +464,10 @@ export const CommentContainer: FunctionComponent<Props> = ({
           classNameIndented={cn({
             [styles.commentSeenEnabled]: commentSeenEnabled,
             [styles.notSeen]: shouldApplyNotSeenClass,
+            [styles.flattenedPadding]: replyIsFlattened(
+              flattenReplies,
+              indentLevel
+            ),
             [CLASSES.comment.notSeen]: shouldApplyNotSeenClass,
           })}
           indentLevel={indentLevel}

--- a/src/core/client/stream/tabs/Comments/Comment/flattenReplies/index.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/flattenReplies/index.ts
@@ -1,6 +1,6 @@
 export const FlattenRepliesIndentLevel = 4 as const;
 
-export const replyIsFlattened = (
+export const isReplyFlattened = (
   flattenedRepliesEnabled?: boolean | null,
   indentLevel?: number | null
 ) => {

--- a/src/core/client/stream/tabs/Comments/Comment/flattenReplies/index.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/flattenReplies/index.ts
@@ -1,0 +1,12 @@
+export const FlattenRepliesIndentLevel = 4 as const;
+
+export const replyIsFlattened = (
+  flattenedRepliesEnabled?: boolean | null,
+  indentLevel?: number | null
+) => {
+  return (
+    flattenedRepliesEnabled &&
+    indentLevel &&
+    indentLevel >= FlattenRepliesIndentLevel
+  );
+};

--- a/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
@@ -63,54 +63,42 @@ const ReplyListCommentContainer: FunctionComponent<Props> = ({
         disableHide={disableHideIgnoredTombstone}
       >
         <HorizontalGutter spacing={commentSeenEnabled ? 0 : undefined}>
-          {isReplyFlattened(flattenRepliesEnabled, indentLevel) ? (
-            <>
-              <DeletedTombstoneContainer comment={comment}>
-                <CommentContainer
-                  viewer={viewer}
-                  comment={comment}
-                  story={story}
-                  collapsed={false}
-                  settings={settings}
-                  indentLevel={indentLevel}
-                  localReply={localReply}
-                  disableReplies={disableReplies}
-                  showConversationLink={!!showConversationLink}
-                  showRemoveAnswered={showRemoveAnswered}
-                />
-              </DeletedTombstoneContainer>
-              {replyListElement}
-            </>
-          ) : (
-            <CollapsableComment>
-              {({ collapsed, toggleCollapsed }) => (
+          <CollapsableComment>
+            {({ collapsed, toggleCollapsed }) => {
+              const collapseEnabled = !isReplyFlattened(
+                flattenRepliesEnabled,
+                indentLevel
+              );
+              return (
                 <>
                   <DeletedTombstoneContainer comment={comment}>
                     <CommentContainer
                       viewer={viewer}
                       comment={comment}
                       story={story}
-                      collapsed={collapsed}
+                      collapsed={collapsed && collapseEnabled}
                       settings={settings}
                       indentLevel={indentLevel}
                       localReply={localReply}
                       disableReplies={disableReplies}
                       showConversationLink={!!showConversationLink}
-                      toggleCollapsed={toggleCollapsed}
+                      toggleCollapsed={
+                        collapseEnabled ? toggleCollapsed : undefined
+                      }
                       showRemoveAnswered={showRemoveAnswered}
                     />
                   </DeletedTombstoneContainer>
                   <div
                     className={cn({
-                      [styles.hiddenReplies]: collapsed,
+                      [styles.hiddenReplies]: collapsed && collapseEnabled,
                     })}
                   >
                     {replyListElement}
                   </div>
                 </>
-              )}
-            </CollapsableComment>
-          )}
+              );
+            }}
+          </CollapsableComment>
         </HorizontalGutter>
       </IgnoredTombstoneOrHideContainer>
     </FadeInTransition>

--- a/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
@@ -14,7 +14,7 @@ import { ReplyListCommentContainer_viewer } from "coral-stream/__generated__/Rep
 
 import CollapsableComment from "../Comment/CollapsableComment";
 import CommentContainer from "../Comment/CommentContainer";
-import { replyIsFlattened } from "../Comment/flattenReplies";
+import { isReplyFlattened } from "../Comment/flattenReplies";
 import { useCommentSeenEnabled } from "../commentSeen";
 import DeletedTombstoneContainer from "../DeletedTombstoneContainer";
 import IgnoredTombstoneOrHideContainer from "../IgnoredTombstoneOrHideContainer";
@@ -63,7 +63,7 @@ const ReplyListCommentContainer: FunctionComponent<Props> = ({
         disableHide={disableHideIgnoredTombstone}
       >
         <HorizontalGutter spacing={commentSeenEnabled ? 0 : undefined}>
-          {replyIsFlattened(flattenRepliesEnabled, indentLevel) ? (
+          {isReplyFlattened(flattenRepliesEnabled, indentLevel) ? (
             <>
               <DeletedTombstoneContainer comment={comment}>
                 <CommentContainer

--- a/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
@@ -4,6 +4,7 @@ import { graphql } from "react-relay";
 
 import FadeInTransition from "coral-framework/components/FadeInTransition";
 import { withFragmentContainer } from "coral-framework/lib/relay";
+import { GQLFEATURE_FLAG } from "coral-framework/schema/";
 import { HorizontalGutter } from "coral-ui/components/v2";
 
 import { ReplyListCommentContainer_comment } from "coral-stream/__generated__/ReplyListCommentContainer_comment.graphql";
@@ -13,6 +14,7 @@ import { ReplyListCommentContainer_viewer } from "coral-stream/__generated__/Rep
 
 import CollapsableComment from "../Comment/CollapsableComment";
 import CommentContainer from "../Comment/CommentContainer";
+import { replyIsFlattened } from "../Comment/flattenReplies";
 import { useCommentSeenEnabled } from "../commentSeen";
 import DeletedTombstoneContainer from "../DeletedTombstoneContainer";
 import IgnoredTombstoneOrHideContainer from "../IgnoredTombstoneOrHideContainer";
@@ -49,6 +51,9 @@ const ReplyListCommentContainer: FunctionComponent<Props> = ({
   replyListElement,
 }) => {
   const commentSeenEnabled = useCommentSeenEnabled();
+  const flattenRepliesEnabled = settings.featureFlags?.includes(
+    GQLFEATURE_FLAG.FLATTEN_REPLIES
+  );
   return (
     <FadeInTransition active={Boolean(comment.enteredLive)}>
       <IgnoredTombstoneOrHideContainer
@@ -58,34 +63,54 @@ const ReplyListCommentContainer: FunctionComponent<Props> = ({
         disableHide={disableHideIgnoredTombstone}
       >
         <HorizontalGutter spacing={commentSeenEnabled ? 0 : undefined}>
-          <CollapsableComment>
-            {({ collapsed, toggleCollapsed }) => (
-              <>
-                <DeletedTombstoneContainer comment={comment}>
-                  <CommentContainer
-                    viewer={viewer}
-                    comment={comment}
-                    story={story}
-                    collapsed={collapsed}
-                    settings={settings}
-                    indentLevel={indentLevel}
-                    localReply={localReply}
-                    disableReplies={disableReplies}
-                    showConversationLink={!!showConversationLink}
-                    toggleCollapsed={toggleCollapsed}
-                    showRemoveAnswered={showRemoveAnswered}
-                  />
-                </DeletedTombstoneContainer>
-                <div
-                  className={cn({
-                    [styles.hiddenReplies]: collapsed,
-                  })}
-                >
-                  {replyListElement}
-                </div>
-              </>
-            )}
-          </CollapsableComment>
+          {replyIsFlattened(flattenRepliesEnabled, indentLevel) ? (
+            <>
+              <DeletedTombstoneContainer comment={comment}>
+                <CommentContainer
+                  viewer={viewer}
+                  comment={comment}
+                  story={story}
+                  collapsed={false}
+                  settings={settings}
+                  indentLevel={indentLevel}
+                  localReply={localReply}
+                  disableReplies={disableReplies}
+                  showConversationLink={!!showConversationLink}
+                  showRemoveAnswered={showRemoveAnswered}
+                />
+              </DeletedTombstoneContainer>
+              {replyListElement}
+            </>
+          ) : (
+            <CollapsableComment>
+              {({ collapsed, toggleCollapsed }) => (
+                <>
+                  <DeletedTombstoneContainer comment={comment}>
+                    <CommentContainer
+                      viewer={viewer}
+                      comment={comment}
+                      story={story}
+                      collapsed={collapsed}
+                      settings={settings}
+                      indentLevel={indentLevel}
+                      localReply={localReply}
+                      disableReplies={disableReplies}
+                      showConversationLink={!!showConversationLink}
+                      toggleCollapsed={toggleCollapsed}
+                      showRemoveAnswered={showRemoveAnswered}
+                    />
+                  </DeletedTombstoneContainer>
+                  <div
+                    className={cn({
+                      [styles.hiddenReplies]: collapsed,
+                    })}
+                  >
+                    {replyListElement}
+                  </div>
+                </>
+              )}
+            </CollapsableComment>
+          )}
         </HorizontalGutter>
       </IgnoredTombstoneOrHideContainer>
     </FadeInTransition>
@@ -107,6 +132,7 @@ const enhanced = withFragmentContainer<Props>({
   settings: graphql`
     fragment ReplyListCommentContainer_settings on Settings {
       ...CommentContainer_settings
+      featureFlags
     }
   `,
   comment: graphql`


### PR DESCRIPTION
## What does this PR do?

Disables collapsible comments on flattened replies.

These comments are no longer nested and so we can't collapse a comment and its children since they have no concept of their children in the stream.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- enable `FLATTEN_REPLIES`
- make a bunch of comments with replies nested deeper than 4 levels
- see that comments that are at the bottom most flattened level cannot be collapsed
- collapsing should work for all the other comment levels
 
## How do we deploy this PR?

If the client needs flattened replies, enable the `FLATTEN_REPLIES` option.
