### PR TITLE
[CORL-2505] Make email domain auto premod/ban work for SSO

### DIFF
--- a/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
+++ b/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
@@ -34,7 +34,10 @@ import {
   verifyJWT,
 } from "coral-server/services/jwt";
 import { AugmentedRedis } from "coral-server/services/redis";
-import { findOrCreate } from "coral-server/services/users";
+import {
+  findOrCreate,
+  processAutomaticBanPremodForNewUser,
+} from "coral-server/services/users";
 
 import {
   GQLSSOAuthIntegration,
@@ -200,6 +203,13 @@ export async function findOrCreateSSOUser(
       );
     }
   }
+
+  // Check the user's email address against emailDomain configurations
+  // to see if they should be set to banned or always pre-moderated.
+  // We do this here, because if a bad actor obtains access to a user and
+  // updates their old email to a new bad domain email, we will catch that
+  // new bad domain here.
+  await processAutomaticBanPremodForNewUser(mongo, tenant, user);
 
   return user;
 }

--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -240,10 +240,16 @@ export async function processAutomaticBanPremodForNewUser(
     return;
   }
 
-  if (newUserEmailDomainModeration === NEW_USER_MODERATION.BAN) {
+  if (
+    newUserEmailDomainModeration === NEW_USER_MODERATION.BAN &&
+    !user.status.ban.active
+  ) {
     await banUser(mongo, tenant.id, user.id);
   }
-  if (newUserEmailDomainModeration === NEW_USER_MODERATION.PREMOD) {
+  if (
+    newUserEmailDomainModeration === NEW_USER_MODERATION.PREMOD &&
+    !user.status.premod.active
+  ) {
     await premodUser(mongo, tenant.id, user.id);
   }
 }


### PR DESCRIPTION
## What does this PR do?

Hooks up the automated premod/ban by email domain work with the SSO auth flow as well as local auth.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No indexes add, no updates to `INDEXES.md`

## How do I test this PR?

- build coral and spin it up in development mode `npm run build:development` then `npm run start:development`
- Go to Configure > Moderation > Users > Email domain, set a domain for banning (I use `ban.com`) and one for premod (I use `premod.com`).
- Set up multi-site-test and add the domains in your `config.json` site setup to the Org with valid sites + domains if you haven't already (see the README in multi-site-test for more info on this)
- Spin up multi-site-test with two new SSO users that match these domains, example users below

  ```
         {
            "id": "c823cdcd-33e1-4c9a-bcf3-1881524ba72b",
            "username": "ban-user-immediate",
            "email": "bad@ban.com",
            "role": "COMMENTER"
          },
          {
            "id": "73f783bd-8bce-4088-8118-804204a3857d",
            "username": "premod-user-immediate",
            "email": "sketchy@premod.com",
            "role": "COMMENTER"
          }
          ...
  ```
- Using the multi-site-test page, go to the site with those users, try and sign in as them (multi-site-test will list them on a story page for you)
- See that the banned domain user is banned, and the premod user when posting comments is pre-modded
 
## How do we deploy this PR?

No special considerations.
