### PR TITLE
[CORL-2437]: Update how links are handled in comments

### DIFF
--- a/src/core/common/helpers/sanitize.spec.ts
+++ b/src/core/common/helpers/sanitize.spec.ts
@@ -141,6 +141,24 @@ it("does not replace anchor tags with their text if href does match inner html",
   `);
 });
 
+it("does not replace anchor tags with their text if href does match inner html and only one has a trailing slash", () => {
+  const sanitize = createSanitize(window as any);
+  const el = sanitize(
+    `
+    <div>
+      This is a link where href matches <a href="http://test.com/">http://test.com</a>.
+    </div>
+  `
+  );
+  expect(el.innerHTML).toMatchInlineSnapshot(`
+    "
+        <div>
+          This is a link where href matches <a href=\\"http://test.com/\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">http://test.com</a>.
+        </div>
+      "
+  `);
+});
+
 it("allows bolded tags", () => {
   const sanitize = createSanitize(window as any, {
     features: {

--- a/src/core/common/helpers/sanitize.spec.ts
+++ b/src/core/common/helpers/sanitize.spec.ts
@@ -89,6 +89,22 @@ it("sanitizes without features enabled", () => {
   `);
 });
 
+it("allows mailto links", () => {
+  const sanitize = createSanitize(window as any);
+  expect(sanitize('<a href="mailto:email@example.com">email@example.com</a>'))
+    .toMatchInlineSnapshot(`
+    <body>
+      <a
+        href="mailto:email@example.com"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        email@example.com
+      </a>
+    </body>
+  `);
+});
+
 it("replaces anchor tags with their text", () => {
   const sanitize = createSanitize(window as any);
   const el = sanitize(
@@ -98,15 +114,31 @@ it("replaces anchor tags with their text", () => {
     </div>
   `
   );
-  expect(el.innerHTML).toMatchInlineSnapshot(
-    `
+  expect(el.innerHTML).toMatchInlineSnapshot(`
     "
         <div>
           This is a link. This is another link with no href in a comment.
         </div>
       "
+  `);
+});
+
+it("does not replace anchor tags with their text if href does match inner html", () => {
+  const sanitize = createSanitize(window as any);
+  const el = sanitize(
+    `
+    <div>
+      This is a link where href matches <a href="http://test.com">http://test.com</a>.
+    </div>
   `
   );
+  expect(el.innerHTML).toMatchInlineSnapshot(`
+    "
+        <div>
+          This is a link where href matches <a href=\\"http://test.com\\" target=\\"_blank\\" rel=\\"noopener noreferrer\\">http://test.com</a>.
+        </div>
+      "
+  `);
 });
 
 it("allows bolded tags", () => {

--- a/src/core/common/helpers/sanitize.ts
+++ b/src/core/common/helpers/sanitize.ts
@@ -5,6 +5,7 @@ import { SARCASM_CLASSNAME, SPOILER_CLASSNAME } from "coral-common/constants";
 // TODO: Reaching directly into coral-framework for the types. Maybe having
 // types in coral-common instead? 🤔
 import { GQLRTEConfiguration } from "../../client/framework/schema/__generated__/types";
+// import { URL_REGEX } from ".";
 
 /** Tags that we remove before looking for suspect/banned words */
 export const WORDLIST_FORBID_TAGS = [
@@ -78,13 +79,18 @@ export function convertGQLRTEConfigToRTEFeatures(
 
 /**
  * Ensure that each anchor tag is replaced with text that
- * corresponds to its inner html.
+ * corresponds to its inner html. If the tag's href matches
+ * its inner html, it remains as is.
  */
 const sanitizeAnchor = (node: Element) => {
   if (node.nodeName === "A") {
-    // Turn anchor into text corresponding to innerHTML.
-    node.insertAdjacentText("beforebegin", node.innerHTML);
-    node.parentNode!.removeChild(node);
+    const anchorHref = node.getAttribute("href");
+    const innerHtml = node.innerHTML;
+    if (!(anchorHref === innerHtml)) {
+      // Turn anchor into text corresponding to innerHTML.
+      node.insertAdjacentText("beforebegin", node.innerHTML);
+      node.parentNode!.removeChild(node);
+    }
   }
 };
 

--- a/src/core/common/helpers/sanitize.ts
+++ b/src/core/common/helpers/sanitize.ts
@@ -85,8 +85,12 @@ const MAILTO_PROTOCOL = "mailto:";
  */
 const sanitizeAnchor = (node: Element) => {
   if (node.nodeName === "A") {
-    const href = node.getAttribute("href");
-    const innerHtml = node.innerHTML;
+    let href = node.getAttribute("href");
+    let innerHtml = node.innerHTML;
+
+    // Account for whether trailing slashes are included or not
+    href = href?.endsWith("/") ? href : (href += "/");
+    innerHtml = innerHtml.endsWith("/") ? innerHtml : (innerHtml += "/");
 
     // Check for a mailto: link with corresponding inner html
     let mailToWithMatchingInnerHtml = false;

--- a/src/core/common/helpers/sanitize.ts
+++ b/src/core/common/helpers/sanitize.ts
@@ -5,7 +5,6 @@ import { SARCASM_CLASSNAME, SPOILER_CLASSNAME } from "coral-common/constants";
 // TODO: Reaching directly into coral-framework for the types. Maybe having
 // types in coral-common instead? 🤔
 import { GQLRTEConfiguration } from "../../client/framework/schema/__generated__/types";
-// import { URL_REGEX } from ".";
 
 /** Tags that we remove before looking for suspect/banned words */
 export const WORDLIST_FORBID_TAGS = [
@@ -87,24 +86,26 @@ const MAILTO_PROTOCOL = "mailto:";
 const sanitizeAnchor = (node: Element) => {
   if (node.nodeName === "A") {
     const href = node.getAttribute("href");
-    let mailToWithMatchingInnerHtml = false;
     const innerHtml = node.innerHTML;
+
+    // Check for a mailto: link with corresponding inner html
+    let mailToWithMatchingInnerHtml = false;
     if (href) {
       const url = new URL(href);
-      // check for a mailto: link with corresponding inner html
       if (url.protocol === MAILTO_PROTOCOL) {
-        const hrefWithoutProtocol = href.replace(url.protocol, "");
-        if (hrefWithoutProtocol === innerHtml) {
+        if (href.replace(url.protocol, "") === innerHtml) {
           mailToWithMatchingInnerHtml = true;
         }
       }
     }
+
+    // When the anchor tag's inner html matches its href
     if ((href && href === innerHtml) || mailToWithMatchingInnerHtml) {
-      // Ensure we wrap all the links with the target + rel set.
+      // Ensure we wrap all the links with the target + rel set
       node.setAttribute("target", "_blank");
       node.setAttribute("rel", "noopener noreferrer");
     } else {
-      // Turn anchor into text corresponding to innerHTML.
+      // Otherwise, turn the anchor link into text corresponding to its inner html
       node.insertAdjacentText("beforebegin", node.innerHTML);
       node.parentNode!.removeChild(node);
     }

--- a/src/core/common/helpers/sanitize.ts
+++ b/src/core/common/helpers/sanitize.ts
@@ -88,19 +88,20 @@ const sanitizeAnchor = (node: Element) => {
     let href = node.getAttribute("href");
     let innerHtml = node.innerHTML;
 
-    // Account for whether trailing slashes are included or not
-    href = href?.endsWith("/") ? href : (href += "/");
-    innerHtml = innerHtml.endsWith("/") ? innerHtml : (innerHtml += "/");
-
-    // Check for a mailto: link with corresponding inner html
     let mailToWithMatchingInnerHtml = false;
     if (href) {
       const url = new URL(href);
+
+      // Check for a mailto: link with corresponding inner html
       if (url.protocol === MAILTO_PROTOCOL) {
         if (href.replace(url.protocol, "") === innerHtml) {
           mailToWithMatchingInnerHtml = true;
         }
       }
+
+      // Account for whether trailing slashes are included or not
+      href = href?.endsWith("/") ? href : (href += "/");
+      innerHtml = innerHtml.endsWith("/") ? innerHtml : (innerHtml += "/");
     }
 
     // When the anchor tag's inner html matches its href


### PR DESCRIPTION
## What does this PR do?

This ensures that when anchor tags are added to comments (typed in or copy/pasted) that have an `href` that matches their text, they remain links. Otherwise, the links are still replaced with the text of the anchor tag. This is for https://vmproduct.atlassian.net/browse/CORL-2437.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## How do I test this PR?

Copy/paste in text that includes anchor tags with hrefs that do **not** match the text. See that the anchor tag is replaced with the text.

Copy/paste in anchor tags with hrefs that match their text. See that they remain as is.

Type in a link. See that it remains a clickable link when the comment is submitted. 

Type in an email address and see that it remains a clickable mailto: link when the comment is submitted.
 
## How do we deploy this PR?

