### PR TITLE
[CORL-2356] Decision history should work when comment revisions get deleted

### DIFF
--- a/src/core/client/admin/App/DecisionHistory/DecisionHistoryItemContainer.tsx
+++ b/src/core/client/admin/App/DecisionHistory/DecisionHistoryItemContainer.tsx
@@ -17,10 +17,10 @@ class DecisionHistoryItemContainer extends React.Component<
   DecisionHistoryItemContainerProps
 > {
   public render() {
-    const href = `/admin/moderate/comment/${this.props.action.revision.comment.id}`;
+    const href = `/admin/moderate/comment/${this.props.action.comment.id}`;
     const username =
-      (this.props.action.revision.comment.author &&
-        this.props.action.revision.comment.author.username) ||
+      (this.props.action.comment.author &&
+        this.props.action.comment.author.username) ||
       "Unknown"; // TODO: (cvle) Figure out what to display, when username is not available.
     if (this.props.action.status === "APPROVED") {
       return (
@@ -49,13 +49,10 @@ const enhanced = withFragmentContainer<DecisionHistoryItemContainerProps>({
   action: graphql`
     fragment DecisionHistoryItemContainer_action on CommentModerationAction {
       id
-      revision {
+      comment {
         id
-        comment {
-          id
-          author {
-            username
-          }
+        author {
+          username
         }
       }
       createdAt

--- a/src/core/client/admin/test/fixtures.ts
+++ b/src/core/client/admin/test/fixtures.ts
@@ -317,15 +317,12 @@ export const sites = createFixtures<GQLSite>([
 export const moderationActions = createFixtures<GQLCommentModerationAction>([
   {
     id: "07e8f815-e165-4b5d-b438-7163415c8cf7",
-    revision: {
-      id: "4210dc8b-c212-4f74-9381-913e8c52e51a",
-      comment: {
-        author: {
-          username: "luke2",
-          id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
-        },
-        id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
+    comment: {
+      author: {
+        username: "luke2",
+        id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
       },
+      id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
     },
     createdAt: "2018-11-29T16:01:51.897Z",
     status: GQLCOMMENT_STATUS.APPROVED,
@@ -333,15 +330,12 @@ export const moderationActions = createFixtures<GQLCommentModerationAction>([
   },
   {
     id: "6869314b-47ef-4cf9-b8ce-42b12bca8231",
-    revision: {
-      id: "4210dc8b-c212-4f74-9381-913e8c52e51a",
-      comment: {
-        author: {
-          username: "addy",
-          id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
-        },
-        id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
+    comment: {
+      author: {
+        username: "addy",
+        id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
       },
+      id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
     },
     createdAt: "2018-11-29T16:01:45.644Z",
     status: GQLCOMMENT_STATUS.REJECTED,
@@ -349,15 +343,12 @@ export const moderationActions = createFixtures<GQLCommentModerationAction>([
   },
   {
     id: "caebbf7f-4813-42c0-ac3c-46b1be8199e0",
-    revision: {
-      id: "4210dc8b-c212-4f74-9381-913e8c52e51a",
-      comment: {
-        author: {
-          username: "dany",
-          id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
-        },
-        id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
+    comment: {
+      author: {
+        username: "dany",
+        id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
       },
+      id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
     },
     createdAt: "2018-11-29T16:01:42.060Z",
     status: GQLCOMMENT_STATUS.APPROVED,
@@ -365,15 +356,12 @@ export const moderationActions = createFixtures<GQLCommentModerationAction>([
   },
   {
     id: "b2f92717-e4a8-4075-a543-95f7c5eaefb2",
-    revision: {
-      id: "4210dc8b-c212-4f74-9381-913e8c52e51a",
-      comment: {
-        author: {
-          username: "admin",
-          id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
-        },
-        id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
+    comment: {
+      author: {
+        username: "admin",
+        id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
       },
+      id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
     },
     createdAt: "2018-11-29T16:01:34.539Z",
     status: GQLCOMMENT_STATUS.REJECTED,
@@ -381,15 +369,12 @@ export const moderationActions = createFixtures<GQLCommentModerationAction>([
   },
   {
     id: "9fb2ff3c-7105-4357-99e1-36cdeea49c75",
-    revision: {
-      id: "4210dc8b-c212-4f74-9381-913e8c52e51a",
-      comment: {
-        author: {
-          username: "mod245",
-          id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
-        },
-        id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
+    comment: {
+      author: {
+        username: "mod245",
+        id: "4383c3d3-bb9b-40b9-847a-240f3cf6c6af",
       },
+      id: "1b41be9f-510f-41f3-a1df-5a431dc98bf3",
     },
     createdAt: "2018-11-29T16:01:30.648Z",
     status: GQLCOMMENT_STATUS.APPROVED,

--- a/src/core/server/graph/resolvers/CommentModerationAction.ts
+++ b/src/core/server/graph/resolvers/CommentModerationAction.ts
@@ -1,6 +1,7 @@
 import * as actions from "coral-server/models/action/moderation/comment";
 
 import { GQLCommentModerationActionTypeResolver } from "../schema/__generated__/types";
+import { maybeLoadOnlyID } from "./Comment";
 
 export const CommentModerationAction: GQLCommentModerationActionTypeResolver<actions.CommentModerationAction> = {
   revision: async (action, input, ctx) => {
@@ -18,6 +19,8 @@ export const CommentModerationAction: GQLCommentModerationActionTypeResolver<act
 
     return { comment, revision };
   },
+  comment: ({ commentID }, args, ctx, info) =>
+    maybeLoadOnlyID(ctx, info, commentID),
   moderator: (action, input, ctx) =>
     action.moderatorID ? ctx.loaders.Users.user.load(action.moderatorID) : null,
 };

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -3020,7 +3020,12 @@ type CommentModerationAction {
   """
   revision is the moderated CommentRevision.
   """
-  revision: CommentRevision!
+  revision: CommentRevision
+
+  """
+  comment is the moderated Comment.
+  """
+  comment: Comment!
 
   """
   status represents the status that was assigned by the moderator.


### PR DESCRIPTION
## What does this PR do?
- When a comment was moderated and the author gets deleted, the decision history would break.
- This will fix it.
<img width="425" alt="Screenshot 2021-10-07 at 00 08 42" src="https://user-images.githubusercontent.com/14221600/136294349-8ce78ab3-1be6-4b5b-8a43-af984bfce353.png">


## How do I test this PR?
- Moderate a comment of a user
- Delete user
- Open decision history