### PR TITLE
[CORL-2555]: fix adding an expert in Q&A

### DIFF
--- a/src/core/client/stream/tabs/Configure/Q&A/ExpertSelectionContainer.css
+++ b/src/core/client/stream/tabs/Configure/Q&A/ExpertSelectionContainer.css
@@ -21,11 +21,6 @@
   margin-bottom: var(--spacing-3);
 }
 
-.searchRoot {
-  position: relative;
-  width: 100%;
-}
-
 .searchField {
   width: 100%;
 

--- a/src/core/client/stream/tabs/Configure/Q&A/ExpertSelectionContainer.tsx
+++ b/src/core/client/stream/tabs/Configure/Q&A/ExpertSelectionContainer.tsx
@@ -1,13 +1,7 @@
 import { Localized } from "@fluent/react/compat";
-import React, {
-  FunctionComponent,
-  useCallback,
-  useEffect,
-  useState,
-} from "react";
+import React, { FunctionComponent, useCallback, useState } from "react";
 import { graphql, RelayPaginationProp } from "react-relay";
 
-import { useCoralContext } from "coral-framework/lib/bootstrap/CoralContext";
 import {
   useLoadMore,
   useMutation,
@@ -15,7 +9,7 @@ import {
   withPaginationContainer,
 } from "coral-framework/lib/relay";
 import { GQLUSER_ROLE_RL, GQLUSER_STATUS_RL } from "coral-framework/schema";
-import { Flex, Icon, TextField } from "coral-ui/components/v2";
+import { ClickOutside, Flex, Icon, TextField } from "coral-ui/components/v2";
 import { Button } from "coral-ui/components/v3";
 
 import { ExpertSelectionContainer_query as QueryData } from "coral-stream/__generated__/ExpertSelectionContainer_query.graphql";
@@ -66,14 +60,11 @@ const ExpertSelectionContainer: FunctionComponent<Props> = ({
   query,
   relay,
 }) => {
-  const { window } = useCoralContext();
   const users = computeUsers(query);
   const experts = computeExperts(query);
   const [removedExperts, setRemovedExperts] = useState(
     new Array<ExpertListItem>()
   );
-
-  const searchRootRef = React.createRef<HTMLDivElement>();
 
   const [loadMore, isLoadingMore] = useLoadMore(relay, 10);
   const [searchFilter, setSearchFilter] = useState<string>("");
@@ -95,28 +86,6 @@ const ExpertSelectionContainer: FunctionComponent<Props> = ({
     setTempSearchFilter("");
     setSearchFilter("");
   }, [setSearchFilter, setTempSearchFilter]);
-
-  // TODO: (cvle) Use <OnClickOutside> component.
-  const onClickOutside = useCallback(
-    (e: any) => {
-      if (
-        searchRootRef &&
-        searchRootRef.current &&
-        searchRootRef.current.contains(e.target)
-      ) {
-        return;
-      }
-
-      clearSearchFilter();
-    },
-    [clearSearchFilter, searchRootRef]
-  );
-  useEffect(() => {
-    window.document.addEventListener("mousedown", onClickOutside);
-    return () => {
-      window.document.removeEventListener("mousedown", onClickOutside);
-    };
-  }, [onClickOutside, window.document]);
 
   const onAddExpert = useCallback(
     (id: string) => {
@@ -219,7 +188,7 @@ const ExpertSelectionContainer: FunctionComponent<Props> = ({
           <span>Search for an expert</span>
         </Localized>
       </div>
-      <div className={styles.searchRoot} ref={searchRootRef}>
+      <ClickOutside onClickOutside={clearSearchFilter}>
         <Flex>
           <Localized
             id="configure-experts-filter-searchField"
@@ -263,42 +232,42 @@ const ExpertSelectionContainer: FunctionComponent<Props> = ({
           disableLoadMore={isLoadingMore}
           onLoadMore={loadMore}
         />
-        <div className={styles.expertListTitle}>
-          <Localized id="configure-experts-assigned-title">
-            <span>Experts</span>
-          </Localized>
-        </div>
-        {expertsList.length > 0 ? (
-          <ul className={styles.list}>
-            {expertsList.map((u) => {
-              if (u.removed) {
-                return (
-                  <NoLongerAnExpert
-                    key={`${u.id}-removed`}
-                    username={u.username}
-                  />
-                );
-              } else {
-                return (
-                  <ExpertListItem
-                    key={u.id}
-                    id={u.id}
-                    username={u.username}
-                    email={u.email}
-                    onClickRemove={onRemoveExpert}
-                  />
-                );
-              }
-            })}
-          </ul>
-        ) : (
-          <Localized id="configure-experts-none-yet">
-            <div className={styles.noExperts}>
-              There are currently no experts for this Q&A.
-            </div>
-          </Localized>
-        )}
+      </ClickOutside>
+      <div className={styles.expertListTitle}>
+        <Localized id="configure-experts-assigned-title">
+          <span>Experts</span>
+        </Localized>
       </div>
+      {expertsList.length > 0 ? (
+        <ul className={styles.list}>
+          {expertsList.map((u) => {
+            if (u.removed) {
+              return (
+                <NoLongerAnExpert
+                  key={`${u.id}-removed`}
+                  username={u.username}
+                />
+              );
+            } else {
+              return (
+                <ExpertListItem
+                  key={u.id}
+                  id={u.id}
+                  username={u.username}
+                  email={u.email}
+                  onClickRemove={onRemoveExpert}
+                />
+              );
+            }
+          })}
+        </ul>
+      ) : (
+        <Localized id="configure-experts-none-yet">
+          <div className={styles.noExperts}>
+            There are currently no experts for this Q&A.
+          </div>
+        </Localized>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## What does this PR do?

These changes make it so that it's possible to add an expert in Q&A mode again. With changes to shadow dom, `window.document` needed to either be updated to `root`, or we use the `ClickOutside` component to control clicking outside of the expert selection search. These changes update to use the `ClickOutside` component.

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can go to `Configure` for a story. Switch to Q&A mode. Search for an expert. Click on the expert you want to add and see that they appear as added under `Experts`. Also clicking outside of the search list when it's open should close it.
 
## How do we deploy this PR?
