### PR TITLE
Fix reaction details username hover styles

### DIFF
--- a/src/core/client/admin/components/ModerateCard/ReactionDetailsContainer.css
+++ b/src/core/client/admin/components/ModerateCard/ReactionDetailsContainer.css
@@ -15,7 +15,6 @@
 .button {
   margin-right: var(--mini-unit);
   padding: var(--spacing-1);
-  margin-left: calc(-1 * var(--spacing-1));
 
   &:hover {
     background-color: var(--palette-grey-200);


### PR DESCRIPTION
## What does this PR do?

These changes ensure that the hover state for usernames in the reaction details in the moderate cards is styled correctly. It removes the left margin styles from the button. The `overflow: auto` setting for the container was causing the left side of the hover state to not be visible as it was.

## What changes to the GraphQL/Database Schema does this PR introduce?

## How do I test this PR?

- Go to a moderate card of a comment that has at least one reaction. Click `Details`, `Reactions`, and then hover over a username. See that the styles look as expected (consistent with the styles of usernames in the `Info` tab):
![Screen Shot 2021-12-06 at 12 42 27 PM](https://user-images.githubusercontent.com/6287012/144895165-e7b7e9e4-90ed-4ff3-a024-f61e39be0729.png)
 
## How do we deploy this PR?

