### PR TITLE
[CORL-2536]: add data-nosnippet

### DIFF
--- a/src/core/client/ui/encapsulation/CoralShadowRootContainer.tsx
+++ b/src/core/client/ui/encapsulation/CoralShadowRootContainer.tsx
@@ -17,7 +17,13 @@ const CoralShadowRootContainer: FunctionComponent<Props> = ({
   ...rest
 }) => {
   return (
-    <DivWithShadowBreakpointClasses ref={forwardRef} {...rest} id="coral" />
+    <DivWithShadowBreakpointClasses
+      ref={forwardRef}
+      {...rest}
+      id="coral"
+      // exclude Coral from snippets
+      data-nosnippet
+    />
   );
 };
 


### PR DESCRIPTION
## What does this PR do?

Adds `data-nosnippet` so that Coral will be excluded from snippets. See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr.

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

See `data-nosnippet` is added to the `#coral` div when you inspect.
 
## How do we deploy this PR?

