### PR TITLE
[CORL-2231] Make stream bundle work with old embed versions in cache

### DIFF
--- a/src/core/client/framework/lib/bootstrap/createManaged.tsx
+++ b/src/core/client/framework/lib/bootstrap/createManaged.tsx
@@ -300,7 +300,7 @@ function resolveStorage(
   pym?: PymChild
 ): PromisifiedStorage {
   if (areWeInIframe()) {
-    // Use local storage over postMessage (or fallback to pym) when we are in an iframe.
+    // Use storage over postMessage (or fallback to pym) when we are in an iframe.
     const pmStorage =
       postMessage && createPostMessageStorage(postMessage, type);
     const pymStorage =

--- a/src/core/client/framework/lib/bootstrap/createManaged.tsx
+++ b/src/core/client/framework/lib/bootstrap/createManaged.tsx
@@ -292,7 +292,7 @@ function createManagedCoralContextProvider(
 }
 
 /*
- * resolveLocalStorage decides which storage to use in the context
+ * resolveStorage decides which storage to use in the context
  */
 function resolveStorage(
   type: "localStorage" | "sessionStorage" | "indexedDB",

--- a/src/core/client/framework/lib/storage/combinePromisifiedStorage.spec.ts
+++ b/src/core/client/framework/lib/storage/combinePromisifiedStorage.spec.ts
@@ -1,0 +1,64 @@
+import combinePromisifiedStorage from "./combinePromisifiedStorage";
+import createInMemoryStorage from "./InMemoryStorage";
+import createPromisifiedStorage, {
+  PromisifiedStorage,
+} from "./PromisifiedStorage";
+
+/**
+ * NotRespondingStorage.
+ */
+class NotRespondingStorage implements PromisifiedStorage {
+  public get length() {
+    return new Promise(() => {}) as any;
+  }
+
+  public clear() {
+    return new Promise(() => {}) as any;
+  }
+
+  public key(n: number) {
+    return new Promise(() => {}) as any;
+  }
+
+  public getItem(key: string) {
+    return new Promise(() => {}) as any;
+  }
+
+  public setItem(key: string, value: string) {
+    return new Promise(() => {}) as any;
+  }
+
+  public removeItem(key: string) {
+    return new Promise(() => {}) as any;
+  }
+}
+
+it("should set and unset values", async () => {
+  const storageA = createPromisifiedStorage(createInMemoryStorage());
+  const storageB = new NotRespondingStorage();
+  const storage = combinePromisifiedStorage(storageA, storageB);
+  await expect(storage.setItem("test", "value")).resolves.toBeUndefined();
+  await expect(storage.getItem("test")).resolves.toBe("value");
+  await storage.removeItem("test");
+  await expect(storage.getItem("test")).resolves.toBeNull();
+});
+
+it("should return length", async () => {
+  const storageA = new NotRespondingStorage();
+  const storageB = createPromisifiedStorage(createInMemoryStorage());
+  const storage = combinePromisifiedStorage(storageA, storageB);
+  await storage.setItem("a", "value");
+  await storage.setItem("b", "value");
+  await storage.setItem("c", "value");
+  await expect(storage.length).resolves.toBe(3);
+});
+
+it("should nth value", async () => {
+  const storageA = createPromisifiedStorage(createInMemoryStorage());
+  const storageB = new NotRespondingStorage();
+  const storage = combinePromisifiedStorage(storageA, storageB);
+  await storage.setItem("a", "a");
+  await storage.setItem("b", "b");
+  await storage.setItem("c", "c");
+  await expect(storage.key(2)).resolves.toBe("c");
+});

--- a/src/core/client/framework/lib/storage/combinePromisifiedStorage.ts
+++ b/src/core/client/framework/lib/storage/combinePromisifiedStorage.ts
@@ -1,24 +1,6 @@
 import { PromisifiedStorage } from "./PromisifiedStorage";
 
-// By @loganfsmyth on https://stackoverflow.com/questions/37234191/how-do-you-implement-a-racetosuccess-helper-given-a-list-of-promises
-function getFirstResolvingPromise<T>(promises: Array<Promise<T>>) {
-  return Promise.all(
-    promises.map((p) => {
-      // If a request fails, count that as a resolution so it will keep
-      // waiting for other possible successes. If a request succeeds,
-      // treat it as a rejection so Promise.all immediately bails out.
-      return p.then(
-        (val) => Promise.reject(val),
-        (err) => Promise.resolve(err)
-      );
-    })
-  ).then(
-    // If '.all' resolved, we've just got an array of errors.
-    (errors) => Promise.reject(errors),
-    // If '.all' rejected, we've got the result we wanted.
-    (val) => Promise.resolve(val)
-  );
-}
+import getFirstResolvingPromise from "coral-common/utils/getFirstResolvingPromise";
 
 /**
  * CombinedPromisfiedStorage.

--- a/src/core/client/framework/lib/storage/combinePromisifiedStorage.ts
+++ b/src/core/client/framework/lib/storage/combinePromisifiedStorage.ts
@@ -1,0 +1,83 @@
+import { PromisifiedStorage } from "./PromisifiedStorage";
+
+// By @loganfsmyth on https://stackoverflow.com/questions/37234191/how-do-you-implement-a-racetosuccess-helper-given-a-list-of-promises
+function getFirstResolvingPromise<T>(promises: Array<Promise<T>>) {
+  return Promise.all(
+    promises.map((p) => {
+      // If a request fails, count that as a resolution so it will keep
+      // waiting for other possible successes. If a request succeeds,
+      // treat it as a rejection so Promise.all immediately bails out.
+      return p.then(
+        (val) => Promise.reject(val),
+        (err) => Promise.resolve(err)
+      );
+    })
+  ).then(
+    // If '.all' resolved, we've just got an array of errors.
+    (errors) => Promise.reject(errors),
+    // If '.all' rejected, we've got the result we wanted.
+    (val) => Promise.resolve(val)
+  );
+}
+
+/**
+ * CombinedPromisfiedStorage.
+ */
+class CombinedPromisifiedStorage implements PromisifiedStorage {
+  private storageA: PromisifiedStorage;
+  private storageB: PromisifiedStorage;
+
+  constructor(storageA: PromisifiedStorage, storageB: PromisifiedStorage) {
+    this.storageA = storageA;
+    this.storageB = storageB;
+  }
+
+  public get length() {
+    return getFirstResolvingPromise([
+      this.storageA.length,
+      this.storageB.length,
+    ]);
+  }
+
+  public clear() {
+    return getFirstResolvingPromise([
+      this.storageA.clear(),
+      this.storageB.clear(),
+    ]);
+  }
+
+  public key(n: number) {
+    return getFirstResolvingPromise([
+      this.storageA.key(n),
+      this.storageB.key(n),
+    ]);
+  }
+
+  public getItem(key: string) {
+    return getFirstResolvingPromise([
+      this.storageA.getItem(key),
+      this.storageB.getItem(key),
+    ]);
+  }
+
+  public setItem(key: string, value: string) {
+    return getFirstResolvingPromise([
+      this.storageA.setItem(key, value),
+      this.storageB.setItem(key, value),
+    ]);
+  }
+
+  public removeItem(key: string) {
+    return getFirstResolvingPromise([
+      this.storageA.removeItem(key),
+      this.storageB.removeItem(key),
+    ]);
+  }
+}
+
+export default function combinePromisifiedStorage(
+  storageA: PromisifiedStorage,
+  storageB: PromisifiedStorage
+) {
+  return new CombinedPromisifiedStorage(storageA, storageB);
+}

--- a/src/core/client/framework/lib/storage/index.ts
+++ b/src/core/client/framework/lib/storage/index.ts
@@ -7,3 +7,4 @@ export {
   default as createPromisifiedStorage,
   PromisifiedStorage,
 } from "./PromisifiedStorage";
+export { default as combinePromisifiedStorage } from "./combinePromisifiedStorage";

--- a/src/core/common/utils/getFirstResolvingPromise.ts
+++ b/src/core/common/utils/getFirstResolvingPromise.ts
@@ -1,0 +1,21 @@
+// By @loganfsmyth on https://stackoverflow.com/questions/37234191/how-do-you-implement-a-racetosuccess-helper-given-a-list-of-promises
+function getFirstResolvingPromise<T>(promises: Array<Promise<T>>) {
+  return Promise.all(
+    promises.map((p) => {
+      // If a request fails, count that as a resolution so it will keep
+      // waiting for other possible successes. If a request succeeds,
+      // treat it as a rejection so Promise.all immediately bails out.
+      return p.then(
+        (val) => Promise.reject(val),
+        (err) => Promise.resolve(err)
+      );
+    })
+  ).then(
+    // If '.all' resolved, we've just got an array of errors.
+    (errors) => Promise.reject(errors),
+    // If '.all' rejected, we've got the result we wanted.
+    (val) => Promise.resolve(val)
+  );
+}
+
+export default getFirstResolvingPromise;

--- a/src/core/common/utils/index.ts
+++ b/src/core/common/utils/index.ts
@@ -15,3 +15,4 @@ export { default as pureMerge } from "./pureMerge";
 export { default as startsWith } from "./startsWith";
 export { default as stringifyQuery } from "./stringifyQuery";
 export { default as roundRating } from "./roundRating";
+export { default as getFirstResolvingPromise } from "./getFirstResolvingPromise";


### PR DESCRIPTION
## What does this PR do?
- In older versions `embed.js` is put in local browser cache for 7 days. Our stream code might run into an issue where it would use a newer feature from `embed.js` that is not yet available.
- This PR adds backwards compatibility for the newer storage access.

## How do I test this PR?
- Find an old `embed.js`
- Build this branch
- Replace with old `embed.js`
- Run Coral with modified files
- See it working!