### PR TITLE
Provide rootURL when using amp embed handler

### DIFF
--- a/src/core/server/app/router/client.ts
+++ b/src/core/server/app/router/client.ts
@@ -153,8 +153,10 @@ const clientHandler = ({
 }: ClientTargetHandlerOptions): RequestHandler => async (req, res, next) => {
   // Grab the locale code from the tenant configuration, if available.
   let locale: LanguageCode = defaultLocale;
+  let rootURL = "";
   if (req.coral.tenant) {
     locale = req.coral.tenant.locale;
+    rootURL = `${req.protocol}://${req.coral.tenant?.domain}`;
   }
 
   const entrypoint = await entrypointLoader();
@@ -170,6 +172,7 @@ const clientHandler = ({
     enableCustomCSS,
     locale,
     config: populateStaticConfig(staticConfig, req),
+    rootURL,
   });
 };
 

--- a/src/core/server/app/views/amp.html
+++ b/src/core/server/app/views/amp.html
@@ -32,6 +32,7 @@
     window.addEventListener("DOMContentLoaded", function() {
       var CoralStreamEmbed = Coral.createStreamEmbed({
         id: "{{ id }}",
+        rootURL: "{{ rootURL }}",
         amp: true,
       });
       window.CoralStreamEmbed = CoralStreamEmbed;


### PR DESCRIPTION
## What does this PR do?

Injects the root URL when possible during amp embed loads.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

TBD
 
## How do we deploy this PR?

No special considerations.
