### PR TITLE
Enabling DLC and removing workflow deps from dev deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,8 @@ workflows:
               only:
                 - /^release-.*/
           requires:
+            - lint
+            - unit_tests
             - build
 
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ setup_remote_docker_defaults: &setup_remote_docker_defaults
   # This is pinned to 19 to resolve a problem described here:
   # https://discuss.circleci.com/t/docker-build-fails-with-nonsensical-eperm-operation-not-permitted-copyfile/37364/24
   version: 19.03.13
+  docker_layer_caching: true
 
 version: 2.1
 jobs:
@@ -270,8 +271,6 @@ workflows:
               only:
                 - /^release-.*/
           requires:
-            - lint
-            - unit_tests
             - build
 
   build-test-deploy:


### PR DESCRIPTION
## What does this PR do?

Adds `docker_layer_caching: true` to the remote docker defaults, enabling layer caching within the CircleCI pipeline.

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

## Does this PR introduce any new environment variables or feature flags? 

No ENV variables but it enables a new CircleCI opt-in setting within any job invoking `setup_remote_docker_defaults`.

## How do I test this PR?

Post a commit and check the Circle workflow. `push_to_gcr` should no longer require `lint` or `unit_tests` to begin, and within the job's stdout you should be able to observe the line `---> Using cache` in the first few docker build steps.
 
## How do we deploy this PR?

No deploy necessary, just merge to develop.