### PR TITLE
Fix bad import on NewCommentersConfiguration resolver

### DIFF
--- a/src/core/server/graph/resolvers/NewCommentersConfiguration.ts
+++ b/src/core/server/graph/resolvers/NewCommentersConfiguration.ts
@@ -3,7 +3,7 @@ import * as settings from "coral-server/models/settings";
 import {
   GQLMODERATION_MODE,
   GQLNewCommentersConfigurationTypeResolver,
-} from "core/client/framework/schema/__generated__/types";
+} from "coral-server/graph/schema/__generated__/types";
 
 export const NewCommentersConfiguration: GQLNewCommentersConfigurationTypeResolver<settings.NewCommentersConfiguration> = {
   premodEnabled: ({ premodEnabled }) => premodEnabled,


### PR DESCRIPTION
## What does this PR do?

Fixes a bad import on NewCommentersConfiguration resolver.

Was importing from client types instead of the server side
schema types which crashes the server when done with a
production build.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No indexes added.

## How do I test this PR?

```
npm run build
npm run start
```
 
- See that the build does not fail and that you don't get a bad import error when the server starts up.
 
## How do we deploy this PR?

No special considerations.
