### PR TITLE
Fix dependencies timing out on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
       - run:
           name: Install dependencies
           command: sh .circleci/npmci.sh
+          no_output_timeout: 20m
       - save_cache:
           key: v1-dependency-cache-{{ checksum "package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
           keys:
             # Find a cache corresponding to this specific package-lock.json
             # checksum when this file is changed, this key will fail.
-            - v2-dependency-cache-{{ checksum "package-lock.json" }}
+            - v1-dependency-cache-{{ checksum "package-lock.json" }}
             # Find the most recently generated cache used from any branch
-            - v2-dependency-cache-
+            - v1-dependency-cache-
       # Disabled as we don't want to use sudo to update packages
       # - run:
       #     name: Update NPM
@@ -51,9 +51,9 @@ jobs:
       #       command: npm audit
       - run:
           name: Install dependencies
-          command: npm ci
+          command: sh .circleci/npmci.sh
       - save_cache:
-          key: v2-dependency-cache-{{ checksum "package-lock.json" }}
+          key: v1-dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - ~/.npm
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       #       command: npm audit
       - run:
           name: Install dependencies
-          command: sh .circleci/npmci.sh
+          command: npm ci
           no_output_timeout: 20m
       - save_cache:
           key: v1-dependency-cache-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
           keys:
             # Find a cache corresponding to this specific package-lock.json
             # checksum when this file is changed, this key will fail.
-            - v1-dependency-cache-{{ checksum "package-lock.json" }}
+            - v2-dependency-cache-{{ checksum "package-lock.json" }}
             # Find the most recently generated cache used from any branch
-            - v1-dependency-cache-
+            - v2-dependency-cache-
       # Disabled as we don't want to use sudo to update packages
       # - run:
       #     name: Update NPM
@@ -53,7 +53,7 @@ jobs:
           name: Install dependencies
           command: npm ci
       - save_cache:
-          key: v1-dependency-cache-{{ checksum "package-lock.json" }}
+          key: v2-dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - ~/.npm
       - persist_to_workspace:

--- a/.circleci/npmci.sh
+++ b/.circleci/npmci.sh
@@ -1,2 +1,0 @@
-echo "installing dependencies using npm ci"
-npm ci

--- a/.circleci/npmci.sh
+++ b/.circleci/npmci.sh
@@ -1,0 +1,2 @@
+echo "installing dependencies using npm ci"
+npm ci


### PR DESCRIPTION
## What does this PR do?

![image](https://user-images.githubusercontent.com/5751504/132398006-7ec6fa71-dd25-42cd-8213-284cdc78522d.png)

Just kidding, there's more to it than green check marks. This counters the issue with CircleCI proxying calls to npm through their network and how that makes npm installs (or `npm ci`) slow. I've boosted the timeout for the installation to 20 minutes. Our builds are taking 13 minutes to install dependencies, so this should give some wiggle room in case something slows down even more.

In case you were wondering, "can we make the npm installs faster?"

Yes, we can, but that's a lot of work right now, and we need builds working today. We have a ticket logged to look into this a bit more robustly or even moving to GitHub Actions to resolve these slow install issues. `npm ci` only takes 5 minutes locally or 6 minutes via a Docker container build, so this is squarely a Circle CI -> NPM network issue.

If we want to continue to use CircleCI long-term, we might want to consider hosting our own package cache that we can pull from which we can ensure we won't get network slow-downs through.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

Check the CircleCI builds and see that this branch isn't failing when everything else is failing.
 
## How do we deploy this PR?

Merge it into develop and let it run free!