### PR TITLE
use correct variable for rejectComments

### DIFF
--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -113,7 +113,7 @@ const BanModal: FunctionComponent<Props> = ({
       try {
         onConfirm(
           updateType,
-          input.rejectExistingComments,
+          rejectComments,
           banSiteIDs,
           unbanSiteIDs,
           customizeMessage ? emailMessage : getDefaultMessage
@@ -132,6 +132,7 @@ const BanModal: FunctionComponent<Props> = ({
       emailMessage,
       customizeMessage,
       getDefaultMessage,
+      rejectComments,
     ]
   );
 

--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -3,6 +3,7 @@ import { FORM_ERROR } from "final-form";
 import React, {
   FunctionComponent,
   useCallback,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -107,6 +108,12 @@ const BanModal: FunctionComponent<Props> = ({
 
   const [banSiteIDs, setBanSiteIDs] = useState<string[]>([]);
   const [unbanSiteIDs, setUnbanSiteIDs] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (viewerIsSingleSiteMod) {
+      setBanSiteIDs(viewerScopes.sites!.map((scopeSite) => scopeSite.id));
+    }
+  }, [viewerIsSingleSiteMod]);
 
   const onFormSubmit = useCallback(() => {
     try {

--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -148,6 +148,12 @@ const BanModal: FunctionComponent<Props> = ({
   } = getTextForUpdateType(updateType);
 
   const pendingSiteBanUpdates = banSiteIDs.length + unbanSiteIDs.length > 0;
+  const requiresSiteBanUpdates =
+    updateType === UpdateType.SPECIFIC_SITES ||
+    (updateType === UpdateType.ALL_SITES && viewerIsSingleSiteMod);
+  const disableForm = requiresSiteBanUpdates && !pendingSiteBanUpdates;
+  /* eslint-disable */
+  console.log({ updateType, viewerIsSingleSiteMod, disableForm });
 
   return (
     <ChangeStatusModal
@@ -290,12 +296,7 @@ const BanModal: FunctionComponent<Props> = ({
                       <Button
                         type="submit"
                         ref={lastFocusableRef}
-                        disabled={
-                          ((updateType === UpdateType.ALL_SITES &&
-                            viewerIsSingleSiteMod) ||
-                            updateType === UpdateType.SPECIFIC_SITES) &&
-                          !pendingSiteBanUpdates
-                        }
+                        disabled={disableForm}
                       >
                         Save
                       </Button>

--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -108,33 +108,30 @@ const BanModal: FunctionComponent<Props> = ({
   const [banSiteIDs, setBanSiteIDs] = useState<string[]>([]);
   const [unbanSiteIDs, setUnbanSiteIDs] = useState<string[]>([]);
 
-  const onFormSubmit = useCallback(
-    (input) => {
-      try {
-        onConfirm(
-          updateType,
-          rejectComments,
-          banSiteIDs,
-          unbanSiteIDs,
-          customizeMessage ? emailMessage : getDefaultMessage
-        );
+  const onFormSubmit = useCallback(() => {
+    try {
+      onConfirm(
+        updateType,
+        rejectComments,
+        banSiteIDs,
+        unbanSiteIDs,
+        customizeMessage ? emailMessage : getDefaultMessage
+      );
 
-        return;
-      } catch (err) {
-        return { [FORM_ERROR]: err.message };
-      }
-    },
-    [
-      onConfirm,
-      updateType,
-      banSiteIDs,
-      unbanSiteIDs,
-      emailMessage,
-      customizeMessage,
-      getDefaultMessage,
-      rejectComments,
-    ]
-  );
+      return;
+    } catch (err) {
+      return { [FORM_ERROR]: err.message };
+    }
+  }, [
+    onConfirm,
+    updateType,
+    banSiteIDs,
+    unbanSiteIDs,
+    emailMessage,
+    customizeMessage,
+    getDefaultMessage,
+    rejectComments,
+  ]);
 
   const {
     title,
@@ -173,15 +170,7 @@ const BanModal: FunctionComponent<Props> = ({
               <p className={styles.bodyText}>{consequence}</p>
             </Localized>
           </HorizontalGutter>
-          <Form
-            onSubmit={onFormSubmit}
-            initialValues={{
-              showMessage: false,
-              rejectExistingComments: false,
-              emailMessage: getDefaultMessage,
-              selectedIDs: [],
-            }}
-          >
+          <Form onSubmit={onFormSubmit}>
             {({ handleSubmit, submitError }) => (
               <form onSubmit={handleSubmit}>
                 <HorizontalGutter spacing={3}>

--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -152,8 +152,6 @@ const BanModal: FunctionComponent<Props> = ({
     updateType === UpdateType.SPECIFIC_SITES ||
     (updateType === UpdateType.ALL_SITES && viewerIsSingleSiteMod);
   const disableForm = requiresSiteBanUpdates && !pendingSiteBanUpdates;
-  /* eslint-disable */
-  console.log({ updateType, viewerIsSingleSiteMod, disableForm });
 
   return (
     <ChangeStatusModal

--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -291,7 +291,9 @@ const BanModal: FunctionComponent<Props> = ({
                         type="submit"
                         ref={lastFocusableRef}
                         disabled={
-                          updateType === UpdateType.SPECIFIC_SITES &&
+                          ((updateType === UpdateType.ALL_SITES &&
+                            viewerIsSingleSiteMod) ||
+                            updateType === UpdateType.SPECIFIC_SITES) &&
                           !pendingSiteBanUpdates
                         }
                       >

--- a/src/core/client/admin/components/UserStatus/BanModal.tsx
+++ b/src/core/client/admin/components/UserStatus/BanModal.tsx
@@ -265,15 +265,16 @@ const BanModal: FunctionComponent<Props> = ({
                     </Flex>
                   )}
 
-                  {!!moderationScopesEnabled &&
-                    updateType === UpdateType.SPECIFIC_SITES && (
-                      <UserStatusSitesList
-                        userBanStatus={userBanStatus}
-                        viewerScopes={viewerScopes}
-                        banState={[banSiteIDs, setBanSiteIDs]}
-                        unbanState={[unbanSiteIDs, setUnbanSiteIDs]}
-                      />
-                    )}
+                  {(viewerIsSingleSiteMod ||
+                    (!!moderationScopesEnabled &&
+                      updateType === UpdateType.SPECIFIC_SITES)) && (
+                    <UserStatusSitesList
+                      userBanStatus={userBanStatus}
+                      viewerScopes={viewerScopes}
+                      banState={[banSiteIDs, setBanSiteIDs]}
+                      unbanState={[unbanSiteIDs, setUnbanSiteIDs]}
+                    />
+                  )}
 
                   {submitError && (
                     <CallOut


### PR DESCRIPTION


## What does this PR do?
This corrects a bug where the BanModal checks a form field instead of a state variable for "rejectComments", and so doesn't submit the correct value.

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## How do I test this PR?
Ban a user via the BanModal, selecting "Reject existing comments" and see that existing comments are rejected.
 
 
## How do we deploy this PR?
No special considerations should be required. 
