### PR TITLE
[CORL-2554] Show full size tweets in comments

### DIFF
--- a/src/core/client/framework/components/Frame.tsx
+++ b/src/core/client/framework/components/Frame.tsx
@@ -9,6 +9,7 @@ interface Props {
   src: string;
   sandbox?: boolean;
   title?: string;
+  width?: string;
 }
 
 export interface FrameHeightMessage {
@@ -18,7 +19,13 @@ export interface FrameHeightMessage {
 
 const iframeStyle = { display: "block" };
 
-const Frame: FunctionComponent<Props> = ({ id, src, sandbox, title }) => {
+const Frame: FunctionComponent<Props> = ({
+  id,
+  src,
+  sandbox,
+  title,
+  width,
+}) => {
   const { postMessage, rootURL } = useCoralContext();
   const [height, setHeight] = useState(0);
   const frameID = useMemo(
@@ -52,6 +59,7 @@ const Frame: FunctionComponent<Props> = ({ id, src, sandbox, title }) => {
         style={iframeStyle}
         src={url}
         height={height}
+        width={width}
         sandbox={sandboxStr}
         scrolling="no"
       />

--- a/src/core/client/stream/common/Media/TwitterMedia.tsx
+++ b/src/core/client/stream/common/Media/TwitterMedia.tsx
@@ -13,6 +13,7 @@ const TwitterMedia: FunctionComponent<Props> = ({ id, url, siteID }) => {
   return (
     <Frame
       id={id}
+      width="100%"
       src={`/api/oembed?type=twitter&url=${component}&siteID=${siteID}`}
     />
   );


### PR DESCRIPTION
## What does this PR do?

Allow tweets to fill the width of a comment so they don't use mobile styling when on desktop. Scales appropriately for mobile as well.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Go to stream
- Post tweet URL
- Add tweet to comment
- See full width large tweet
 
## How do we deploy this PR?

No special considerations.
