### PR TITLE
Pass scrape_max_response_size to scaper's FetchOptions

### DIFF
--- a/src/core/server/services/stories/scraper/scraper.ts
+++ b/src/core/server/services/stories/scraper/scraper.ts
@@ -89,10 +89,11 @@ class Scraper {
     customUserAgent,
     proxyURL,
     authorization,
+    size,
   }: ScrapeOptions) {
     const log = this.log.child({ storyURL: url }, true);
 
-    const options: FetchOptions = { method: "GET", timeout };
+    const options: FetchOptions = { method: "GET", timeout, size };
     if (customUserAgent) {
       options.headers = {
         ...options.headers,


### PR DESCRIPTION
## What does this PR do?

Passes scrape_max_response_size to scaper's FetchOptions.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

See original PR from @felkerch 's original PR here: https://github.com/coralproject/talk/pull/3695 
 
## How do we deploy this PR?

N/A

NOTE: Apologies to @felkerch, my git client failed to add you as the co-author on this.