### PR TITLE
[CORL-2399] Do not archive ratings and reviews stories

### DIFF
--- a/src/core/client/admin/routes/Stories/StoryActions/StoryActionsContainer.tsx
+++ b/src/core/client/admin/routes/Stories/StoryActions/StoryActionsContainer.tsx
@@ -3,7 +3,7 @@ import { graphql } from "react-relay";
 
 import { Ability, can } from "coral-admin/permissions";
 import { useMutation, withFragmentContainer } from "coral-framework/lib/relay";
-import { GQLSTORY_STATUS } from "coral-framework/schema";
+import { GQLSTORY_MODE, GQLSTORY_STATUS } from "coral-framework/schema";
 
 import { StoryActionsContainer_story } from "coral-admin/__generated__/StoryActionsContainer_story.graphql";
 import { StoryActionsContainer_viewer } from "coral-admin/__generated__/StoryActionsContainer_viewer.graphql";
@@ -60,7 +60,10 @@ const StoryActionsContainer: FunctionComponent<Props> = (props) => {
         !props.story.isArchiving
       }
       canArchive={
-        viewCanArchive && !props.story.isArchiving && !props.story.isArchived
+        viewCanArchive &&
+        !props.story.isArchiving &&
+        !props.story.isArchived &&
+        props.story.settings?.mode !== GQLSTORY_MODE.RATINGS_AND_REVIEWS
       }
       canUnarchive={
         props.story.status === GQLSTORY_STATUS.CLOSED &&
@@ -85,6 +88,9 @@ const enhanced = withFragmentContainer<Props>({
       status
       isArchived
       isArchiving
+      settings {
+        mode
+      }
     }
   `,
 })(StoryActionsContainer);

--- a/src/core/server/models/story/story.ts
+++ b/src/core/server/models/story/story.ts
@@ -777,6 +777,7 @@ export async function markStoryForArchiving(
       tenantID,
       isArchiving: { $in: [null, false] },
       isArchived: { $in: [null, false] },
+      "settings.mode": { $ne: GQLSTORY_MODE.RATINGS_AND_REVIEWS },
     },
     getMarkStoryForArchivingSetParam(now),
     {
@@ -835,6 +836,7 @@ export async function retrieveLockedStoryToBeArchived(
       isArchived: { $in: [null, false] },
       startedUnarchivingAt: { $in: [null, false] },
       unarchivedAt: { $in: [null, false] },
+      "settings.mode": { $ne: GQLSTORY_MODE.RATINGS_AND_REVIEWS },
     },
     getMarkStoryForArchivingSetParam(now),
     { returnOriginal: false }


### PR DESCRIPTION
## What does this PR do?

- Block auto-archiving and standard archiving for stories whose mode is set to `RATINGS_AND_REVIEWS`.
- Filter out R&R stories when searching for new stories to auto-archive

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

- Create a ratings and reviews story
- Attempt to archive it
- See that it does not succeed
- Edit its `createdAt` date so that it will be auto-archived
- Wait for or trigger the auto archiving job
    - Set `ENABLE_AUTO_ARCHIVING=true`
    - Modify the `AUTO_ARCHIVING_INTERVAL` to something that runs more often than every 15 minutes
    - For more info on these env vars, see `src/core/server/config.ts`
- See that this story is not auto archived
    - It can be helpful to have fewer than 500 stories so that auto archiving will definitely try and pick up the story if it can
 
## How do we deploy this PR?

N/A