### PR TITLE
[CORL-2553]: Use textcontent not innerhtml for sanitizing anchor links

### DIFF
--- a/src/core/common/helpers/sanitize.ts
+++ b/src/core/common/helpers/sanitize.ts
@@ -86,7 +86,7 @@ const MAILTO_PROTOCOL = "mailto:";
 const sanitizeAnchor = (node: Element) => {
   if (node.nodeName === "A") {
     let href = node.getAttribute("href");
-    let innerHtml = node.innerHTML;
+    let textContent = node.textContent;
 
     let mailToWithMatchingInnerHtml = false,
       invalidURL = false;
@@ -100,19 +100,21 @@ const sanitizeAnchor = (node: Element) => {
 
       // Check for a mailto: link with corresponding inner html
       if (url && url.protocol === MAILTO_PROTOCOL) {
-        if (href.replace(url.protocol, "") === innerHtml) {
+        if (href.replace(url.protocol, "") === textContent) {
           mailToWithMatchingInnerHtml = true;
         }
       }
 
       // Account for whether trailing slashes are included or not
       href = href?.endsWith("/") ? href : (href += "/");
-      innerHtml = innerHtml.endsWith("/") ? innerHtml : (innerHtml += "/");
+      textContent = textContent?.endsWith("/")
+        ? textContent
+        : (textContent += "/");
     }
     // When the url is valid and the anchor tag's inner html matches its href
     if (
       !invalidURL &&
-      ((href && href === innerHtml) || mailToWithMatchingInnerHtml)
+      ((href && href === textContent) || mailToWithMatchingInnerHtml)
     ) {
       // Ensure we wrap all the links with the target + rel set
       node.setAttribute("target", "_blank");


### PR DESCRIPTION
## What does this PR do?

These changes update to use the text content when sanitizing anchor links. Urls should post as links in comments as expected now, even when special characters such as ampersand are present.

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Post a comment with a link that includes ampersands. See that when the comment posts it includes the link, clickable, with `&` as expected. 
 
## How do we deploy this PR?

