### PR TITLE
[CORL-2385] Downgrade to node v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ job_node_defaults: &job_node_defaults
   <<: *job_defaults
   working_directory: ~/coralproject/talk
   docker:
-    - image: circleci/node:14
+    - image: circleci/node:12
   environment:
     <<: *job_node_environment
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:12-alpine
 
 # Install build dependancies.
 RUN apk --no-cache add git python

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -8,7 +8,7 @@ description: A guide to developing and extending Coral.
 Running Coral for development is very similar to installing Coral via Source as
 described in our [Getting Started](/#source) guide.
 
-Coral requires NodeJS ^14.18, we recommend using `nvm` to help manage node
+Coral requires NodeJS ^12.20, we recommend using `nvm` to help manage node
 versions: https://github.com/creationix/nvm.
 
 ```bash

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -20,7 +20,7 @@ Built with ❤️ by Coral by [Vox Media](https://product.voxmedia.com/).
 
 - MongoDB ^4.2
 - Redis ^3.2
-- NodeJS ^14.18
+- NodeJS ^12.20
 - NPM ^8.0
 
 ## Running
@@ -80,7 +80,7 @@ Then head on over to http://localhost:5000 to install Coral!
 
 ### Source
 
-Coral requires NodeJS >=14, we recommend using `nvm` to help manage node
+Coral requires NodeJS >=12, we recommend using `nvm` to help manage node
 versions https://github.com/nvm-sh/nvm.
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git://github.com/coralproject/talk.git"
   },
   "engines": {
-    "node": "^14.18",
+    "node": "^12.20",
     "npm": "^8.0.0"
   },
   "bugs": "https://github.com/coralproject/talk/issues",


### PR DESCRIPTION
## What does this PR do?

- Downgrades to node v12

The following issue describes memory leak issues with `vm.Script` that we are using to scan comment content for suspect and banned words.

Contrary to the issue's title, it also does affect Node v12 but in a different way.
Before we introduce more "weirdness", we should deal with current mem leaks, or find an alternative to `vm.Script`.

- https://github.com/nodejs/node/issues/40014

Additionally memory dumps are crashing in v14 builds:

- https://github.com/nodejs/node/issues/39258