### PR TITLE
update label comments-postCommentFormFake-signInAndJoin for de-CH

### DIFF
--- a/src/locales/de-CH/stream.ftl
+++ b/src/locales/de-CH/stream.ftl
@@ -129,7 +129,7 @@ comments-rte-externalImage =
 
 comments-remainingCharacters = { $remaining } Zeichen übrig
 
-comments-postCommentFormFake-signInAndJoin = Melde dich an und nimm an der Diskussion teil
+comments-postCommentFormFake-signInAndJoin = Anmelden und mitdiskutieren
 
 comments-postCommentForm-rteLabel = Kommentar schreiben
 


### PR DESCRIPTION
<h1>What I did</h1>

Update login button label for locale de-CH

@losowsky as discussed in CH-Media Slack channel, here is the PR to changing the Login Button Label

**Before**
<img width="502" alt="Screenshot 2022-03-01 at 08 11 07" src="https://user-images.githubusercontent.com/73962379/156121973-deec518b-9b48-4f56-b80d-d715a531efce.png">

**Now**
<img width="1126" alt="Screenshot 2022-03-01 at 07 58 50" src="https://user-images.githubusercontent.com/73962379/156121884-47b0d4a3-cb74-404b-8fcc-4c68aba3d855.png">


