### PR TITLE
[CORL-2433]: update npm and override mathjs dep version

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -21,7 +21,7 @@ Built with ❤️ by Coral by [Vox Media](https://product.voxmedia.com/).
 - MongoDB ^4.2
 - Redis ^3.2
 - NodeJS ^14.18
-- NPM ^8.0
+- NPM ^8.3.0
 
 ## Running
 

--- a/package.json
+++ b/package.json
@@ -327,7 +327,6 @@
     "lodash-es": "^4.17.15",
     "marked": "^0.8.2",
     "material-design-icons-iconfont": "^6.1.0",
-    "mathjs": "^3.17.0",
     "mini-css-extract-plugin": "^0.9.0",
     "postcss-advanced-variables": "^3.0.1",
     "postcss-calc-function": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "engines": {
     "node": "^14.18",
-    "npm": "^8.0.0"
+    "npm": "^8.3.0"
   },
   "bugs": "https://github.com/coralproject/talk/issues",
   "contributors": [
@@ -327,6 +327,7 @@
     "lodash-es": "^4.17.15",
     "marked": "^0.8.2",
     "material-design-icons-iconfont": "^6.1.0",
+    "mathjs": "^3.17.0",
     "mini-css-extract-plugin": "^0.9.0",
     "postcss-advanced-variables": "^3.0.1",
     "postcss-calc-function": "^1.1.0",
@@ -403,6 +404,11 @@
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0",
     "whatwg-fetch": "^3.4.0"
+  },
+  "overrides": {
+    "postcss-calc-function": {
+      "mathjs": "3.17.0"
+    }
   },
   "dependencies-pins-documentation": {
     "react-final-form@6.3.0": [

--- a/package.json
+++ b/package.json
@@ -407,7 +407,7 @@
   },
   "overrides": {
     "postcss-calc-function": {
-      "mathjs": "3.17.0"
+      "mathjs": "^3.17.0"
     }
   },
   "dependencies-pins-documentation": {


### PR DESCRIPTION
## What does this PR do?

These changes add an override to the version of `mathjs` that is required by `postcss-calc-function`. To be able to use `overrides`, it also updates `npm` to at least `8.3.0`. See [docs on overrides](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides).

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You'll need to update your npm version to at least 8.3.0. `npm upgrade npm@8.3.0 -g`
Delete your `node_modules` and then `npm install` and go into your node modules and see that the correct version of `mathjs` (3.17.0) is installed. Run an `npm audit` and see that mathjs no longer has a critical issue. Check that everything builds and works as expected still.
 
## How do we deploy this PR?

