### PR TITLE
Fix Circle CI dependency failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ job_node_defaults: &job_node_defaults
   <<: *job_defaults
   working_directory: ~/coralproject/talk
   docker:
-    - image: circleci/node:12
+    - image: circleci/node:14
   environment:
     <<: *job_node_environment
 
@@ -37,9 +37,10 @@ jobs:
             - v1-dependency-cache-{{ checksum "package-lock.json" }}
             # Find the most recently generated cache used from any branch
             - v1-dependency-cache-
-      - run:
-          name: Update NPM
-          command: sudo npm update -g npm
+      # Disabled as we don't want to use sudo to update packages
+      # - run:
+      #     name: Update NPM
+      #     command: sudo npm update -g npm
       # Disabled until there's capabilities to ignore a specific vun. Related:
       # https://npm.community/t/please-provide-option-to-ignore-packages-in-npm-audit/403/4
       # https://github.com/npm/cli/pull/10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ job_node_defaults: &job_node_defaults
   <<: *job_defaults
   working_directory: ~/coralproject/talk
   docker:
-    - image: circleci/node:14
+    - image: circleci/node:12
   environment:
     <<: *job_node_environment
 


### PR DESCRIPTION
## What does this PR do?

~~Update image to node:14 LTS and~~ disable sudo npm update -g
(Note: we will update to Node 14 later when we have updated Coral to run on Node 14)

We can't be using sudo to do npm updates as it modifies
the ~/.npm and node_modules/ ownership. Instead we need to
use the CircleCI images as-is and regularly update to the
latest LTS as they come out.

This will give us the security of a stable and secure npm
command as well as prevent permissions issues around the
dependencies breaking our builds and causing `npm ci` to
hang.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

See working builds in CI from CircleCI.
 
## How do we deploy this PR?

N/A