### PR TITLE
[CORL-2410] Prevent infinite reactions by checking comment revision ID

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/ReactionButton/RemoveCommentReactionMutation.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/ReactionButton/RemoveCommentReactionMutation.ts
@@ -56,7 +56,7 @@ async function commit(
         mutation,
         variables: {
           input: {
-            ...pick(input, ["commentID"]),
+            ...pick(input, ["commentID", "commentRevisionID"]),
             clientMutationId: (clientMutationId++).toString(),
           },
         },

--- a/src/core/server/graph/mutators/Comments.ts
+++ b/src/core/server/graph/mutators/Comments.ts
@@ -111,9 +111,13 @@ export const Comments = (ctx: GraphContext) => ({
       },
       ctx.now
     ),
-  removeReaction: ({ commentID }: GQLRemoveCommentReactionInput) =>
+  removeReaction: ({
+    commentID,
+    commentRevisionID,
+  }: GQLRemoveCommentReactionInput) =>
     removeReaction(ctx.mongo, ctx.redis, ctx.broker, ctx.tenant, ctx.user!, {
       commentID,
+      commentRevisionID,
     }),
   createDontAgree: ({
     commentID,
@@ -137,9 +141,13 @@ export const Comments = (ctx: GraphContext) => ({
       },
       ctx.now
     ),
-  removeDontAgree: ({ commentID }: GQLRemoveCommentDontAgreeInput) =>
+  removeDontAgree: ({
+    commentID,
+    commentRevisionID,
+  }: GQLRemoveCommentDontAgreeInput) =>
     removeDontAgree(ctx.mongo, ctx.redis, ctx.broker, ctx.tenant, ctx.user!, {
       commentID,
+      commentRevisionID,
     }),
   createFlag: ({
     commentID,

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -5513,6 +5513,12 @@ input RemoveCommentReactionInput {
   commentID: ID!
 
   """
+  commentRevisionID is the Comment's revision ID that we want to remove a
+  reaction on.
+  """
+  commentRevisionID: ID!
+
+  """
   clientMutationId is required for Relay support.
   """
   clientMutationId: String!
@@ -5579,6 +5585,12 @@ input RemoveCommentDontAgreeInput {
   commentID is the Comment's ID that we want to remove a DontAgree on.
   """
   commentID: ID!
+
+  """
+  commentRevisionID is the Comment's revision ID that we want to remove a
+  reaction on.
+  """
+  commentRevisionID: ID!
 
   """
   clientMutationId is required for Relay support.


### PR DESCRIPTION
## What does this PR do?

Check comment's revisionID exists before adding/removing comment actions.

We weren't checking these revisions existed, so users could just tweak the `commentRevisionID` before each request and the system would happily add or remove a new reaction. This allows the user to infinitely upvote or downvote any comment they wish.

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds a `commentRevisionID` to `CreateCommentReactionInput`, `RemoveCommentReactionInput`, and `CreateCommentDontAgreeInput` and `RemoveCommentDontAgreeInput`.

## How do I test this PR?

- Create a new comment
- Open dev tools and go to network
- React to the comment and open the `POST` network request with the mutation query to add the reaction
- Paste the request into Insomnia or a similar GraphQL enabled API testing tool
    - Copy over the request body, looks something like below:
       ```
       mutation CreateCommentReactionMutation(  $input: CreateCommentReactionInput!) {  createCommentReaction(input: $input) {    comment {      ...ReactionButtonContainer_comment      id    }    clientMutationId  }}fragment ReactionButtonContainer_comment on Comment {  id  author {    id    username  }  revision {    id  }  viewerActionPresence {    reaction  }  actionCounts {    reaction {      total    }  }}
       ```
    - Copy over the auth token as a `Bearer` value
    - Set the query variables for the request, looks something like below:
       ```
       {
	    "input": {
		"clientMutationId": "0",
                "commentID": "fdbcf42a-9172-4b19-bf41-b8c51f6280d8",
                "commentRevisionID": "09fbd3a2-0d03-41f1-a6e2-657dc73ff25c"
	     }
       }
       ```
- Tweak the `commentRevisionID` variable randomly (I just modify the last two characters and increment up from `00` to `99`) and keep submitting the request
- You should get a `COMMENT_NOT_FOUND` and even if you re-submit with the valid `commentRevisionID` you aren't able to infinitely up the reaction count
- If you want to have some fun, switch to `develop` and try this. You can send the reaction counts sky high or crush them down to zero on a whim.
 
## How do we deploy this PR?

- Release it and deploy, same as usual
