### PR TITLE
[CORL-2347] Add MAINTENANCE mode and Heapdump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ dist
 __generated__
 persisted-queries.json
 docs/out
+
+# don't include runtime files
+MAINTENANCE
+*.heapsnapshot

--- a/src/core/server/app/handlers/api/index.ts
+++ b/src/core/server/app/handlers/api/index.ts
@@ -3,6 +3,7 @@ export * from "./auth";
 export * from "./dashboard";
 export * from "./externalMedia";
 export * from "./health";
+export * from "./ready";
 export * from "./install";
 export * from "./oembed";
 export * from "./remoteMedia";

--- a/src/core/server/app/handlers/api/ready.ts
+++ b/src/core/server/app/handlers/api/ready.ts
@@ -1,0 +1,27 @@
+import { F_OK } from "constants";
+import { RequestHandler } from "express";
+import fs from "fs";
+
+/**
+ * The readiness handler will always return 200 unless
+ * it finds a MAINTENANCE file under the root folder in which it
+ * will send a 500 code.
+ *
+ * If the orchestration platform such as Kubernetes is configured with a
+ * readiness probe on this endpoint `/api/ready` it will seize to serve
+ * any traffic to this process.
+ *
+ * It can take up to 7 minutes until no traffic is being handled anymore.
+ */
+export const readyHandler: RequestHandler = async (req, res, next) => {
+  try {
+    await fs.promises.access("./MAINTENANCE", F_OK);
+    res
+      .status(500)
+      .send(
+        "Currently under maintenance. To resume remove the MAINTENANCE file."
+      );
+  } catch {
+    res.status(200).send("OK");
+  }
+};

--- a/src/core/server/app/index.ts
+++ b/src/core/server/app/index.ts
@@ -45,7 +45,7 @@ import { PersistedQueryCache } from "coral-server/services/queries";
 import { AugmentedRedis } from "coral-server/services/redis";
 import { TenantCache } from "coral-server/services/tenant/cache";
 
-import { healthHandler, versionHandler } from "./handlers";
+import { healthHandler, readyHandler, versionHandler } from "./handlers";
 import { compileTrust } from "./helpers";
 import { basicAuth } from "./middleware/basicAuth";
 import { accessLogger } from "./middleware/logging";
@@ -113,6 +113,9 @@ export async function createApp(options: AppOptions): Promise<Express> {
 
   // Configure the health check endpoint.
   parent.get("/api/health", healthHandler);
+
+  // Configure the readiness endpoint.
+  parent.get("/api/ready", readyHandler);
 
   // Configure the version route.
   parent.get("/api/version", versionHandler);


### PR DESCRIPTION
## What does this PR do?
- Adds a HTTP api route to `/api/ready` that we can use as a [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes)
  - `/api/ready` always returns 200 unless there is a `MAINTENANCE` file in the root folder.
  - If pod is configured to use this endpoint as the readiness probe, we can stop Kubernetes from serving traffic to this pod, allowing us to debug the containers in production without affecting users.
  - To enter maintenance mode simply run `touch MAINTENANCE`, and to restore run `rm MAINTENANCE` in the root folder.
  - It can take 10 minutes until no traffic is beind handled anymore
  - We can then do cool things like attaching a debugger and so on :-)
- Adds possibility to dump the memory heap to a file. On unix systems you can trigger this by calling `kill -SIGUSR2 <process_pid>`. ATTENTION: This blocks main thread for quite a while. That's why you should put the pod in `MAINTENANCE` mode first, if you are doing this in production.

## What to test this PR?
- Build using `npm run build`
- Start server using `npm start`
- Run `curl --head http://localhost:3000/api/ready`
- Run `touch MAINTENANCE`
- Run `curl --head http://localhost:3000/api/ready` again
- Run `ps -A | grep node` and find your node process and its pid number
- Run `kill -SIGUSR2 <process_pid>` to dump the heap
- Run `rm MAINTENANCE` to end maintenance
- Run `curl --head http://localhost:3000/api/ready` to see that maintenance is over