### PR TITLE
[CORL-2384] Upgrade to node v16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ job_node_defaults: &job_node_defaults
   <<: *job_defaults
   working_directory: ~/coralproject/talk
   docker:
-    - image: circleci/node:14
+    - image: circleci/node:16
   environment:
     <<: *job_node_environment
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:14-alpine
+FROM node:16-alpine
 
 # Install build dependancies.
-RUN apk --no-cache add git python
+RUN apk --no-cache add git python3
 
 # Create app directory.
 RUN mkdir -p /usr/src/app

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -8,7 +8,7 @@ description: A guide to developing and extending Coral.
 Running Coral for development is very similar to installing Coral via Source as
 described in our [Getting Started](/#source) guide.
 
-Coral requires NodeJS ^14.18, we recommend using `nvm` to help manage node
+Coral requires NodeJS ^16.12, we recommend using `nvm` to help manage node
 versions: https://github.com/creationix/nvm.
 
 ```bash

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -20,8 +20,8 @@ Built with ❤️ by Coral by [Vox Media](https://product.voxmedia.com/).
 
 - MongoDB ^4.2
 - Redis ^3.2
-- NodeJS ^14.18
-- NPM ^8.0
+- NodeJS ^16.12
+- NPM ^8.1
 
 ## Running
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -80,7 +80,7 @@ Then head on over to http://localhost:5000 to install Coral!
 
 ### Source
 
-Coral requires NodeJS >=14, we recommend using `nvm` to help manage node
+Coral requires NodeJS >=16, we recommend using `nvm` to help manage node
 versions https://github.com/nvm-sh/nvm.
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "git://github.com/coralproject/talk.git"
   },
   "engines": {
-    "node": "^14.18",
-    "npm": "^8.0.0"
+    "node": "^16.12.0",
+    "npm": "^8.1.0"
   },
   "bugs": "https://github.com/coralproject/talk/issues",
   "contributors": [
@@ -68,7 +68,7 @@
     "@coralproject/bunyan-prettystream": "^0.1.4",
     "@fluent/bundle": "^0.15.0",
     "@fluent/dom": "^0.6.0",
-    "@google-cloud/profiler": "^4.1.0",
+    "@google-cloud/profiler": "^4.1.5",
     "@graphql-tools/schema": "^6.2.4",
     "@graphql-tools/utils": "^6.2.4",
     "@metascraper/helpers": "^5.22.5",


### PR DESCRIPTION
**Blocked** 

The following issue describes memory leak issues with `vm.Script` that we are using to scan comment content for suspect and banned words.

Contrary to the issue's title, it also does affect Node v12 but in a different way.
Before we introduce more "weirdness", we should deal with current mem leaks, or find an alternative to `vm.Script`.

- https://github.com/nodejs/node/issues/40014

## What does this PR do?

- Upgrades to node v16