### PR TITLE
[CORL-2551]: fix so RTE buttons show as activated in shadow dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "@babel/preset-typescript": "^7.10.1",
     "@babel/runtime-corejs3": "^7.10.3",
     "@coralproject/npm-run-all": "^4.1.5",
-    "@coralproject/rte": "^2.2.1",
+    "@coralproject/rte": "^2.2.2",
     "@fluent/react": "^0.11.1",
     "@giphy/js-fetch-api": "^4.1.2",
     "@giphy/react-components": "^5.4.0",

--- a/src/core/client/framework/lib/encapsulation/IframeEncapsulation.tsx
+++ b/src/core/client/framework/lib/encapsulation/IframeEncapsulation.tsx
@@ -163,6 +163,7 @@ const IframeEncapsulation: FunctionComponent<IframeEncapsulationProps> = ({
         height={height || 0}
         scrolling="no"
         style={iframeStyle}
+        id="Coral-RTE"
       ></iframe>
       {target && (
         <TargetPortal target={target}>

--- a/src/core/client/framework/lib/encapsulation/IframeEncapsulation.tsx
+++ b/src/core/client/framework/lib/encapsulation/IframeEncapsulation.tsx
@@ -16,6 +16,7 @@ import {
   useCoralContext,
 } from "coral-framework/lib/bootstrap";
 import { getUIContextPropsFromCoralContext } from "coral-framework/lib/bootstrap/CoralContext";
+import { RTE_ELEMENT_ID } from "coral-stream/constants";
 import { UIContext } from "coral-ui/components/v2";
 import CoralWindowContainer from "coral-ui/encapsulation/CoralWindowContainer";
 import CSSAsset from "coral-ui/encapsulation/CSSAsset";
@@ -163,7 +164,7 @@ const IframeEncapsulation: FunctionComponent<IframeEncapsulationProps> = ({
         height={height || 0}
         scrolling="no"
         style={iframeStyle}
-        id="Coral-RTE"
+        id={RTE_ELEMENT_ID}
       ></iframe>
       {target && (
         <TargetPortal target={target}>

--- a/src/core/client/stream/constants.ts
+++ b/src/core/client/stream/constants.ts
@@ -5,3 +5,5 @@ export const VIEWER_STATUS_CONTAINER_ID = "viewer-status";
 export const POST_COMMENT_FORM_ID = "post-comment-form";
 
 export const MAX_REPLY_INDENT_DEPTH = 4;
+
+export const RTE_ELEMENT_ID = "Coral-RTE";

--- a/src/core/client/stream/tabs/Comments/RTE/RTE.tsx
+++ b/src/core/client/stream/tabs/Comments/RTE/RTE.tsx
@@ -77,12 +77,15 @@ const createSanitizeToDOMFragment = (
 export const RTELocalized = React.forwardRef<
   any,
   PropTypesOf<typeof LocalizedOriginal>
->(function RTELocalized({ ctrlKey, squire, ButtonComponent, ...props }, ref) {
+>(function RTELocalized(
+  { ctrlKey, squire, ButtonComponent, rteElementID, ...props },
+  ref
+) {
   return (
     <LocalizedOriginal {...props}>
       {React.cloneElement(
         React.Children.only(props.children as React.ReactElement),
-        { ctrlKey, squire, ButtonComponent, ref }
+        { ctrlKey, squire, ButtonComponent, rteElementID, ref }
       )}
     </LocalizedOriginal>
   );
@@ -275,6 +278,7 @@ const RTE: FunctionComponent<Props> = (props) => {
     <div role="none">
       <CoralRTE
         inputID={inputID}
+        rteElementID="Coral-RTE"
         className={cn(CLASSES.rte.$root, className)}
         contentClassName={cn(
           CLASSES.rte.content,

--- a/src/core/client/stream/tabs/Comments/RTE/RTE.tsx
+++ b/src/core/client/stream/tabs/Comments/RTE/RTE.tsx
@@ -22,6 +22,7 @@ import { createSanitize } from "coral-common/helpers/sanitize";
 import { useCoralContext } from "coral-framework/lib/bootstrap/CoralContext";
 import IframeEncapsulation from "coral-framework/lib/encapsulation/IframeEncapsulation";
 import CLASSES from "coral-stream/classes";
+import { RTE_ELEMENT_ID } from "coral-stream/constants";
 import { Icon } from "coral-ui/components/v2";
 import { PropTypesOf } from "coral-ui/types";
 
@@ -278,7 +279,7 @@ const RTE: FunctionComponent<Props> = (props) => {
     <div role="none">
       <CoralRTE
         inputID={inputID}
-        rteElementID="Coral-RTE"
+        rteElementID={RTE_ELEMENT_ID}
         className={cn(CLASSES.rte.$root, className)}
         contentClassName={cn(
           CLASSES.rte.content,

--- a/src/core/client/stream/tabs/Comments/RTE/RTEButton.tsx
+++ b/src/core/client/stream/tabs/Comments/RTE/RTEButton.tsx
@@ -10,7 +10,14 @@ const RTEButton = React.forwardRef<
   HTMLButtonElement,
   React.ButtonHTMLAttributes<HTMLButtonElement> & Partial<InjectedProps>
 >(function RTEButtonForwarded(props, ref) {
-  const { ctrlKey, squire, ButtonComponent, className, ...rest } = props;
+  const {
+    ctrlKey,
+    squire,
+    ButtonComponent,
+    className,
+    rteElementID,
+    ...rest
+  } = props;
   return (
     <BaseButton {...rest} className={cn(styles.button, className)} ref={ref} />
   );

--- a/src/core/client/stream/tabs/Comments/RTE/__snapshots__/RTE.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/RTE/__snapshots__/RTE.spec.tsx.snap
@@ -22,6 +22,7 @@ exports[`renders correctly 1`] = `
     placeholder="Post a comment"
     placeholderClassName="coral coral-rte-placeholder RTE-placeholder"
     placeholderClassNameDisabled=""
+    rteElementID="Coral-RTE"
     sanitizeToDOMFragment={[Function]}
     sanitizeValue={true}
     toolbarClassName="coral coral-rte-toolbar RTE-toolbar RTE-toolbarHidden"


### PR DESCRIPTION
## What does this PR do?

These changes add an `rteElementID` to support updates to the `isActive` check in this corresponding PR in the `rte`: https://github.com/coralproject/rte/pull/40.

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

With the changes in this PR (https://github.com/coralproject/rte/pull/40), `npm link` `rte` with this branch (run `npm link path/to/rte` in `talk`) and run. See that if you select text in the editor and bold, italicize, or apply other styles to it, the corresponding button is activated in the RTE. See that if you click to another part of the page, the button is no longer activated. If you select the text again, the button is again activated as expected. 
 
## How do we deploy this PR?
