### PR TITLE
[CORL-2412]: ban modal site selection fixes

### DIFF
--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -68,6 +68,7 @@ const BanModal: FunctionComponent<Props> = ({
     (input) => {
       try {
         let selectedIDs = input.selectedIDs || [];
+        const showSingleSites = input.showSingleSites;
 
         // single site mods can only ban for their
         // one assigned site, override anything else that
@@ -80,8 +81,12 @@ const BanModal: FunctionComponent<Props> = ({
           selectedIDs = [viewerScopes.sites[0].id];
         }
 
-        if (isSiteMod && (!selectedIDs || selectedIDs.length === 0)) {
-          return { [FORM_ERROR]: "At least one site must be selected" };
+        // if All sites is selected, then admins/org mods ban across
+        // all sites, and site mods ban across all scoped sites
+        if (!showSingleSites) {
+          selectedIDs = !isSiteMod
+            ? []
+            : viewerScopes.sites?.map((site) => site.id);
         }
 
         onConfirm(

--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -68,7 +68,7 @@ const BanModal: FunctionComponent<Props> = ({
     (input) => {
       try {
         let selectedIDs = input.selectedIDs || [];
-        const showSingleSites = input.showSingleSites;
+        const showSpecificSites = input.showSpecificSites;
 
         // single site mods can only ban for their
         // one assigned site, override anything else that
@@ -83,7 +83,7 @@ const BanModal: FunctionComponent<Props> = ({
 
         // if All sites is selected, then admins/org mods ban across
         // all sites, and site mods ban across all scoped sites
-        if (!showSingleSites) {
+        if (!showSpecificSites) {
           selectedIDs = !isSiteMod
             ? []
             : viewerScopes.sites?.map((site) => site.id);

--- a/src/core/client/admin/components/UserStatus/UserStatusSitesList.css
+++ b/src/core/client/admin/components/UserStatus/UserStatusSitesList.css
@@ -5,3 +5,7 @@
 .sitesToggle {
   margin-bottom: var(--spacing-3);
 }
+
+.validationMessage {
+  margin-top: var(--spacing-3);
+}

--- a/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
+++ b/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
@@ -74,18 +74,16 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
   });
 
   useEffect(() => {
+    // Site mods should have all sites within scope selected by default
     if (viewerIsSiteMod) {
-      const sites = viewerScopes.sites?.map((site) => site.id);
-      selectedIDsInput.onChange(sites);
+      selectedIDsInput.onChange(viewerScopes.sites?.map((site) => site.id));
     }
   }, []);
 
   const [candidateSites, setCandidateSites] = useState<string[]>(
-    viewerIsSiteMod
-      ? viewerScopes.sites
-        ? viewerScopes.sites.map((site) => site.id)
-        : []
-      : selectedIDsInput.value
+    viewerIsSiteMod && viewerScopes.sites
+      ? viewerScopes.sites.map((site) => site.id)
+      : []
   );
 
   const onHideSingleSites = useCallback(() => {

--- a/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
+++ b/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
@@ -1,10 +1,21 @@
 import { Localized } from "@fluent/react/compat";
-import React, { FunctionComponent, useCallback, useState } from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { useField } from "react-final-form";
 
 import SiteSearch from "coral-admin/components/SiteSearch";
 import { IntersectionProvider } from "coral-framework/lib/intersection";
 import { GQLUSER_ROLE } from "coral-framework/schema";
+import { hasError } from "coral-framework/lib/form";
+import {
+  Condition,
+  required,
+  validateWhen,
+} from "coral-framework/lib/validation";
 import {
   FieldSet,
   Flex,
@@ -12,6 +23,7 @@ import {
   HorizontalGutter,
   Label,
   RadioButton,
+  ValidationMessage,
 } from "coral-ui/components/v2";
 
 import { USER_ROLE } from "coral-admin/__generated__/UserStatusChangeContainer_viewer.graphql";
@@ -48,18 +60,41 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
     viewerScopes.sites.length === 1
   );
 
-  const [showSites, setShowSites] = useState<boolean>(
-    !!(viewerIsScoped || viewerIsSingleSiteMod)
+  const singleSitesIsEnabled: Condition = (_value, values) => {
+    return values.showSingleSites;
+  };
+
+  const { input: selectedIDsInput, meta: selectedIDsInputMeta } = useField<
+    string[]
+  >("selectedIDs", {
+    validate: validateWhen(singleSitesIsEnabled, required),
+  });
+  const { input: showSingleSitesInput } = useField<boolean>("showSingleSites", {
+    initialValue: !!(viewerIsScoped || viewerIsSingleSiteMod),
+  });
+
+  useEffect(() => {
+    if (viewerIsSiteMod) {
+      const sites = viewerScopes.sites?.map((site) => site.id);
+      selectedIDsInput.onChange(sites);
+    }
+  }, []);
+
+  const [candidateSites, setCandidateSites] = useState<string[]>(
+    viewerIsSiteMod
+      ? viewerScopes.sites
+        ? viewerScopes.sites.map((site) => site.id)
+        : []
+      : selectedIDsInput.value
   );
 
-  const { input: selectedIDsInput } = useField<string[]>("selectedIDs");
+  const onHideSingleSites = useCallback(() => {
+    showSingleSitesInput.onChange(false);
+  }, [showSingleSitesInput]);
+  const onShowSingleSites = useCallback(() => {
+    showSingleSitesInput.onChange(true);
+  }, [showSingleSitesInput]);
 
-  const onHideSites = useCallback(() => {
-    setShowSites(false);
-  }, [setShowSites]);
-  const onShowSites = useCallback(() => {
-    setShowSites(true);
-  }, [setShowSites]);
   const onRemoveSite = useCallback(
     (siteID: string) => {
       const changed = [...selectedIDsInput.value];
@@ -81,11 +116,20 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
       const index = changed.indexOf(siteID);
       if (index === -1) {
         changed.push(siteID);
+        if (!candidateSites.includes(siteID)) {
+          setCandidateSites([...candidateSites, siteID]);
+        }
       }
 
       selectedIDsInput.onChange(changed);
     },
     [selectedIDsInput]
+  );
+
+  const onToggleSite = useCallback(
+    (siteID: string, checked: boolean) =>
+      checked ? onRemoveSite(siteID) : onAddSite(siteID),
+    [onAddSite, onRemoveSite]
   );
 
   return (
@@ -104,14 +148,20 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
             <Flex className={styles.sitesToggle} spacing={5}>
               <FormField>
                 <Localized id="community-banModal-allSites">
-                  <RadioButton checked={!showSites} onChange={onHideSites}>
+                  <RadioButton
+                    checked={!showSingleSitesInput.value}
+                    onChange={onHideSingleSites}
+                  >
                     All sites
                   </RadioButton>
                 </Localized>
               </FormField>
               <FormField>
                 <Localized id="community-banModal-specificSites">
-                  <RadioButton checked={showSites} onChange={onShowSites}>
+                  <RadioButton
+                    checked={showSingleSitesInput.value}
+                    onChange={onShowSingleSites}
+                  >
                     Specific Sites
                   </RadioButton>
                 </Localized>
@@ -119,25 +169,36 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
             </Flex>
           )}
 
-          {showSites && (
+          {showSingleSitesInput.value && (
             <>
               <HorizontalGutter spacing={3} mt={5} mb={4}>
-                {selectedIDsInput.value.map((siteID) => {
+                {candidateSites.map((siteID) => {
+                  const checked = selectedIDsInput.value.includes(siteID);
                   return (
                     <UserStatusSitesListSelectedSiteQuery
                       key={siteID}
                       siteID={siteID}
-                      onChange={onRemoveSite}
+                      onChange={onToggleSite}
+                      checked={checked}
                     />
                   );
                 })}
               </HorizontalGutter>
-              <SiteSearch
-                onSelect={onAddSite}
-                showSiteSearchLabel={false}
-                showOnlyScopedSitesInSearchResults={true}
-                showAllSitesSearchFilterOption={false}
-              />
+              {!viewerIsSiteMod && (
+                <SiteSearch
+                  onSelect={onAddSite}
+                  showSiteSearchLabel={false}
+                  showOnlyScopedSitesInSearchResults={true}
+                  showAllSitesSearchFilterOption={false}
+                />
+              )}
+              {hasError(selectedIDsInputMeta) ? (
+                <Localized id="singleSitesSelect-validation">
+                  <ValidationMessage className={styles.validationMessage}>
+                    You must select at least one site.
+                  </ValidationMessage>
+                </Localized>
+              ) : null}
             </>
           )}
         </FieldSet>

--- a/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
+++ b/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
@@ -8,8 +8,8 @@ import React, {
 import { useField } from "react-final-form";
 
 import SiteSearch from "coral-admin/components/SiteSearch";
-import { IntersectionProvider } from "coral-framework/lib/intersection";
 import { hasError } from "coral-framework/lib/form";
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import {
   Condition,
   required,

--- a/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
+++ b/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
@@ -64,11 +64,12 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
     return values.showSpecificSites;
   };
 
-  const { input: selectedIDsInput, meta: selectedIDsInputMeta } = useField<
-    string[]
-  >("selectedIDs", {
-    validate: validateWhen(specificSitesIsEnabled, required),
-  });
+  const { input: selectedIDsInput, meta: selectedIDsMeta } = useField<string[]>(
+    "selectedIDs",
+    {
+      validate: validateWhen(specificSitesIsEnabled, required),
+    }
+  );
   const { input: showSpecificSitesInput } = useField<boolean>(
     "showSpecificSites",
     {
@@ -193,7 +194,7 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
                   showAllSitesSearchFilterOption={false}
                 />
               )}
-              {hasError(selectedIDsInputMeta) ? (
+              {hasError(selectedIDsMeta) ? (
                 <Localized id="specificSitesSelect-validation">
                   <ValidationMessage className={styles.validationMessage}>
                     You must select at least one site.

--- a/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
+++ b/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
@@ -9,13 +9,13 @@ import { useField } from "react-final-form";
 
 import SiteSearch from "coral-admin/components/SiteSearch";
 import { IntersectionProvider } from "coral-framework/lib/intersection";
-import { GQLUSER_ROLE } from "coral-framework/schema";
 import { hasError } from "coral-framework/lib/form";
 import {
   Condition,
   required,
   validateWhen,
 } from "coral-framework/lib/validation";
+import { GQLUSER_ROLE } from "coral-framework/schema";
 import {
   FieldSet,
   Flex,

--- a/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
+++ b/src/core/client/admin/components/UserStatus/UserStatusSitesList.tsx
@@ -60,18 +60,21 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
     viewerScopes.sites.length === 1
   );
 
-  const singleSitesIsEnabled: Condition = (_value, values) => {
-    return values.showSingleSites;
+  const specificSitesIsEnabled: Condition = (_value, values) => {
+    return values.showSpecificSites;
   };
 
   const { input: selectedIDsInput, meta: selectedIDsInputMeta } = useField<
     string[]
   >("selectedIDs", {
-    validate: validateWhen(singleSitesIsEnabled, required),
+    validate: validateWhen(specificSitesIsEnabled, required),
   });
-  const { input: showSingleSitesInput } = useField<boolean>("showSingleSites", {
-    initialValue: !!(viewerIsScoped || viewerIsSingleSiteMod),
-  });
+  const { input: showSpecificSitesInput } = useField<boolean>(
+    "showSpecificSites",
+    {
+      initialValue: !!(viewerIsScoped || viewerIsSingleSiteMod),
+    }
+  );
 
   useEffect(() => {
     // Site mods should have all sites within scope selected by default
@@ -86,12 +89,12 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
       : []
   );
 
-  const onHideSingleSites = useCallback(() => {
-    showSingleSitesInput.onChange(false);
-  }, [showSingleSitesInput]);
-  const onShowSingleSites = useCallback(() => {
-    showSingleSitesInput.onChange(true);
-  }, [showSingleSitesInput]);
+  const onHideSpecificSites = useCallback(() => {
+    showSpecificSitesInput.onChange(false);
+  }, [showSpecificSitesInput]);
+  const onShowSpecificSites = useCallback(() => {
+    showSpecificSitesInput.onChange(true);
+  }, [showSpecificSitesInput]);
 
   const onRemoveSite = useCallback(
     (siteID: string) => {
@@ -147,8 +150,8 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
               <FormField>
                 <Localized id="community-banModal-allSites">
                   <RadioButton
-                    checked={!showSingleSitesInput.value}
-                    onChange={onHideSingleSites}
+                    checked={!showSpecificSitesInput.value}
+                    onChange={onHideSpecificSites}
                   >
                     All sites
                   </RadioButton>
@@ -157,8 +160,8 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
               <FormField>
                 <Localized id="community-banModal-specificSites">
                   <RadioButton
-                    checked={showSingleSitesInput.value}
-                    onChange={onShowSingleSites}
+                    checked={showSpecificSitesInput.value}
+                    onChange={onShowSpecificSites}
                   >
                     Specific Sites
                   </RadioButton>
@@ -167,7 +170,7 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
             </Flex>
           )}
 
-          {showSingleSitesInput.value && (
+          {showSpecificSitesInput.value && (
             <>
               <HorizontalGutter spacing={3} mt={5} mb={4}>
                 {candidateSites.map((siteID) => {
@@ -191,7 +194,7 @@ const UserStatusSitesList: FunctionComponent<Props> = ({ viewerScopes }) => {
                 />
               )}
               {hasError(selectedIDsInputMeta) ? (
-                <Localized id="singleSitesSelect-validation">
+                <Localized id="specificSitesSelect-validation">
                   <ValidationMessage className={styles.validationMessage}>
                     You must select at least one site.
                   </ValidationMessage>

--- a/src/core/client/admin/components/UserStatus/UserStatusSitesListSelectedSiteQuery.tsx
+++ b/src/core/client/admin/components/UserStatus/UserStatusSitesListSelectedSiteQuery.tsx
@@ -9,12 +9,14 @@ import { UserStatusSitesListSelectedSiteQuery as QueryTypes } from "coral-admin/
 
 interface Props {
   siteID: string;
-  onChange: (id: string | null) => void;
+  onChange: (id: string | null, checked: boolean) => void;
+  checked: boolean;
 }
 
 const UserStatusSitesListSelectedSiteQuery: FunctionComponent<Props> = ({
   siteID,
   onChange,
+  checked,
 }) => {
   return (
     <QueryRenderer<QueryTypes>
@@ -35,8 +37,8 @@ const UserStatusSitesListSelectedSiteQuery: FunctionComponent<Props> = ({
         if (props && props.site) {
           return (
             <CheckBox
-              checked={true}
-              onChange={() => onChange(siteID)}
+              checked={checked}
+              onChange={() => onChange(siteID, checked)}
               data-testid="user-status-selected-site"
             >
               {props.site.name}

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -556,6 +556,7 @@ site-search-textField =
 site-search-textField =
   .placeholder = Search by site name
 site-search-none-found = No sites were found with that search
+singleSitesSelect-validation = You must select at least one site.
 
 stories-column-actions = Actions
 stories-column-rescrape = Re-scrape
@@ -1161,7 +1162,7 @@ moderate-forReview-reportedSpam = Spam
 # Archive
 
 moderate-archived-queue-title = This story has been archived
-moderate-archived-queue-noModerationActions = 
+moderate-archived-queue-noModerationActions =
   No moderation actions can be made on the comments when a story is archived.
 moderate-archived-queue-toPerformTheseActions =
   To perform these actions, unarchive the story.

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -556,7 +556,7 @@ site-search-textField =
 site-search-textField =
   .placeholder = Search by site name
 site-search-none-found = No sites were found with that search
-singleSitesSelect-validation = You must select at least one site.
+specificSitesSelect-validation = You must select at least one site.
 
 stories-column-actions = Actions
 stories-column-rescrape = Re-scrape


### PR DESCRIPTION
## What does this PR do?

These changes ensure that the site search is only shown for admins/org moderators in the ban modal; otherwise, a list of checkboxes should be shown for the Specific sites selection option. If a user attempts to click `Ban` in the modal while on the `Specific sites` option and they have no sites selected, they should see an error that `You must select at least one site.`. In addition, if a user has `All sites` selected, it should always ban across all sites, no matter what is/isn't selected by a user under the `Specific sites` option. They address the issues in https://vmproduct.atlassian.net/browse/CORL-2411 and https://vmproduct.atlassian.net/browse/CORL-2412. 

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## How do I test this PR?

As a site moderator (single- and multi-):
- Go to the admin `Community` page and select `Ban` for a user. See that the `Specific sites` option is default selected. See that all sites within that moderator's scope are listed as checkboxes and checked by default.
- If all sites are unchecked, and `Ban` is clicked, there should be an error that `You must select at least one site.`
- If some sites are checked and `Ban` is clicked, it should ban across those sites.
- If `All sites` is checked and `Ban` is clicked, it should always ban across all sites, no matter what is/isn't selected in `Specific sites`. For example, unselect all sites in `Specific sites`, then select `All sites`, and click `Ban`. The user should be banned across all sites within the moderator's scope.
- Single-site moderators should still only see 1 checkbox option, and they shouldn't see radio buttons for `All sites`/`Specific sites`.

As an admin/org moderator: 
- Go to the admin `Community` page and select `Ban` for a user. See that if you select the `Specific sites` option, the site search will be shown.
- If all sites are unchecked, and `Ban` is clicked, there should be an error that `You must select at least one site.`
- If some sites are checked and `Ban` is clicked, it should ban across those sites.
- If `All sites` is checked and `Ban` is clicked, it should always ban across all sites, no matter what is/isn't selected in `Specific sites`. For example, unselect all sites in `Specific sites`, then select `All sites`, and click `Ban`. The user should be banned across all sites within the moderator's scope.
 
## How do we deploy this PR?

