### PR TITLE
[CPSRE-205] Prepending 'develop-' to commit tag to organize image tags

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -57,6 +57,7 @@ deploy_branch() {
 
 deploy_commit() {
   SHORT_GIT_HASH=$(echo $CIRCLE_SHA1 | cut -c -6)
+  SHORT_GIT_HASH="develop-${SHORT_GIT_HASH}"
   echo "==> tagging commit ${SHORT_GIT_HASH}"
   docker tag "coralproject/talk:latest" "${GCR_IMAGE_NAME}:${SHORT_GIT_HASH}"
 


### PR DESCRIPTION
## What does this PR do?

Upgrades the docker tag on the image being generated in the push_to_gcr job of .circleci/config.yml so that it's of the template `develop-shorthash` instead of `shorthash`. This should keep the images this generates to the Container Registry easier to organize.

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

## How do I test this PR?

This one is easy enough to test in your local shell. Works in bash or zsh:

```
export CIRCLE_BRANCH='c0c69e6e63cb1d11a11c3e77f4a484a66ea910ec'
export SHORT_GIT_HASH=$(echo $CIRCLE_BRANCH | cut -c -6)
echo $SHORT_GIT_HASH # <-- the current format

export SHORT_GIT_HASH="develop-${SHORT_GIT_HASH}"
echo $SHORT_GIT_HASH # <-- the new format
```
 
## How do we deploy this PR?

Just validate that CircleCI's run passes and a develop image is successfully built and stored in GCR.