### PR TITLE
Fix YouTube embed widths

### DIFF
--- a/src/core/client/stream/common/Media/YouTubeMedia.css
+++ b/src/core/client/stream/common/Media/YouTubeMedia.css
@@ -1,0 +1,4 @@
+.container {
+  display: block;
+  width: calc(100% - var(--spacing-3));
+}

--- a/src/core/client/stream/common/Media/YouTubeMedia.tsx
+++ b/src/core/client/stream/common/Media/YouTubeMedia.tsx
@@ -2,6 +2,8 @@ import React, { FunctionComponent } from "react";
 
 import Frame from "coral-framework/components/Frame";
 
+import styles from "./YouTubeMedia.css";
+
 interface Props {
   id?: string;
   url: string;
@@ -11,10 +13,13 @@ interface Props {
 const YouTubeMedia: FunctionComponent<Props> = ({ id, url, siteID }) => {
   const component = encodeURIComponent(url);
   return (
-    <Frame
-      id={id}
-      src={`/api/oembed?type=youtube&url=${component}&siteID=${siteID}`}
-    />
+    <div className={styles.container}>
+      <Frame
+        id={id}
+        width="100%"
+        src={`/api/oembed?type=youtube&url=${component}&siteID=${siteID}`}
+      />
+    </div>
   );
 };
 

--- a/src/core/client/stream/common/Media/YouTubeMedia.tsx
+++ b/src/core/client/stream/common/Media/YouTubeMedia.tsx
@@ -16,7 +16,7 @@ const YouTubeMedia: FunctionComponent<Props> = ({ id, url, siteID }) => {
     <div className={styles.container}>
       <Frame
         id={id}
-        width="100%"
+        width="75%"
         src={`/api/oembed?type=youtube&url=${component}&siteID=${siteID}`}
       />
     </div>


### PR DESCRIPTION
## What does this PR do?

Set the frame width to 75% for YouTube embeds.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Enable youtube embeds in config
- Post a Youtube Link
- Add video to comment
- Post comment
- See that YouTube embedded video is a nice size for the comment
 
## How do we deploy this PR?

No special considerations.
