### PR TITLE
[CORL-2505 (part 2)] Always ban bad domain users, auto-premod only on newly created user

### DIFF
--- a/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
+++ b/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
@@ -36,7 +36,8 @@ import {
 import { AugmentedRedis } from "coral-server/services/redis";
 import {
   findOrCreate,
-  processAutomaticBanPremodForNewUser,
+  processAutomaticBanForUser,
+  processAutomaticPremodForUser,
 } from "coral-server/services/users";
 
 import {
@@ -175,6 +176,8 @@ export async function findOrCreateSSOUser(
       { skipUsernameValidation: true },
       now
     );
+
+    await processAutomaticPremodForUser(mongo, tenant, user);
   } else if (iat && needsSSOUpdate(decodedToken.user, user)) {
     // Get the SSO Profile.
     const profile = getSSOProfile(user);
@@ -209,7 +212,7 @@ export async function findOrCreateSSOUser(
   // We do this here, because if a bad actor obtains access to a user and
   // updates their old email to a new bad domain email, we will catch that
   // new bad domain here.
-  await processAutomaticBanPremodForNewUser(mongo, tenant, user);
+  await processAutomaticBanForUser(mongo, tenant, user);
 
   return user;
 }


### PR DESCRIPTION
## What does this PR do?

This splits the checks for auto premod/ban for SSO/local auth users. Auto-banning will always be checked for SSO users, so that when a bad domain email is found, it is always auto-banned.

Pre-moderation is only set on the creation of a new SSO account. This allows the pre-moderation to automatically be set, but if a mod/admin decides to remove the pre-moderation later, they can and the system won't automatically re-premod the user because it was in the domain list.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes added.

## How do I test this PR?

 ## How do I test this PR?

- build coral and spin it up in development mode `npm run build:development` then `npm run start:development`
- Go to Configure > Moderation > Users > Email domain, set a domain for banning (I use `ban.com`) and one for premod (I use `premod.com`).
- Set up multi-site-test and add the domains in your `config.json` site setup to the Org with valid sites + domains if you haven't already (see the README in multi-site-test for more info on this)
- Spin up multi-site-test with two new SSO users that match these domains, example users below

  ```
         {
            "id": "c823cdcd-33e1-4c9a-bcf3-1881524ba72b",
            "username": "ban-user-immediate",
            "email": "bad@ban.com",
            "role": "COMMENTER"
          },
          {
            "id": "73f783bd-8bce-4088-8118-804204a3857d",
            "username": "premod-user-immediate",
            "email": "sketchy@premod.com",
            "role": "COMMENTER"
          }
          ...
  ```
- Using the multi-site-test page, go to the site with those users, try and sign in as them (multi-site-test will list them on a story page for you)
- See that the banned domain user is banned, and the premod user when posting comments is pre-modded
- Remove the pre-mod on the user
- Post a comment as the formerly pre-modded user and see that pre-mod is lifted
 
## How do we deploy this PR?

No special considerations.
