### PR TITLE
[CORL-2560] Create a story tree lookup for finding next unseen comment

### DIFF
--- a/src/core/server/graph/mutators/Stories.ts
+++ b/src/core/server/graph/mutators/Stories.ts
@@ -4,8 +4,10 @@ import { ERROR_CODES } from "coral-common/errors";
 import GraphContext from "coral-server/graph/context";
 import { mapFieldsetToErrorCodes } from "coral-server/graph/errors";
 import {
+  generateTreeForStory,
   markStoryForArchiving,
   markStoryForUnarchiving,
+  regenerateStoryTrees,
   retrieveStory,
   Story,
 } from "coral-server/models/story";
@@ -29,6 +31,7 @@ import {
   GQLArchiveStoriesInput,
   GQLCloseStoryInput,
   GQLCreateStoryInput,
+  GQLGenerateStoryTreeInput,
   GQLMergeStoriesInput,
   GQLOpenStoryInput,
   GQLRemoveStoryExpertInput,
@@ -187,5 +190,12 @@ export const Stories = (ctx: GraphContext) => ({
     }
 
     return stories;
+  },
+  generateStoryTree: async (input: GQLGenerateStoryTreeInput) => {
+    await generateTreeForStory(ctx.mongo, ctx.tenant.id, input.storyID);
+    return { storyID: input.storyID };
+  },
+  regenerateStoryTrees: async () => {
+    return await regenerateStoryTrees(ctx.mongo, ctx.tenant.id);
   },
 });

--- a/src/core/server/graph/resolvers/Mutation.ts
+++ b/src/core/server/graph/resolvers/Mutation.ts
@@ -489,4 +489,12 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     comments: await ctx.mutators.Comments.markAsSeen(input),
     clientMutationId: input.clientMutationId,
   }),
+  generateStoryTree: async (source, { input }, ctx) => ({
+    storyID: (await ctx.mutators.Stories.generateStoryTree(input)).storyID,
+    clientMutationId: input.clientMutationId,
+  }),
+  regenerateStoryTrees: async (source, { input }, ctx) => ({
+    accepted: await ctx.mutators.Stories.regenerateStoryTrees(),
+    clientMutationId: input.clientMutationId,
+  }),
 };

--- a/src/core/server/graph/resolvers/Query.ts
+++ b/src/core/server/graph/resolvers/Query.ts
@@ -5,11 +5,13 @@ import {
   getEmailDomain,
   getExternalModerationPhase,
 } from "coral-server/models/settings";
-import { getWebhookEndpoint } from "coral-server/models/tenant";
+import { findNextUnseenVisibleCommentID } from "coral-server/models/story";
+import { getWebhookEndpoint, hasFeatureFlag } from "coral-server/models/tenant";
 
 import {
   GQLCOMMENT_FLAG_REPORTED_REASON,
   GQLCOMMENT_SORT,
+  GQLFEATURE_FLAG,
   GQLQueryTypeResolver,
 } from "coral-server/graph/schema/__generated__/types";
 
@@ -71,4 +73,65 @@ export const Query: Required<GQLQueryTypeResolver<void>> = {
         },
       },
     }),
+  nextUnseenComment: async (
+    source,
+    { id, storyID, orderBy, viewNewCount },
+    ctx
+  ) => {
+    // unseen comments is only available to logged in users
+    if (!ctx.user) {
+      return null;
+    }
+    if (!storyID) {
+      return null;
+    }
+    // unseen comments is only compatible with newest or oldest first
+    // sort orders.
+    if (
+      ![
+        GQLCOMMENT_SORT.CREATED_AT_ASC,
+        GQLCOMMENT_SORT.CREATED_AT_DESC,
+      ].includes(orderBy)
+    ) {
+      return null;
+    }
+    // unseen comments is only enabled if Z_KEY is turned on
+    if (!hasFeatureFlag(ctx.tenant, GQLFEATURE_FLAG.Z_KEY)) {
+      return null;
+    }
+
+    const {
+      commentID,
+      index,
+      needToLoadNew,
+    } = await findNextUnseenVisibleCommentID(
+      ctx.mongo,
+      ctx.tenant.id,
+      storyID,
+      ctx.user.id,
+      orderBy,
+      id,
+      viewNewCount
+    );
+
+    if (commentID) {
+      const comment = await ctx.loaders.Comments.comment.load(commentID);
+
+      if (comment) {
+        const rootCommentID =
+          comment?.ancestorIDs?.length > 0
+            ? comment?.ancestorIDs[comment.ancestorIDs.length - 1]
+            : comment.id;
+
+        return {
+          commentID: comment.id,
+          parentID: comment.parentID,
+          rootCommentID,
+          index,
+          needToLoadNew,
+        };
+      }
+    }
+    return null;
+  },
 };

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -4257,7 +4257,7 @@ type Queues {
 
 type NextUnseenCommentPayload {
   """
-  commentID is the new comment the next comment ID to focus on.
+  commentID is the next comment ID to traverse to.
   """
   commentID: ID
 
@@ -4275,7 +4275,7 @@ type NextUnseenCommentPayload {
 
   """
   index is the next root level index that matches the virtualized
-  rendering order of the next commennt ID to focus on.
+  rendering order of the next comment ID to traverse to.
   """
   index: Int
 

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -4255,6 +4255,37 @@ type Queues {
   rejector: Queue!
 }
 
+type NextUnseenCommentPayload {
+  """
+  commentID is the new comment the next comment ID to focus on.
+  """
+  commentID: ID
+
+  """
+  parentID is the comment ID of the parent of the next comment ID
+  to traverse to.
+  """
+  parentID: ID
+
+  """
+  rootCommentID is the root comment (0th indent level) of the next
+  comment ID to traverse to.
+  """
+  rootCommentID: ID
+
+  """
+  index is the next root level index that matches the virtualized
+  rendering order of the next commennt ID to focus on.
+  """
+  index: Int
+
+  """
+  needToLoadNew is a recommendation that loading in the "view new comments"
+  is likely available prior to making this next Z_KEY traversal.
+  """
+  needToLoadNew: Boolean
+}
+
 ################################################################################
 ## Query
 ################################################################################
@@ -4421,6 +4452,17 @@ type Query {
   emailDomain will return a specific emailDomain configuration if it exists.
   """
   emailDomain(id: ID!): EmailDomain @auth(roles: [ADMIN])
+
+  """
+  nextUnseenComment will return the next unseen comment for the viewer
+  if Z_KEY is enabled.
+  """
+  nextUnseenComment(
+    id: ID
+    storyID: ID
+    orderBy: COMMENT_SORT!
+    viewNewCount: Int
+  ): NextUnseenCommentPayload
 }
 
 ################################################################################
@@ -8670,6 +8712,49 @@ type MarkCommentsAsSeenPayload {
   comments: [Comment!]!
 }
 
+input GenerateStoryTreeInput {
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+
+  """
+  storyID is the story to generate a story tree for.
+  """
+  storyID: ID!
+}
+
+type GenerateStoryTreePayload {
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+
+  """
+  storyID is the identifier for the story the tree was generated for.
+  """
+  storyID: ID!
+}
+
+input RegenerateStoryTreesInput {
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+type RegenerateStoryTreesPayload {
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+
+  """
+  accepted is whether the regeneration request was accepted.
+  """
+  accepted: Boolean!
+}
+
 ##################
 ## Mutation
 ##################
@@ -9351,6 +9436,13 @@ type Mutation {
   markCommentsAsSeen(
     input: MarkCommentsAsSeenInput!
   ): MarkCommentsAsSeenPayload!
+
+  generateStoryTree(input: GenerateStoryTreeInput!): GenerateStoryTreePayload!
+    @auth(roles: [ADMIN])
+
+  regenerateStoryTrees(
+    input: RegenerateStoryTreesInput!
+  ): RegenerateStoryTreesPayload! @auth(roles: [ADMIN])
 }
 
 ##################

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -9437,9 +9437,16 @@ type Mutation {
     input: MarkCommentsAsSeenInput!
   ): MarkCommentsAsSeenPayload!
 
+  """
+  generateStoryTree will create a story tree for a specific story.
+  """
   generateStoryTree(input: GenerateStoryTreeInput!): GenerateStoryTreePayload!
     @auth(roles: [ADMIN])
 
+  """
+  regenerateStoryTrees will regenerate all story trees for this organization and
+  all of its sites.
+  """
   regenerateStoryTrees(
     input: RegenerateStoryTreesInput!
   ): RegenerateStoryTreesPayload! @auth(roles: [ADMIN])

--- a/src/core/server/models/seenComments/seenComments.ts
+++ b/src/core/server/models/seenComments/seenComments.ts
@@ -58,7 +58,7 @@ export async function findSeenComments(
   return result ?? null;
 }
 
-function reduceCommentIDs(commentIDs: string[], now: Date) {
+export function reduceCommentIDs(commentIDs: string[], now: Date) {
   const comments = commentIDs.reduce<Record<string, Date>>((acc, commentID) => {
     acc[commentID] = now;
     return acc;

--- a/src/core/server/models/story/story.ts
+++ b/src/core/server/models/story/story.ts
@@ -1415,7 +1415,7 @@ export async function findNextUnseenVisibleCommentID(
   return { commentID: null, index: null };
 }
 
-async function executBulkStoryTreeWrites(
+async function executeBulkStoryTreeWrites(
   mongo: MongoContext,
   operations: StoryTreeUpdate[]
 ) {
@@ -1453,13 +1453,13 @@ export async function regenerateStoryTrees(
     count++;
 
     if (count >= BATCH_SIZE) {
-      await executBulkStoryTreeWrites(mongo, operations);
+      await executeBulkStoryTreeWrites(mongo, operations);
       operations = [];
     }
   }
 
   if (operations.length > 0) {
-    await executBulkStoryTreeWrites(mongo, operations);
+    await executeBulkStoryTreeWrites(mongo, operations);
   }
 
   return true;

--- a/src/core/server/models/story/story.ts
+++ b/src/core/server/models/story/story.ts
@@ -986,10 +986,11 @@ async function createTree(
 export async function generateTreeForStory(
   mongo: MongoContext,
   tenantID: string,
-  storyID: string
+  storyID: string,
+  archived = false
 ) {
-  const result = await mongo
-    .comments()
+  const comments = archived ? mongo.archivedComments() : mongo.comments();
+  const result = await comments
     .find({
       tenantID,
       storyID,

--- a/src/core/server/models/story/story.ts
+++ b/src/core/server/models/story/story.ts
@@ -1433,7 +1433,11 @@ export async function regenerateStoryTrees(
 ) {
   const BATCH_SIZE = 100;
 
-  const cursor = mongo.stories().find({ tenantID });
+  const cursor = mongo.stories().find({
+    tenantID,
+    isArchiving: { $in: [null, false] },
+    isArchived: { $in: [null, false] },
+  });
 
   let operations = [];
   let count = 0;

--- a/src/core/server/models/story/story.ts
+++ b/src/core/server/models/story/story.ts
@@ -40,7 +40,6 @@ import {
 } from "../seenComments/seenComments";
 
 export * from "./helpers";
-
 export interface StreamModeSettings {
   /**
    * mode is whether the story stream is in commenting or Q&A mode.
@@ -1335,11 +1334,7 @@ export async function findNextUnseenVisibleCommentID(
   // order is descending.
   let cursor = 0;
   if (!currentCommentID) {
-    if (orderBy === GQLCOMMENT_SORT.CREATED_AT_ASC) {
-      cursor = -1;
-    } else if (orderBy === GQLCOMMENT_SORT.CREATED_AT_DESC) {
-      cursor = 0;
-    }
+    cursor = -1;
   } else {
     cursor = stack.findIndex((c) => c.id === currentCommentID);
     if (cursor === -1) {

--- a/src/core/server/models/story/story.ts
+++ b/src/core/server/models/story/story.ts
@@ -8,7 +8,9 @@ import {
   DuplicateStoryIDError,
   DuplicateStoryURLError,
   StoryNotFoundError,
+  UserNotFoundError,
 } from "coral-server/errors";
+import { Comment } from "coral-server/models/comment";
 import {
   Connection,
   NodeToCursorTransformer,
@@ -20,6 +22,8 @@ import { GlobalModerationSettings } from "coral-server/models/settings";
 import { TenantResource } from "coral-server/models/tenant";
 
 import {
+  GQLCOMMENT_SORT,
+  GQLCOMMENT_STATUS,
   GQLSTORY_MODE,
   GQLStoryMetadata,
   GQLStorySettings,
@@ -30,6 +34,10 @@ import {
   RelatedCommentCounts,
   updateRelatedCommentCounts,
 } from "../comment/counts";
+import {
+  findSeenComments,
+  reduceCommentIDs,
+} from "../seenComments/seenComments";
 
 export * from "./helpers";
 
@@ -107,6 +115,8 @@ export interface Story extends TenantResource {
 
   isArchiving?: boolean;
   isArchived?: boolean;
+
+  tree: StoryTreeComment[];
 }
 
 export interface UpsertStoryInput {
@@ -137,6 +147,7 @@ export async function upsertStory(
     createdAt: now,
     commentCounts: createEmptyRelatedCommentCounts(),
     settings: {},
+    tree: [],
   };
 
   if (mode) {
@@ -290,6 +301,7 @@ export async function createStory(
     closedAt,
     commentCounts: createEmptyRelatedCommentCounts(),
     settings: {},
+    tree: [],
   };
 
   if (mode) {
@@ -318,7 +330,9 @@ export async function retrieveStoryByURL(
   tenantID: string,
   url: string
 ) {
-  return mongo.stories().findOne({ url, tenantID });
+  return mongo
+    .stories()
+    .findOne({ url, tenantID }, { projection: { tree: 0 } });
 }
 
 export async function retrieveStory(
@@ -326,7 +340,7 @@ export async function retrieveStory(
   tenantID: string,
   id: string
 ) {
-  return mongo.stories().findOne({ id, tenantID });
+  return mongo.stories().findOne({ id, tenantID }, { projection: { tree: 0 } });
 }
 
 export async function retrieveManyStories(
@@ -334,10 +348,13 @@ export async function retrieveManyStories(
   tenantID: string,
   ids: ReadonlyArray<string>
 ) {
-  const cursor = mongo.stories().find({
-    id: { $in: ids },
-    tenantID,
-  });
+  const cursor = mongo.stories().find(
+    {
+      id: { $in: ids },
+      tenantID,
+    },
+    { projection: { tree: 0 } }
+  );
 
   const stories = await cursor.toArray();
 
@@ -349,10 +366,13 @@ export async function retrieveManyStoriesByURL(
   tenantID: string,
   urls: ReadonlyArray<string>
 ) {
-  const cursor = mongo.stories().find({
-    url: { $in: urls },
-    tenantID,
-  });
+  const cursor = mongo.stories().find(
+    {
+      url: { $in: urls },
+      tenantID,
+    },
+    { projection: { tree: 0 } }
+  );
 
   const stories = await cursor.toArray();
 
@@ -595,14 +615,17 @@ export async function retrieveActiveStories(
 ) {
   const stories = await mongo
     .stories()
-    .find({
-      tenantID,
-      // We limit this query to stories that have the following field. This
-      // allows us to use the index.
-      lastCommentedAt: {
-        $exists: true,
+    .find(
+      {
+        tenantID,
+        // We limit this query to stories that have the following field. This
+        // allows us to use the index.
+        lastCommentedAt: {
+          $exists: true,
+        },
       },
-    })
+      { projection: { tree: 0 } }
+    )
     .sort({ lastCommentedAt: -1 })
     .limit(limit)
     .toArray();
@@ -846,20 +869,26 @@ export async function retrieveStoriesToBeArchived(
 ): Promise<Readonly<Story>[]> {
   const result = await mongo
     .stories()
-    .find({
-      tenantID,
-      $or: [
-        { lastCommentedAt: { $lte: olderThan } },
-        {
-          $and: [{ lastCommentedAt: null }, { createdAt: { $lte: olderThan } }],
-        },
-      ],
-      isArchiving: { $in: [null, false] },
-      isArchived: { $in: [null, false] },
-      startedUnarchivingAt: { $in: [null, false] },
-      unarchivedAt: { $in: [null, false] },
-      "settings.mode": { $ne: GQLSTORY_MODE.RATINGS_AND_REVIEWS },
-    })
+    .find(
+      {
+        tenantID,
+        $or: [
+          { lastCommentedAt: { $lte: olderThan } },
+          {
+            $and: [
+              { lastCommentedAt: null },
+              { createdAt: { $lte: olderThan } },
+            ],
+          },
+        ],
+        isArchiving: { $in: [null, false] },
+        isArchived: { $in: [null, false] },
+        startedUnarchivingAt: { $in: [null, false] },
+        unarchivedAt: { $in: [null, false] },
+        "settings.mode": { $ne: GQLSTORY_MODE.RATINGS_AND_REVIEWS },
+      },
+      { projection: { tree: 0 } }
+    )
     .limit(count)
     .toArray();
 
@@ -910,4 +939,532 @@ export async function markStoryAsUnarchived(
   );
 
   return result.value;
+}
+
+interface StoryTreeComment {
+  id: string;
+  authorID: string | null;
+  status: GQLCOMMENT_STATUS;
+  replies: StoryTreeComment[];
+}
+
+async function findChildren(
+  root: Readonly<StoryTreeComment>,
+  comments: Readonly<Comment>[]
+) {
+  return comments
+    .filter((c) => c.parentID === root.id)
+    .map((c) => {
+      return {
+        id: c.id,
+        authorID: c.authorID,
+        status: c.status,
+        replies: [],
+      };
+    });
+}
+
+async function createTree(
+  root: Readonly<StoryTreeComment>,
+  comments: Readonly<Comment>[]
+) {
+  const tree: StoryTreeComment = {
+    id: root.id,
+    authorID: root.authorID,
+    status: root.status,
+    replies: [],
+  };
+
+  const children = await findChildren(root, comments);
+  for (const child of children) {
+    const subTree = await createTree(child, comments);
+    tree.replies.push(subTree);
+  }
+
+  return tree;
+}
+
+export async function generateTreeForStory(
+  mongo: MongoContext,
+  tenantID: string,
+  storyID: string
+) {
+  const result = await mongo
+    .comments()
+    .find({
+      tenantID,
+      storyID,
+    })
+    .sort({ createdAt: -1 })
+    .toArray();
+
+  const tree = await createTreeFromComments(result);
+  await writeTreeToStory(mongo, tenantID, storyID, tree);
+}
+
+async function createTreeFromComments(comments: Readonly<Comment>[]) {
+  const rootComments = comments.filter(
+    (c) => c.parentID === null || c.parentID === undefined
+  );
+
+  const tree: StoryTreeComment[] = [];
+
+  for (const rootComment of rootComments) {
+    const subTree = await createTree(
+      {
+        id: rootComment.id,
+        authorID: rootComment.authorID,
+        status: rootComment.status,
+        replies: [],
+      },
+      comments
+    );
+    tree.push(subTree);
+  }
+
+  return tree;
+}
+
+interface StoryTreeUpdate {
+  filter: any;
+  update: any;
+}
+
+function computeWriteStoryToTreeUpdate(
+  tenantID: string,
+  storyID: string,
+  tree: StoryTreeComment[]
+): StoryTreeUpdate {
+  return {
+    filter: { tenantID, id: storyID },
+    update: {
+      $set: {
+        tree,
+      },
+    },
+  };
+}
+
+async function writeTreeToStory(
+  mongo: MongoContext,
+  tenantID: string,
+  storyID: string,
+  tree: StoryTreeComment[]
+) {
+  const operation = computeWriteStoryToTreeUpdate(tenantID, storyID, tree);
+
+  await mongo.stories().updateOne(operation.filter, operation.update);
+}
+
+/**
+ * Max level of nesting from MongoDB.
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Documents
+ */
+const MAX_LEVEL_NESTING = 100;
+
+/**
+ * Max level of ancestors is nesting max, halved (because of the structure of
+ * the tree) and minus two (because the root and tree element itself count).
+ */
+const MAX_ANCESTORS = Math.ceil(MAX_LEVEL_NESTING / 2) - 2;
+
+const KEYS = "abcdefghijklmnopqrstuvwxyz";
+
+const createArrayKeyChar = (i: number) => {
+  return KEYS[i % KEYS.length].repeat(Math.floor(i / KEYS.length) + 1);
+};
+
+const createKey = (ids: string[]) => {
+  if (ids.length > MAX_ANCESTORS) {
+    throw new Error("too many ancestors");
+  }
+
+  let key = "tree";
+
+  // ancestorIDs are in reverse order. So process this in reverse.
+  for (let i = ids.length - 1; i >= 0; i--) {
+    key += `.$[${createArrayKeyChar(i)}].replies`;
+  }
+
+  return key;
+};
+
+const createArrayFilters = (ids: string[]) => {
+  if (ids.length > MAX_ANCESTORS) {
+    throw new Error("too many ancestors");
+  }
+
+  const filters = [];
+
+  // ancestorIDs are in reverse order. So process this in reverse.
+  for (let i = ids.length - 1; i >= 0; i--) {
+    filters.push({ [`${createArrayKeyChar(i)}.id`]: ids[i] });
+  }
+
+  return filters;
+};
+
+const createNode = ({
+  id,
+  status,
+  authorID,
+}: Readonly<Comment>): StoryTreeComment => ({
+  id,
+  status,
+  authorID,
+  replies: [],
+});
+
+export async function addCommentToStoryTree(
+  mongo: MongoContext,
+  tenantID: string,
+  storyID: string,
+  comment: Readonly<Comment>
+) {
+  const query = { tenantID, id: storyID };
+  const update = {
+    $push: {
+      [createKey(comment.ancestorIDs)]: {
+        $each: [createNode(comment)],
+        $position: 0,
+      },
+    },
+  };
+  const options = {
+    arrayFilters: createArrayFilters(comment.ancestorIDs),
+    returnDocument: "after",
+  };
+
+  const result = await mongo.stories().findOneAndUpdate(query, update, options);
+
+  return result.value;
+}
+
+export async function updateCommentOnStoryTree(
+  mongo: MongoContext,
+  tenantID: string,
+  storyID: string,
+  comment: Readonly<Comment>
+) {
+  let key = createKey([comment.id, ...comment.ancestorIDs]);
+
+  // key now contains a `.replies` we want to replace with `.status`.
+  key = key.replace(/\.replies$/, ".status");
+
+  const query = { tenantID, id: storyID };
+  const update = {
+    $set: {
+      [key]: comment.status,
+    },
+  };
+  const options = {
+    arrayFilters: createArrayFilters([comment.id, ...comment.ancestorIDs]),
+    returnDocument: "after",
+  };
+
+  const result = await mongo.stories().findOneAndUpdate(query, update, options);
+
+  return result.value;
+}
+
+const VISIBLE_STATUSES = [GQLCOMMENT_STATUS.APPROVED, GQLCOMMENT_STATUS.NONE];
+
+function pruneCommentForVisibleComments(
+  comment: StoryTreeComment,
+  visibleStatuses: GQLCOMMENT_STATUS[],
+  ignoredAuthorIDs: string[]
+) {
+  // If a comment is not visible to the stream, the user cannot
+  // tab/Z_KEY/c-key to it, ignore it and continue on.
+  if (!VISIBLE_STATUSES.includes(comment.status)) {
+    return null;
+  }
+  // Ignore any ignored users, we do not stop to read these comments
+  // as they are not visible to the current user.
+  if (comment.authorID && ignoredAuthorIDs.includes(comment.authorID)) {
+    return null;
+  }
+
+  // Recursively check all our replies the same as we did the root above.
+  // We'll walk down each level and if it's null, we don't include it.
+  const visibleReplies: StoryTreeComment[] = [];
+  for (const reply of comment.replies) {
+    const result = pruneCommentForVisibleComments(
+      reply,
+      visibleStatuses,
+      ignoredAuthorIDs
+    );
+    if (result) {
+      visibleReplies.push(result);
+    }
+  }
+
+  // Return the us + the valid replies under ourself.
+  return {
+    ...comment,
+    replies: visibleReplies,
+  };
+}
+
+// Helper function to iterate over all the linear first array of
+// root comments at the start of the story's comment tree. This is
+// essentially just a filter in a for-loop that starts the recursion
+// down the tree with the above actual recursive op function.
+function pruneTreeForVisibleComments(
+  tree: StoryTreeComment[],
+  visibleStatuses: GQLCOMMENT_STATUS[],
+  ignoredAuthorIDs: string[]
+) {
+  const visibleRootComments: StoryTreeComment[] = [];
+  for (const rootComment of tree) {
+    // Start the recursion
+    const result = pruneCommentForVisibleComments(
+      rootComment,
+      visibleStatuses,
+      ignoredAuthorIDs
+    );
+
+    // If it's null, the comment is ignored or not visible, only
+    // add to visible list if the comment isn't null.
+    if (result) {
+      visibleRootComments.push(result);
+    }
+  }
+
+  return visibleRootComments;
+}
+
+interface FlattenedTreeComment extends StoryTreeComment {
+  rootIndex: number;
+}
+
+function flattenComment(
+  comment: StoryTreeComment,
+  rootIndex: number,
+  result: FlattenedTreeComment[]
+) {
+  result.push({ ...comment, rootIndex });
+
+  // Default ordering in story tree is newest first, but replies are
+  // always oldest first order, so we need to flip this around.
+  for (let i = comment.replies.length - 1; i >= 0; i--) {
+    const reply = comment.replies[i];
+    flattenComment(reply, rootIndex, result);
+  }
+}
+
+function flattenTree(
+  tree: StoryTreeComment[],
+  orderBy: GQLCOMMENT_SORT,
+  result: FlattenedTreeComment[]
+) {
+  if (orderBy === GQLCOMMENT_SORT.CREATED_AT_DESC) {
+    for (let i = 0; i < tree.length; i++) {
+      const rootComment = tree[i];
+      flattenComment(rootComment, i, result);
+    }
+  } else if (orderBy === GQLCOMMENT_SORT.CREATED_AT_ASC) {
+    let index = 0;
+    for (let i = tree.length - 1; i >= 0; i--) {
+      const rootComment = tree[i];
+      flattenComment(rootComment, index, result);
+      index++;
+    }
+  }
+}
+
+export async function findNextUnseenVisibleCommentID(
+  mongo: MongoContext,
+  tenantID: string,
+  storyID: string,
+  userID: string,
+  orderBy: GQLCOMMENT_SORT,
+  currentCommentID?: string,
+  viewNewCount?: number
+) {
+  if (
+    ![GQLCOMMENT_SORT.CREATED_AT_ASC, GQLCOMMENT_SORT.CREATED_AT_DESC].includes(
+      orderBy
+    )
+  ) {
+    throw new Error(
+      "invalid orderBy detected: only ascending and descending order is supported."
+    );
+  }
+
+  const story = await mongo.stories().findOne({ tenantID, id: storyID });
+  if (!story) {
+    throw new StoryNotFoundError(storyID);
+  }
+
+  const user = await mongo.users().findOne({ tenantID, id: userID });
+  if (!user) {
+    throw new UserNotFoundError(userID);
+  }
+  const ignoredUserIDs = user.ignoredUsers.map((u) => u.id);
+
+  // Grab the user's seen comments collection and handle if it is null.
+  // Our dictionary/map of id -> Date will be the `seen` variable.
+  const seenComments = await findSeenComments(mongo, tenantID, {
+    storyID,
+    userID,
+  });
+  const seen = seenComments
+    ? seenComments.comments
+    : reduceCommentIDs([], new Date());
+
+  // Find a tree of only the visible comments. A comment is deemed
+  // visible if its status is in the VISIBLE_STATUSES or it is not
+  // authored by one of the user's ignored users.
+  const prunedTree = pruneTreeForVisibleComments(
+    story.tree,
+    VISIBLE_STATUSES,
+    ignoredUserIDs
+  );
+
+  // Flatten our pruned tree with only visible comments
+  const stack: FlattenedTreeComment[] = [];
+  flattenTree(prunedTree, orderBy, stack);
+
+  // Find our current position in the stack by the passed in
+  // commentID that our commenter is currently focused on
+  // with Z_KEY traversal.
+  // If currentCommentID is null, set cursor so we start at
+  // beginning of stack if order is ascending and end of stack if
+  // order is descending.
+  let cursor = 0;
+  if (!currentCommentID) {
+    if (orderBy === GQLCOMMENT_SORT.CREATED_AT_ASC) {
+      cursor = -1;
+    } else if (orderBy === GQLCOMMENT_SORT.CREATED_AT_DESC) {
+      cursor = 0;
+    }
+  } else {
+    cursor = stack.findIndex((c) => c.id === currentCommentID);
+    if (cursor === -1) {
+      return { commentID: null, index: null };
+    }
+  }
+
+  // We are going to walk the full length of the stack now, but
+  // we will use the cursor position we found to determine our start
+  // position for our search.
+  //
+  // If we hit the end of the stack, we will loop around to the
+  // "start" depending on the direction we're going so that
+  // we search the whole stream for unseen comments even if we are
+  // at the bottom/top of the stream.
+  //
+  // Because of this weird offset traversal, we are doing one loop
+  // with i through the whole stack length, but we will also increment
+  // the cursor we computed earlier. Some folks might prefer using one
+  // variable to traverse this with an offset, but I tend to like
+  // abstracting the "do the whole loop" (with `i`) and the "where am
+  // I in the search?" (with `cursor`) as two separate variables.
+
+  let loopedAround = false;
+
+  // eslint-disable-next-line @typescript-eslint/prefer-for-of
+  for (let i = 0; i < stack.length; i++) {
+    cursor++;
+
+    // If we hit the end of the stack, start at the beginning
+    // and "loopAround" until we get to right behind where our
+    // cursor started
+    if (cursor >= stack.length) {
+      loopedAround = true;
+      cursor = 0;
+    }
+
+    // Pull the comment out via the cursor
+    const comment = stack[cursor];
+
+    // We don't count our own comments as unread stops, we have always
+    // seen our own comments
+    if (comment.authorID === userID) {
+      continue;
+    }
+
+    // If this is true, we have found a new unseen comment
+    // return it, we're done!
+    if (!(comment.id in seen)) {
+      // Offset by the client's provided viewNewCount so that our
+      // indices are accurate
+      const computedIndex =
+        viewNewCount && viewNewCount > 0
+          ? comment.rootIndex - viewNewCount
+          : comment.rootIndex;
+
+      let needToLoadNew = false;
+      // If the user did not provide a comment ID (at start of stream)
+      // and they have a viewNewCount, tell them to load in the new
+      // comments
+      if (!currentCommentID && viewNewCount && viewNewCount > 0) {
+        needToLoadNew = true;
+      }
+      // If the user looped around and they have have a viewNewCount,
+      // they likely want to load in the new comments before traversing
+      // to the next comment
+      if (loopedAround && viewNewCount && viewNewCount > 0) {
+        needToLoadNew = true;
+      }
+
+      return { commentID: comment.id, index: computedIndex, needToLoadNew };
+    }
+  }
+
+  // If we get here, we traversed the whole stream and found no unseen
+  // comments. We're done, return nothing.
+  return { commentID: null, index: null };
+}
+
+async function executBulkStoryTreeWrites(
+  mongo: MongoContext,
+  operations: StoryTreeUpdate[]
+) {
+  const bulk = mongo.stories().initializeUnorderedBulkOp();
+  for (const operation of operations) {
+    bulk.find(operation.filter).updateOne(operation.update);
+  }
+
+  await bulk.execute();
+}
+
+export async function regenerateStoryTrees(
+  mongo: MongoContext,
+  tenantID: string
+) {
+  const BATCH_SIZE = 100;
+
+  const cursor = mongo.stories().find({ tenantID });
+
+  let operations = [];
+  let count = 0;
+  let story = await cursor.next();
+  while (story !== null) {
+    const comments = await mongo
+      .comments()
+      .find({ tenantID, storyID: story.id })
+      .sort({ createdAt: -1 })
+      .toArray();
+    const tree = await createTreeFromComments(comments);
+
+    const operation = computeWriteStoryToTreeUpdate(tenantID, story.id, tree);
+    operations.push(operation);
+
+    story = await cursor.next();
+    count++;
+
+    if (count >= BATCH_SIZE) {
+      await executBulkStoryTreeWrites(mongo, operations);
+      operations = [];
+    }
+  }
+
+  if (operations.length > 0) {
+    await executBulkStoryTreeWrites(mongo, operations);
+  }
+
+  return true;
 }

--- a/src/core/server/services/archive/index.ts
+++ b/src/core/server/services/archive/index.ts
@@ -9,6 +9,7 @@ import {
 } from "coral-server/models/comment/counts";
 import { updateSiteCounts } from "coral-server/models/site";
 import {
+  generateTreeForStory,
   markStoryAsArchived,
   markStoryAsUnarchived,
 } from "coral-server/models/story";
@@ -124,6 +125,8 @@ export async function unarchiveStory(
   }
 
   logger.info("story is able to be unarchived, proceeding");
+
+  await generateTreeForStory(mongo, tenantID, id, true);
 
   const targetComments = {
     tenantID,

--- a/src/core/server/stacks/approveComment.ts
+++ b/src/core/server/stacks/approveComment.ts
@@ -1,6 +1,7 @@
 import { MongoContext } from "coral-server/data/context";
 import { CoralEventPublisherBroker } from "coral-server/events/publisher";
 import { getLatestRevision } from "coral-server/models/comment";
+import { updateCommentOnStoryTree } from "coral-server/models/story";
 import { Tenant } from "coral-server/models/tenant";
 import { moderate } from "coral-server/services/comments/moderation";
 import { AugmentedRedis } from "coral-server/services/redis";
@@ -54,6 +55,13 @@ const approveComment = async (
   if (!result.after) {
     return result.before;
   }
+
+  await updateCommentOnStoryTree(
+    mongo,
+    tenant.id,
+    result.after.storyID,
+    result.after
+  );
 
   if (counts) {
     // Publish changes to the event publisher.

--- a/src/core/server/stacks/createComment.ts
+++ b/src/core/server/stacks/createComment.ts
@@ -30,6 +30,7 @@ import { getDepth, hasAncestors } from "coral-server/models/comment/helpers";
 import { markSeenComments } from "coral-server/models/seenComments/seenComments";
 import { retrieveSite } from "coral-server/models/site";
 import {
+  addCommentToStoryTree,
   isUserStoryExpert,
   resolveStoryMode,
   retrieveStory,
@@ -331,6 +332,7 @@ export default async function create(
 
   // Updating some associated data.
   await Promise.all([
+    addCommentToStoryTree(mongo, tenant.id, story.id, comment),
     updateUserLastCommentID(redis, tenant, author, comment.id),
     updateStoryLastCommentedAt(mongo, tenant.id, story.id, now),
     markCommentAsAnswered(

--- a/src/core/server/stacks/editComment.ts
+++ b/src/core/server/stacks/editComment.ts
@@ -28,7 +28,11 @@ import {
   YouTubeMedia,
 } from "coral-server/models/comment";
 import { retrieveSite } from "coral-server/models/site";
-import { resolveStoryMode, retrieveStory } from "coral-server/models/story";
+import {
+  resolveStoryMode,
+  retrieveStory,
+  updateCommentOnStoryTree,
+} from "coral-server/models/story";
 import { Tenant } from "coral-server/models/tenant";
 import { User } from "coral-server/models/user";
 import { isSiteBanned } from "coral-server/models/user/helpers";
@@ -263,6 +267,8 @@ export default async function edit(
       now
     );
   }
+
+  await updateCommentOnStoryTree(mongo, tenant.id, story.id, result.after);
 
   // Update all the comment counts on stories and users.
   const counts = await updateAllCommentCounts(mongo, redis, {

--- a/src/core/server/stacks/rejectComment.ts
+++ b/src/core/server/stacks/rejectComment.ts
@@ -1,6 +1,7 @@
 import { MongoContext } from "coral-server/data/context";
 import { CoralEventPublisherBroker } from "coral-server/events/publisher";
 import { getLatestRevision, hasTag } from "coral-server/models/comment";
+import { updateCommentOnStoryTree } from "coral-server/models/story";
 import { Tenant } from "coral-server/models/tenant";
 import { removeTag } from "coral-server/services/comments";
 import { moderate } from "coral-server/services/comments/moderation";
@@ -60,6 +61,13 @@ const rejectComment = async (
   if (!result.after) {
     return result.before;
   }
+
+  await updateCommentOnStoryTree(
+    mongo,
+    tenant.id,
+    result.after.storyID,
+    result.after
+  );
 
   // TODO: (wyattjoh) (tessalt) broker cannot easily be passed to stack from tasks,
   // see CORL-935 in jira


### PR DESCRIPTION
## What does this PR do?

This is the first of two stages of changes to allow creation of story tree's that contain the comment ID hierarchy of the story on the the story document. In part 2 of these changes, we will update the front end to use this to perform unseen comment traversal via the `Z_KEY` flag.

## What changes to the GraphQL/Database Schema does this PR introduce?

- adds a `nextUnseenComment` query
- adds a `generateStoryTree` mutation
- adds a `regenerateStoryTrees` mutation

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes added.

## How do I test this PR?

- Enable `Z_KEY`
- Call `regenerateStoryTrees` with the following mutation

```
mutation ($clientMutationId: String!) {
  regenerateStoryTrees(input: {
    clientMutationId: $clientMutationId
  }) {
    accepted
  }
}
```

- Wait until the mutation returns
- Check your story documents and see that it creates descending order (newest first) ordered story trees that match the streams you see for those stories
- Try creating, editing, approving, rejecting comments in streams, see that they update in the story tree and match the right statuses
 
## How do we deploy this PR?

There are some special considerations when deploying this PR.

- Wait until a scheduled downtime for the target client
- Disable all commenting via `General > Sitewide commenting > Off`
- Set a message explaining that we are having a downtime in the provided RTE text box.
- Execute the below mutation on the cluster using the API

```
mutation ($clientMutationId: String!) {
  regenerateStoryTrees(input: {
    clientMutationId: $clientMutationId
  }) {
    accepted
  }
}
```
- Wait until the mutation has finished (for large clients will likely be about an hour)
- Check the stories to see they have story trees generated
- Enable all commenting via `General > Sitewide commenting > On`
