### PR TITLE
[CORL-604] Make `FORCE_ADMIN_LOCAL_AUTH` into an env var config option

### DIFF
--- a/src/core/client/admin/local/__snapshots__/initLocalState.spec.ts.snap
+++ b/src/core/client/admin/local/__snapshots__/initLocalState.spec.ts.snap
@@ -10,7 +10,8 @@ exports[`get access token from url 1`] = `
   \\"redirectPath\\": null,
   \\"authView\\": \\"SIGN_IN\\",
   \\"authError\\": null,
-  \\"moderationQueueSort\\": \\"CREATED_AT_DESC\\"
+  \\"moderationQueueSort\\": \\"CREATED_AT_DESC\\",
+  \\"forceAdminLocalAuth\\": false
 }"
 `;
 
@@ -32,7 +33,8 @@ exports[`init local state 1`] = `
     \\"redirectPath\\": null,
     \\"authView\\": \\"SIGN_IN\\",
     \\"authError\\": null,
-    \\"moderationQueueSort\\": \\"CREATED_AT_DESC\\"
+    \\"moderationQueueSort\\": \\"CREATED_AT_DESC\\",
+    \\"forceAdminLocalAuth\\": false
   }
 }"
 `;

--- a/src/core/client/admin/local/initLocalState.ts
+++ b/src/core/client/admin/local/initLocalState.ts
@@ -48,7 +48,13 @@ const initLocalState: InitLocalState = async ({
     }
   }
 
-  await initLocalBaseState({ environment, context, auth, ...rest });
+  await initLocalBaseState({
+    environment,
+    context,
+    auth,
+    staticConfig,
+    ...rest,
+  });
 
   const modQueueSortOrder = await context.localStorage.getItem(
     MOD_QUEUE_SORT_ORDER

--- a/src/core/client/admin/local/initLocalState.ts
+++ b/src/core/client/admin/local/initLocalState.ts
@@ -17,6 +17,7 @@ const initLocalState: InitLocalState = async ({
   environment,
   context,
   auth = null,
+  staticConfig,
   ...rest
 }) => {
   let redirectPath = await context.localStorage.getItem(
@@ -62,6 +63,10 @@ const initLocalState: InitLocalState = async ({
     localRecord.setValue(
       modQueueSortOrder ? modQueueSortOrder : GQLCOMMENT_SORT.CREATED_AT_DESC,
       "moderationQueueSort"
+    );
+    localRecord.setValue(
+      staticConfig?.forceAdminLocalAuth ?? false,
+      "forceAdminLocalAuth"
     );
   });
 };

--- a/src/core/client/admin/local/local.graphql
+++ b/src/core/client/admin/local/local.graphql
@@ -33,4 +33,5 @@ extend type Local {
   authDuplicateEmail: String
   siteID: String
   moderationQueueSort: COMMENT_SORT
+  forceAdminLocalAuth: Boolean!
 }

--- a/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AuthConfigContainer.tsx
@@ -25,7 +25,7 @@ import { AuthConfigContainer_auth as AuthData } from "coral-admin/__generated__/
 import { AuthConfigContainer_settings as SettingsData } from "coral-admin/__generated__/AuthConfigContainer_settings.graphql";
 
 import AccountFeaturesConfig from "./AccountFeaturesConfig";
-import AuthIntegrationsConfigContainer from "./AuthIntegrationsConfigContainer";
+import AuthIntegrationsConfig from "./AuthIntegrationsConfig";
 import SessionConfig from "./SessionConfig";
 
 export type FormProps = DeepNullable<
@@ -108,10 +108,9 @@ class AuthConfigContainer extends React.Component<Props> {
       <HorizontalGutter size="double" data-testid="configure-authContainer">
         <AccountFeaturesConfig disabled={this.props.submitting} />
         <SessionConfig disabled={this.props.submitting} />
-        <AuthIntegrationsConfigContainer
+        <AuthIntegrationsConfig
           auth={this.props.auth}
           disabled={this.props.submitting}
-          settings={this.props.settings}
         />
       </HorizontalGutter>
     );
@@ -123,7 +122,6 @@ const enhanced = withForm(
     settings: graphql`
       fragment AuthConfigContainer_settings on Settings {
         ...AccountFeaturesConfig_formValues @relay(mask: false)
-        ...AuthIntegrationsConfigContainer_settings
       }
     `,
     auth: graphql`

--- a/src/core/client/admin/routes/Configure/sections/Auth/AuthIntegrationsConfig.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/AuthIntegrationsConfig.tsx
@@ -1,11 +1,7 @@
 import React, { FunctionComponent } from "react";
-import { graphql } from "react-relay";
 
-import { withFragmentContainer } from "coral-framework/lib/relay";
 import { PropTypesOf } from "coral-framework/types";
 import { HorizontalGutter } from "coral-ui/components/v2";
-
-import { AuthIntegrationsConfigContainer_settings } from "coral-admin/__generated__/AuthIntegrationsConfigContainer_settings.graphql";
 
 import FacebookConfigContainer from "./FacebookConfigContainer";
 import GoogleConfigContainer from "./GoogleConfigContainer";
@@ -19,16 +15,14 @@ interface Props {
     PropTypesOf<typeof GoogleConfigContainer>["auth"] &
     PropTypesOf<typeof SSOConfigContainer>["auth"] &
     PropTypesOf<typeof OIDCConfigContainer>["auth"];
-  settings: AuthIntegrationsConfigContainer_settings;
 }
 
-const AuthIntegrationsConfigContainer: FunctionComponent<Props> = ({
+const AuthIntegrationsConfig: FunctionComponent<Props> = ({
   disabled,
   auth,
-  settings,
 }) => (
   <HorizontalGutter size="double">
-    <LocalAuthConfigContainer disabled={disabled} settings={settings} />
+    <LocalAuthConfigContainer disabled={disabled} />
     <OIDCConfigContainer disabled={disabled} auth={auth} />
     <SSOConfigContainer disabled={disabled} auth={auth} />
     <GoogleConfigContainer disabled={disabled} auth={auth} />
@@ -36,12 +30,4 @@ const AuthIntegrationsConfigContainer: FunctionComponent<Props> = ({
   </HorizontalGutter>
 );
 
-const enhanced = withFragmentContainer<Props>({
-  settings: graphql`
-    fragment AuthIntegrationsConfigContainer_settings on Settings {
-      ...LocalAuthConfigContainer_settings
-    }
-  `,
-})(AuthIntegrationsConfigContainer);
-
-export default enhanced;
+export default AuthIntegrationsConfig;

--- a/src/core/client/admin/routes/Configure/sections/Auth/LocalAuthConfigContainer.tsx
+++ b/src/core/client/admin/routes/Configure/sections/Auth/LocalAuthConfigContainer.tsx
@@ -2,12 +2,11 @@ import { Localized } from "@fluent/react/compat";
 import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
-import { withFragmentContainer } from "coral-framework/lib/relay";
-import { GQLFEATURE_FLAG } from "coral-framework/schema";
+import { useLocal } from "coral-framework/lib/relay";
 import { Icon } from "coral-ui/components/v2";
 import { CallOut } from "coral-ui/components/v3";
 
-import { LocalAuthConfigContainer_settings } from "coral-admin/__generated__/LocalAuthConfigContainer_settings.graphql";
+import { LocalAuthConfigContainerLocal } from "coral-admin/__generated__/LocalAuthConfigContainerLocal.graphql";
 
 import Header from "../../Header";
 import ConfigBoxWithToggleField from "./ConfigBoxWithToggleField";
@@ -34,16 +33,16 @@ graphql`
 
 interface Props {
   disabled?: boolean;
-  settings: LocalAuthConfigContainer_settings;
 }
 
-const LocalAuthConfigContainer: FunctionComponent<Props> = ({
-  disabled,
-  settings,
-}) => {
-  const forceAdminLocalAuth = settings.featureFlags.includes(
-    GQLFEATURE_FLAG.FORCE_ADMIN_LOCAL_AUTH
-  );
+const LocalAuthConfigContainer: FunctionComponent<Props> = ({ disabled }) => {
+  const [{ forceAdminLocalAuth }] = useLocal<
+    LocalAuthConfigContainerLocal
+  >(graphql`
+    fragment LocalAuthConfigContainerLocal on Local {
+      forceAdminLocalAuth
+    }
+  `);
 
   return (
     <ConfigBoxWithToggleField
@@ -90,12 +89,4 @@ const LocalAuthConfigContainer: FunctionComponent<Props> = ({
   );
 };
 
-const enhanced = withFragmentContainer<Props>({
-  settings: graphql`
-    fragment LocalAuthConfigContainer_settings on Settings {
-      featureFlags
-    }
-  `,
-})(LocalAuthConfigContainer);
-
-export default enhanced;
+export default LocalAuthConfigContainer;

--- a/src/core/client/admin/test/create.tsx
+++ b/src/core/client/admin/test/create.tsx
@@ -16,6 +16,8 @@ export default function create(params: CreateTestRendererParams<GQLResolver>) {
         "moderationQueueSort"
       );
 
+      localRecord.setValue(false, "forceAdminLocalAuth");
+
       if (params.initLocalState) {
         params.initLocalState(localRecord, source, environment);
       }

--- a/src/core/common/config.ts
+++ b/src/core/common/config.ts
@@ -45,4 +45,11 @@ export interface StaticConfig {
    * featureFlags are all the feature flags currently enabled on the tenant.
    */
   featureFlags: string[];
+
+  /**
+   * forceAdminLocalAuth is whether local authentication is always available
+   * for this Coral deployment. This is useful for ensuring that Coral service
+   * teams can access the admin with their Coral local authentication.
+   */
+  forceAdminLocalAuth: boolean;
 }

--- a/src/core/server/app/authenticators/facebook/facebook.ts
+++ b/src/core/server/app/authenticators/facebook/facebook.ts
@@ -50,14 +50,16 @@ interface FacebookUserProfile {
 const VERSION = "v3.2";
 
 export class FacebookAuthenticator extends OAuth2Authenticator {
+  private readonly config: Config;
   private readonly mongo: Db;
   private readonly profileURL = `https://graph.facebook.com/${VERSION}/me`;
   private readonly integration: Readonly<Required<FacebookAuthIntegration>>;
 
-  constructor({ integration, mongo, ...options }: Options) {
+  constructor({ integration, mongo, config, ...options }: Options) {
     super({
       ...options,
       ...integration,
+      config,
       authorizationURL: `https://www.facebook.com/${VERSION}/dialog/oauth`,
       tokenURL: `https://graph.facebook.com/${VERSION}/oauth/access_token`,
       scope: "email",
@@ -68,6 +70,7 @@ export class FacebookAuthenticator extends OAuth2Authenticator {
 
     this.integration = integration;
     this.mongo = mongo;
+    this.config = config;
   }
 
   /**
@@ -151,6 +154,7 @@ export class FacebookAuthenticator extends OAuth2Authenticator {
 
       // Create the user this time.
       user = await findOrCreate(
+        this.config,
         this.mongo,
         tenant,
         {

--- a/src/core/server/app/authenticators/google/google.ts
+++ b/src/core/server/app/authenticators/google/google.ts
@@ -37,14 +37,16 @@ interface GoogleUserProfile {
 }
 
 export class GoogleAuthenticator extends OAuth2Authenticator {
+  private readonly config: Config;
   private readonly mongo: Db;
   private readonly profileURL = "https://www.googleapis.com/oauth2/v3/userinfo";
   private readonly integration: Readonly<Required<GoogleAuthIntegration>>;
 
-  constructor({ integration, mongo, ...options }: Options) {
+  constructor({ integration, mongo, config, ...options }: Options) {
     super({
       ...options,
       ...integration,
+      config,
       authorizationURL: "https://accounts.google.com/o/oauth2/v2/auth",
       tokenURL: "https://www.googleapis.com/oauth2/v4/token",
       scope: "profile email",
@@ -52,6 +54,7 @@ export class GoogleAuthenticator extends OAuth2Authenticator {
 
     this.integration = integration;
     this.mongo = mongo;
+    this.config = config;
   }
 
   private async getProfile(accessToken: string): Promise<GoogleUserProfile> {
@@ -115,6 +118,7 @@ export class GoogleAuthenticator extends OAuth2Authenticator {
 
       // Create the user this time.
       user = await findOrCreate(
+        this.config,
         this.mongo,
         tenant,
         {

--- a/src/core/server/app/authenticators/oidc/oidc.ts
+++ b/src/core/server/app/authenticators/oidc/oidc.ts
@@ -29,15 +29,17 @@ interface Options {
 }
 
 export class OIDCAuthenticator extends OAuth2Authenticator {
+  private readonly config: Config;
   private readonly jwks: JwksClient;
   private readonly integration: Readonly<Required<OIDCAuthIntegration>>;
   private readonly mongo: Db;
   private readonly redis: Redis;
 
-  constructor({ integration, mongo, redis, ...options }: Options) {
+  constructor({ integration, mongo, redis, config, ...options }: Options) {
     super({
       ...options,
       ...integration,
+      config,
       scope: "openid email profile",
     });
 
@@ -45,6 +47,7 @@ export class OIDCAuthenticator extends OAuth2Authenticator {
     this.integration = integration;
     this.mongo = mongo;
     this.redis = redis;
+    this.config = config;
   }
 
   private async verifyToken(
@@ -130,6 +133,7 @@ export class OIDCAuthenticator extends OAuth2Authenticator {
 
       // Find or create the user.
       const user = await findOrCreateOIDCUser(
+        this.config,
         this.mongo,
         tenant,
         this.integration,

--- a/src/core/server/app/handlers/api/auth/local/forgot.ts
+++ b/src/core/server/app/handlers/api/auth/local/forgot.ts
@@ -58,7 +58,7 @@ export const forgotHandler = ({
       const { tenant, logger, now } = req.coral;
 
       // Check to ensure that the local integration has been enabled.
-      if (!hasEnabledAuthIntegration(tenant, "local")) {
+      if (!hasEnabledAuthIntegration(config, tenant, "local")) {
         throw new IntegrationDisabled("local");
       }
 
@@ -172,7 +172,7 @@ export const forgotResetHandler = ({
       const { tenant, now } = req.coral;
 
       // Check to ensure that the local integration has been enabled.
-      if (!hasEnabledAuthIntegration(tenant, "local")) {
+      if (!hasEnabledAuthIntegration(config, tenant, "local")) {
         throw new IntegrationDisabled("local");
       }
 
@@ -246,7 +246,7 @@ export const forgotCheckHandler = ({
       const { tenant, now } = req.coral;
 
       // Check to ensure that the local integration has been enabled.
-      if (!hasEnabledAuthIntegration(tenant, "local")) {
+      if (!hasEnabledAuthIntegration(config, tenant, "local")) {
         throw new IntegrationDisabled("local");
       }
 

--- a/src/core/server/app/handlers/api/auth/local/link.ts
+++ b/src/core/server/app/handlers/api/auth/local/link.ts
@@ -45,7 +45,7 @@ export const linkHandler = ({
       const { tenant, now } = req.coral;
 
       // Check to ensure that the local integration has been enabled.
-      if (!linkUsersAvailable(tenant)) {
+      if (!linkUsersAvailable(config, tenant)) {
         throw new Error("cannot link users, not available");
       }
 
@@ -56,7 +56,10 @@ export const linkHandler = ({
       // Start the account linking process. We are assured the user at this
       // point because of the middleware inserted before which rejects any
       // unauthenticated requests.
-      const user = await link(mongo, tenant, req.user!, { email, password });
+      const user = await link(config, mongo, tenant, req.user!, {
+        email,
+        password,
+      });
 
       // Account linking is complete! Return the new access token for the
       // request.

--- a/src/core/server/app/handlers/api/auth/local/signup.ts
+++ b/src/core/server/app/handlers/api/auth/local/signup.ts
@@ -54,7 +54,7 @@ export const signupHandler = ({
       const { tenant, now } = req.coral;
 
       // Check to ensure that the local integration has been enabled.
-      if (!hasEnabledAuthIntegration(tenant, "local")) {
+      if (!hasEnabledAuthIntegration(config, tenant, "local")) {
         throw new IntegrationDisabled("local");
       }
 

--- a/src/core/server/app/middleware/passport/strategies/jwt.ts
+++ b/src/core/server/app/middleware/passport/strategies/jwt.ts
@@ -22,7 +22,7 @@ import { SSOToken, SSOVerifier } from "./verifiers/sso";
 
 export type JWTStrategyOptions = Pick<
   AppOptions,
-  "signingConfig" | "mongo" | "redis" | "tenantCache" | "mongo"
+  "signingConfig" | "mongo" | "redis" | "tenantCache" | "mongo" | "config"
 >;
 
 /**

--- a/src/core/server/app/middleware/passport/strategies/verifiers/oidc.ts
+++ b/src/core/server/app/middleware/passport/strategies/verifiers/oidc.ts
@@ -3,6 +3,7 @@ import { Db } from "mongodb";
 
 import { AppOptions } from "coral-server/app";
 import { getEnabledIntegration } from "coral-server/app/authenticators/oidc/helpers";
+import { Config } from "coral-server/config";
 import logger from "coral-server/logger";
 import { Tenant } from "coral-server/models/tenant";
 import {
@@ -14,15 +15,20 @@ import { TenantCacheAdapter } from "coral-server/services/tenant/cache";
 
 import { Verifier } from "../jwt";
 
-export type OIDCVerifierOptions = Pick<AppOptions, "mongo" | "tenantCache">;
+export type OIDCVerifierOptions = Pick<
+  AppOptions,
+  "mongo" | "tenantCache" | "config"
+>;
 
 export class OIDCVerifier implements Verifier<OIDCIDToken> {
+  private config: Config;
   private mongo: Db;
   private cache: TenantCacheAdapter<JwksClient>;
 
-  constructor({ mongo, tenantCache }: OIDCVerifierOptions) {
+  constructor({ mongo, tenantCache, config }: OIDCVerifierOptions) {
     this.mongo = mongo;
     this.cache = new TenantCacheAdapter(tenantCache);
+    this.config = config;
   }
 
   public async verify(
@@ -48,6 +54,7 @@ export class OIDCVerifier implements Verifier<OIDCIDToken> {
     }
 
     return findOrCreateOIDCUserWithToken(
+      this.config,
       this.mongo,
       tenant,
       client,

--- a/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
+++ b/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
@@ -7,6 +7,7 @@ import { URL } from "url";
 
 import validateImagePathname from "coral-common/helpers/validateImagePathname";
 import { validate } from "coral-server/app/request/body";
+import { Config } from "coral-server/config";
 import { IntegrationDisabled, TokenInvalidError } from "coral-server/errors";
 import logger from "coral-server/logger";
 import {
@@ -98,6 +99,7 @@ export const SSOTokenSchema = Joi.object().keys({
 });
 
 export async function findOrCreateSSOUser(
+  config: Config,
   mongo: Db,
   redis: AugmentedRedis,
   tenant: Tenant,
@@ -153,6 +155,7 @@ export async function findOrCreateSSOUser(
 
     // Create the new user, as one didn't exist before!
     user = await findOrCreate(
+      config,
       mongo,
       tenant,
       {
@@ -218,6 +221,7 @@ const updateLastUsedAtKID = throttle(
 );
 
 export interface SSOVerifierOptions {
+  config: Config;
   mongo: Db;
   redis: AugmentedRedis;
 }
@@ -261,10 +265,12 @@ export function getRelevantSSOSigningSecrets(
 }
 
 export class SSOVerifier implements Verifier<SSOToken> {
+  private config: Config;
   private mongo: Db;
   private redis: AugmentedRedis;
 
-  constructor({ mongo, redis }: SSOVerifierOptions) {
+  constructor({ mongo, redis, config }: SSOVerifierOptions) {
+    this.config = config;
     this.mongo = mongo;
     this.redis = redis;
   }
@@ -353,6 +359,7 @@ export class SSOVerifier implements Verifier<SSOToken> {
     }
 
     return findOrCreateSSOUser(
+      this.config,
       this.mongo,
       this.redis,
       tenant,

--- a/src/core/server/app/router/index.ts
+++ b/src/core/server/app/router/index.ts
@@ -32,6 +32,7 @@ export function createRouter(app: AppOptions, options: RouterOptions) {
       staticURI: app.config.get("static_uri") || "/",
       graphQLSubscriptionURI: app.config.get("graphql_subscription_uri") || "",
       featureFlags: [],
+      forceAdminLocalAuth: app.config.get("force_admin_local_auth"),
     };
 
     // If sentry is configured, then add it's config to the config.

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -454,6 +454,13 @@ const config = convict({
     default: ms("30 minutes"),
     env: "NON_FINGERPRINTED_CACHE_MAX_AGE",
   },
+  force_admin_local_auth: {
+    doc:
+      "Will force local auth in the admin to on so that it cannot be turned off.",
+    format: Boolean,
+    default: false,
+    env: "FORCE_ADMIN_LOCAL_AUTH",
+  },
 });
 
 export type Config = typeof config;

--- a/src/core/server/graph/resolvers/AuthenticationTargetFilter.ts
+++ b/src/core/server/graph/resolvers/AuthenticationTargetFilter.ts
@@ -1,14 +1,11 @@
-import { hasFeatureFlag } from "coral-server/models/tenant";
-
 import {
   GQLAuthenticationTargetFilter,
   GQLAuthenticationTargetFilterTypeResolver,
-  GQLFEATURE_FLAG,
 } from "coral-server/graph/schema/__generated__/types";
 
 export const AuthenticationTargetFilter: GQLAuthenticationTargetFilterTypeResolver<GQLAuthenticationTargetFilter> = {
-  admin: ({ admin }, _, { tenant }) => {
-    if (hasFeatureFlag(tenant, GQLFEATURE_FLAG.FORCE_ADMIN_LOCAL_AUTH)) {
+  admin: ({ admin }, _, { tenant, config }) => {
+    if (config.get("force_admin_local_auth")) {
       return true;
     }
 

--- a/src/core/server/graph/resolvers/AuthenticationTargetFilter.ts
+++ b/src/core/server/graph/resolvers/AuthenticationTargetFilter.ts
@@ -4,7 +4,7 @@ import {
 } from "coral-server/graph/schema/__generated__/types";
 
 export const AuthenticationTargetFilter: GQLAuthenticationTargetFilterTypeResolver<GQLAuthenticationTargetFilter> = {
-  admin: ({ admin }, _, { tenant, config }) => {
+  admin: ({ admin }, _, { config }) => {
     if (config.get("force_admin_local_auth")) {
       return true;
     }

--- a/src/core/server/graph/resolvers/LocalAuthIntegration.ts
+++ b/src/core/server/graph/resolvers/LocalAuthIntegration.ts
@@ -1,13 +1,11 @@
 import {
-  GQLFEATURE_FLAG,
   GQLLocalAuthIntegration,
   GQLLocalAuthIntegrationTypeResolver,
 } from "coral-server/graph/schema/__generated__/types";
-import { hasFeatureFlag } from "coral-server/models/tenant";
 
 export const LocalAuthIntegration: GQLLocalAuthIntegrationTypeResolver<GQLLocalAuthIntegration> = {
-  enabled: ({ enabled }, _, { tenant }) => {
-    if (hasFeatureFlag(tenant, GQLFEATURE_FLAG.FORCE_ADMIN_LOCAL_AUTH)) {
+  enabled: ({ enabled }, _, { config }) => {
+    if (config.get("force_admin_local_auth")) {
       return true;
     }
 

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -575,13 +575,6 @@ enum FEATURE_FLAG {
   (European Directive 2000/31/CE).
   """
   FOR_REVIEW
-
-  """
-  FORCE_ADMIN_LOCAL_AUTH will force local auth in the admin to on so that it cannot be turned
-  off. This is useful for SSO clients who use SSO for their admin access and might try and
-  turn off the local admin auth.
-  """
-  FORCE_ADMIN_LOCAL_AUTH
 }
 
 # The moderation mode of the site.

--- a/src/core/server/models/tenant/helpers.ts
+++ b/src/core/server/models/tenant/helpers.ts
@@ -1,5 +1,6 @@
 import { FluentBundle } from "@fluent/bundle/compat";
 
+import { Config } from "coral-server/config";
 import { InternalError } from "coral-server/errors";
 import { translate } from "coral-server/services/i18n";
 
@@ -62,13 +63,11 @@ export function ensureFeatureFlag(
 }
 
 export function hasEnabledAuthIntegration(
+  config: Config,
   tenant: Pick<Tenant, "auth" | "featureFlags">,
   integration: keyof AuthIntegrations
 ) {
-  const forceAdminLocalAuth = hasFeatureFlag(
-    tenant,
-    GQLFEATURE_FLAG.FORCE_ADMIN_LOCAL_AUTH
-  );
+  const forceAdminLocalAuth = config.get("force_admin_local_auth");
   if (integration === "local" && forceAdminLocalAuth) {
     return true;
   }
@@ -76,11 +75,14 @@ export function hasEnabledAuthIntegration(
   return tenant.auth.integrations[integration].enabled;
 }
 
-export function linkUsersAvailable(tenant: Pick<Tenant, "auth">) {
+export function linkUsersAvailable(
+  config: Config,
+  tenant: Pick<Tenant, "auth">
+) {
   return (
-    hasEnabledAuthIntegration(tenant, "local") &&
-    (hasEnabledAuthIntegration(tenant, "facebook") ||
-      hasEnabledAuthIntegration(tenant, "google"))
+    hasEnabledAuthIntegration(config, tenant, "local") &&
+    (hasEnabledAuthIntegration(config, tenant, "facebook") ||
+      hasEnabledAuthIntegration(config, tenant, "google"))
   );
 }
 

--- a/src/core/server/services/oidc/oidc.ts
+++ b/src/core/server/services/oidc/oidc.ts
@@ -9,6 +9,7 @@ import {
 import { isNil } from "lodash";
 import { Db } from "mongodb";
 
+import { Config } from "coral-server/config";
 import { TokenInvalidError } from "coral-server/errors";
 import { validateSchema } from "coral-server/helpers";
 import { OIDCAuthIntegration } from "coral-server/models/settings";
@@ -149,6 +150,7 @@ export function verifyIDToken(
 }
 
 export async function findOrCreateOIDCUser(
+  config: Config,
   mongo: Db,
   tenant: Tenant,
   integration: OIDCAuthIntegration,
@@ -195,6 +197,7 @@ export async function findOrCreateOIDCUser(
 
   // Create the new user, as one didn't exist before!
   return await findOrCreate(
+    config,
     mongo,
     tenant,
     {
@@ -211,6 +214,7 @@ export async function findOrCreateOIDCUser(
 }
 
 export async function findOrCreateOIDCUserWithToken(
+  config: Config,
   mongo: Db,
   tenant: Tenant,
   client: JwksClient,
@@ -227,5 +231,5 @@ export async function findOrCreateOIDCUserWithToken(
   );
 
   // Find or create the user based on the verified token.
-  return findOrCreateOIDCUser(mongo, tenant, integration, token, now);
+  return findOrCreateOIDCUser(config, mongo, tenant, integration, token, now);
 }

--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -145,6 +145,7 @@ export interface FindOrCreateUserOptions {
 }
 
 export async function findOrCreate(
+  config: Config,
   mongo: Db,
   tenant: Tenant,
   input: FindOrCreateUser,
@@ -174,7 +175,10 @@ export async function findOrCreate(
     // If this is an error related to a duplicate email, we might be in a
     // position where the user can link their accounts. This can only occur if
     // the tenant has both local and another social profile enabled.
-    if (err instanceof DuplicateEmailError && linkUsersAvailable(tenant)) {
+    if (
+      err instanceof DuplicateEmailError &&
+      linkUsersAvailable(config, tenant)
+    ) {
       // Pull the email address out of the input, and re-try creating the user
       // given that. We need to pull the verified property out because we don't
       // want to have that embedded in the `...rest` object.
@@ -1659,12 +1663,13 @@ export interface LinkUser {
 }
 
 export async function link(
+  config: Config,
   mongo: Db,
   tenant: Tenant,
   source: User,
   { email, password }: LinkUser
 ) {
-  if (!linkUsersAvailable(tenant)) {
+  if (!linkUsersAvailable(config, tenant)) {
     throw new Error("cannot link users, not available");
   }
 


### PR DESCRIPTION
## What does this PR do?

Make `FORCE_ADMIN_LOCAL_AUTH` into an env var config option

Was previously a feature flag, can now more easily be set across tenants via an environment variable.

## What changes to the GraphQL/Database Schema does this PR introduce?

Removes the previously added `FORCE_ADMIN_LOCAL_AUTH` feature flag in favour of a same named env var instead.

## How do I test this PR?

- Set `FORCE_ADMIN_LOCAL_AUTH=true` in your `.env`
- Go to Admin > Config > Authentication and see that the `Login with email authentication` is forced on and the local auth for Admin is forced on
 
 
## How do we deploy this PR?

- When deploying on clients that need local admin auth forced on, set `FORCE_ADMIN_LOCAL_AUTH` in the deployment yaml.
