### PR TITLE
[CORL-1697]: add premoderateAllSitesComments to settings resolver with default

### DIFF
--- a/src/core/server/graph/resolvers/Settings.ts
+++ b/src/core/server/graph/resolvers/Settings.ts
@@ -32,6 +32,8 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
   memberBios: ({ memberBios = false }) => memberBios,
   premoderateSuspectWords: ({ premoderateSuspectWords = false }) =>
     premoderateSuspectWords,
+  premoderateAllCommentsSites: ({ premoderateAllCommentsSites = [] }) =>
+    premoderateAllCommentsSites,
   stories: ({ stories }) => stories,
   amp: (parent, args, ctx) => isAMPEnabled(ctx.tenant),
   flattenReplies: (parent, args, ctx) => areRepliesFlattened(ctx.tenant),


### PR DESCRIPTION
## What does this PR do?

This adds `premoderateAllSitesComments` to the settings resolver with a default.

## What changes to the GraphQL/Database Schema does this PR introduce?


## How do I test this PR?
 
## How do we deploy this PR?
