### PR TITLE
CORL-2122: remove point-events: none; from scroll container for modal

### DIFF
--- a/src/core/client/ui/components/v2/Modal/Modal.css
+++ b/src/core/client/ui/components/v2/Modal/Modal.css
@@ -9,7 +9,6 @@
 }
 
 .baseScroll {
-  pointer-events: none;
   position: relative;
 
   width: 100%;

--- a/src/core/client/ui/components/v2/Modal/Modal.spec.tsx
+++ b/src/core/client/ui/components/v2/Modal/Modal.spec.tsx
@@ -56,7 +56,7 @@ it("relays backdrop click events", () => {
     );
   });
   testRenderer!.root
-    .findByProps({ "data-testid": "backdrop" })
+    .findByProps({ "data-testid": "scroll" })
     .props.onClick(event);
   act(() => {
     testRenderer.unmount();

--- a/src/core/client/ui/components/v2/Modal/Modal.tsx
+++ b/src/core/client/ui/components/v2/Modal/Modal.tsx
@@ -105,7 +105,7 @@ const Modal: FunctionComponent<ModalProps> = ({
     return ReactDOM.createPortal(
       <div role="dialog" className={rootClassName} {...rest}>
         <NoScroll active={open} />
-        <Backdrop active={open} data-testid="backdrop" />
+        <Backdrop active={open} />
         <div
           role="presentation"
           className={cn(
@@ -114,6 +114,7 @@ const Modal: FunctionComponent<ModalProps> = ({
           )}
           onKeyDown={handleEscapeKeyDown}
           onClick={handleBackdropClick}
+          data-testid="scroll"
         >
           <div className={styles.alignContainer1}>
             <div className={styles.alignContainer2}>

--- a/src/core/client/ui/components/v2/Modal/Modal.tsx
+++ b/src/core/client/ui/components/v2/Modal/Modal.tsx
@@ -105,11 +105,7 @@ const Modal: FunctionComponent<ModalProps> = ({
     return ReactDOM.createPortal(
       <div role="dialog" className={rootClassName} {...rest}>
         <NoScroll active={open} />
-        <Backdrop
-          active={open}
-          data-testid="backdrop"
-          onClick={handleBackdropClick}
-        />
+        <Backdrop active={open} data-testid="backdrop" />
         <div
           role="presentation"
           className={cn(
@@ -117,6 +113,7 @@ const Modal: FunctionComponent<ModalProps> = ({
             disableScroll ? styles.noScroll : styles.scroll
           )}
           onKeyDown={handleEscapeKeyDown}
+          onClick={handleBackdropClick}
         >
           <div className={styles.alignContainer1}>
             <div className={styles.alignContainer2}>

--- a/src/core/client/ui/components/v2/Modal/__snapshots__/Modal.spec.tsx.snap
+++ b/src/core/client/ui/components/v2/Modal/__snapshots__/Modal.spec.tsx.snap
@@ -7,11 +7,11 @@ exports[`renders correctly 1`] = `
 >
   <div
     className="Backdrop-root Backdrop-active"
-    data-testid="backdrop"
-    onClick={[Function]}
   />
   <div
     className="Modal-baseScroll Modal-scroll"
+    data-testid="scroll"
+    onClick={[Function]}
     onKeyDown={[Function]}
     role="presentation"
   >


### PR DESCRIPTION
## What does this PR do?
This PR addresses https://vmproduct.atlassian.net/browse/CORL-2122 by fixing a bug where modals can't scroll. 

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## How do I test this PR?
Create a deep reply thread, then report a comment near the bottom. As an admin, click on the comment in "moderate" tab, then click "SHOW MORE OF THIS CONVERSATION" until the content extends past the height of the screen. The modal should be scrollable, while the rest of the UI remains locked. 

## How do we deploy this PR?
No special actions should need to be taken.
