### PR TITLE
[CORL-2547]: fix unmark all keyboard shortcut not working

### DIFF
--- a/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -337,7 +337,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({ loggedIn, storyID }) => {
       UnmarkAllEvent.emit(eventEmitter, { source: config.source });
 
       // eslint-disable-next-line no-restricted-globals
-      const notSeenComments = window.document.querySelectorAll<HTMLElement>(
+      const notSeenComments = root.querySelectorAll<HTMLElement>(
         "[data-not-seen=true]"
       );
       const commentIDs: string[] = [];


### PR DESCRIPTION
## What does this PR do?

These changes make it so that the unmark all keyboard shortcut is working again. We needed to update to look for unseen comments in the `root`, as we updated to do throughout the rest of the keyboard shortcuts.

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Mark sure that `COMMENT_SEEN` feature flag is enabled. Use shift + a to unmark all comments and see that they are unmarked. Also can test out that the mobile button works to unmark all comments with these changes. 
 
## How do we deploy this PR?

