### PR TITLE
[CORL-2270] Throw better error when removing story with comments

### DIFF
--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -234,8 +234,9 @@ export async function remove(
       "attempted to remove story that has linked comments without consent for deleting comments"
     );
 
-    // TODO: (wyattjoh) improve error
-    throw new Error("asset has comments, cannot remove");
+    throw new Error(
+      "Failed to delete story. Attempted to remove a story that still has comments. It is preferable that you merge a story instead of trying to delete it. If you are sure about what you're doing and want to delete this story with its comments. Use the option `includeComments = true`. For more details check the schema suggestions for this mutation input."
+    );
   }
 
   const removedStory = await removeStory(mongo, tenant.id, story.id);

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -235,7 +235,7 @@ export async function remove(
     );
 
     throw new Error(
-      "Failed to delete story. Attempted to remove a story that still has comments. It is preferable that you merge a story instead of trying to delete it. If you are sure about what you're doing and want to delete this story with its comments. Use the option `includeComments = true`. For more details check the schema suggestions for this mutation input."
+      "Failed to delete story. Attempted to remove a story that still has comments. It is preferable that you merge a story or update its Story URL instead of trying to delete it. If you are sure about what you're doing and want to delete this story with its comments. Use the option `includeComments = true`. For more details check the schema suggestions for this mutation input."
     );
   }
 


### PR DESCRIPTION
## What does this PR do?

When removing a story with comments and `includeComments = false/not set`, throws a better error message to indicate our preference that they use `mergeStory` instead.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Create a story
- Create comments
- Call `removeStory` mutation
- See that it throws a descriptive error message
 
## How do we deploy this PR?

No special deploy actions necessary.
