### PR TITLE
Update Docker builds to use npm 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM node:14-alpine
 # Install build dependancies.
 RUN apk --no-cache add git python3
 
+RUN npm install -g npm@8.0.0
+
 # Create app directory.
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
## What does this PR do?

Installs npm 8 during dockerfile build to match our `package.json`.

We use node 14 both in dev and on Docker builds, but node 14 comes with npm `6.14.x` by default and that doesn't match our `package.json` requirement of npm `8.0.0`.

Without this, the build fails trying to pull in the chokidar package from npm.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

Perform a docker build with `docker build -t <SOME_TAG>` and see it succeed to build the image.
 
## How do we deploy this PR?

N/A
