### PR TITLE
[CORL-2312]: Add option to provide another domain for comment downloads

### DIFF
--- a/src/core/server/app/url.ts
+++ b/src/core/server/app/url.ts
@@ -48,6 +48,24 @@ export function reconstructTenantURL(
   return constructTenantURL(config, tenant, path);
 }
 
+export function constructDownloadLinkURL(
+  config: Config,
+  tenant: Pick<Tenant, "domain">,
+  path = "/",
+  downloadLinkDomainOverride: string
+): string {
+  const linkDomain =
+    downloadLinkDomainOverride !== ""
+      ? downloadLinkDomainOverride
+      : tenant.domain;
+  let url: URL = new URL(path, `https://${linkDomain}`);
+  if (config.get("env") === "development") {
+    url = new URL(path, `http://${linkDomain}:${config.get("dev_port")}`);
+  }
+
+  return url.href;
+}
+
 export function doesRequireSchemePrefixing(url: string) {
   return !url.startsWith("http");
 }

--- a/src/core/server/app/url.ts
+++ b/src/core/server/app/url.ts
@@ -48,6 +48,11 @@ export function reconstructTenantURL(
   return constructTenantURL(config, tenant, path);
 }
 
+/**
+ * constructDownloadLinkURL will construct a URL based off of either a domain
+ * override set by the download_gdpr_comments_link_domain env var or default to
+ * the Tenant's domain.
+ */
 export function constructDownloadLinkURL(
   config: Config,
   tenant: Pick<Tenant, "domain">,

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -455,6 +455,13 @@ const config = convict({
     default: ms("30s"),
     env: "MAILER_JOB_TIMEOUT",
   },
+  download_gdpr_comments_link_domain: {
+    doc:
+      "Specifies an alternative domain to be used for the download GDPR comments link sent out in emails. If set to default empty string, will use the tenant domain. Example: yourdomain.com",
+    format: String,
+    default: "",
+    env: "DOWNLOAD_GDPR_COMMENTS_LINK_DOMAIN",
+  },
   non_fingerprinted_cache_max_age: {
     doc: "Max age for the ",
     format: "ms",

--- a/src/core/server/config.ts
+++ b/src/core/server/config.ts
@@ -58,6 +58,16 @@ convict.addFormat({
   },
 });
 
+// Add a custom format for domain.
+convict.addFormat({
+  name: "domain",
+  validate: (domain: string) => {
+    if (domain) {
+      Joi.assert(domain, Joi.string().domain());
+    }
+  },
+});
+
 // Add a custom format for a list of comma seperated strings.
 convict.addFormat({
   name: "list",
@@ -458,7 +468,7 @@ const config = convict({
   download_gdpr_comments_link_domain: {
     doc:
       "Specifies an alternative domain to be used for the download GDPR comments link sent out in emails. If set to default empty string, will use the tenant domain. Example: yourdomain.com",
-    format: String,
+    format: "domain",
     default: "",
     env: "DOWNLOAD_GDPR_COMMENTS_LINK_DOMAIN",
   },

--- a/src/core/server/services/users/download/token.ts
+++ b/src/core/server/services/users/download/token.ts
@@ -4,7 +4,10 @@ import { isNull } from "lodash";
 import { DateTime } from "luxon";
 import { v4 as uuid } from "uuid";
 
-import { constructTenantURL } from "coral-server/app/url";
+import {
+  constructDownloadLinkURL,
+  constructTenantURL,
+} from "coral-server/app/url";
 import { Config } from "coral-server/config";
 import { MongoContext } from "coral-server/data/context";
 import { TokenInvalidError, UserNotFoundError } from "coral-server/errors";
@@ -67,10 +70,15 @@ export async function generateDownloadLink(
     now
   );
 
-  return constructTenantURL(
+  const downloadLinkDomainOverride = config.get(
+    "download_gdpr_comments_link_domain"
+  );
+
+  return constructDownloadLinkURL(
     config,
     tenant,
-    `/account/download#downloadToken=${token}`
+    `/account/download#downloadToken=${token}`,
+    downloadLinkDomainOverride
   );
 }
 


### PR DESCRIPTION
## What does this PR do?
This PR adds an optional server config env var for the domain to be used in the download GDPR comments link that's sent out in emails. If set to its default empty string, the tenant domain will still be used. If set to a domain, then this domain will be used in the download link sent out.

I am interested in any feedback on what to do in `constructDownloadLinkUrl` regarding the domain in the case of working in `development`. I opted to include the link domain override in that url even though it means the url won't work in that case, so that the link could be inspected for testing that the override is working.

## What changes to the GraphQL/Database Schema does this PR introduce?
None

## How do I test this PR?
You can test this PR by
1. Setting the new env var (`DOWNLOAD_GDPR_COMMENTS_LINK_DOMAIN`) to a domain. (Can also test with it not set to make sure still working as expected in that case.)
1. Configuring Coral to allow users to download their comment history.
1. You'll need your local dev set up to mock email sending.
1. Request your comment history from your profile in the stream.
1. View the email you receive at localhost:9000. You should see when you hover over `Download my comment archive` that the link is using the domain you set.
 
## How do we deploy this PR?
This adds a new env var to the server config, but it doesn't need to be set to anything.
