### PR TITLE
feat: embed.js now reports its version to stream

### DIFF
--- a/src/core/client/embed/StreamEmbed.ts
+++ b/src/core/client/embed/StreamEmbed.ts
@@ -94,6 +94,7 @@ export class StreamEmbed {
       withConfig({
         accessToken: config.accessToken,
         bodyClassName: config.bodyClassName,
+        version: process.env.TALK_VERSION,
       }),
       withKeypressEvent,
       withRefreshAccessToken(config.refreshAccessToken),

--- a/src/core/client/framework/lib/externalConfig.ts
+++ b/src/core/client/framework/lib/externalConfig.ts
@@ -6,6 +6,7 @@ import { areWeInIframe } from "coral-framework/utils";
 export interface ExternalConfig {
   accessToken?: string;
   bodyClassName?: string;
+  version?: string;
 }
 
 export function getExternalConfig(

--- a/src/core/client/stream/local/initLocalState.ts
+++ b/src/core/client/stream/local/initLocalState.ts
@@ -139,6 +139,9 @@ const initLocalState: InitLocalState = async ({
       featureFlags.includes(GQLFEATURE_FLAG.COMMENT_SEEN),
       "enableCommentSeen"
     );
+
+    // Version as reported by the embed.js
+    localRecord.setValue(config?.version, "embedVersion");
   });
 };
 

--- a/src/core/client/stream/local/local.graphql
+++ b/src/core/client/stream/local/local.graphql
@@ -68,6 +68,8 @@ extend type Local {
   storyID: String
   storyURL: String
   storyMode: STORY_MODE
+  # Version as reported by the embed.js
+  embedVersion: String
   # If set, then we are in single comment view.
   commentID: String
   siteID: String


### PR DESCRIPTION
## What does this PR do?
- `embed.js` now sends its version over to the stream bundle
- This lets us detect and handle situations where we encounter an old cached `embed.js`
 
## How do we deploy this PR?
- Maybe just add a `console.log` somewhere? 