### PR TITLE
[CORL-2300] Stop highlighting comments longer than 500 characters

### DIFF
--- a/src/core/client/admin/components/Comment/CommentContent.css
+++ b/src/core/client/admin/components/Comment/CommentContent.css
@@ -54,3 +54,13 @@ $comment-link-active: $colors-teal-900;
 .highlight {
   white-space: pre-wrap;
 }
+
+.lengthWarning {
+  padding-top: var(--spacing-3);
+  padding-bottom: var(--spacing-2);
+}
+
+.warningTag {
+  background-color: var(--palette-warning-100);
+  color: var(--palette-text-500);
+}

--- a/src/core/client/admin/helpers/markHTMLNode.ts
+++ b/src/core/client/admin/helpers/markHTMLNode.ts
@@ -35,6 +35,8 @@ function markPhrasesHTML(text: string, expression: RegExp) {
 // markHTMLNode manipulates the node by looking for #text nodes and adding
 // markers.
 export default function markHTMLNode(parentNode: Node, expression: RegExp) {
+  let exceededLength = false;
+
   parentNode.childNodes.forEach((node) => {
     // Anchor links are already marked by default, skip them now.
     if (node.nodeName === "A") {
@@ -43,12 +45,20 @@ export default function markHTMLNode(parentNode: Node, expression: RegExp) {
 
     // If the node isn't of text type then we can't mark it directly.
     if (node.nodeName !== "#text") {
-      return markHTMLNode(node, expression);
+      const result = markHTMLNode(node, expression);
+      if (result.exceededLength) {
+        exceededLength = result.exceededLength;
+      }
+      return;
     }
 
     // If the node doesn't have any text content, then we can't mark it either.
     if (!node.textContent) {
       return;
+    }
+
+    if (node.textContent.length > LENGTH_CUTOFF) {
+      exceededLength = true;
     }
 
     // We've encountered a text node with text content that isn't in an anchor
@@ -60,5 +70,10 @@ export default function markHTMLNode(parentNode: Node, expression: RegExp) {
       newNode.innerHTML = replacement;
       parentNode.replaceChild(newNode, node);
     }
+    return;
   });
+
+  return {
+    exceededLength,
+  };
 }

--- a/src/core/client/admin/helpers/markHTMLNode.ts
+++ b/src/core/client/admin/helpers/markHTMLNode.ts
@@ -1,7 +1,13 @@
+const LENGTH_CUTOFF = 500;
+
 // markPhrasesHTML looks for `suspect` and `banned` words inside `text` given
 // the settings applied for the locale and highlights them by returning an HTML
 // string.
 function markPhrasesHTML(text: string, expression: RegExp) {
+  if (text.length >= LENGTH_CUTOFF) {
+    return null;
+  }
+
   const tokens = text.split(expression);
 
   // If there were less than two matches, then there was no matched word

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -1092,6 +1092,9 @@ moderate-user-drawer-notes-button = Add note
 moderatorNote-left-by = Left by
 moderatorNote-delete = Delete
 
+moderate-highlightLengthWarning =
+  Highlighting has been disabled for this comment due to its length
+
 # For Review Queue
 
 moderate-forReview-reviewedButton =


### PR DESCRIPTION
## What does this PR do?

For really really long comments, this prevents the UI from hanging up trying to parse both a huge word list and a huge comment body for suspect/banned words.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- See CORL-2300 case for notes on the comment that prompted this bug fix. Make one.
- Report the comment
- Copy a huge banned/suspect word list from a big client
- Head to mod queue and see the mod queue load even with the giant comment body
    - No slowdowns or hangs
- Note that there is no highlighting on those long comments due to resource constraints on our RegEx
 
## How do we deploy this PR?

No special notes, will deploy same as any PR.
