### PR TITLE
[CORL-2573]: Mark comments as read on scroll up out of view and at bottom

### DIFF
--- a/src/core/client/admin/App/UserMenu/__snapshots__/UserMenu.spec.tsx.snap
+++ b/src/core/client/admin/App/UserMenu/__snapshots__/UserMenu.spec.tsx.snap
@@ -9,13 +9,13 @@ exports[`renders correctly 1`] = `
   }
   id="userMenu-popover"
 >
-  <withPropsOnChange(withUIContext(Popover))
+  <withPropsOnChange(Popover)
     body={[Function]}
     description="A dialog of the user menu with related links and actions"
     id="userMenu"
     placement="bottom-end"
   >
     [Function]
-  </withPropsOnChange(withUIContext(Popover))>
+  </withPropsOnChange(Popover)>
 </Localized>
 `;

--- a/src/core/client/framework/lib/intersection/IntersectionContext.tsx
+++ b/src/core/client/framework/lib/intersection/IntersectionContext.tsx
@@ -16,7 +16,14 @@ const IntersectionContext = React.createContext<IntersectionContext>({} as any);
 export const useIntersectionContext = () =>
   React.useContext(IntersectionContext);
 
-export const IntersectionProvider: React.FunctionComponent = ({ children }) => {
+interface Props {
+  threshold?: number | number[];
+}
+
+export const IntersectionProvider: React.FunctionComponent<Props> = ({
+  threshold,
+  children,
+}) => {
   const callbacks = useRef(new Map<Element, IntersectionCallback>());
 
   const onIntersect = useCallback(
@@ -39,7 +46,7 @@ export const IntersectionProvider: React.FunctionComponent = ({ children }) => {
     () =>
       new IntersectionObserver(onIntersect, {
         rootMargin: "0px",
-        threshold: 0.25,
+        threshold: threshold ? threshold : 0.25,
       }),
     [onIntersect]
   );

--- a/src/core/client/framework/lib/intersection/useInView.ts
+++ b/src/core/client/framework/lib/intersection/useInView.ts
@@ -6,6 +6,10 @@ const useInView = () => {
   const { observe } = useIntersectionContext();
   const [intersectionRef, setIntersectionRef] = useState<Element | null>(null);
   const [inView, setInView] = useState<boolean>(false);
+  const [previousY, setPreviousY] = useState<number | null>(null);
+  const [scrolledUpOutOfView, setScrolledUpOutOfView] = useState<boolean>(
+    false
+  );
 
   useEffect(() => {
     if (!intersectionRef) {
@@ -14,14 +18,33 @@ const useInView = () => {
 
     // Begin observing te ref element. This will return a function for
     // unobserving the element.
-    return observe(intersectionRef, ({ intersectionRatio }) => {
-      // We will use the intersection ratio. Once the ratio is greater than zero
-      // we will mark that the element is in view.
-      setInView(intersectionRatio > 0);
-    });
-  }, [intersectionRef, observe]);
+    return observe(
+      intersectionRef,
+      ({ intersectionRatio, boundingClientRect }) => {
+        const currentY = boundingClientRect.y;
+        // If the current and previous Y are both negative, and the current is larger
+        // than the previous, and the element is no longer in view, and the element is not
+        // already marked as having been scrolled up, then we know that the element has been
+        // scrolled up and out of view for the first time.
+        if (
+          previousY &&
+          currentY < 0 &&
+          previousY < 0 &&
+          Math.abs(currentY) > Math.abs(previousY) &&
+          !scrolledUpOutOfView &&
+          !inView
+        ) {
+          setScrolledUpOutOfView(true);
+        }
+        // We will use the intersection ratio. Once the ratio is greater than zero
+        // we will mark that the element is in view.
+        setInView(intersectionRatio > 0);
+        setPreviousY(currentY);
+      }
+    );
+  }, [intersectionRef, observe, scrolledUpOutOfView, previousY]);
 
-  return { inView, intersectionRef: setIntersectionRef };
+  return { inView, intersectionRef: setIntersectionRef, scrolledUpOutOfView };
 };
 
 export default useInView;

--- a/src/core/client/stream/local/local.graphql
+++ b/src/core/client/stream/local/local.graphql
@@ -118,6 +118,8 @@ extend type Local {
   # media settings)
   expandedMediaSettings: ExpandedMediaSettings
 
+  commentsLinksInView: Boolean
+
   archivingEnabled: Boolean!
   autoArchiveOlderThanMs: Int!
 

--- a/src/core/client/stream/local/local.graphql
+++ b/src/core/client/stream/local/local.graphql
@@ -118,7 +118,7 @@ extend type Local {
   # media settings)
   expandedMediaSettings: ExpandedMediaSettings
 
-  commentsLinksInView: Boolean
+  bottomOfCommentsInView: Boolean
 
   archivingEnabled: Boolean!
   autoArchiveOlderThanMs: Int!

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -14,7 +14,8 @@ import { isBeforeDate } from "coral-common/utils";
 import { getURLWithCommentID } from "coral-framework/helpers";
 import { useToggleState } from "coral-framework/hooks";
 import { useCoralContext } from "coral-framework/lib/bootstrap";
-import { MutationProp, useMutation } from "coral-framework/lib/relay";
+import { useInView } from "coral-framework/lib/intersection";
+import { MutationProp, useLocal, useMutation } from "coral-framework/lib/relay";
 import withFragmentContainer from "coral-framework/lib/relay/withFragmentContainer";
 import { Ability, can } from "coral-framework/permissions";
 import {
@@ -77,6 +78,8 @@ import ReportFlowContainer, { ReportButton } from "./ReportFlow";
 import ShowConversationLink from "./ShowConversationLink";
 import { UsernameContainer, UsernameWithPopoverContainer } from "./Username";
 import UserTagsContainer, { commentHasTags } from "./UserTagsContainer";
+
+import { CommentContainerLocal } from "coral-stream/__generated__/CommentContainerLocal.graphql";
 
 import styles from "./CommentContainer.css";
 
@@ -146,6 +149,7 @@ export const CommentContainer: FunctionComponent<Props> = ({
   const commentSeenEnabled = useCommentSeenEnabled();
   const canCommitCommentSeen = !!(viewer && viewer.id) && commentSeenEnabled;
   const { eventEmitter } = useCoralContext();
+  const { intersectionRef, scrolledUpOutOfView, inView } = useInView();
   const setTraversalFocus = useMutation(SetTraversalFocus);
   const markCommentsAsSeen = useMutation(MarkCommentsAsSeenMutation);
   const handleFocus = useCallback(() => {
@@ -177,6 +181,14 @@ export const CommentContainer: FunctionComponent<Props> = ({
     toggleShowEditDialog,
   ] = useToggleState(false);
   const [showReportFlow, , toggleShowReportFlow] = useToggleState(false);
+  const [{ commentsLinksInView }] = useLocal<CommentContainerLocal>(
+    graphql`
+      fragment CommentContainerLocal on Local {
+        commentsLinksInView
+      }
+    `
+  );
+
   const handleShowConversation = useCallback(
     (e: MouseEvent) => {
       ViewConversationEvent.emit(eventEmitter, {
@@ -356,6 +368,35 @@ export const CommentContainer: FunctionComponent<Props> = ({
     </>
   );
 
+  // This marks comments as seen if they are scrolled up and off the top of the
+  // stream by the user.
+  useEffect(() => {
+    if (scrolledUpOutOfView) {
+      if (canCommitCommentSeen && !comment.seen) {
+        void markCommentsAsSeen({
+          commentIDs: [comment.id],
+          storyID: story.id,
+          updateSeen: true,
+        });
+      }
+    }
+  }, [scrolledUpOutOfView, canCommitCommentSeen, comment.seen]);
+
+  // This marks comments as seen if they are in view when we reach the comments
+  // links at the bottom of the stream (otherwise these won't be marked as seen
+  // because they will never be scrolled up and off the top of the screen).
+  useEffect(() => {
+    if (commentsLinksInView) {
+      if (inView && canCommitCommentSeen && !comment.seen) {
+        void markCommentsAsSeen({
+          commentIDs: [comment.id],
+          storyID: story.id,
+          updateSeen: true,
+        });
+      }
+    }
+  }, [commentsLinksInView, canCommitCommentSeen, comment.seen, showEditDialog]);
+
   const showModerationCaret: boolean =
     !!viewer &&
     story.canModerate &&
@@ -366,13 +407,15 @@ export const CommentContainer: FunctionComponent<Props> = ({
 
   if (showEditDialog) {
     return (
-      <div data-testid={`comment-${comment.id}`}>
-        <EditCommentFormContainer
-          settings={settings}
-          comment={comment}
-          story={story}
-          onClose={toggleShowEditDialog}
-        />
+      <div ref={intersectionRef}>
+        <div data-testid={`comment-${comment.id}`}>
+          <EditCommentFormContainer
+            settings={settings}
+            comment={comment}
+            story={story}
+            onClose={toggleShowEditDialog}
+          />
+        </div>
       </div>
     );
   }
@@ -417,354 +460,359 @@ export const CommentContainer: FunctionComponent<Props> = ({
     comment.lastViewerAction !== "EDIT";
 
   return (
-    <div
-      className={cn(
-        styles.root,
-        className,
-        CLASSES.comment.$root,
-        `${CLASSES.comment.reacted}-${comment.actionCounts.reaction.total}`,
-        badgesClassName
-      )}
-      tabIndex={-1}
-      id={commentElementID}
-      role="article"
-      aria-labelledby={`${commentElementID}-label`}
-      data-testid={commentElementID}
-      // Added for keyboard shortcut support.
-      data-key-stop
-      data-not-seen={canCommitCommentSeen && !comment.seen ? true : undefined}
-      onFocus={handleFocus}
-    >
-      {/* TODO: (cvle) Refactor at some point */}
-      <Hidden id={`${commentElementID}-label`}>
-        {indentLevel && (
-          <>
+    <div ref={intersectionRef}>
+      <div
+        className={cn(
+          styles.root,
+          className,
+          CLASSES.comment.$root,
+          `${CLASSES.comment.reacted}-${comment.actionCounts.reaction.total}`,
+          badgesClassName
+        )}
+        tabIndex={-1}
+        id={commentElementID}
+        role="article"
+        aria-labelledby={`${commentElementID}-label`}
+        data-testid={commentElementID}
+        // Added for keyboard shortcut support.
+        data-key-stop
+        data-not-seen={canCommitCommentSeen && !comment.seen ? true : undefined}
+        onFocus={handleFocus}
+      >
+        {/* TODO: (cvle) Refactor at some point */}
+        <Hidden id={`${commentElementID}-label`}>
+          {indentLevel && (
+            <>
+              <Localized
+                id="comments-commentContainer-threadLevelLabel"
+                $level={indentLevel}
+              >
+                <span>Thread Level {indentLevel}:</span>
+              </Localized>{" "}
+            </>
+          )}
+          {ariaIsHighlighted && (
+            <>
+              <Localized id="comments-commentContainer-highlightedLabel">
+                <span>Highlighted:</span>
+              </Localized>{" "}
+            </>
+          )}
+          {ariaIsAncestor && (
+            <>
+              <Localized id="comments-commentContainer-ancestorLabel">
+                <span>Ancestor:</span>
+              </Localized>{" "}
+            </>
+          )}
+          {comment.parent && (
             <Localized
-              id="comments-commentContainer-threadLevelLabel"
-              $level={indentLevel}
+              id="comments-commentContainer-replyLabel"
+              $username={comment.author?.username}
+              RelativeTime={<RelativeTime date={comment.createdAt} />}
             >
-              <span>Thread Level {indentLevel}:</span>
-            </Localized>{" "}
-          </>
-        )}
-        {ariaIsHighlighted && (
-          <>
-            <Localized id="comments-commentContainer-highlightedLabel">
-              <span>Highlighted:</span>
-            </Localized>{" "}
-          </>
-        )}
-        {ariaIsAncestor && (
-          <>
-            <Localized id="comments-commentContainer-ancestorLabel">
-              <span>Ancestor:</span>
-            </Localized>{" "}
-          </>
-        )}
-        {comment.parent && (
-          <Localized
-            id="comments-commentContainer-replyLabel"
-            $username={comment.author?.username}
-            RelativeTime={<RelativeTime date={comment.createdAt} />}
-          >
-            <span>
-              Reply from {comment.author?.username}{" "}
-              <RelativeTime date={comment.createdAt} />
-            </span>
-          </Localized>
-        )}
-        {!comment.parent && isQA && (
-          <Localized
-            id="comments-commentContainer-questionLabel"
-            $username={comment.author?.username}
-            RelativeTime={<RelativeTime date={comment.createdAt} />}
-          >
-            <span>
-              Question from {comment.author?.username}{" "}
-              <RelativeTime date={comment.createdAt} />
-            </span>
-          </Localized>
-        )}
-        {!comment.parent && !isQA && (
-          <Localized
-            id="comments-commentContainer-commentLabel"
-            $username={comment.author?.username}
-            RelativeTime={<RelativeTime date={comment.createdAt} />}
-          >
-            <span>
-              Comment from {comment.author?.username}{" "}
-              <RelativeTime date={comment.createdAt} />
-            </span>
-          </Localized>
-        )}
-      </Hidden>
-      <HorizontalGutter>
-        <IndentedComment
-          enableJumpToParent={enableJumpToParent}
-          classNameIndented={cn(styles.indentedCommentRoot, {
-            [styles.indented]: indentLevel && indentLevel > 0,
-            [styles.commentSeenEnabled]: canCommitCommentSeen,
-            [styles.notSeen]: shouldApplyNotSeenClass,
-            [styles.flattenedPadding]: isReplyFlattened(
-              settings.flattenReplies,
-              indentLevel
-            ),
-            [CLASSES.comment.notSeen]: shouldApplyNotSeenClass,
-            [styles.traversalFocus]: comment.hasTraversalFocus,
-            [CLASSES.comment.focus]: comment.hasTraversalFocus,
-          })}
-          indentLevel={indentLevel}
-          collapsed={collapsed}
-          body={comment.body}
-          rating={isRatingsAndReviews ? comment.rating : null}
-          createdAt={comment.createdAt}
-          blur={!!comment.pending}
-          showEditedMarker={comment.editing.edited}
-          highlight={highlight}
-          toggleCollapsed={toggleCollapsed}
-          parent={comment.parent}
-          staticUsername={
-            comment.author && (
-              <Flex direction="row" alignItems="center" wrap>
-                <UsernameContainer
+              <span>
+                Reply from {comment.author?.username}{" "}
+                <RelativeTime date={comment.createdAt} />
+              </span>
+            </Localized>
+          )}
+          {!comment.parent && isQA && (
+            <Localized
+              id="comments-commentContainer-questionLabel"
+              $username={comment.author?.username}
+              RelativeTime={<RelativeTime date={comment.createdAt} />}
+            >
+              <span>
+                Question from {comment.author?.username}{" "}
+                <RelativeTime date={comment.createdAt} />
+              </span>
+            </Localized>
+          )}
+          {!comment.parent && !isQA && (
+            <Localized
+              id="comments-commentContainer-commentLabel"
+              $username={comment.author?.username}
+              RelativeTime={<RelativeTime date={comment.createdAt} />}
+            >
+              <span>
+                Comment from {comment.author?.username}{" "}
+                <RelativeTime date={comment.createdAt} />
+              </span>
+            </Localized>
+          )}
+        </Hidden>
+        <HorizontalGutter>
+          <IndentedComment
+            enableJumpToParent={enableJumpToParent}
+            classNameIndented={cn(styles.indentedCommentRoot, {
+              [styles.indented]: indentLevel && indentLevel > 0,
+              [styles.commentSeenEnabled]: canCommitCommentSeen,
+              [styles.notSeen]: shouldApplyNotSeenClass,
+              [styles.flattenedPadding]: isReplyFlattened(
+                settings.flattenReplies,
+                indentLevel
+              ),
+              [CLASSES.comment.notSeen]: shouldApplyNotSeenClass,
+              [styles.traversalFocus]: comment.hasTraversalFocus,
+              [CLASSES.comment.focus]: comment.hasTraversalFocus,
+            })}
+            indentLevel={indentLevel}
+            collapsed={collapsed}
+            body={comment.body}
+            rating={isRatingsAndReviews ? comment.rating : null}
+            createdAt={comment.createdAt}
+            blur={!!comment.pending}
+            showEditedMarker={comment.editing.edited}
+            highlight={highlight}
+            toggleCollapsed={toggleCollapsed}
+            parent={comment.parent}
+            staticUsername={
+              comment.author && (
+                <Flex direction="row" alignItems="center" wrap>
+                  <UsernameContainer
+                    className={cn(
+                      styles.staticUsername,
+                      CLASSES.comment.topBar.username
+                    )}
+                    comment={comment}
+                  />
+                  <UserTagsContainer
+                    className={CLASSES.comment.topBar.userTag}
+                    story={story}
+                    comment={comment}
+                    settings={settings}
+                  />
+                  {badges && (
+                    <AuthorBadges
+                      className={CLASSES.comment.topBar.userBadge}
+                      badges={badges}
+                    />
+                  )}
+                </Flex>
+              )
+            }
+            username={
+              comment.author && (
+                <UsernameWithPopoverContainer
                   className={cn(
-                    styles.staticUsername,
+                    styles.usernameButton,
                     CLASSES.comment.topBar.username
                   )}
                   comment={comment}
+                  viewer={viewer}
+                  settings={settings}
                 />
+              )
+            }
+            tags={
+              comment.author &&
+              hasTags && (
                 <UserTagsContainer
                   className={CLASSES.comment.topBar.userTag}
                   story={story}
                   comment={comment}
                   settings={settings}
                 />
-                {badges && (
-                  <AuthorBadges
-                    className={CLASSES.comment.topBar.userBadge}
-                    badges={badges}
-                  />
-                )}
-              </Flex>
-            )
-          }
-          username={
-            comment.author && (
-              <UsernameWithPopoverContainer
-                className={cn(
-                  styles.usernameButton,
-                  CLASSES.comment.topBar.username
-                )}
-                comment={comment}
-                viewer={viewer}
-                settings={settings}
-              />
-            )
-          }
-          tags={
-            comment.author &&
-            hasTags && (
-              <UserTagsContainer
-                className={CLASSES.comment.topBar.userTag}
-                story={story}
-                comment={comment}
-                settings={settings}
-              />
-            )
-          }
-          badges={
-            comment.author &&
-            badges && (
-              <AuthorBadges
-                className={CLASSES.comment.topBar.userBadge}
-                badges={badges}
-              />
-            )
-          }
-          staticTopBarRight={commentTags}
-          topBarRight={
-            <>
-              <MatchMedia gteWidth="mobile">
-                {(matches) => (
-                  <>
-                    <Flex
-                      alignItems="center"
-                      justifyContent="flex-end"
-                      itemGutter
-                    >
-                      {matches ? commentTags : null}
-                      {editable && (
-                        <Button
-                          color="stream"
-                          variant="text"
-                          onClick={openEditDialog}
-                          className={cn(
-                            CLASSES.comment.topBar.editButton,
-                            styles.editButton
-                          )}
-                          data-testid="comment-edit-button"
-                        >
-                          <Flex alignItems="center" justifyContent="center">
-                            <Icon className={styles.editIcon}>edit</Icon>
-                            <Localized id="comments-commentContainer-editButton">
-                              Edit
-                            </Localized>
-                          </Flex>
-                        </Button>
-                      )}
-                      {showAvatar && comment.author?.avatar && (
-                        <div className={styles.avatarContainer}>
-                          <Localized
-                            id="comments-commentContainer-avatar"
-                            attrs={{ alt: true }}
-                            $username={comment.author.username}
+              )
+            }
+            badges={
+              comment.author &&
+              badges && (
+                <AuthorBadges
+                  className={CLASSES.comment.topBar.userBadge}
+                  badges={badges}
+                />
+              )
+            }
+            staticTopBarRight={commentTags}
+            topBarRight={
+              <>
+                <MatchMedia gteWidth="mobile">
+                  {(matches) => (
+                    <>
+                      <Flex
+                        alignItems="center"
+                        justifyContent="flex-end"
+                        itemGutter
+                      >
+                        {matches ? commentTags : null}
+                        {editable && (
+                          <Button
+                            color="stream"
+                            variant="text"
+                            onClick={openEditDialog}
+                            className={cn(
+                              CLASSES.comment.topBar.editButton,
+                              styles.editButton
+                            )}
+                            data-testid="comment-edit-button"
                           >
-                            <img
-                              src={comment.author.avatar}
-                              className={styles.avatar}
-                              loading="lazy"
-                              referrerPolicy="no-referrer"
-                              alt={`Avatar for ${comment.author.username}`}
-                            />
-                          </Localized>
-                        </div>
+                            <Flex alignItems="center" justifyContent="center">
+                              <Icon className={styles.editIcon}>edit</Icon>
+                              <Localized id="comments-commentContainer-editButton">
+                                Edit
+                              </Localized>
+                            </Flex>
+                          </Button>
+                        )}
+                        {showAvatar && comment.author?.avatar && (
+                          <div className={styles.avatarContainer}>
+                            <Localized
+                              id="comments-commentContainer-avatar"
+                              attrs={{ alt: true }}
+                              $username={comment.author.username}
+                            >
+                              <img
+                                src={comment.author.avatar}
+                                className={styles.avatar}
+                                loading="lazy"
+                                referrerPolicy="no-referrer"
+                                alt={`Avatar for ${comment.author.username}`}
+                              />
+                            </Localized>
+                          </div>
+                        )}
+                        {showModerationCaret && (
+                          <CaretContainer
+                            comment={comment}
+                            story={story}
+                            viewer={viewer!}
+                            settings={settings}
+                          />
+                        )}
+                      </Flex>
+                      {!matches ? commentTags : null}
+                    </>
+                  )}
+                </MatchMedia>
+              </>
+            }
+            media={
+              <MediaSectionContainer
+                comment={comment}
+                settings={settings}
+                defaultExpanded={viewer?.mediaSettings?.unfurlEmbeds}
+              />
+            }
+            footer={
+              <>
+                <Flex
+                  justifyContent="space-between"
+                  className={CLASSES.comment.actionBar.$root}
+                >
+                  <ButtonsBar className={styles.actionBar}>
+                    <ReactionButtonContainer
+                      comment={comment}
+                      settings={settings}
+                      viewer={viewer}
+                      readOnly={
+                        isViewerBanned ||
+                        isViewerSuspended ||
+                        isViewerWarned ||
+                        story.isArchived ||
+                        story.isArchiving
+                      }
+                      className={cn(
+                        styles.actionButton,
+                        CLASSES.comment.actionBar.reactButton
                       )}
-                      {showModerationCaret && (
-                        <CaretContainer
-                          comment={comment}
-                          story={story}
-                          viewer={viewer!}
-                          settings={settings}
+                      reactedClassName={cn(
+                        styles.actionButton,
+                        CLASSES.comment.actionBar.reactedButton
+                      )}
+                      isQA={story.settings.mode === GQLSTORY_MODE.QA}
+                    />
+                    {!disableReplies &&
+                      !isViewerBanned &&
+                      !isViewerSuspended &&
+                      !isViewerWarned &&
+                      !isViewerScheduledForDeletion && (
+                        <ReplyButton
+                          id={`comments-commentContainer-replyButton-${comment.id}`}
+                          author={comment.author?.username}
+                          onClick={toggleShowReplyDialog}
+                          active={showReplyDialog}
+                          disabled={
+                            settings.disableCommenting.enabled ||
+                            story.isClosed ||
+                            story.isArchived ||
+                            story.isArchiving
+                          }
+                          className={cn(
+                            styles.actionButton,
+                            CLASSES.comment.actionBar.replyButton
+                          )}
                         />
                       )}
-                    </Flex>
-                    {!matches ? commentTags : null}
-                  </>
+                    <PermalinkButtonContainer
+                      story={story}
+                      commentID={comment.id}
+                      author={comment.author?.username}
+                      className={cn(
+                        styles.actionButton,
+                        CLASSES.comment.actionBar.shareButton
+                      )}
+                    />
+                  </ButtonsBar>
+                  <ButtonsBar>
+                    {!isViewerBanned &&
+                      !isViewerSuspended &&
+                      !isViewerWarned &&
+                      !hideReportButton && (
+                        <ReportButton
+                          onClick={toggleShowReportFlow}
+                          open={showReportFlow}
+                          viewer={viewer}
+                          comment={comment}
+                        />
+                      )}
+                  </ButtonsBar>
+                </Flex>
+                {showConversationLink && (
+                  <ShowConversationLink
+                    className={CLASSES.comment.readMoreOfConversation}
+                    id={`comments-commentContainer-showConversation-${comment.id}`}
+                    onClick={handleShowConversation}
+                    href={getURLWithCommentID(story.url, comment.id)}
+                  />
                 )}
-              </MatchMedia>
-            </>
-          }
-          media={
-            <MediaSectionContainer
+              </>
+            }
+          />
+          {showReportFlow && !story.isArchived && !story.isArchiving && (
+            <ReportFlowContainer
+              viewer={viewer}
               comment={comment}
               settings={settings}
-              defaultExpanded={viewer?.mediaSettings?.unfurlEmbeds}
+              onClose={toggleShowReportFlow}
             />
-          }
-          footer={
-            <>
-              <Flex
-                justifyContent="space-between"
-                className={CLASSES.comment.actionBar.$root}
-              >
-                <ButtonsBar className={styles.actionBar}>
-                  <ReactionButtonContainer
-                    comment={comment}
-                    settings={settings}
-                    viewer={viewer}
-                    readOnly={
-                      isViewerBanned ||
-                      isViewerSuspended ||
-                      isViewerWarned ||
-                      story.isArchived ||
-                      story.isArchiving
-                    }
-                    className={cn(
-                      styles.actionButton,
-                      CLASSES.comment.actionBar.reactButton
-                    )}
-                    reactedClassName={cn(
-                      styles.actionButton,
-                      CLASSES.comment.actionBar.reactedButton
-                    )}
-                    isQA={story.settings.mode === GQLSTORY_MODE.QA}
-                  />
-                  {!disableReplies &&
-                    !isViewerBanned &&
-                    !isViewerSuspended &&
-                    !isViewerWarned &&
-                    !isViewerScheduledForDeletion && (
-                      <ReplyButton
-                        id={`comments-commentContainer-replyButton-${comment.id}`}
-                        author={comment.author?.username}
-                        onClick={toggleShowReplyDialog}
-                        active={showReplyDialog}
-                        disabled={
-                          settings.disableCommenting.enabled ||
-                          story.isClosed ||
-                          story.isArchived ||
-                          story.isArchiving
-                        }
-                        className={cn(
-                          styles.actionButton,
-                          CLASSES.comment.actionBar.replyButton
-                        )}
-                      />
-                    )}
-                  <PermalinkButtonContainer
-                    story={story}
-                    commentID={comment.id}
-                    author={comment.author?.username}
-                    className={cn(
-                      styles.actionButton,
-                      CLASSES.comment.actionBar.shareButton
-                    )}
-                  />
-                </ButtonsBar>
-                <ButtonsBar>
-                  {!isViewerBanned &&
-                    !isViewerSuspended &&
-                    !isViewerWarned &&
-                    !hideReportButton && (
-                      <ReportButton
-                        onClick={toggleShowReportFlow}
-                        open={showReportFlow}
-                        viewer={viewer}
-                        comment={comment}
-                      />
-                    )}
-                </ButtonsBar>
-              </Flex>
-              {showConversationLink && (
-                <ShowConversationLink
-                  className={CLASSES.comment.readMoreOfConversation}
-                  id={`comments-commentContainer-showConversation-${comment.id}`}
-                  onClick={handleShowConversation}
-                  href={getURLWithCommentID(story.url, comment.id)}
-                />
+          )}
+          {showReportFlow && (story.isArchived || story.isArchiving) && (
+            <ArchivedReportFlowContainer
+              settings={settings}
+              comment={comment}
+            />
+          )}
+          {showReplyDialog && !comment.deleted && (
+            <ReplyCommentFormContainer
+              settings={settings}
+              comment={comment}
+              story={story}
+              onClose={toggleShowReplyDialog}
+              localReply={localReply}
+              showJumpToComment={Boolean(
+                indentLevel &&
+                  indentLevel >= MAX_REPLY_INDENT_DEPTH - 1 &&
+                  settings.flattenReplies
               )}
-            </>
-          }
-        />
-        {showReportFlow && !story.isArchived && !story.isArchiving && (
-          <ReportFlowContainer
-            viewer={viewer}
-            comment={comment}
-            settings={settings}
-            onClose={toggleShowReportFlow}
-          />
-        )}
-        {showReportFlow && (story.isArchived || story.isArchiving) && (
-          <ArchivedReportFlowContainer settings={settings} comment={comment} />
-        )}
-        {showReplyDialog && !comment.deleted && (
-          <ReplyCommentFormContainer
-            settings={settings}
-            comment={comment}
-            story={story}
-            onClose={toggleShowReplyDialog}
-            localReply={localReply}
-            showJumpToComment={Boolean(
-              indentLevel &&
-                indentLevel >= MAX_REPLY_INDENT_DEPTH - 1 &&
-                settings.flattenReplies
-            )}
-          />
-        )}
-        {removeAnswered && (
-          <RemoveAnswered commentID={comment.id} storyID={story.id} />
-        )}
-      </HorizontalGutter>
+            />
+          )}
+          {removeAnswered && (
+            <RemoveAnswered commentID={comment.id} storyID={story.id} />
+          )}
+        </HorizontalGutter>
+      </div>
     </div>
   );
 };

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -371,29 +371,30 @@ export const CommentContainer: FunctionComponent<Props> = ({
   // This marks comments as seen if they are scrolled up and off the top of the
   // stream by the user.
   useEffect(() => {
-    if (scrolledUpOutOfView) {
-      if (canCommitCommentSeen && !comment.seen) {
-        void markCommentsAsSeen({
-          commentIDs: [comment.id],
-          storyID: story.id,
-          updateSeen: true,
-        });
-      }
+    if (scrolledUpOutOfView && canCommitCommentSeen && !comment.seen) {
+      void markCommentsAsSeen({
+        commentIDs: [comment.id],
+        storyID: story.id,
+        updateSeen: true,
+      });
     }
   }, [scrolledUpOutOfView, canCommitCommentSeen, comment.seen]);
 
-  // This marks comments as seen if they are in view when we reach the comments
-  // links at the bottom of the stream (otherwise these won't be marked as seen
-  // because they will never be scrolled up and off the top of the screen).
+  // This marks comments as seen if they are in view when we reach the bottom of
+  // the comments, whether stream or permalink (otherwise these won't be marked as
+  // seen because they will never be scrolled up and off the top of the screen).
   useEffect(() => {
-    if (bottomOfCommentsInView) {
-      if (inView && canCommitCommentSeen && !comment.seen) {
-        void markCommentsAsSeen({
-          commentIDs: [comment.id],
-          storyID: story.id,
-          updateSeen: true,
-        });
-      }
+    if (
+      bottomOfCommentsInView &&
+      inView &&
+      canCommitCommentSeen &&
+      !comment.seen
+    ) {
+      void markCommentsAsSeen({
+        commentIDs: [comment.id],
+        storyID: story.id,
+        updateSeen: true,
+      });
     }
   }, [
     bottomOfCommentsInView,

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -181,10 +181,10 @@ export const CommentContainer: FunctionComponent<Props> = ({
     toggleShowEditDialog,
   ] = useToggleState(false);
   const [showReportFlow, , toggleShowReportFlow] = useToggleState(false);
-  const [{ commentsLinksInView }] = useLocal<CommentContainerLocal>(
+  const [{ bottomOfCommentsInView }] = useLocal<CommentContainerLocal>(
     graphql`
       fragment CommentContainerLocal on Local {
-        commentsLinksInView
+        bottomOfCommentsInView
       }
     `
   );
@@ -386,7 +386,7 @@ export const CommentContainer: FunctionComponent<Props> = ({
   // links at the bottom of the stream (otherwise these won't be marked as seen
   // because they will never be scrolled up and off the top of the screen).
   useEffect(() => {
-    if (commentsLinksInView) {
+    if (bottomOfCommentsInView) {
       if (inView && canCommitCommentSeen && !comment.seen) {
         void markCommentsAsSeen({
           commentIDs: [comment.id],
@@ -395,7 +395,12 @@ export const CommentContainer: FunctionComponent<Props> = ({
         });
       }
     }
-  }, [commentsLinksInView, canCommitCommentSeen, comment.seen, showEditDialog]);
+  }, [
+    bottomOfCommentsInView,
+    canCommitCommentSeen,
+    comment.seen,
+    showEditDialog,
+  ]);
 
   const showModerationCaret: boolean =
     !!viewer &&
@@ -407,13 +412,15 @@ export const CommentContainer: FunctionComponent<Props> = ({
 
   if (showEditDialog) {
     return (
-      <div ref={intersectionRef} data-testid={`comment-${comment.id}`}>
-        <EditCommentFormContainer
-          settings={settings}
-          comment={comment}
-          story={story}
-          onClose={toggleShowEditDialog}
-        />
+      <div ref={intersectionRef}>
+        <div data-testid={`comment-${comment.id}`}>
+          <EditCommentFormContainer
+            settings={settings}
+            comment={comment}
+            story={story}
+            onClose={toggleShowEditDialog}
+          />
+        </div>
       </div>
     );
   }

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -378,7 +378,12 @@ export const CommentContainer: FunctionComponent<Props> = ({
         updateSeen: true,
       });
     }
-  }, [scrolledUpOutOfView, canCommitCommentSeen, comment.seen]);
+  }, [
+    scrolledUpOutOfView,
+    canCommitCommentSeen,
+    comment.seen,
+    markCommentsAsSeen,
+  ]);
 
   // This marks comments as seen if they are in view when we reach the bottom of
   // the comments, whether stream or permalink (otherwise these won't be marked as
@@ -400,7 +405,7 @@ export const CommentContainer: FunctionComponent<Props> = ({
     bottomOfCommentsInView,
     canCommitCommentSeen,
     comment.seen,
-    showEditDialog,
+    markCommentsAsSeen,
   ]);
 
   const showModerationCaret: boolean =

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -407,15 +407,13 @@ export const CommentContainer: FunctionComponent<Props> = ({
 
   if (showEditDialog) {
     return (
-      <div ref={intersectionRef}>
-        <div data-testid={`comment-${comment.id}`}>
-          <EditCommentFormContainer
-            settings={settings}
-            comment={comment}
-            story={story}
-            onClose={toggleShowEditDialog}
-          />
-        </div>
+      <div ref={intersectionRef} data-testid={`comment-${comment.id}`}>
+        <EditCommentFormContainer
+          settings={settings}
+          comment={comment}
+          story={story}
+          onClose={toggleShowEditDialog}
+        />
       </div>
     );
   }

--- a/src/core/client/stream/tabs/Comments/PermalinkView/ConversationThreadContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/ConversationThreadContainer.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent, useCallback } from "react";
 import { graphql, RelayPaginationProp } from "react-relay";
 
 import { useViewerNetworkEvent } from "coral-framework/lib/events";
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import {
   useLoadMore,
   withPaginationContainer,
@@ -75,13 +76,15 @@ const ConversationThreadContainer: FunctionComponent<Props> = ({
         >
           <RejectedTombstoneContainer comment={comment}>
             <DeletedTombstoneContainer comment={comment}>
-              <CommentContainer
-                comment={comment}
-                story={story}
-                settings={settings}
-                viewer={viewer}
-                highlight
-              />
+              <IntersectionProvider>
+                <CommentContainer
+                  comment={comment}
+                  story={story}
+                  settings={settings}
+                  viewer={viewer}
+                  highlight
+                />
+              </IntersectionProvider>
             </DeletedTombstoneContainer>
           </RejectedTombstoneContainer>
         </IgnoredTombstoneOrHideContainer>
@@ -106,14 +109,16 @@ const ConversationThreadContainer: FunctionComponent<Props> = ({
                 >
                   <RejectedTombstoneContainer comment={rootParent}>
                     <DeletedTombstoneContainer comment={rootParent}>
-                      <CommentContainer
-                        comment={rootParent}
-                        story={story}
-                        viewer={viewer}
-                        settings={settings}
-                        localReply
-                        ariaIsAncestor
-                      />
+                      <IntersectionProvider>
+                        <CommentContainer
+                          comment={rootParent}
+                          story={story}
+                          viewer={viewer}
+                          settings={settings}
+                          localReply
+                          ariaIsAncestor
+                        />
+                      </IntersectionProvider>
                     </DeletedTombstoneContainer>
                   </RejectedTombstoneContainer>
                   {viewer && (
@@ -172,14 +177,16 @@ const ConversationThreadContainer: FunctionComponent<Props> = ({
                   >
                     <RejectedTombstoneContainer comment={parent}>
                       <DeletedTombstoneContainer comment={parent}>
-                        <CommentContainer
-                          comment={parent}
-                          story={story}
-                          viewer={viewer}
-                          settings={settings}
-                          localReply
-                          ariaIsAncestor
-                        />
+                        <IntersectionProvider>
+                          <CommentContainer
+                            comment={parent}
+                            story={story}
+                            viewer={viewer}
+                            settings={settings}
+                            localReply
+                            ariaIsAncestor
+                          />
+                        </IntersectionProvider>
                       </DeletedTombstoneContainer>
                     </RejectedTombstoneContainer>
                     {viewer && (
@@ -209,16 +216,18 @@ const ConversationThreadContainer: FunctionComponent<Props> = ({
             >
               <RejectedTombstoneContainer comment={comment}>
                 <DeletedTombstoneContainer comment={comment}>
-                  <CommentContainer
-                    enableJumpToParent={remaining === 0}
-                    className={CLASSES.conversationThread.hightlighted}
-                    comment={comment}
-                    story={story}
-                    settings={settings}
-                    viewer={viewer}
-                    highlight
-                    ariaIsHighlighted
-                  />
+                  <IntersectionProvider>
+                    <CommentContainer
+                      enableJumpToParent={remaining === 0}
+                      className={CLASSES.conversationThread.hightlighted}
+                      comment={comment}
+                      story={story}
+                      settings={settings}
+                      viewer={viewer}
+                      highlight
+                      ariaIsHighlighted
+                    />
+                  </IntersectionProvider>
                 </DeletedTombstoneContainer>
               </RejectedTombstoneContainer>
             </IgnoredTombstoneOrHideContainer>

--- a/src/core/client/stream/tabs/Comments/PermalinkView/ConversationThreadContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/ConversationThreadContainer.tsx
@@ -76,7 +76,7 @@ const ConversationThreadContainer: FunctionComponent<Props> = ({
         >
           <RejectedTombstoneContainer comment={comment}>
             <DeletedTombstoneContainer comment={comment}>
-              <IntersectionProvider>
+              <IntersectionProvider threshold={[0, 1]}>
                 <CommentContainer
                   comment={comment}
                   story={story}
@@ -109,7 +109,7 @@ const ConversationThreadContainer: FunctionComponent<Props> = ({
                 >
                   <RejectedTombstoneContainer comment={rootParent}>
                     <DeletedTombstoneContainer comment={rootParent}>
-                      <IntersectionProvider>
+                      <IntersectionProvider threshold={[0, 1]}>
                         <CommentContainer
                           comment={rootParent}
                           story={story}
@@ -177,7 +177,7 @@ const ConversationThreadContainer: FunctionComponent<Props> = ({
                   >
                     <RejectedTombstoneContainer comment={parent}>
                       <DeletedTombstoneContainer comment={parent}>
-                        <IntersectionProvider>
+                        <IntersectionProvider threshold={[0, 1]}>
                           <CommentContainer
                             comment={parent}
                             story={story}
@@ -216,7 +216,7 @@ const ConversationThreadContainer: FunctionComponent<Props> = ({
             >
               <RejectedTombstoneContainer comment={comment}>
                 <DeletedTombstoneContainer comment={comment}>
-                  <IntersectionProvider>
+                  <IntersectionProvider threshold={[0, 1]}>
                     <CommentContainer
                       enableJumpToParent={remaining === 0}
                       className={CLASSES.conversationThread.hightlighted}

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
@@ -11,6 +11,7 @@ import { graphql } from "react-relay";
 
 import { getURLWithCommentID } from "coral-framework/helpers";
 import { useCoralContext } from "coral-framework/lib/bootstrap";
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import {
   useMutation,
   useSubscription,
@@ -149,12 +150,14 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
           )}
           {comment && commentVisible && (
             <HorizontalGutter>
-              <ConversationThreadContainer
-                viewer={viewer}
-                comment={comment}
-                story={story}
-                settings={settings}
-              />
+              <IntersectionProvider>
+                <ConversationThreadContainer
+                  viewer={viewer}
+                  comment={comment}
+                  story={story}
+                  settings={settings}
+                />
+              </IntersectionProvider>
               <div className={styles.replyList}>
                 <ReplyListContainer
                   viewer={viewer}

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
@@ -11,8 +11,9 @@ import { graphql } from "react-relay";
 
 import { getURLWithCommentID } from "coral-framework/helpers";
 import { useCoralContext } from "coral-framework/lib/bootstrap";
-import { IntersectionProvider } from "coral-framework/lib/intersection";
+import { useInView } from "coral-framework/lib/intersection";
 import {
+  useLocal,
   useMutation,
   useSubscription,
   withFragmentContainer,
@@ -36,6 +37,8 @@ import { PermalinkViewContainer_viewer as ViewerData } from "coral-stream/__gene
 import { isPublished } from "../helpers";
 import ConversationThreadContainer from "./ConversationThreadContainer";
 
+import { PermalinkViewContainerLocal } from "coral-stream/__generated__/PermalinkViewContainerLocal.graphql";
+
 import styles from "./PermalinkViewContainer.css";
 
 interface Props {
@@ -50,6 +53,14 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
   const setCommentID = useMutation(SetCommentIDMutation);
   const { renderWindow, eventEmitter, window } = useCoralContext();
   const root = useShadowRootOrDocument();
+
+  const [, setLocal] = useLocal<PermalinkViewContainerLocal>(
+    graphql`
+      fragment PermalinkViewContainerLocal on Local {
+        bottomOfCommentsInView
+      }
+    `
+  );
 
   const subscribeToCommentEntered = useSubscription(CommentEnteredSubscription);
 
@@ -92,6 +103,12 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
   }, [window.location.href]);
 
   const commentVisible = comment && isPublished(comment.status);
+
+  const { intersectionRef, inView } = useInView();
+
+  useEffect(() => {
+    setLocal({ bottomOfCommentsInView: inView });
+  }, [inView]);
 
   return (
     <HorizontalGutter
@@ -150,14 +167,12 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
           )}
           {comment && commentVisible && (
             <HorizontalGutter>
-              <IntersectionProvider threshold={[0, 1]}>
-                <ConversationThreadContainer
-                  viewer={viewer}
-                  comment={comment}
-                  story={story}
-                  settings={settings}
-                />
-              </IntersectionProvider>
+              <ConversationThreadContainer
+                viewer={viewer}
+                comment={comment}
+                story={story}
+                settings={settings}
+              />
               <div className={styles.replyList}>
                 <ReplyListContainer
                   viewer={viewer}
@@ -173,6 +188,7 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
           )}
         </HorizontalGutter>
       </Localized>
+      <div ref={intersectionRef}></div>
     </HorizontalGutter>
   );
 };

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
@@ -150,7 +150,7 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
           )}
           {comment && commentVisible && (
             <HorizontalGutter>
-              <IntersectionProvider>
+              <IntersectionProvider threshold={[0, 1]}>
                 <ConversationThreadContainer
                   viewer={viewer}
                   comment={comment}

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewQuery.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewQuery.tsx
@@ -31,7 +31,7 @@ export const render = ({ error, props }: QueryRenderData<QueryTypes>) => {
       );
     }
     return (
-      <IntersectionProvider threshold={[0, 1]}>
+      <IntersectionProvider threshold={1}>
         <PermalinkViewContainer
           viewer={props.viewer}
           settings={props.settings}

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewQuery.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewQuery.tsx
@@ -2,6 +2,7 @@ import { Localized } from "@fluent/react/compat";
 import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import {
   QueryRenderData,
   QueryRenderer,
@@ -30,12 +31,14 @@ export const render = ({ error, props }: QueryRenderData<QueryTypes>) => {
       );
     }
     return (
-      <PermalinkViewContainer
-        viewer={props.viewer}
-        settings={props.settings}
-        comment={props.comment}
-        story={props.story}
-      />
+      <IntersectionProvider threshold={[0, 1]}>
+        <PermalinkViewContainer
+          viewer={props.viewer}
+          settings={props.settings}
+          comment={props.comment}
+          story={props.story}
+        />
+      </IntersectionProvider>
     );
   }
   return (

--- a/src/core/client/stream/tabs/Comments/PermalinkView/__snapshots__/PermalinkViewQuery.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/__snapshots__/PermalinkViewQuery.spec.tsx.snap
@@ -13,8 +13,12 @@ exports[`renders loading 1`] = `
 `;
 
 exports[`renders permalink view container 1`] = `
-<Relay(PermalinkViewContainer)
-  comment={Object {}}
-  story={Object {}}
-/>
+<IntersectionProvider
+  threshold={1}
+>
+  <Relay(PermalinkViewContainer)
+    comment={Object {}}
+    story={Object {}}
+  />
+</IntersectionProvider>
 `;

--- a/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import FadeInTransition from "coral-framework/components/FadeInTransition";
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import { withFragmentContainer } from "coral-framework/lib/relay";
 import { HorizontalGutter } from "coral-ui/components/v2";
 
@@ -68,21 +69,23 @@ const ReplyListCommentContainer: FunctionComponent<Props> = ({
               return (
                 <>
                   <DeletedTombstoneContainer comment={comment}>
-                    <CommentContainer
-                      viewer={viewer}
-                      comment={comment}
-                      story={story}
-                      collapsed={collapsed && collapseEnabled}
-                      settings={settings}
-                      indentLevel={indentLevel}
-                      localReply={localReply}
-                      disableReplies={disableReplies}
-                      showConversationLink={!!showConversationLink}
-                      toggleCollapsed={
-                        collapseEnabled ? toggleCollapsed : undefined
-                      }
-                      showRemoveAnswered={showRemoveAnswered}
-                    />
+                    <IntersectionProvider>
+                      <CommentContainer
+                        viewer={viewer}
+                        comment={comment}
+                        story={story}
+                        collapsed={collapsed && collapseEnabled}
+                        settings={settings}
+                        indentLevel={indentLevel}
+                        localReply={localReply}
+                        disableReplies={disableReplies}
+                        showConversationLink={!!showConversationLink}
+                        toggleCollapsed={
+                          collapseEnabled ? toggleCollapsed : undefined
+                        }
+                        showRemoveAnswered={showRemoveAnswered}
+                      />
+                    </IntersectionProvider>
                   </DeletedTombstoneContainer>
                   <div
                     className={cn({

--- a/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/ReplyList/ReplyListCommentContainer.tsx
@@ -69,7 +69,7 @@ const ReplyListCommentContainer: FunctionComponent<Props> = ({
               return (
                 <>
                   <DeletedTombstoneContainer comment={comment}>
-                    <IntersectionProvider>
+                    <IntersectionProvider threshold={[0, 1]}>
                       <CommentContainer
                         viewer={viewer}
                         comment={comment}

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabCommentContainer.tsx
@@ -39,7 +39,6 @@ const AllCommentsTabCommentContainer: FunctionComponent<Props> = ({
   const commentSeenEnabled = useCommentSeenEnabled();
   const canCommitCommentSeen = !!(viewer && viewer.id) && commentSeenEnabled;
   const commentSeen = canCommitCommentSeen && comment.seen;
-
   return (
     <IgnoredTombstoneOrHideContainer viewer={viewer} comment={comment}>
       <FadeInTransition active={!!comment.enteredLive}>

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabCommentContainer.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import FadeInTransition from "coral-framework/components/FadeInTransition";
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import { withFragmentContainer } from "coral-framework/lib/relay";
 import { HorizontalGutter } from "coral-ui/components/v2";
 
@@ -38,6 +39,7 @@ const AllCommentsTabCommentContainer: FunctionComponent<Props> = ({
   const commentSeenEnabled = useCommentSeenEnabled();
   const canCommitCommentSeen = !!(viewer && viewer.id) && commentSeenEnabled;
   const commentSeen = canCommitCommentSeen && comment.seen;
+
   return (
     <IgnoredTombstoneOrHideContainer viewer={viewer} comment={comment}>
       <FadeInTransition active={!!comment.enteredLive}>
@@ -53,14 +55,16 @@ const AllCommentsTabCommentContainer: FunctionComponent<Props> = ({
               spacing={commentSeenEnabled ? 0 : undefined}
             >
               <DeletedTombstoneContainer comment={comment}>
-                <CommentContainer
-                  collapsed={collapsed}
-                  viewer={viewer}
-                  settings={settings}
-                  comment={comment}
-                  story={story}
-                  toggleCollapsed={toggleCollapsed}
-                />
+                <IntersectionProvider threshold={[0, 1]}>
+                  <CommentContainer
+                    collapsed={collapsed}
+                    viewer={viewer}
+                    settings={settings}
+                    comment={comment}
+                    story={story}
+                    toggleCollapsed={toggleCollapsed}
+                  />
+                </IntersectionProvider>
               </DeletedTombstoneContainer>
               {!collapsed && (
                 <div>

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -316,7 +316,7 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
           viewNewCount={viewNewCount}
         />
         {!alternateOldestViewEnabled && (
-          <IntersectionProvider threshold={[0, 1]}>
+          <IntersectionProvider threshold={1}>
             <CommentsLinks
               showGoToDiscussions={showGoToDiscussions}
               showGoToProfile={!!viewer}
@@ -338,7 +338,7 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
             />
           )}
           <div className={styles.borderedFooter}>
-            <IntersectionProvider threshold={[0, 1]}>
+            <IntersectionProvider threshold={1}>
               <CommentsLinks
                 showGoToDiscussions={showGoToDiscussions}
                 showGoToProfile={!!viewer}

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -316,10 +316,12 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
           viewNewCount={viewNewCount}
         />
         {!alternateOldestViewEnabled && (
-          <CommentsLinks
-            showGoToDiscussions={showGoToDiscussions}
-            showGoToProfile={!!viewer}
-          />
+          <IntersectionProvider threshold={[0, 1]}>
+            <CommentsLinks
+              showGoToDiscussions={showGoToDiscussions}
+              showGoToProfile={!!viewer}
+            />
+          </IntersectionProvider>
         )}
       </HorizontalGutter>
       {alternateOldestViewEnabled && (
@@ -336,10 +338,12 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
             />
           )}
           <div className={styles.borderedFooter}>
-            <CommentsLinks
-              showGoToDiscussions={showGoToDiscussions}
-              showGoToProfile={!!viewer}
-            />
+            <IntersectionProvider threshold={[0, 1]}>
+              <CommentsLinks
+                showGoToDiscussions={showGoToDiscussions}
+                showGoToProfile={!!viewer}
+              />
+            </IntersectionProvider>
           </div>
         </HorizontalGutter>
       )}

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
@@ -9,7 +9,6 @@ import React, {
 import { graphql } from "react-relay";
 import { Virtuoso } from "react-virtuoso";
 
-import { IntersectionProvider } from "coral-framework/lib/intersection";
 import { useFetch, useLocal } from "coral-framework/lib/relay";
 import { GQLCOMMENT_SORT, GQLFEATURE_FLAG } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
@@ -444,16 +443,14 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
             const comment = comments[index];
             return (
               <>
-                <IntersectionProvider>
-                  <AllCommentsTabCommentContainer
-                    key={comment.node.id}
-                    viewer={viewer}
-                    comment={comment.node}
-                    story={story}
-                    settings={settings}
-                    isLast={index === comments.length - 1}
-                  />
-                </IntersectionProvider>
+                <AllCommentsTabCommentContainer
+                  key={comment.node.id}
+                  viewer={viewer}
+                  comment={comment.node}
+                  story={story}
+                  settings={settings}
+                  isLast={index === comments.length - 1}
+                />
                 {/* If alternate oldest view, show any newly posted
                 comments above Load All Comments button */}
                 {alternateOldestViewEnabled &&

--- a/src/core/client/stream/tabs/Comments/Stream/AnsweredCommentsTab/AnsweredCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AnsweredCommentsTab/AnsweredCommentContainer.tsx
@@ -71,7 +71,7 @@ const AnsweredCommentContainer: FunctionComponent<Props> = (props) => {
   return (
     <IgnoredTombstoneOrHideContainer viewer={props.viewer} comment={comment}>
       {comment.parent && (
-        <IntersectionProvider>
+        <IntersectionProvider threshold={[0, 1]}>
           <CommentContainer
             viewer={props.viewer}
             settings={props.settings}

--- a/src/core/client/stream/tabs/Comments/Stream/AnsweredCommentsTab/AnsweredCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AnsweredCommentsTab/AnsweredCommentContainer.tsx
@@ -5,6 +5,7 @@ import { graphql } from "react-relay";
 
 import { getURLWithCommentID } from "coral-framework/helpers";
 import { useViewerEvent } from "coral-framework/lib/events";
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import { useMutation } from "coral-framework/lib/relay";
 import withFragmentContainer from "coral-framework/lib/relay/withFragmentContainer";
 import { GQLUSER_STATUS } from "coral-framework/schema";
@@ -70,17 +71,19 @@ const AnsweredCommentContainer: FunctionComponent<Props> = (props) => {
   return (
     <IgnoredTombstoneOrHideContainer viewer={props.viewer} comment={comment}>
       {comment.parent && (
-        <CommentContainer
-          viewer={props.viewer}
-          settings={props.settings}
-          comment={comment.parent}
-          story={props.story}
-          hideAnsweredTag
-          hideReportButton
-          hideModerationCarat
-          disableReplies
-          highlight
-        />
+        <IntersectionProvider>
+          <CommentContainer
+            viewer={props.viewer}
+            settings={props.settings}
+            comment={comment.parent}
+            story={props.story}
+            hideAnsweredTag
+            hideReportButton
+            hideModerationCarat
+            disableReplies
+            highlight
+          />
+        </IntersectionProvider>
       )}
       <article
         className={cn(CLASSES.featuredComment.$root, styles.root)}

--- a/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
@@ -79,7 +79,7 @@ const CommentsLinks: FunctionComponent<Props> = ({
   const [, setLocal] = useLocal<CommentsLinksLocal>(
     graphql`
       fragment CommentsLinksLocal on Local {
-        commentsLinksInView
+        bottomOfCommentsInView
       }
     `
   );
@@ -87,7 +87,7 @@ const CommentsLinks: FunctionComponent<Props> = ({
   const { intersectionRef, inView } = useInView();
 
   useEffect(() => {
-    setLocal({ commentsLinksInView: inView });
+    setLocal({ bottomOfCommentsInView: inView });
   }, [inView]);
 
   return (

--- a/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
@@ -1,15 +1,19 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
-import React, { FC, FunctionComponent, useCallback } from "react";
+import React, { FC, FunctionComponent, useCallback, useEffect } from "react";
+import { graphql } from "react-relay";
 
 import { useCoralContext } from "coral-framework/lib/bootstrap";
-import { useMutation } from "coral-framework/lib/relay";
+import { useInView } from "coral-framework/lib/intersection";
+import { useLocal, useMutation } from "coral-framework/lib/relay";
 import { Mutation as SetActiveTabMutation } from "coral-stream/App/SetActiveTabMutation";
 import CLASSES from "coral-stream/classes";
 import scrollToBeginning from "coral-stream/common/scrollToBeginning";
 import { Button, ButtonIcon } from "coral-ui/components/v2";
 import { useShadowRootOrDocument } from "coral-ui/encapsulation";
 import { PropTypesOf } from "coral-ui/types";
+
+import { CommentsLinksLocal } from "coral-stream/__generated__/CommentsLinksLocal.graphql";
 
 import styles from "./CommentsLinks.css";
 
@@ -72,71 +76,87 @@ const CommentsLinks: FunctionComponent<Props> = ({
     disabled: styles.disabled,
   };
 
+  const [, setLocal] = useLocal<CommentsLinksLocal>(
+    graphql`
+      fragment CommentsLinksLocal on Local {
+        commentsLinksInView
+      }
+    `
+  );
+
+  const { intersectionRef, inView } = useInView();
+
+  useEffect(() => {
+    setLocal({ commentsLinksInView: inView });
+  }, [inView]);
+
   return (
-    <Localized id="stream-footer-navigation" attrs={{ "aria-label": true }}>
-      <nav
-        className={cn(styles.container, CLASSES.streamFooter.$root)}
-        aria-label="Comments Footer"
-      >
-        {showGoToProfile && (
-          <Localized id="stream-footer-links-profile" attrs={{ title: true }}>
-            <FooterButton
-              className={CLASSES.streamFooter.profileLink}
-              title="Go to profile and replies"
-              onClick={onGoToProfile}
-              classes={classes}
-              icon="account_box"
+    <div ref={intersectionRef}>
+      <Localized id="stream-footer-navigation" attrs={{ "aria-label": true }}>
+        <nav
+          className={cn(styles.container, CLASSES.streamFooter.$root)}
+          aria-label="Comments Footer"
+        >
+          {showGoToProfile && (
+            <Localized id="stream-footer-links-profile" attrs={{ title: true }}>
+              <FooterButton
+                className={CLASSES.streamFooter.profileLink}
+                title="Go to profile and replies"
+                onClick={onGoToProfile}
+                classes={classes}
+                icon="account_box"
+              >
+                Profile and replies
+              </FooterButton>
+            </Localized>
+          )}
+          {showGoToDiscussions && (
+            <Localized
+              id="stream-footer-links-discussions"
+              attrs={{ title: true }}
             >
-              Profile and replies
-            </FooterButton>
-          </Localized>
-        )}
-        {showGoToDiscussions && (
+              <FooterButton
+                className={CLASSES.streamFooter.discussionsLink}
+                title="Go to more discussions"
+                onClick={onGoToDiscussions}
+                classes={classes}
+                icon="list_alt"
+              >
+                More discussions
+              </FooterButton>
+            </Localized>
+          )}
           <Localized
-            id="stream-footer-links-discussions"
+            id="stream-footer-links-top-of-comments"
             attrs={{ title: true }}
           >
             <FooterButton
-              className={CLASSES.streamFooter.discussionsLink}
-              title="Go to more discussions"
-              onClick={onGoToDiscussions}
+              className={CLASSES.streamFooter.commentsTopLink}
+              title="Go to top of comments"
+              onClick={onGoToCommentsTop}
               classes={classes}
-              icon="list_alt"
+              icon="forum"
             >
-              More discussions
+              Top of comments
             </FooterButton>
           </Localized>
-        )}
-        <Localized
-          id="stream-footer-links-top-of-comments"
-          attrs={{ title: true }}
-        >
-          <FooterButton
-            className={CLASSES.streamFooter.commentsTopLink}
-            title="Go to top of comments"
-            onClick={onGoToCommentsTop}
-            classes={classes}
-            icon="forum"
+          <Localized
+            id="stream-footer-links-top-of-article"
+            attrs={{ title: true }}
           >
-            Top of comments
-          </FooterButton>
-        </Localized>
-        <Localized
-          id="stream-footer-links-top-of-article"
-          attrs={{ title: true }}
-        >
-          <FooterButton
-            className={CLASSES.streamFooter.articleTopLink}
-            title="Go to top of article"
-            onClick={onGoToArticleTop}
-            classes={classes}
-            icon="description"
-          >
-            Top of article
-          </FooterButton>
-        </Localized>
-      </nav>
-    </Localized>
+            <FooterButton
+              className={CLASSES.streamFooter.articleTopLink}
+              title="Go to top of article"
+              onClick={onGoToArticleTop}
+              classes={classes}
+              icon="description"
+            >
+              Top of article
+            </FooterButton>
+          </Localized>
+        </nav>
+      </Localized>
+    </div>
   );
 };
 

--- a/src/core/client/stream/tabs/Comments/Stream/FeaturedComments/FeaturedCommentsContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/FeaturedComments/FeaturedCommentsContainer.tsx
@@ -175,10 +175,12 @@ export const FeaturedCommentsContainer: FunctionComponent<Props> = (props) => {
             />
           )}
           <div className={styles.borderedFooter}>
-            <CommentsLinks
-              showGoToDiscussions={showGoToDiscussions}
-              showGoToProfile={!!props.viewer}
-            />
+            <IntersectionProvider threshold={[0, 1]}>
+              <CommentsLinks
+                showGoToDiscussions={showGoToDiscussions}
+                showGoToProfile={!!props.viewer}
+              />
+            </IntersectionProvider>
           </div>
         </HorizontalGutter>
       )}

--- a/src/core/client/stream/tabs/Comments/Stream/FeaturedComments/FeaturedCommentsContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/FeaturedComments/FeaturedCommentsContainer.tsx
@@ -175,7 +175,7 @@ export const FeaturedCommentsContainer: FunctionComponent<Props> = (props) => {
             />
           )}
           <div className={styles.borderedFooter}>
-            <IntersectionProvider threshold={[0, 1]}>
+            <IntersectionProvider threshold={1}>
               <CommentsLinks
                 showGoToDiscussions={showGoToDiscussions}
                 showGoToProfile={!!props.viewer}

--- a/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabCommentContainer.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import FadeInTransition from "coral-framework/components/FadeInTransition";
+import { IntersectionProvider } from "coral-framework/lib/intersection";
 import { withFragmentContainer } from "coral-framework/lib/relay";
 import { HorizontalGutter } from "coral-ui/components/v2";
 
@@ -43,14 +44,16 @@ const UnansweredCommentsTabCommentContainer: FunctionComponent<Props> = ({
                 [styles.borderedComment]: !collapsed && !isLast,
               })}
             >
-              <CommentContainer
-                collapsed={collapsed}
-                viewer={viewer}
-                settings={settings}
-                comment={comment}
-                story={story}
-                toggleCollapsed={toggleCollapsed}
-              />
+              <IntersectionProvider>
+                <CommentContainer
+                  collapsed={collapsed}
+                  viewer={viewer}
+                  settings={settings}
+                  comment={comment}
+                  story={story}
+                  toggleCollapsed={toggleCollapsed}
+                />
+              </IntersectionProvider>
               <div
                 className={cn({
                   [styles.hiddenReplies]: collapsed,

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
@@ -126,65 +126,93 @@ exports[`renders permalink view 1`] = `
                         />
                       </svg>
                     </div>
-                    <div
-                      aria-labelledby="comment-comment-1-label"
-                      className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-                      data-key-stop={true}
-                      data-testid="comment-comment-1"
-                      id="comment-comment-1"
-                      onFocus={[Function]}
-                      role="article"
-                      tabIndex={-1}
-                    >
+                    <div>
                       <div
-                        className="Hidden-root"
-                        id="comment-comment-1-label"
-                      >
-                        <span>
-                          Ancestor:
-                        </span>
-                         
-                        <span>
-                          Comment from Lukas 
-                          <time
-                            className="RelativeTime-root"
-                            dateTime="2018-07-06T18:24:00.000Z"
-                            title="2018-07-06T18:24:00.000Z"
-                          >
-                            2018-07-06T18:24:00.000Z
-                          </time>
-                        </span>
-                      </div>
-                      <div
-                        className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                        aria-labelledby="comment-comment-1-label"
+                        className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                        data-key-stop={true}
+                        data-testid="comment-comment-1"
+                        id="comment-comment-1"
+                        onFocus={[Function]}
+                        role="article"
+                        tabIndex={-1}
                       >
                         <div
-                          className="coral coral-comment-collapse-toggle-indent Indent-root"
+                          className="Hidden-root"
+                          id="comment-comment-1-label"
+                        >
+                          <span>
+                            Ancestor:
+                          </span>
+                           
+                          <span>
+                            Comment from Lukas 
+                            <time
+                              className="RelativeTime-root"
+                              dateTime="2018-07-06T18:24:00.000Z"
+                              title="2018-07-06T18:24:00.000Z"
+                            >
+                              2018-07-06T18:24:00.000Z
+                            </time>
+                          </span>
+                        </div>
+                        <div
+                          className="Box-root HorizontalGutter-root HorizontalGutter-full"
                         >
                           <div
-                            className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                            className="coral coral-comment-collapse-toggle-indent Indent-root"
                           >
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                              className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                             >
                               <div
-                                className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                                className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                               >
                                 <div
-                                  className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                                  className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                                 >
                                   <div
-                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                                    className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                                   >
                                     <div
-                                      className="Comment-username"
+                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                                     >
                                       <div
-                                        className="Popover-root"
+                                        className="Comment-username"
+                                      >
+                                        <div
+                                          className="Popover-root"
+                                        >
+                                          <button
+                                            aria-controls="username-popover-comment-1"
+                                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseOut={[Function]}
+                                            onMouseOver={[Function]}
+                                            onTouchEnd={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="Username-root"
+                                            >
+                                              Lukas
+                                            </span>
+                                          </button>
+                                          <div
+                                            aria-hidden={true}
+                                            aria-label="A popover with more user information"
+                                            id="username-popover-comment-1"
+                                            role="dialog"
+                                          />
+                                        </div>
+                                      </div>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                                       >
                                         <button
-                                          aria-controls="username-popover-comment-1"
-                                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                          className="BaseButton-root Timestamp-root"
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onFocus={[Function]}
@@ -193,129 +221,46 @@ exports[`renders permalink view 1`] = `
                                           onTouchEnd={[Function]}
                                           type="button"
                                         >
-                                          <span
-                                            className="Username-root"
+                                          <time
+                                            className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                            dateTime="2018-07-06T18:24:00.000Z"
+                                            title="2018-07-06T18:24:00.000Z"
                                           >
-                                            Lukas
-                                          </span>
+                                            2018-07-06T18:24:00.000Z
+                                          </time>
                                         </button>
-                                        <div
-                                          aria-hidden={true}
-                                          aria-label="A popover with more user information"
-                                          id="username-popover-comment-1"
-                                          role="dialog"
-                                        />
                                       </div>
                                     </div>
                                     <div
-                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                                     >
-                                      <button
-                                        className="BaseButton-root Timestamp-root"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <time
-                                          className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                          dateTime="2018-07-06T18:24:00.000Z"
-                                          title="2018-07-06T18:24:00.000Z"
-                                        >
-                                          2018-07-06T18:24:00.000Z
-                                        </time>
-                                      </button>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                                      />
                                     </div>
                                   </div>
                                   <div
-                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                                    className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                                   >
                                     <div
-                                      className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                                    />
-                                  </div>
-                                </div>
-                                <div
-                                  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                                >
-                                  <div
-                                    className="HTMLContent-root coral coral-content coral-comment-content"
-                                    dangerouslySetInnerHTML={
-                                      Object {
-                                        "__html": "What's up?",
+                                      className="HTMLContent-root coral coral-content coral-comment-content"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "What's up?",
+                                        }
                                       }
-                                    }
-                                  />
-                                  <div
-                                    className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                                  >
+                                    />
                                     <div
-                                      className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                      className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                                     >
-                                      <button
-                                        aria-label="Respect comment by Lukas"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                        data-testid="comment-reaction-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                        >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReactionButton-icon"
-                                          >
-                                            thumb_up
-                                          </i>
-                                        </span>
-                                      </button>
-                                      <button
-                                        aria-label="Reply to comment by Lukas"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                        data-testid="comment-reply-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        id="comments-commentContainer-replyButton-comment-1"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                        >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReplyButton-icon"
-                                          >
-                                            reply
-                                          </i>
-                                        </span>
-                                      </button>
                                       <div
-                                        className="Popover-root"
+                                        className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                       >
                                         <button
-                                          aria-controls="permalink-popover-comment-1"
-                                          aria-label="Share comment by Lukas"
+                                          aria-label="Respect comment by Lukas"
                                           aria-pressed={false}
-                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                          data-testid="comment-reaction-button"
                                           data-variant="flat"
                                           disabled={false}
                                           onBlur={[Function]}
@@ -331,49 +276,106 @@ exports[`renders permalink view 1`] = `
                                           >
                                             <i
                                               aria-hidden="true"
-                                              className="Icon-root Icon-sm PermalinkButton-icon"
+                                              className="Icon-root Icon-sm ReactionButton-icon"
                                             >
-                                              share
+                                              thumb_up
+                                            </i>
+                                          </span>
+                                        </button>
+                                        <button
+                                          aria-label="Reply to comment by Lukas"
+                                          aria-pressed={false}
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                          data-testid="comment-reply-button"
+                                          data-variant="flat"
+                                          disabled={false}
+                                          id="comments-commentContainer-replyButton-comment-1"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseOut={[Function]}
+                                          onMouseOver={[Function]}
+                                          onTouchEnd={[Function]}
+                                          type="button"
+                                        >
+                                          <span
+                                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          >
+                                            <i
+                                              aria-hidden="true"
+                                              className="Icon-root Icon-sm ReplyButton-icon"
+                                            >
+                                              reply
                                             </i>
                                           </span>
                                         </button>
                                         <div
-                                          aria-hidden={true}
-                                          aria-label="A dialog showing a permalink to the comment"
-                                          id="permalink-popover-comment-1"
-                                          role="dialog"
-                                        />
-                                      </div>
-                                    </div>
-                                    <div
-                                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                                    >
-                                      <button
-                                        aria-label="Report comment by Lukas"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                        data-testid="comment-report-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          className="Popover-root"
                                         >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReportButton-icon"
+                                          <button
+                                            aria-controls="permalink-popover-comment-1"
+                                            aria-label="Share comment by Lukas"
+                                            aria-pressed={false}
+                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                            data-variant="flat"
+                                            disabled={false}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseOut={[Function]}
+                                            onMouseOver={[Function]}
+                                            onTouchEnd={[Function]}
+                                            type="button"
                                           >
-                                            flag
-                                          </i>
-                                        </span>
-                                      </button>
+                                            <span
+                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                            >
+                                              <i
+                                                aria-hidden="true"
+                                                className="Icon-root Icon-sm PermalinkButton-icon"
+                                              >
+                                                share
+                                              </i>
+                                            </span>
+                                          </button>
+                                          <div
+                                            aria-hidden={true}
+                                            aria-label="A dialog showing a permalink to the comment"
+                                            id="permalink-popover-comment-1"
+                                            role="dialog"
+                                          />
+                                        </div>
+                                      </div>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                      >
+                                        <button
+                                          aria-label="Report comment by Lukas"
+                                          aria-pressed={false}
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                          data-testid="comment-report-button"
+                                          data-variant="flat"
+                                          disabled={false}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseOut={[Function]}
+                                          onMouseOver={[Function]}
+                                          onTouchEnd={[Function]}
+                                          type="button"
+                                        >
+                                          <span
+                                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          >
+                                            <i
+                                              aria-hidden="true"
+                                              className="Icon-root Icon-sm ReportButton-icon"
+                                            >
+                                              flag
+                                            </i>
+                                          </span>
+                                        </button>
+                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -410,65 +412,93 @@ exports[`renders permalink view 1`] = `
                         />
                       </svg>
                     </div>
-                    <div
-                      aria-labelledby="comment-comment-2-label"
-                      className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-                      data-key-stop={true}
-                      data-testid="comment-comment-2"
-                      id="comment-comment-2"
-                      onFocus={[Function]}
-                      role="article"
-                      tabIndex={-1}
-                    >
+                    <div>
                       <div
-                        className="Hidden-root"
-                        id="comment-comment-2-label"
-                      >
-                        <span>
-                          Ancestor:
-                        </span>
-                         
-                        <span>
-                          Comment from Isabelle 
-                          <time
-                            className="RelativeTime-root"
-                            dateTime="2018-07-06T18:24:00.000Z"
-                            title="2018-07-06T18:24:00.000Z"
-                          >
-                            2018-07-06T18:24:00.000Z
-                          </time>
-                        </span>
-                      </div>
-                      <div
-                        className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                        aria-labelledby="comment-comment-2-label"
+                        className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                        data-key-stop={true}
+                        data-testid="comment-comment-2"
+                        id="comment-comment-2"
+                        onFocus={[Function]}
+                        role="article"
+                        tabIndex={-1}
                       >
                         <div
-                          className="coral coral-comment-collapse-toggle-indent Indent-root"
+                          className="Hidden-root"
+                          id="comment-comment-2-label"
+                        >
+                          <span>
+                            Ancestor:
+                          </span>
+                           
+                          <span>
+                            Comment from Isabelle 
+                            <time
+                              className="RelativeTime-root"
+                              dateTime="2018-07-06T18:24:00.000Z"
+                              title="2018-07-06T18:24:00.000Z"
+                            >
+                              2018-07-06T18:24:00.000Z
+                            </time>
+                          </span>
+                        </div>
+                        <div
+                          className="Box-root HorizontalGutter-root HorizontalGutter-full"
                         >
                           <div
-                            className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                            className="coral coral-comment-collapse-toggle-indent Indent-root"
                           >
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                              className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                             >
                               <div
-                                className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                                className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                               >
                                 <div
-                                  className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                                  className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                                 >
                                   <div
-                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                                    className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                                   >
                                     <div
-                                      className="Comment-username"
+                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                                     >
                                       <div
-                                        className="Popover-root"
+                                        className="Comment-username"
+                                      >
+                                        <div
+                                          className="Popover-root"
+                                        >
+                                          <button
+                                            aria-controls="username-popover-comment-2"
+                                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseOut={[Function]}
+                                            onMouseOver={[Function]}
+                                            onTouchEnd={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="Username-root"
+                                            >
+                                              Isabelle
+                                            </span>
+                                          </button>
+                                          <div
+                                            aria-hidden={true}
+                                            aria-label="A popover with more user information"
+                                            id="username-popover-comment-2"
+                                            role="dialog"
+                                          />
+                                        </div>
+                                      </div>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                                       >
                                         <button
-                                          aria-controls="username-popover-comment-2"
-                                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                          className="BaseButton-root Timestamp-root"
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onFocus={[Function]}
@@ -477,129 +507,46 @@ exports[`renders permalink view 1`] = `
                                           onTouchEnd={[Function]}
                                           type="button"
                                         >
-                                          <span
-                                            className="Username-root"
+                                          <time
+                                            className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                            dateTime="2018-07-06T18:24:00.000Z"
+                                            title="2018-07-06T18:24:00.000Z"
                                           >
-                                            Isabelle
-                                          </span>
+                                            2018-07-06T18:24:00.000Z
+                                          </time>
                                         </button>
-                                        <div
-                                          aria-hidden={true}
-                                          aria-label="A popover with more user information"
-                                          id="username-popover-comment-2"
-                                          role="dialog"
-                                        />
                                       </div>
                                     </div>
                                     <div
-                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                                     >
-                                      <button
-                                        className="BaseButton-root Timestamp-root"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <time
-                                          className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                          dateTime="2018-07-06T18:24:00.000Z"
-                                          title="2018-07-06T18:24:00.000Z"
-                                        >
-                                          2018-07-06T18:24:00.000Z
-                                        </time>
-                                      </button>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                                      />
                                     </div>
                                   </div>
                                   <div
-                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                                    className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                                   >
                                     <div
-                                      className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                                    />
-                                  </div>
-                                </div>
-                                <div
-                                  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                                >
-                                  <div
-                                    className="HTMLContent-root coral coral-content coral-comment-content"
-                                    dangerouslySetInnerHTML={
-                                      Object {
-                                        "__html": "Hey!",
+                                      className="HTMLContent-root coral coral-content coral-comment-content"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "Hey!",
+                                        }
                                       }
-                                    }
-                                  />
-                                  <div
-                                    className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                                  >
+                                    />
                                     <div
-                                      className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                      className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                                     >
-                                      <button
-                                        aria-label="Respect comment by Isabelle"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                        data-testid="comment-reaction-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                        >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReactionButton-icon"
-                                          >
-                                            thumb_up
-                                          </i>
-                                        </span>
-                                      </button>
-                                      <button
-                                        aria-label="Reply to comment by Isabelle"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                        data-testid="comment-reply-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        id="comments-commentContainer-replyButton-comment-2"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                        >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReplyButton-icon"
-                                          >
-                                            reply
-                                          </i>
-                                        </span>
-                                      </button>
                                       <div
-                                        className="Popover-root"
+                                        className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                       >
                                         <button
-                                          aria-controls="permalink-popover-comment-2"
-                                          aria-label="Share comment by Isabelle"
+                                          aria-label="Respect comment by Isabelle"
                                           aria-pressed={false}
-                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                          data-testid="comment-reaction-button"
                                           data-variant="flat"
                                           disabled={false}
                                           onBlur={[Function]}
@@ -615,49 +562,106 @@ exports[`renders permalink view 1`] = `
                                           >
                                             <i
                                               aria-hidden="true"
-                                              className="Icon-root Icon-sm PermalinkButton-icon"
+                                              className="Icon-root Icon-sm ReactionButton-icon"
                                             >
-                                              share
+                                              thumb_up
+                                            </i>
+                                          </span>
+                                        </button>
+                                        <button
+                                          aria-label="Reply to comment by Isabelle"
+                                          aria-pressed={false}
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                          data-testid="comment-reply-button"
+                                          data-variant="flat"
+                                          disabled={false}
+                                          id="comments-commentContainer-replyButton-comment-2"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseOut={[Function]}
+                                          onMouseOver={[Function]}
+                                          onTouchEnd={[Function]}
+                                          type="button"
+                                        >
+                                          <span
+                                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          >
+                                            <i
+                                              aria-hidden="true"
+                                              className="Icon-root Icon-sm ReplyButton-icon"
+                                            >
+                                              reply
                                             </i>
                                           </span>
                                         </button>
                                         <div
-                                          aria-hidden={true}
-                                          aria-label="A dialog showing a permalink to the comment"
-                                          id="permalink-popover-comment-2"
-                                          role="dialog"
-                                        />
-                                      </div>
-                                    </div>
-                                    <div
-                                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                                    >
-                                      <button
-                                        aria-label="Report comment by Isabelle"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                        data-testid="comment-report-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          className="Popover-root"
                                         >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReportButton-icon"
+                                          <button
+                                            aria-controls="permalink-popover-comment-2"
+                                            aria-label="Share comment by Isabelle"
+                                            aria-pressed={false}
+                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                            data-variant="flat"
+                                            disabled={false}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseOut={[Function]}
+                                            onMouseOver={[Function]}
+                                            onTouchEnd={[Function]}
+                                            type="button"
                                           >
-                                            flag
-                                          </i>
-                                        </span>
-                                      </button>
+                                            <span
+                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                            >
+                                              <i
+                                                aria-hidden="true"
+                                                className="Icon-root Icon-sm PermalinkButton-icon"
+                                              >
+                                                share
+                                              </i>
+                                            </span>
+                                          </button>
+                                          <div
+                                            aria-hidden={true}
+                                            aria-label="A dialog showing a permalink to the comment"
+                                            id="permalink-popover-comment-2"
+                                            role="dialog"
+                                          />
+                                        </div>
+                                      </div>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                      >
+                                        <button
+                                          aria-label="Report comment by Isabelle"
+                                          aria-pressed={false}
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                          data-testid="comment-report-button"
+                                          data-variant="flat"
+                                          disabled={false}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseOut={[Function]}
+                                          onMouseOver={[Function]}
+                                          onTouchEnd={[Function]}
+                                          type="button"
+                                        >
+                                          <span
+                                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          >
+                                            <i
+                                              aria-hidden="true"
+                                              className="Icon-root Icon-sm ReportButton-icon"
+                                            >
+                                              flag
+                                            </i>
+                                          </span>
+                                        </button>
+                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -692,26 +696,303 @@ exports[`renders permalink view 1`] = `
                     />
                   </svg>
                 </div>
+                <div>
+                  <div
+                    aria-labelledby="comment-comment-with-replies-label"
+                    className="CommentContainer-root coral coral-conversationThread-highlighted coral coral-comment coral coral-reacted-0"
+                    data-key-stop={true}
+                    data-testid="comment-comment-with-replies"
+                    id="comment-comment-with-replies"
+                    onFocus={[Function]}
+                    role="article"
+                    tabIndex={-1}
+                  >
+                    <div
+                      className="Hidden-root"
+                      id="comment-comment-with-replies-label"
+                    >
+                      <span>
+                        Highlighted:
+                      </span>
+                       
+                      <span>
+                        Comment from Markus 
+                        <time
+                          className="RelativeTime-root"
+                          dateTime="2018-07-06T18:24:00.000Z"
+                          title="2018-07-06T18:24:00.000Z"
+                        >
+                          2018-07-06T18:24:00.000Z
+                        </time>
+                      </span>
+                    </div>
+                    <div
+                      className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                    >
+                      <div
+                        className="coral coral-comment-collapse-toggle-indent Indent-root"
+                      >
+                        <div
+                          className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                        >
+                          <div
+                            className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                          >
+                            <div
+                              className="Box-root HorizontalGutter-root Comment-root Comment-highlight coral coral-comment-highlight HorizontalGutter-half"
+                            >
+                              <div
+                                className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                              >
+                                <div
+                                  className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                                >
+                                  <div
+                                    className="Comment-username"
+                                  >
+                                    <div
+                                      className="Popover-root"
+                                    >
+                                      <button
+                                        aria-controls="username-popover-comment-with-replies"
+                                        className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseOut={[Function]}
+                                        onMouseOver={[Function]}
+                                        onTouchEnd={[Function]}
+                                        type="button"
+                                      >
+                                        <span
+                                          className="Username-root"
+                                        >
+                                          Markus
+                                        </span>
+                                      </button>
+                                      <div
+                                        aria-hidden={true}
+                                        aria-label="A popover with more user information"
+                                        id="username-popover-comment-with-replies"
+                                        role="dialog"
+                                      />
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                  >
+                                    <button
+                                      className="BaseButton-root Timestamp-root"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                      onTouchEnd={[Function]}
+                                      type="button"
+                                    >
+                                      <time
+                                        className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                        dateTime="2018-07-06T18:24:00.000Z"
+                                        title="2018-07-06T18:24:00.000Z"
+                                      >
+                                        2018-07-06T18:24:00.000Z
+                                      </time>
+                                    </button>
+                                  </div>
+                                </div>
+                                <div
+                                  className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                                >
+                                  <div
+                                    className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
+                              >
+                                <div
+                                  className="HTMLContent-root coral coral-content coral-comment-content"
+                                  dangerouslySetInnerHTML={
+                                    Object {
+                                      "__html": "I like yoghurt",
+                                    }
+                                  }
+                                />
+                                <div
+                                  className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                                >
+                                  <div
+                                    className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                  >
+                                    <button
+                                      aria-label="Respect comment by Markus"
+                                      aria-pressed={false}
+                                      className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                      data-testid="comment-reaction-button"
+                                      data-variant="flat"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                      onTouchEnd={[Function]}
+                                      type="button"
+                                    >
+                                      <span
+                                        className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                      >
+                                        <i
+                                          aria-hidden="true"
+                                          className="Icon-root Icon-sm ReactionButton-icon"
+                                        >
+                                          thumb_up
+                                        </i>
+                                      </span>
+                                    </button>
+                                    <button
+                                      aria-label="Reply to comment by Markus"
+                                      aria-pressed={false}
+                                      className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                      data-testid="comment-reply-button"
+                                      data-variant="flat"
+                                      disabled={false}
+                                      id="comments-commentContainer-replyButton-comment-with-replies"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                      onTouchEnd={[Function]}
+                                      type="button"
+                                    >
+                                      <span
+                                        className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                      >
+                                        <i
+                                          aria-hidden="true"
+                                          className="Icon-root Icon-sm ReplyButton-icon"
+                                        >
+                                          reply
+                                        </i>
+                                      </span>
+                                    </button>
+                                    <div
+                                      className="Popover-root"
+                                    >
+                                      <button
+                                        aria-controls="permalink-popover-comment-with-replies"
+                                        aria-label="Share comment by Markus"
+                                        aria-pressed={false}
+                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                        data-variant="flat"
+                                        disabled={false}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        onMouseOut={[Function]}
+                                        onMouseOver={[Function]}
+                                        onTouchEnd={[Function]}
+                                        type="button"
+                                      >
+                                        <span
+                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                        >
+                                          <i
+                                            aria-hidden="true"
+                                            className="Icon-root Icon-sm PermalinkButton-icon"
+                                          >
+                                            share
+                                          </i>
+                                        </span>
+                                      </button>
+                                      <div
+                                        aria-hidden={true}
+                                        aria-label="A dialog showing a permalink to the comment"
+                                        id="permalink-popover-comment-with-replies"
+                                        role="dialog"
+                                      />
+                                    </div>
+                                  </div>
+                                  <div
+                                    className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                  >
+                                    <button
+                                      aria-label="Report comment by Markus"
+                                      aria-pressed={false}
+                                      className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                      data-testid="comment-report-button"
+                                      data-variant="flat"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                      onTouchEnd={[Function]}
+                                      type="button"
+                                    >
+                                      <span
+                                        className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                      >
+                                        <i
+                                          aria-hidden="true"
+                                          className="Icon-root Icon-sm ReportButton-icon"
+                                        >
+                                          flag
+                                        </i>
+                                      </span>
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="PermalinkViewContainer-replyList"
+        >
+          <div
+            aria-live="off"
+            className="Box-root HorizontalGutter-root ReplyList-withPadding HorizontalGutter-full"
+            data-testid="commentReplyList-comment-with-replies"
+            id="coral-comments-replyList-log--comment-with-replies"
+            role="log"
+          >
+            <div
+              className="Box-root HorizontalGutter-root HorizontalGutter-full"
+            >
+              <div>
                 <div
-                  aria-labelledby="comment-comment-with-replies-label"
-                  className="CommentContainer-root coral coral-conversationThread-highlighted coral coral-comment coral coral-reacted-0"
+                  aria-labelledby="comment-comment-3-label"
+                  className="CommentContainer-root coral coral-comment coral coral-reacted-0"
                   data-key-stop={true}
-                  data-testid="comment-comment-with-replies"
-                  id="comment-comment-with-replies"
+                  data-testid="comment-comment-3"
+                  id="comment-comment-3"
                   onFocus={[Function]}
                   role="article"
                   tabIndex={-1}
                 >
                   <div
                     className="Hidden-root"
-                    id="comment-comment-with-replies-label"
+                    id="comment-comment-3-label"
                   >
                     <span>
-                      Highlighted:
+                      Thread Level 1:
                     </span>
                      
                     <span>
-                      Comment from Markus 
+                      Reply from Isabelle 
                       <time
                         className="RelativeTime-root"
                         dateTime="2018-07-06T18:24:00.000Z"
@@ -728,13 +1009,31 @@ exports[`renders permalink view 1`] = `
                       className="coral coral-comment-collapse-toggle-indent Indent-root"
                     >
                       <div
-                        className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                        className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
                       >
                         <div
                           className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                         >
+                          <button
+                            aria-label="Collapse comment thread"
+                            className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                            >
+                              remove
+                            </i>
+                          </button>
                           <div
-                            className="Box-root HorizontalGutter-root Comment-root Comment-highlight coral coral-comment-highlight HorizontalGutter-half"
+                            className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                           >
                             <div
                               className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
@@ -749,7 +1048,7 @@ exports[`renders permalink view 1`] = `
                                     className="Popover-root"
                                   >
                                     <button
-                                      aria-controls="username-popover-comment-with-replies"
+                                      aria-controls="username-popover-comment-3"
                                       className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                       onBlur={[Function]}
                                       onClick={[Function]}
@@ -762,13 +1061,13 @@ exports[`renders permalink view 1`] = `
                                       <span
                                         className="Username-root"
                                       >
-                                        Markus
+                                        Isabelle
                                       </span>
                                     </button>
                                     <div
                                       aria-hidden={true}
                                       aria-label="A popover with more user information"
-                                      id="username-popover-comment-with-replies"
+                                      id="username-popover-comment-3"
                                       role="dialog"
                                     />
                                   </div>
@@ -805,13 +1104,51 @@ exports[`renders permalink view 1`] = `
                               </div>
                             </div>
                             <div
+                              className="Comment-subBar"
+                            >
+                              <button
+                                className="BaseButton-root InReplyTo-button"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm InReplyTo-icon"
+                                  >
+                                    reply
+                                  </i>
+                                  <span>
+                                     
+                                  </span>
+                                  <span
+                                    className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                                  >
+                                    In reply to 
+                                    <span
+                                      className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                                    >
+                                      Markus
+                                    </span>
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                            <div
                               className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                             >
                               <div
                                 className="HTMLContent-root coral coral-content coral-comment-content"
                                 dangerouslySetInnerHTML={
                                   Object {
-                                    "__html": "I like yoghurt",
+                                    "__html": "Comment Body 3",
                                   }
                                 }
                               />
@@ -822,7 +1159,7 @@ exports[`renders permalink view 1`] = `
                                   className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                 >
                                   <button
-                                    aria-label="Respect comment by Markus"
+                                    aria-label="Respect comment by Isabelle"
                                     aria-pressed={false}
                                     className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
                                     data-testid="comment-reaction-button"
@@ -848,13 +1185,13 @@ exports[`renders permalink view 1`] = `
                                     </span>
                                   </button>
                                   <button
-                                    aria-label="Reply to comment by Markus"
+                                    aria-label="Reply to comment by Isabelle"
                                     aria-pressed={false}
                                     className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
                                     data-testid="comment-reply-button"
                                     data-variant="flat"
                                     disabled={false}
-                                    id="comments-commentContainer-replyButton-comment-with-replies"
+                                    id="comments-commentContainer-replyButton-comment-3"
                                     onBlur={[Function]}
                                     onClick={[Function]}
                                     onFocus={[Function]}
@@ -878,8 +1215,8 @@ exports[`renders permalink view 1`] = `
                                     className="Popover-root"
                                   >
                                     <button
-                                      aria-controls="permalink-popover-comment-with-replies"
-                                      aria-label="Share comment by Markus"
+                                      aria-controls="permalink-popover-comment-3"
+                                      aria-label="Share comment by Isabelle"
                                       aria-pressed={false}
                                       className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
                                       data-variant="flat"
@@ -906,7 +1243,7 @@ exports[`renders permalink view 1`] = `
                                     <div
                                       aria-hidden={true}
                                       aria-label="A dialog showing a permalink to the comment"
-                                      id="permalink-popover-comment-with-replies"
+                                      id="permalink-popover-comment-3"
                                       role="dialog"
                                     />
                                   </div>
@@ -915,7 +1252,7 @@ exports[`renders permalink view 1`] = `
                                   className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                 >
                                   <button
-                                    aria-label="Report comment by Markus"
+                                    aria-label="Report comment by Isabelle"
                                     aria-pressed={false}
                                     className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
                                     data-testid="comment-report-button"
@@ -950,335 +1287,6 @@ exports[`renders permalink view 1`] = `
                   </div>
                 </div>
               </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="PermalinkViewContainer-replyList"
-        >
-          <div
-            aria-live="off"
-            className="Box-root HorizontalGutter-root ReplyList-withPadding HorizontalGutter-full"
-            data-testid="commentReplyList-comment-with-replies"
-            id="coral-comments-replyList-log--comment-with-replies"
-            role="log"
-          >
-            <div
-              className="Box-root HorizontalGutter-root HorizontalGutter-full"
-            >
-              <div
-                aria-labelledby="comment-comment-3-label"
-                className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-                data-key-stop={true}
-                data-testid="comment-comment-3"
-                id="comment-comment-3"
-                onFocus={[Function]}
-                role="article"
-                tabIndex={-1}
-              >
-                <div
-                  className="Hidden-root"
-                  id="comment-comment-3-label"
-                >
-                  <span>
-                    Thread Level 1:
-                  </span>
-                   
-                  <span>
-                    Reply from Isabelle 
-                    <time
-                      className="RelativeTime-root"
-                      dateTime="2018-07-06T18:24:00.000Z"
-                      title="2018-07-06T18:24:00.000Z"
-                    >
-                      2018-07-06T18:24:00.000Z
-                    </time>
-                  </span>
-                </div>
-                <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-full"
-                >
-                  <div
-                    className="coral coral-comment-collapse-toggle-indent Indent-root"
-                  >
-                    <div
-                      className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
-                    >
-                      <div
-                        className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
-                      >
-                        <button
-                          aria-label="Collapse comment thread"
-                          className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
-                          onTouchEnd={[Function]}
-                          type="button"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                          >
-                            remove
-                          </i>
-                        </button>
-                        <div
-                          className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
-                        >
-                          <div
-                            className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
-                          >
-                            <div
-                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
-                            >
-                              <div
-                                className="Comment-username"
-                              >
-                                <div
-                                  className="Popover-root"
-                                >
-                                  <button
-                                    aria-controls="username-popover-comment-3"
-                                    className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseOut={[Function]}
-                                    onMouseOver={[Function]}
-                                    onTouchEnd={[Function]}
-                                    type="button"
-                                  >
-                                    <span
-                                      className="Username-root"
-                                    >
-                                      Isabelle
-                                    </span>
-                                  </button>
-                                  <div
-                                    aria-hidden={true}
-                                    aria-label="A popover with more user information"
-                                    id="username-popover-comment-3"
-                                    role="dialog"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
-                              >
-                                <button
-                                  className="BaseButton-root Timestamp-root"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <time
-                                    className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                    dateTime="2018-07-06T18:24:00.000Z"
-                                    title="2018-07-06T18:24:00.000Z"
-                                  >
-                                    2018-07-06T18:24:00.000Z
-                                  </time>
-                                </button>
-                              </div>
-                            </div>
-                            <div
-                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
-                            >
-                              <div
-                                className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            className="Comment-subBar"
-                          >
-                            <button
-                              className="BaseButton-root InReplyTo-button"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm InReplyTo-icon"
-                                >
-                                  reply
-                                </i>
-                                <span>
-                                   
-                                </span>
-                                <span
-                                  className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
-                                >
-                                  In reply to 
-                                  <span
-                                    className="InReplyTo-username coral coral-comment-inReplyToUsername"
-                                  >
-                                    Markus
-                                  </span>
-                                </span>
-                              </span>
-                            </button>
-                          </div>
-                          <div
-                            className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                          >
-                            <div
-                              className="HTMLContent-root coral coral-content coral-comment-content"
-                              dangerouslySetInnerHTML={
-                                Object {
-                                  "__html": "Comment Body 3",
-                                }
-                              }
-                            />
-                            <div
-                              className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                            >
-                              <div
-                                className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                              >
-                                <button
-                                  aria-label="Respect comment by Isabelle"
-                                  aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                  data-testid="comment-reaction-button"
-                                  data-variant="flat"
-                                  disabled={false}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <span
-                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                  >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm ReactionButton-icon"
-                                    >
-                                      thumb_up
-                                    </i>
-                                  </span>
-                                </button>
-                                <button
-                                  aria-label="Reply to comment by Isabelle"
-                                  aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                  data-testid="comment-reply-button"
-                                  data-variant="flat"
-                                  disabled={false}
-                                  id="comments-commentContainer-replyButton-comment-3"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <span
-                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                  >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm ReplyButton-icon"
-                                    >
-                                      reply
-                                    </i>
-                                  </span>
-                                </button>
-                                <div
-                                  className="Popover-root"
-                                >
-                                  <button
-                                    aria-controls="permalink-popover-comment-3"
-                                    aria-label="Share comment by Isabelle"
-                                    aria-pressed={false}
-                                    className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
-                                    data-variant="flat"
-                                    disabled={false}
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseOut={[Function]}
-                                    onMouseOver={[Function]}
-                                    onTouchEnd={[Function]}
-                                    type="button"
-                                  >
-                                    <span
-                                      className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                    >
-                                      <i
-                                        aria-hidden="true"
-                                        className="Icon-root Icon-sm PermalinkButton-icon"
-                                      >
-                                        share
-                                      </i>
-                                    </span>
-                                  </button>
-                                  <div
-                                    aria-hidden={true}
-                                    aria-label="A dialog showing a permalink to the comment"
-                                    id="permalink-popover-comment-3"
-                                    role="dialog"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                              >
-                                <button
-                                  aria-label="Report comment by Isabelle"
-                                  aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                  data-testid="comment-report-button"
-                                  data-variant="flat"
-                                  disabled={false}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <span
-                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                  >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm ReportButton-icon"
-                                    >
-                                      flag
-                                    </i>
-                                  </span>
-                                </button>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
               <div
                 className=""
               />
@@ -1286,83 +1294,111 @@ exports[`renders permalink view 1`] = `
             <div
               className="Box-root HorizontalGutter-root HorizontalGutter-full"
             >
-              <div
-                aria-labelledby="comment-comment-4-label"
-                className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-                data-key-stop={true}
-                data-testid="comment-comment-4"
-                id="comment-comment-4"
-                onFocus={[Function]}
-                role="article"
-                tabIndex={-1}
-              >
+              <div>
                 <div
-                  className="Hidden-root"
-                  id="comment-comment-4-label"
-                >
-                  <span>
-                    Thread Level 1:
-                  </span>
-                   
-                  <span>
-                    Reply from Isabelle 
-                    <time
-                      className="RelativeTime-root"
-                      dateTime="2018-07-06T18:24:00.000Z"
-                      title="2018-07-06T18:24:00.000Z"
-                    >
-                      2018-07-06T18:24:00.000Z
-                    </time>
-                  </span>
-                </div>
-                <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                  aria-labelledby="comment-comment-4-label"
+                  className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                  data-key-stop={true}
+                  data-testid="comment-comment-4"
+                  id="comment-comment-4"
+                  onFocus={[Function]}
+                  role="article"
+                  tabIndex={-1}
                 >
                   <div
-                    className="coral coral-comment-collapse-toggle-indent Indent-root"
+                    className="Hidden-root"
+                    id="comment-comment-4-label"
+                  >
+                    <span>
+                      Thread Level 1:
+                    </span>
+                     
+                    <span>
+                      Reply from Isabelle 
+                      <time
+                        className="RelativeTime-root"
+                        dateTime="2018-07-06T18:24:00.000Z"
+                        title="2018-07-06T18:24:00.000Z"
+                      >
+                        2018-07-06T18:24:00.000Z
+                      </time>
+                    </span>
+                  </div>
+                  <div
+                    className="Box-root HorizontalGutter-root HorizontalGutter-full"
                   >
                     <div
-                      className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
+                      className="coral coral-comment-collapse-toggle-indent Indent-root"
                     >
                       <div
-                        className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                        className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
                       >
-                        <button
-                          aria-label="Collapse comment thread"
-                          className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
-                          onTouchEnd={[Function]}
-                          type="button"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                          >
-                            remove
-                          </i>
-                        </button>
                         <div
-                          className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                          className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                         >
+                          <button
+                            aria-label="Collapse comment thread"
+                            className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                            >
+                              remove
+                            </i>
+                          </button>
                           <div
-                            className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                            className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                           >
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                              className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                             >
                               <div
-                                className="Comment-username"
+                                className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                               >
                                 <div
-                                  className="Popover-root"
+                                  className="Comment-username"
+                                >
+                                  <div
+                                    className="Popover-root"
+                                  >
+                                    <button
+                                      aria-controls="username-popover-comment-4"
+                                      className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                      onTouchEnd={[Function]}
+                                      type="button"
+                                    >
+                                      <span
+                                        className="Username-root"
+                                      >
+                                        Isabelle
+                                      </span>
+                                    </button>
+                                    <div
+                                      aria-hidden={true}
+                                      aria-label="A popover with more user information"
+                                      id="username-popover-comment-4"
+                                      role="dialog"
+                                    />
+                                  </div>
+                                </div>
+                                <div
+                                  className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                                 >
                                   <button
-                                    aria-controls="username-popover-comment-4"
-                                    className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                    className="BaseButton-root Timestamp-root"
                                     onBlur={[Function]}
                                     onClick={[Function]}
                                     onFocus={[Function]}
@@ -1371,167 +1407,84 @@ exports[`renders permalink view 1`] = `
                                     onTouchEnd={[Function]}
                                     type="button"
                                   >
-                                    <span
-                                      className="Username-root"
+                                    <time
+                                      className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                      dateTime="2018-07-06T18:24:00.000Z"
+                                      title="2018-07-06T18:24:00.000Z"
                                     >
-                                      Isabelle
-                                    </span>
+                                      2018-07-06T18:24:00.000Z
+                                    </time>
                                   </button>
-                                  <div
-                                    aria-hidden={true}
-                                    aria-label="A popover with more user information"
-                                    id="username-popover-comment-4"
-                                    role="dialog"
-                                  />
                                 </div>
                               </div>
                               <div
-                                className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                               >
-                                <button
-                                  className="BaseButton-root Timestamp-root"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <time
-                                    className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                    dateTime="2018-07-06T18:24:00.000Z"
-                                    title="2018-07-06T18:24:00.000Z"
-                                  >
-                                    2018-07-06T18:24:00.000Z
-                                  </time>
-                                </button>
+                                <div
+                                  className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                                />
                               </div>
                             </div>
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                              className="Comment-subBar"
                             >
-                              <div
-                                className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            className="Comment-subBar"
-                          >
-                            <button
-                              className="BaseButton-root InReplyTo-button"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
+                              <button
+                                className="BaseButton-root InReplyTo-button"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
                               >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm InReplyTo-icon"
-                                >
-                                  reply
-                                </i>
-                                <span>
-                                   
-                                </span>
                                 <span
-                                  className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                                  className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
                                 >
-                                  In reply to 
-                                  <span
-                                    className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm InReplyTo-icon"
                                   >
-                                    Markus
+                                    reply
+                                  </i>
+                                  <span>
+                                     
+                                  </span>
+                                  <span
+                                    className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                                  >
+                                    In reply to 
+                                    <span
+                                      className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                                    >
+                                      Markus
+                                    </span>
                                   </span>
                                 </span>
-                              </span>
-                            </button>
-                          </div>
-                          <div
-                            className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                          >
+                              </button>
+                            </div>
                             <div
-                              className="HTMLContent-root coral coral-content coral-comment-content"
-                              dangerouslySetInnerHTML={
-                                Object {
-                                  "__html": "Comment Body 4",
-                                }
-                              }
-                            />
-                            <div
-                              className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                              className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                             >
                               <div
-                                className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                className="HTMLContent-root coral coral-content coral-comment-content"
+                                dangerouslySetInnerHTML={
+                                  Object {
+                                    "__html": "Comment Body 4",
+                                  }
+                                }
+                              />
+                              <div
+                                className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                               >
-                                <button
-                                  aria-label="Respect comment by Isabelle"
-                                  aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                  data-testid="comment-reaction-button"
-                                  data-variant="flat"
-                                  disabled={false}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <span
-                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                  >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm ReactionButton-icon"
-                                    >
-                                      thumb_up
-                                    </i>
-                                  </span>
-                                </button>
-                                <button
-                                  aria-label="Reply to comment by Isabelle"
-                                  aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                  data-testid="comment-reply-button"
-                                  data-variant="flat"
-                                  disabled={false}
-                                  id="comments-commentContainer-replyButton-comment-4"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <span
-                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                  >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm ReplyButton-icon"
-                                    >
-                                      reply
-                                    </i>
-                                  </span>
-                                </button>
                                 <div
-                                  className="Popover-root"
+                                  className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                 >
                                   <button
-                                    aria-controls="permalink-popover-comment-4"
-                                    aria-label="Share comment by Isabelle"
+                                    aria-label="Respect comment by Isabelle"
                                     aria-pressed={false}
-                                    className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                    className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                    data-testid="comment-reaction-button"
                                     data-variant="flat"
                                     disabled={false}
                                     onBlur={[Function]}
@@ -1547,49 +1500,106 @@ exports[`renders permalink view 1`] = `
                                     >
                                       <i
                                         aria-hidden="true"
-                                        className="Icon-root Icon-sm PermalinkButton-icon"
+                                        className="Icon-root Icon-sm ReactionButton-icon"
                                       >
-                                        share
+                                        thumb_up
+                                      </i>
+                                    </span>
+                                  </button>
+                                  <button
+                                    aria-label="Reply to comment by Isabelle"
+                                    aria-pressed={false}
+                                    className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                    data-testid="comment-reply-button"
+                                    data-variant="flat"
+                                    disabled={false}
+                                    id="comments-commentContainer-replyButton-comment-4"
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseOut={[Function]}
+                                    onMouseOver={[Function]}
+                                    onTouchEnd={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                    >
+                                      <i
+                                        aria-hidden="true"
+                                        className="Icon-root Icon-sm ReplyButton-icon"
+                                      >
+                                        reply
                                       </i>
                                     </span>
                                   </button>
                                   <div
-                                    aria-hidden={true}
-                                    aria-label="A dialog showing a permalink to the comment"
-                                    id="permalink-popover-comment-4"
-                                    role="dialog"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                              >
-                                <button
-                                  aria-label="Report comment by Isabelle"
-                                  aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                  data-testid="comment-report-button"
-                                  data-variant="flat"
-                                  disabled={false}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <span
-                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                    className="Popover-root"
                                   >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm ReportButton-icon"
+                                    <button
+                                      aria-controls="permalink-popover-comment-4"
+                                      aria-label="Share comment by Isabelle"
+                                      aria-pressed={false}
+                                      className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                      data-variant="flat"
+                                      disabled={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                      onTouchEnd={[Function]}
+                                      type="button"
                                     >
-                                      flag
-                                    </i>
-                                  </span>
-                                </button>
+                                      <span
+                                        className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                      >
+                                        <i
+                                          aria-hidden="true"
+                                          className="Icon-root Icon-sm PermalinkButton-icon"
+                                        >
+                                          share
+                                        </i>
+                                      </span>
+                                    </button>
+                                    <div
+                                      aria-hidden={true}
+                                      aria-label="A dialog showing a permalink to the comment"
+                                      id="permalink-popover-comment-4"
+                                      role="dialog"
+                                    />
+                                  </div>
+                                </div>
+                                <div
+                                  className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                >
+                                  <button
+                                    aria-label="Report comment by Isabelle"
+                                    aria-pressed={false}
+                                    className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                    data-testid="comment-report-button"
+                                    data-variant="flat"
+                                    disabled={false}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseOut={[Function]}
+                                    onMouseOver={[Function]}
+                                    onTouchEnd={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                    >
+                                      <i
+                                        aria-hidden="true"
+                                        className="Icon-root Icon-sm ReportButton-icon"
+                                      >
+                                        flag
+                                      </i>
+                                    </span>
+                                  </button>
+                                </div>
                               </div>
                             </div>
                           </div>

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
@@ -1617,6 +1617,7 @@ exports[`renders permalink view 1`] = `
         </div>
       </div>
     </section>
+    <div />
   </div>
 </section>
 `;

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
@@ -99,6 +99,7 @@ exports[`renders permalink view with unknown comment 1`] = `
         </div>
       </div>
     </section>
+    <div />
   </div>
 </section>
 `;

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewLoadMoreParents.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewLoadMoreParents.spec.tsx.snap
@@ -34,65 +34,106 @@ exports[`renders conversation thread 1`] = `
               />
             </svg>
           </div>
-          <div
-            aria-labelledby="comment-comment-from-staff-0-label"
-            className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-            data-key-stop={true}
-            data-testid="comment-comment-from-staff-0"
-            id="comment-comment-from-staff-0"
-            onFocus={[Function]}
-            role="article"
-            tabIndex={-1}
-          >
+          <div>
             <div
-              className="Hidden-root"
-              id="comment-comment-from-staff-0-label"
-            >
-              <span>
-                Ancestor:
-              </span>
-               
-              <span>
-                Comment from Moderator 
-                <time
-                  className="RelativeTime-root"
-                  dateTime="2018-07-06T18:24:00.000Z"
-                  title="2018-07-06T18:24:00.000Z"
-                >
-                  2018-07-06T18:24:00.000Z
-                </time>
-              </span>
-            </div>
-            <div
-              className="Box-root HorizontalGutter-root HorizontalGutter-full"
+              aria-labelledby="comment-comment-from-staff-0-label"
+              className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+              data-key-stop={true}
+              data-testid="comment-comment-from-staff-0"
+              id="comment-comment-from-staff-0"
+              onFocus={[Function]}
+              role="article"
+              tabIndex={-1}
             >
               <div
-                className="coral coral-comment-collapse-toggle-indent Indent-root"
+                className="Hidden-root"
+                id="comment-comment-from-staff-0-label"
+              >
+                <span>
+                  Ancestor:
+                </span>
+                 
+                <span>
+                  Comment from Moderator 
+                  <time
+                    className="RelativeTime-root"
+                    dateTime="2018-07-06T18:24:00.000Z"
+                    title="2018-07-06T18:24:00.000Z"
+                  >
+                    2018-07-06T18:24:00.000Z
+                  </time>
+                </span>
+              </div>
+              <div
+                className="Box-root HorizontalGutter-root HorizontalGutter-full"
               >
                 <div
-                  className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                  className="coral coral-comment-collapse-toggle-indent Indent-root"
                 >
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                    className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                   >
                     <div
-                      className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                      className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                     >
                       <div
-                        className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                        className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                       >
                         <div
-                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                          className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                         >
                           <div
-                            className="Comment-username"
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                           >
                             <div
-                              className="Popover-root"
+                              className="Comment-username"
                             >
+                              <div
+                                className="Popover-root"
+                              >
+                                <button
+                                  aria-controls="username-popover-comment-from-staff-0"
+                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Username-root"
+                                  >
+                                    Moderator
+                                  </span>
+                                </button>
+                                <div
+                                  aria-hidden={true}
+                                  aria-label="A popover with more user information"
+                                  id="username-popover-comment-from-staff-0"
+                                  role="dialog"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                            >
+                              <div
+                                className="Box-root Flex-root Comment-tags Flex-flex Flex-alignCenter"
+                              >
+                                <div
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <span
+                                    className="Tag-root coral coral-userTag coral-comment-userTag BadgeTagContainer-tag Tag-colorGrey Tag-uppercase"
+                                  >
+                                    Staff
+                                  </span>
+                                </div>
+                              </div>
                               <button
-                                aria-controls="username-popover-comment-from-staff-0"
-                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                className="BaseButton-root Timestamp-root"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onFocus={[Function]}
@@ -101,142 +142,46 @@ exports[`renders conversation thread 1`] = `
                                 onTouchEnd={[Function]}
                                 type="button"
                               >
-                                <span
-                                  className="Username-root"
+                                <time
+                                  className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                  dateTime="2018-07-06T18:24:00.000Z"
+                                  title="2018-07-06T18:24:00.000Z"
                                 >
-                                  Moderator
-                                </span>
+                                  2018-07-06T18:24:00.000Z
+                                </time>
                               </button>
-                              <div
-                                aria-hidden={true}
-                                aria-label="A popover with more user information"
-                                id="username-popover-comment-from-staff-0"
-                                role="dialog"
-                              />
                             </div>
                           </div>
                           <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                           >
                             <div
-                              className="Box-root Flex-root Comment-tags Flex-flex Flex-alignCenter"
-                            >
-                              <div
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <span
-                                  className="Tag-root coral coral-userTag coral-comment-userTag BadgeTagContainer-tag Tag-colorGrey Tag-uppercase"
-                                >
-                                  Staff
-                                </span>
-                              </div>
-                            </div>
-                            <button
-                              className="BaseButton-root Timestamp-root"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <time
-                                className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                dateTime="2018-07-06T18:24:00.000Z"
-                                title="2018-07-06T18:24:00.000Z"
-                              >
-                                2018-07-06T18:24:00.000Z
-                              </time>
-                            </button>
+                              className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                            />
                           </div>
                         </div>
                         <div
-                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                         >
                           <div
-                            className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                          />
-                        </div>
-                      </div>
-                      <div
-                        className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                      >
-                        <div
-                          className="HTMLContent-root coral coral-content coral-comment-content"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Joining Too",
+                            className="HTMLContent-root coral coral-content coral-comment-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Joining Too",
+                              }
                             }
-                          }
-                        />
-                        <div
-                          className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                        >
+                          />
                           <div
-                            className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                            className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                           >
-                            <button
-                              aria-label="Respect comment by Moderator"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                              data-testid="comment-reaction-button"
-                              data-variant="flat"
-                              disabled={false}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReactionButton-icon"
-                                >
-                                  thumb_up
-                                </i>
-                              </span>
-                            </button>
-                            <button
-                              aria-label="Reply to comment by Moderator"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                              data-testid="comment-reply-button"
-                              data-variant="flat"
-                              disabled={false}
-                              id="comments-commentContainer-replyButton-comment-from-staff-0"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReplyButton-icon"
-                                >
-                                  reply
-                                </i>
-                              </span>
-                            </button>
                             <div
-                              className="Popover-root"
+                              className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                             >
                               <button
-                                aria-controls="permalink-popover-comment-from-staff-0"
-                                aria-label="Share comment by Moderator"
+                                aria-label="Respect comment by Moderator"
                                 aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                data-testid="comment-reaction-button"
                                 data-variant="flat"
                                 disabled={false}
                                 onBlur={[Function]}
@@ -252,49 +197,106 @@ exports[`renders conversation thread 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                    className="Icon-root Icon-sm ReactionButton-icon"
                                   >
-                                    share
+                                    thumb_up
+                                  </i>
+                                </span>
+                              </button>
+                              <button
+                                aria-label="Reply to comment by Moderator"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                data-testid="comment-reply-button"
+                                data-variant="flat"
+                                disabled={false}
+                                id="comments-commentContainer-replyButton-comment-from-staff-0"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReplyButton-icon"
+                                  >
+                                    reply
                                   </i>
                                 </span>
                               </button>
                               <div
-                                aria-hidden={true}
-                                aria-label="A dialog showing a permalink to the comment"
-                                id="permalink-popover-comment-from-staff-0"
-                                role="dialog"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                          >
-                            <button
-                              aria-label="Report comment by Moderator"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                              data-testid="comment-report-button"
-                              data-variant="flat"
-                              disabled={false}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                className="Popover-root"
                               >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReportButton-icon"
+                                <button
+                                  aria-controls="permalink-popover-comment-from-staff-0"
+                                  aria-label="Share comment by Moderator"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
                                 >
-                                  flag
-                                </i>
-                              </span>
-                            </button>
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                    >
+                                      share
+                                    </i>
+                                  </span>
+                                </button>
+                                <div
+                                  aria-hidden={true}
+                                  aria-label="A dialog showing a permalink to the comment"
+                                  id="permalink-popover-comment-from-staff-0"
+                                  role="dialog"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                            >
+                              <button
+                                aria-label="Report comment by Moderator"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                data-testid="comment-report-button"
+                                data-variant="flat"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReportButton-icon"
+                                  >
+                                    flag
+                                  </i>
+                                </span>
+                              </button>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -356,65 +358,93 @@ exports[`renders conversation thread 1`] = `
             />
           </svg>
         </div>
-        <div
-          aria-labelledby="comment-comment-0-label"
-          className="CommentContainer-root coral coral-conversationThread-highlighted coral coral-comment coral coral-reacted-0"
-          data-key-stop={true}
-          data-testid="comment-comment-0"
-          id="comment-comment-0"
-          onFocus={[Function]}
-          role="article"
-          tabIndex={-1}
-        >
+        <div>
           <div
-            className="Hidden-root"
-            id="comment-comment-0-label"
-          >
-            <span>
-              Highlighted:
-            </span>
-             
-            <span>
-              Comment from Markus 
-              <time
-                className="RelativeTime-root"
-                dateTime="2018-07-06T18:24:00.000Z"
-                title="2018-07-06T18:24:00.000Z"
-              >
-                2018-07-06T18:24:00.000Z
-              </time>
-            </span>
-          </div>
-          <div
-            className="Box-root HorizontalGutter-root HorizontalGutter-full"
+            aria-labelledby="comment-comment-0-label"
+            className="CommentContainer-root coral coral-conversationThread-highlighted coral coral-comment coral coral-reacted-0"
+            data-key-stop={true}
+            data-testid="comment-comment-0"
+            id="comment-comment-0"
+            onFocus={[Function]}
+            role="article"
+            tabIndex={-1}
           >
             <div
-              className="coral coral-comment-collapse-toggle-indent Indent-root"
+              className="Hidden-root"
+              id="comment-comment-0-label"
+            >
+              <span>
+                Highlighted:
+              </span>
+               
+              <span>
+                Comment from Markus 
+                <time
+                  className="RelativeTime-root"
+                  dateTime="2018-07-06T18:24:00.000Z"
+                  title="2018-07-06T18:24:00.000Z"
+                >
+                  2018-07-06T18:24:00.000Z
+                </time>
+              </span>
+            </div>
+            <div
+              className="Box-root HorizontalGutter-root HorizontalGutter-full"
             >
               <div
-                className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                className="coral coral-comment-collapse-toggle-indent Indent-root"
               >
                 <div
-                  className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                  className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                 >
                   <div
-                    className="Box-root HorizontalGutter-root Comment-root Comment-highlight coral coral-comment-highlight HorizontalGutter-half"
+                    className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                   >
                     <div
-                      className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                      className="Box-root HorizontalGutter-root Comment-root Comment-highlight coral coral-comment-highlight HorizontalGutter-half"
                     >
                       <div
-                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                        className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                       >
                         <div
-                          className="Comment-username"
+                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                         >
                           <div
-                            className="Popover-root"
+                            className="Comment-username"
+                          >
+                            <div
+                              className="Popover-root"
+                            >
+                              <button
+                                aria-controls="username-popover-comment-0"
+                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Username-root"
+                                >
+                                  Markus
+                                </span>
+                              </button>
+                              <div
+                                aria-hidden={true}
+                                aria-label="A popover with more user information"
+                                id="username-popover-comment-0"
+                                role="dialog"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                           >
                             <button
-                              aria-controls="username-popover-comment-0"
-                              className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                              className="BaseButton-root Timestamp-root"
                               onBlur={[Function]}
                               onClick={[Function]}
                               onFocus={[Function]}
@@ -423,129 +453,46 @@ exports[`renders conversation thread 1`] = `
                               onTouchEnd={[Function]}
                               type="button"
                             >
-                              <span
-                                className="Username-root"
+                              <time
+                                className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                dateTime="2018-07-06T18:24:00.000Z"
+                                title="2018-07-06T18:24:00.000Z"
                               >
-                                Markus
-                              </span>
+                                2018-07-06T18:24:00.000Z
+                              </time>
                             </button>
-                            <div
-                              aria-hidden={true}
-                              aria-label="A popover with more user information"
-                              id="username-popover-comment-0"
-                              role="dialog"
-                            />
                           </div>
                         </div>
                         <div
-                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                         >
-                          <button
-                            className="BaseButton-root Timestamp-root"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
-                            onTouchEnd={[Function]}
-                            type="button"
-                          >
-                            <time
-                              className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                              dateTime="2018-07-06T18:24:00.000Z"
-                              title="2018-07-06T18:24:00.000Z"
-                            >
-                              2018-07-06T18:24:00.000Z
-                            </time>
-                          </button>
+                          <div
+                            className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                          />
                         </div>
                       </div>
                       <div
-                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                        className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                       >
                         <div
-                          className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                    >
-                      <div
-                        className="HTMLContent-root coral coral-content coral-comment-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Joining Too",
+                          className="HTMLContent-root coral coral-content coral-comment-content"
+                          dangerouslySetInnerHTML={
+                            Object {
+                              "__html": "Joining Too",
+                            }
                           }
-                        }
-                      />
-                      <div
-                        className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                      >
+                        />
                         <div
-                          className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                          className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                         >
-                          <button
-                            aria-label="Respect comment by Markus"
-                            aria-pressed={false}
-                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                            data-testid="comment-reaction-button"
-                            data-variant="flat"
-                            disabled={false}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
-                            onTouchEnd={[Function]}
-                            type="button"
-                          >
-                            <span
-                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                            >
-                              <i
-                                aria-hidden="true"
-                                className="Icon-root Icon-sm ReactionButton-icon"
-                              >
-                                thumb_up
-                              </i>
-                            </span>
-                          </button>
-                          <button
-                            aria-label="Reply to comment by Markus"
-                            aria-pressed={false}
-                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                            data-testid="comment-reply-button"
-                            data-variant="flat"
-                            disabled={false}
-                            id="comments-commentContainer-replyButton-comment-0"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
-                            onTouchEnd={[Function]}
-                            type="button"
-                          >
-                            <span
-                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                            >
-                              <i
-                                aria-hidden="true"
-                                className="Icon-root Icon-sm ReplyButton-icon"
-                              >
-                                reply
-                              </i>
-                            </span>
-                          </button>
                           <div
-                            className="Popover-root"
+                            className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                           >
                             <button
-                              aria-controls="permalink-popover-comment-0"
-                              aria-label="Share comment by Markus"
+                              aria-label="Respect comment by Markus"
                               aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                              data-testid="comment-reaction-button"
                               data-variant="flat"
                               disabled={false}
                               onBlur={[Function]}
@@ -561,49 +508,106 @@ exports[`renders conversation thread 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm PermalinkButton-icon"
+                                  className="Icon-root Icon-sm ReactionButton-icon"
                                 >
-                                  share
+                                  thumb_up
+                                </i>
+                              </span>
+                            </button>
+                            <button
+                              aria-label="Reply to comment by Markus"
+                              aria-pressed={false}
+                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                              data-testid="comment-reply-button"
+                              data-variant="flat"
+                              disabled={false}
+                              id="comments-commentContainer-replyButton-comment-0"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                              onTouchEnd={[Function]}
+                              type="button"
+                            >
+                              <span
+                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                              >
+                                <i
+                                  aria-hidden="true"
+                                  className="Icon-root Icon-sm ReplyButton-icon"
+                                >
+                                  reply
                                 </i>
                               </span>
                             </button>
                             <div
-                              aria-hidden={true}
-                              aria-label="A dialog showing a permalink to the comment"
-                              id="permalink-popover-comment-0"
-                              role="dialog"
-                            />
-                          </div>
-                        </div>
-                        <div
-                          className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                        >
-                          <button
-                            aria-label="Report comment by Markus"
-                            aria-pressed={false}
-                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                            data-testid="comment-report-button"
-                            data-variant="flat"
-                            disabled={false}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
-                            onTouchEnd={[Function]}
-                            type="button"
-                          >
-                            <span
-                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                              className="Popover-root"
                             >
-                              <i
-                                aria-hidden="true"
-                                className="Icon-root Icon-sm ReportButton-icon"
+                              <button
+                                aria-controls="permalink-popover-comment-0"
+                                aria-label="Share comment by Markus"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                data-variant="flat"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
                               >
-                                flag
-                              </i>
-                            </span>
-                          </button>
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                  >
+                                    share
+                                  </i>
+                                </span>
+                              </button>
+                              <div
+                                aria-hidden={true}
+                                aria-label="A dialog showing a permalink to the comment"
+                                id="permalink-popover-comment-0"
+                                role="dialog"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                          >
+                            <button
+                              aria-label="Report comment by Markus"
+                              aria-pressed={false}
+                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                              data-testid="comment-report-button"
+                              data-variant="flat"
+                              disabled={false}
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
+                              onTouchEnd={[Function]}
+                              type="button"
+                            >
+                              <span
+                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                              >
+                                <i
+                                  aria-hidden="true"
+                                  className="Icon-root Icon-sm ReportButton-icon"
+                                >
+                                  flag
+                                </i>
+                              </span>
+                            </button>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -653,26 +657,613 @@ exports[`shows more of this conversation 1`] = `
               />
             </svg>
           </div>
+          <div>
+            <div
+              aria-labelledby="comment-comment-from-staff-0-label"
+              className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+              data-key-stop={true}
+              data-testid="comment-comment-from-staff-0"
+              id="comment-comment-from-staff-0"
+              onFocus={[Function]}
+              role="article"
+              tabIndex={-1}
+            >
+              <div
+                className="Hidden-root"
+                id="comment-comment-from-staff-0-label"
+              >
+                <span>
+                  Ancestor:
+                </span>
+                 
+                <span>
+                  Comment from Moderator 
+                  <time
+                    className="RelativeTime-root"
+                    dateTime="2018-07-06T18:24:00.000Z"
+                    title="2018-07-06T18:24:00.000Z"
+                  >
+                    2018-07-06T18:24:00.000Z
+                  </time>
+                </span>
+              </div>
+              <div
+                className="Box-root HorizontalGutter-root HorizontalGutter-full"
+              >
+                <div
+                  className="coral coral-comment-collapse-toggle-indent Indent-root"
+                >
+                  <div
+                    className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                  >
+                    <div
+                      className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                    >
+                      <div
+                        className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                      >
+                        <div
+                          className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                        >
+                          <div
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                          >
+                            <div
+                              className="Comment-username"
+                            >
+                              <div
+                                className="Popover-root"
+                              >
+                                <button
+                                  aria-controls="username-popover-comment-from-staff-0"
+                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Username-root"
+                                  >
+                                    Moderator
+                                  </span>
+                                </button>
+                                <div
+                                  aria-hidden={true}
+                                  aria-label="A popover with more user information"
+                                  id="username-popover-comment-from-staff-0"
+                                  role="dialog"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                            >
+                              <div
+                                className="Box-root Flex-root Comment-tags Flex-flex Flex-alignCenter"
+                              >
+                                <div
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <span
+                                    className="Tag-root coral coral-userTag coral-comment-userTag BadgeTagContainer-tag Tag-colorGrey Tag-uppercase"
+                                  >
+                                    Staff
+                                  </span>
+                                </div>
+                              </div>
+                              <button
+                                className="BaseButton-root Timestamp-root"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <time
+                                  className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                  dateTime="2018-07-06T18:24:00.000Z"
+                                  title="2018-07-06T18:24:00.000Z"
+                                >
+                                  2018-07-06T18:24:00.000Z
+                                </time>
+                              </button>
+                            </div>
+                          </div>
+                          <div
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                          >
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
+                        >
+                          <div
+                            className="HTMLContent-root coral coral-content coral-comment-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Joining Too",
+                              }
+                            }
+                          />
+                          <div
+                            className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                          >
+                            <div
+                              className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                            >
+                              <button
+                                aria-label="Respect comment by Moderator"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                data-testid="comment-reaction-button"
+                                data-variant="flat"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReactionButton-icon"
+                                  >
+                                    thumb_up
+                                  </i>
+                                </span>
+                              </button>
+                              <button
+                                aria-label="Reply to comment by Moderator"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                data-testid="comment-reply-button"
+                                data-variant="flat"
+                                disabled={false}
+                                id="comments-commentContainer-replyButton-comment-from-staff-0"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReplyButton-icon"
+                                  >
+                                    reply
+                                  </i>
+                                </span>
+                              </button>
+                              <div
+                                className="Popover-root"
+                              >
+                                <button
+                                  aria-controls="permalink-popover-comment-from-staff-0"
+                                  aria-label="Share comment by Moderator"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                    >
+                                      share
+                                    </i>
+                                  </span>
+                                </button>
+                                <div
+                                  aria-hidden={true}
+                                  aria-label="A dialog showing a permalink to the comment"
+                                  id="permalink-popover-comment-from-staff-0"
+                                  role="dialog"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                            >
+                              <button
+                                aria-label="Report comment by Moderator"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                data-testid="comment-report-button"
+                                data-variant="flat"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReportButton-icon"
+                                  >
+                                    flag
+                                  </i>
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ConversationThreadContainer-parentList"
+    >
+      <div
+        className="ConversationThreadContainer-parentContainer"
+      >
+        <div
+          className="Line-root"
+        >
           <div
-            aria-labelledby="comment-comment-from-staff-0-label"
-            className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+            className="Circle-circleContainer"
+          >
+            <div
+              className="Circle-circleSubContainer"
+            >
+              <svg
+                className="Circle-circle"
+                viewBox="0 0 100 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="50"
+                  cy="50"
+                  r="50"
+                />
+              </svg>
+            </div>
+            <div>
+              <div
+                aria-labelledby="comment-comment-1-label"
+                className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                data-key-stop={true}
+                data-testid="comment-comment-1"
+                id="comment-comment-1"
+                onFocus={[Function]}
+                role="article"
+                tabIndex={-1}
+              >
+                <div
+                  className="Hidden-root"
+                  id="comment-comment-1-label"
+                >
+                  <span>
+                    Ancestor:
+                  </span>
+                   
+                  <span>
+                    Comment from Lukas 
+                    <time
+                      className="RelativeTime-root"
+                      dateTime="2018-07-06T18:24:00.000Z"
+                      title="2018-07-06T18:24:00.000Z"
+                    >
+                      2018-07-06T18:24:00.000Z
+                    </time>
+                  </span>
+                </div>
+                <div
+                  className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                >
+                  <div
+                    className="coral coral-comment-collapse-toggle-indent Indent-root"
+                  >
+                    <div
+                      className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                    >
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                      >
+                        <div
+                          className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                        >
+                          <div
+                            className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                          >
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                            >
+                              <div
+                                className="Comment-username"
+                              >
+                                <div
+                                  className="Popover-root"
+                                >
+                                  <button
+                                    aria-controls="username-popover-comment-1"
+                                    className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseOut={[Function]}
+                                    onMouseOver={[Function]}
+                                    onTouchEnd={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="Username-root"
+                                    >
+                                      Lukas
+                                    </span>
+                                  </button>
+                                  <div
+                                    aria-hidden={true}
+                                    aria-label="A popover with more user information"
+                                    id="username-popover-comment-1"
+                                    role="dialog"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                              >
+                                <button
+                                  className="BaseButton-root Timestamp-root"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <time
+                                    className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                    dateTime="2018-07-06T18:24:00.000Z"
+                                    title="2018-07-06T18:24:00.000Z"
+                                  >
+                                    2018-07-06T18:24:00.000Z
+                                  </time>
+                                </button>
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                            >
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                              />
+                            </div>
+                          </div>
+                          <div
+                            className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
+                          >
+                            <div
+                              className="HTMLContent-root coral coral-content coral-comment-content"
+                              dangerouslySetInnerHTML={
+                                Object {
+                                  "__html": "What's up?",
+                                }
+                              }
+                            />
+                            <div
+                              className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                            >
+                              <div
+                                className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                              >
+                                <button
+                                  aria-label="Respect comment by Lukas"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                  data-testid="comment-reaction-button"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm ReactionButton-icon"
+                                    >
+                                      thumb_up
+                                    </i>
+                                  </span>
+                                </button>
+                                <button
+                                  aria-label="Reply to comment by Lukas"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                  data-testid="comment-reply-button"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  id="comments-commentContainer-replyButton-comment-1"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm ReplyButton-icon"
+                                    >
+                                      reply
+                                    </i>
+                                  </span>
+                                </button>
+                                <div
+                                  className="Popover-root"
+                                >
+                                  <button
+                                    aria-controls="permalink-popover-comment-1"
+                                    aria-label="Share comment by Lukas"
+                                    aria-pressed={false}
+                                    className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                    data-variant="flat"
+                                    disabled={false}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseOut={[Function]}
+                                    onMouseOver={[Function]}
+                                    onTouchEnd={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                    >
+                                      <i
+                                        aria-hidden="true"
+                                        className="Icon-root Icon-sm PermalinkButton-icon"
+                                      >
+                                        share
+                                      </i>
+                                    </span>
+                                  </button>
+                                  <div
+                                    aria-hidden={true}
+                                    aria-label="A dialog showing a permalink to the comment"
+                                    id="permalink-popover-comment-1"
+                                    role="dialog"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                              >
+                                <button
+                                  aria-label="Report comment by Lukas"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                  data-testid="comment-report-button"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm ReportButton-icon"
+                                    >
+                                      flag
+                                    </i>
+                                  </span>
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ConversationThreadContainer-targetComment"
+    >
+      <div
+        className="Circle-circleContainer"
+      >
+        <div
+          className="Circle-circleSubContainer Circle-end"
+        >
+          <svg
+            className="Circle-circle"
+            viewBox="0 0 100 100"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="50"
+              cy="50"
+              r="50"
+            />
+          </svg>
+        </div>
+        <div>
+          <div
+            aria-labelledby="comment-comment-0-label"
+            className="CommentContainer-root coral coral-conversationThread-highlighted coral coral-comment coral coral-reacted-0"
             data-key-stop={true}
-            data-testid="comment-comment-from-staff-0"
-            id="comment-comment-from-staff-0"
+            data-testid="comment-comment-0"
+            id="comment-comment-0"
             onFocus={[Function]}
             role="article"
             tabIndex={-1}
           >
             <div
               className="Hidden-root"
-              id="comment-comment-from-staff-0-label"
+              id="comment-comment-0-label"
             >
               <span>
-                Ancestor:
+                Highlighted:
               </span>
                
               <span>
-                Comment from Moderator 
+                Comment from Markus 
                 <time
                   className="RelativeTime-root"
                   dateTime="2018-07-06T18:24:00.000Z"
@@ -695,7 +1286,7 @@ exports[`shows more of this conversation 1`] = `
                     className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                   >
                     <div
-                      className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                      className="Box-root HorizontalGutter-root Comment-root Comment-highlight coral coral-comment-highlight HorizontalGutter-half"
                     >
                       <div
                         className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
@@ -710,7 +1301,7 @@ exports[`shows more of this conversation 1`] = `
                               className="Popover-root"
                             >
                               <button
-                                aria-controls="username-popover-comment-from-staff-0"
+                                aria-controls="username-popover-comment-0"
                                 className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
                                 onBlur={[Function]}
                                 onClick={[Function]}
@@ -723,13 +1314,13 @@ exports[`shows more of this conversation 1`] = `
                                 <span
                                   className="Username-root"
                                 >
-                                  Moderator
+                                  Markus
                                 </span>
                               </button>
                               <div
                                 aria-hidden={true}
                                 aria-label="A popover with more user information"
-                                id="username-popover-comment-from-staff-0"
+                                id="username-popover-comment-0"
                                 role="dialog"
                               />
                             </div>
@@ -737,19 +1328,6 @@ exports[`shows more of this conversation 1`] = `
                           <div
                             className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                           >
-                            <div
-                              className="Box-root Flex-root Comment-tags Flex-flex Flex-alignCenter"
-                            >
-                              <div
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <span
-                                  className="Tag-root coral coral-userTag coral-comment-userTag BadgeTagContainer-tag Tag-colorGrey Tag-uppercase"
-                                >
-                                  Staff
-                                </span>
-                              </div>
-                            </div>
                             <button
                               className="BaseButton-root Timestamp-root"
                               onBlur={[Function]}
@@ -796,7 +1374,7 @@ exports[`shows more of this conversation 1`] = `
                             className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                           >
                             <button
-                              aria-label="Respect comment by Moderator"
+                              aria-label="Respect comment by Markus"
                               aria-pressed={false}
                               className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
                               data-testid="comment-reaction-button"
@@ -822,13 +1400,13 @@ exports[`shows more of this conversation 1`] = `
                               </span>
                             </button>
                             <button
-                              aria-label="Reply to comment by Moderator"
+                              aria-label="Reply to comment by Markus"
                               aria-pressed={false}
                               className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
                               data-testid="comment-reply-button"
                               data-variant="flat"
                               disabled={false}
-                              id="comments-commentContainer-replyButton-comment-from-staff-0"
+                              id="comments-commentContainer-replyButton-comment-0"
                               onBlur={[Function]}
                               onClick={[Function]}
                               onFocus={[Function]}
@@ -852,8 +1430,8 @@ exports[`shows more of this conversation 1`] = `
                               className="Popover-root"
                             >
                               <button
-                                aria-controls="permalink-popover-comment-from-staff-0"
-                                aria-label="Share comment by Moderator"
+                                aria-controls="permalink-popover-comment-0"
+                                aria-label="Share comment by Markus"
                                 aria-pressed={false}
                                 className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
                                 data-variant="flat"
@@ -880,7 +1458,7 @@ exports[`shows more of this conversation 1`] = `
                               <div
                                 aria-hidden={true}
                                 aria-label="A dialog showing a permalink to the comment"
-                                id="permalink-popover-comment-from-staff-0"
+                                id="permalink-popover-comment-0"
                                 role="dialog"
                               />
                             </div>
@@ -889,7 +1467,7 @@ exports[`shows more of this conversation 1`] = `
                             className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                           >
                             <button
-                              aria-label="Report comment by Moderator"
+                              aria-label="Report comment by Markus"
                               aria-pressed={false}
                               className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
                               data-testid="comment-report-button"
@@ -915,574 +1493,6 @@ exports[`shows more of this conversation 1`] = `
                               </span>
                             </button>
                           </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="ConversationThreadContainer-parentList"
-    >
-      <div
-        className="ConversationThreadContainer-parentContainer"
-      >
-        <div
-          className="Line-root"
-        >
-          <div
-            className="Circle-circleContainer"
-          >
-            <div
-              className="Circle-circleSubContainer"
-            >
-              <svg
-                className="Circle-circle"
-                viewBox="0 0 100 100"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="50"
-                  cy="50"
-                  r="50"
-                />
-              </svg>
-            </div>
-            <div
-              aria-labelledby="comment-comment-1-label"
-              className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-              data-key-stop={true}
-              data-testid="comment-comment-1"
-              id="comment-comment-1"
-              onFocus={[Function]}
-              role="article"
-              tabIndex={-1}
-            >
-              <div
-                className="Hidden-root"
-                id="comment-comment-1-label"
-              >
-                <span>
-                  Ancestor:
-                </span>
-                 
-                <span>
-                  Comment from Lukas 
-                  <time
-                    className="RelativeTime-root"
-                    dateTime="2018-07-06T18:24:00.000Z"
-                    title="2018-07-06T18:24:00.000Z"
-                  >
-                    2018-07-06T18:24:00.000Z
-                  </time>
-                </span>
-              </div>
-              <div
-                className="Box-root HorizontalGutter-root HorizontalGutter-full"
-              >
-                <div
-                  className="coral coral-comment-collapse-toggle-indent Indent-root"
-                >
-                  <div
-                    className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
-                  >
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
-                    >
-                      <div
-                        className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
-                      >
-                        <div
-                          className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
-                        >
-                          <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
-                          >
-                            <div
-                              className="Comment-username"
-                            >
-                              <div
-                                className="Popover-root"
-                              >
-                                <button
-                                  aria-controls="username-popover-comment-1"
-                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <span
-                                    className="Username-root"
-                                  >
-                                    Lukas
-                                  </span>
-                                </button>
-                                <div
-                                  aria-hidden={true}
-                                  aria-label="A popover with more user information"
-                                  id="username-popover-comment-1"
-                                  role="dialog"
-                                />
-                              </div>
-                            </div>
-                            <div
-                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
-                            >
-                              <button
-                                className="BaseButton-root Timestamp-root"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <time
-                                  className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                  dateTime="2018-07-06T18:24:00.000Z"
-                                  title="2018-07-06T18:24:00.000Z"
-                                >
-                                  2018-07-06T18:24:00.000Z
-                                </time>
-                              </button>
-                            </div>
-                          </div>
-                          <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
-                          >
-                            <div
-                              className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                            />
-                          </div>
-                        </div>
-                        <div
-                          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                        >
-                          <div
-                            className="HTMLContent-root coral coral-content coral-comment-content"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "What's up?",
-                              }
-                            }
-                          />
-                          <div
-                            className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                          >
-                            <div
-                              className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                            >
-                              <button
-                                aria-label="Respect comment by Lukas"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                data-testid="comment-reaction-button"
-                                data-variant="flat"
-                                disabled={false}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReactionButton-icon"
-                                  >
-                                    thumb_up
-                                  </i>
-                                </span>
-                              </button>
-                              <button
-                                aria-label="Reply to comment by Lukas"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                data-testid="comment-reply-button"
-                                data-variant="flat"
-                                disabled={false}
-                                id="comments-commentContainer-replyButton-comment-1"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReplyButton-icon"
-                                  >
-                                    reply
-                                  </i>
-                                </span>
-                              </button>
-                              <div
-                                className="Popover-root"
-                              >
-                                <button
-                                  aria-controls="permalink-popover-comment-1"
-                                  aria-label="Share comment by Lukas"
-                                  aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
-                                  data-variant="flat"
-                                  disabled={false}
-                                  onBlur={[Function]}
-                                  onClick={[Function]}
-                                  onFocus={[Function]}
-                                  onMouseOut={[Function]}
-                                  onMouseOver={[Function]}
-                                  onTouchEnd={[Function]}
-                                  type="button"
-                                >
-                                  <span
-                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                  >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm PermalinkButton-icon"
-                                    >
-                                      share
-                                    </i>
-                                  </span>
-                                </button>
-                                <div
-                                  aria-hidden={true}
-                                  aria-label="A dialog showing a permalink to the comment"
-                                  id="permalink-popover-comment-1"
-                                  role="dialog"
-                                />
-                              </div>
-                            </div>
-                            <div
-                              className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                            >
-                              <button
-                                aria-label="Report comment by Lukas"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                data-testid="comment-report-button"
-                                data-variant="flat"
-                                disabled={false}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReportButton-icon"
-                                  >
-                                    flag
-                                  </i>
-                                </span>
-                              </button>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="ConversationThreadContainer-targetComment"
-    >
-      <div
-        className="Circle-circleContainer"
-      >
-        <div
-          className="Circle-circleSubContainer Circle-end"
-        >
-          <svg
-            className="Circle-circle"
-            viewBox="0 0 100 100"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <circle
-              cx="50"
-              cy="50"
-              r="50"
-            />
-          </svg>
-        </div>
-        <div
-          aria-labelledby="comment-comment-0-label"
-          className="CommentContainer-root coral coral-conversationThread-highlighted coral coral-comment coral coral-reacted-0"
-          data-key-stop={true}
-          data-testid="comment-comment-0"
-          id="comment-comment-0"
-          onFocus={[Function]}
-          role="article"
-          tabIndex={-1}
-        >
-          <div
-            className="Hidden-root"
-            id="comment-comment-0-label"
-          >
-            <span>
-              Highlighted:
-            </span>
-             
-            <span>
-              Comment from Markus 
-              <time
-                className="RelativeTime-root"
-                dateTime="2018-07-06T18:24:00.000Z"
-                title="2018-07-06T18:24:00.000Z"
-              >
-                2018-07-06T18:24:00.000Z
-              </time>
-            </span>
-          </div>
-          <div
-            className="Box-root HorizontalGutter-root HorizontalGutter-full"
-          >
-            <div
-              className="coral coral-comment-collapse-toggle-indent Indent-root"
-            >
-              <div
-                className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
-              >
-                <div
-                  className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
-                >
-                  <div
-                    className="Box-root HorizontalGutter-root Comment-root Comment-highlight coral coral-comment-highlight HorizontalGutter-half"
-                  >
-                    <div
-                      className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
-                    >
-                      <div
-                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
-                      >
-                        <div
-                          className="Comment-username"
-                        >
-                          <div
-                            className="Popover-root"
-                          >
-                            <button
-                              aria-controls="username-popover-comment-0"
-                              className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Username-root"
-                              >
-                                Markus
-                              </span>
-                            </button>
-                            <div
-                              aria-hidden={true}
-                              aria-label="A popover with more user information"
-                              id="username-popover-comment-0"
-                              role="dialog"
-                            />
-                          </div>
-                        </div>
-                        <div
-                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
-                        >
-                          <button
-                            className="BaseButton-root Timestamp-root"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
-                            onTouchEnd={[Function]}
-                            type="button"
-                          >
-                            <time
-                              className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                              dateTime="2018-07-06T18:24:00.000Z"
-                              title="2018-07-06T18:24:00.000Z"
-                            >
-                              2018-07-06T18:24:00.000Z
-                            </time>
-                          </button>
-                        </div>
-                      </div>
-                      <div
-                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
-                      >
-                        <div
-                          className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                    >
-                      <div
-                        className="HTMLContent-root coral coral-content coral-comment-content"
-                        dangerouslySetInnerHTML={
-                          Object {
-                            "__html": "Joining Too",
-                          }
-                        }
-                      />
-                      <div
-                        className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                      >
-                        <div
-                          className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                        >
-                          <button
-                            aria-label="Respect comment by Markus"
-                            aria-pressed={false}
-                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                            data-testid="comment-reaction-button"
-                            data-variant="flat"
-                            disabled={false}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
-                            onTouchEnd={[Function]}
-                            type="button"
-                          >
-                            <span
-                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                            >
-                              <i
-                                aria-hidden="true"
-                                className="Icon-root Icon-sm ReactionButton-icon"
-                              >
-                                thumb_up
-                              </i>
-                            </span>
-                          </button>
-                          <button
-                            aria-label="Reply to comment by Markus"
-                            aria-pressed={false}
-                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                            data-testid="comment-reply-button"
-                            data-variant="flat"
-                            disabled={false}
-                            id="comments-commentContainer-replyButton-comment-0"
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
-                            onTouchEnd={[Function]}
-                            type="button"
-                          >
-                            <span
-                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                            >
-                              <i
-                                aria-hidden="true"
-                                className="Icon-root Icon-sm ReplyButton-icon"
-                              >
-                                reply
-                              </i>
-                            </span>
-                          </button>
-                          <div
-                            className="Popover-root"
-                          >
-                            <button
-                              aria-controls="permalink-popover-comment-0"
-                              aria-label="Share comment by Markus"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
-                              data-variant="flat"
-                              disabled={false}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm PermalinkButton-icon"
-                                >
-                                  share
-                                </i>
-                              </span>
-                            </button>
-                            <div
-                              aria-hidden={true}
-                              aria-label="A dialog showing a permalink to the comment"
-                              id="permalink-popover-comment-0"
-                              role="dialog"
-                            />
-                          </div>
-                        </div>
-                        <div
-                          className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                        >
-                          <button
-                            aria-label="Report comment by Markus"
-                            aria-pressed={false}
-                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                            data-testid="comment-report-button"
-                            data-variant="flat"
-                            disabled={false}
-                            onBlur={[Function]}
-                            onClick={[Function]}
-                            onFocus={[Function]}
-                            onMouseOut={[Function]}
-                            onMouseOver={[Function]}
-                            onTouchEnd={[Function]}
-                            type="button"
-                          >
-                            <span
-                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                            >
-                              <i
-                                aria-hidden="true"
-                                className="Icon-root Icon-sm ReportButton-icon"
-                              >
-                                flag
-                              </i>
-                            </span>
-                          </button>
                         </div>
                       </div>
                     </div>

--- a/src/core/client/stream/test/comments/permalink/permalinkViewPostReply.spec.tsx
+++ b/src/core/client/stream/test/comments/permalink/permalinkViewPostReply.spec.tsx
@@ -99,7 +99,7 @@ const createTestRenderer = async (
 };
 
 it("post a reply", async () => {
-  const { testRenderer, rte, form } = await createTestRenderer({
+  const { form, testRenderer, rte } = await createTestRenderer({
     resolvers: createResolversStub<GQLResolver>({
       Mutation: {
         createCommentReply: ({ variables }) => {
@@ -126,7 +126,9 @@ it("post a reply", async () => {
     }),
   });
 
-  expect(await within(form).axe()).toHaveNoViolations();
+  await act(async () => {
+    expect(await within(form).axe()).toHaveNoViolations();
+  });
 
   // Write reply .
   act(() => rte.props.onChange("<b>Hello world!</b>"));

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
@@ -476,83 +476,111 @@ exports[`post a reply: optimistic response 1`] = `
   <div
     className="Box-root HorizontalGutter-root HorizontalGutter-full"
   >
-    <div
-      aria-labelledby="comment-uuid-0-label"
-      className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-      data-key-stop={true}
-      data-testid="comment-uuid-0"
-      id="comment-uuid-0"
-      onFocus={[Function]}
-      role="article"
-      tabIndex={-1}
-    >
+    <div>
       <div
-        className="Hidden-root"
-        id="comment-uuid-0-label"
-      >
-        <span>
-          Thread Level 1:
-        </span>
-         
-        <span>
-          Reply from Markus 
-          <time
-            className="RelativeTime-root"
-            dateTime="2018-07-06T18:24:00.000Z"
-            title="2018-07-06T18:24:00.000Z"
-          >
-            2018-07-06T18:24:00.000Z
-          </time>
-        </span>
-      </div>
-      <div
-        className="Box-root HorizontalGutter-root HorizontalGutter-full"
+        aria-labelledby="comment-uuid-0-label"
+        className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+        data-key-stop={true}
+        data-testid="comment-uuid-0"
+        id="comment-uuid-0"
+        onFocus={[Function]}
+        role="article"
+        tabIndex={-1}
       >
         <div
-          className="IndentedComment-blur coral coral-comment-collapse-toggle-indent Indent-root"
+          className="Hidden-root"
+          id="comment-uuid-0-label"
+        >
+          <span>
+            Thread Level 1:
+          </span>
+           
+          <span>
+            Reply from Markus 
+            <time
+              className="RelativeTime-root"
+              dateTime="2018-07-06T18:24:00.000Z"
+              title="2018-07-06T18:24:00.000Z"
+            >
+              2018-07-06T18:24:00.000Z
+            </time>
+          </span>
+        </div>
+        <div
+          className="Box-root HorizontalGutter-root HorizontalGutter-full"
         >
           <div
-            className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
+            className="IndentedComment-blur coral coral-comment-collapse-toggle-indent Indent-root"
           >
             <div
-              className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+              className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
             >
-              <button
-                aria-label="Collapse comment thread"
-                className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                onTouchEnd={[Function]}
-                type="button"
-              >
-                <i
-                  aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                >
-                  remove
-                </i>
-              </button>
               <div
-                className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
               >
+                <button
+                  aria-label="Collapse comment thread"
+                  className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  onTouchEnd={[Function]}
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                  >
+                    remove
+                  </i>
+                </button>
                 <div
-                  className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                  className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                 >
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                    className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                   >
                     <div
-                      className="Comment-username"
+                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                     >
                       <div
-                        className="Popover-root"
+                        className="Comment-username"
+                      >
+                        <div
+                          className="Popover-root"
+                        >
+                          <button
+                            aria-controls="username-popover-uuid-0"
+                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="Username-root"
+                            >
+                              Markus
+                            </span>
+                          </button>
+                          <div
+                            aria-hidden={true}
+                            aria-label="A popover with more user information"
+                            id="username-popover-uuid-0"
+                            role="dialog"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                       >
                         <button
-                          aria-controls="username-popover-uuid-0"
-                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                          className="BaseButton-root Timestamp-root"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -561,192 +589,109 @@ exports[`post a reply: optimistic response 1`] = `
                           onTouchEnd={[Function]}
                           type="button"
                         >
-                          <span
-                            className="Username-root"
+                          <time
+                            className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                            dateTime="2018-07-06T18:24:00.000Z"
+                            title="2018-07-06T18:24:00.000Z"
                           >
-                            Markus
-                          </span>
+                            2018-07-06T18:24:00.000Z
+                          </time>
                         </button>
-                        <div
-                          aria-hidden={true}
-                          aria-label="A popover with more user information"
-                          id="username-popover-uuid-0"
-                          role="dialog"
-                        />
                       </div>
                     </div>
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                     >
-                      <button
-                        className="BaseButton-root Timestamp-root"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <time
-                          className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                          dateTime="2018-07-06T18:24:00.000Z"
-                          title="2018-07-06T18:24:00.000Z"
-                        >
-                          2018-07-06T18:24:00.000Z
-                        </time>
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
-                  >
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                    >
-                      <button
-                        className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantText Button-uppercase coral coral-comment-editButton CommentContainer-editButton"
-                        data-testid="comment-edit-button"
-                        data-variant="text"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <div
-                          className="Box-root Flex-root Flex-flex Flex-justifyCenter Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm CommentContainer-editIcon"
-                          >
-                            edit
-                          </i>
-                          Edit
-                        </div>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className="Comment-subBar"
-                >
-                  <button
-                    className="BaseButton-root InReplyTo-button"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    onTouchEnd={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
-                    >
-                      <i
-                        aria-hidden="true"
-                        className="Icon-root Icon-sm InReplyTo-icon"
-                      >
-                        reply
-                      </i>
-                      <span>
-                         
-                      </span>
-                      <span
-                        className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
-                      >
-                        In reply to 
-                        <span
-                          className="InReplyTo-username coral coral-comment-inReplyToUsername"
-                        >
-                          Markus
-                        </span>
-                      </span>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                >
-                  <div
-                    className="HTMLContent-root coral coral-content coral-comment-content"
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "<b>Hello world!</b>",
-                      }
-                    }
-                  />
-                  <div
-                    className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                  >
-                    <div
-                      className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                    >
-                      <button
-                        aria-label="Respect comment by Markus"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                        data-testid="comment-reaction-button"
-                        data-variant="flat"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReactionButton-icon"
-                          >
-                            thumb_up
-                          </i>
-                        </span>
-                      </button>
-                      <button
-                        aria-label="Reply to comment by Markus"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                        data-testid="comment-reply-button"
-                        data-variant="flat"
-                        disabled={false}
-                        id="comments-commentContainer-replyButton-uuid-0"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReplyButton-icon"
-                          >
-                            reply
-                          </i>
-                        </span>
-                      </button>
                       <div
-                        className="Popover-root"
+                        className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
                       >
                         <button
-                          aria-controls="permalink-popover-uuid-0"
-                          aria-label="Share comment by Markus"
+                          className="BaseButton-root Button-root Button-sizeRegular Button-colorStream Button-variantText Button-uppercase coral coral-comment-editButton CommentContainer-editButton"
+                          data-testid="comment-edit-button"
+                          data-variant="text"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <div
+                            className="Box-root Flex-root Flex-flex Flex-justifyCenter Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm CommentContainer-editIcon"
+                            >
+                              edit
+                            </i>
+                            Edit
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="Comment-subBar"
+                  >
+                    <button
+                      className="BaseButton-root InReplyTo-button"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      onTouchEnd={[Function]}
+                      type="button"
+                    >
+                      <span
+                        className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="Icon-root Icon-sm InReplyTo-icon"
+                        >
+                          reply
+                        </i>
+                        <span>
+                           
+                        </span>
+                        <span
+                          className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                        >
+                          In reply to 
+                          <span
+                            className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                          >
+                            Markus
+                          </span>
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
+                  >
+                    <div
+                      className="HTMLContent-root coral coral-content coral-comment-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "<b>Hello world!</b>",
+                        }
+                      }
+                    />
+                    <div
+                      className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                    >
+                      <div
+                        className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <button
+                          aria-label="Respect comment by Markus"
                           aria-pressed={false}
-                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                          data-testid="comment-reaction-button"
                           data-variant="flat"
                           disabled={false}
                           onBlur={[Function]}
@@ -762,49 +707,106 @@ exports[`post a reply: optimistic response 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm PermalinkButton-icon"
+                              className="Icon-root Icon-sm ReactionButton-icon"
                             >
-                              share
+                              thumb_up
+                            </i>
+                          </span>
+                        </button>
+                        <button
+                          aria-label="Reply to comment by Markus"
+                          aria-pressed={false}
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                          data-testid="comment-reply-button"
+                          data-variant="flat"
+                          disabled={false}
+                          id="comments-commentContainer-replyButton-uuid-0"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span
+                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ReplyButton-icon"
+                            >
+                              reply
                             </i>
                           </span>
                         </button>
                         <div
-                          aria-hidden={true}
-                          aria-label="A dialog showing a permalink to the comment"
-                          id="permalink-popover-uuid-0"
-                          role="dialog"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                    >
-                      <button
-                        aria-label="Report comment by Markus"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                        data-testid="comment-report-button"
-                        data-variant="flat"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          className="Popover-root"
                         >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReportButton-icon"
+                          <button
+                            aria-controls="permalink-popover-uuid-0"
+                            aria-label="Share comment by Markus"
+                            aria-pressed={false}
+                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                            data-variant="flat"
+                            disabled={false}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
                           >
-                            flag
-                          </i>
-                        </span>
-                      </button>
+                            <span
+                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                            >
+                              <i
+                                aria-hidden="true"
+                                className="Icon-root Icon-sm PermalinkButton-icon"
+                              >
+                                share
+                              </i>
+                            </span>
+                          </button>
+                          <div
+                            aria-hidden={true}
+                            aria-label="A dialog showing a permalink to the comment"
+                            id="permalink-popover-uuid-0"
+                            role="dialog"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <button
+                          aria-label="Report comment by Markus"
+                          aria-pressed={false}
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                          data-testid="comment-report-button"
+                          data-variant="flat"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span
+                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ReportButton-icon"
+                            >
+                              flag
+                            </i>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderCommunityGuidelines.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderCommunityGuidelines.spec.tsx.snap
@@ -389,79 +389,107 @@ exports[`renders comment stream with community guidelines 1`] = `
                   <div
                     className="Box-root HorizontalGutter-root AllCommentsTabCommentContainer-borderedCommentNotSeen HorizontalGutter-full"
                   >
-                    <div
-                      aria-labelledby="comment-comment-0-label"
-                      className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-                      data-key-stop={true}
-                      data-testid="comment-comment-0"
-                      id="comment-comment-0"
-                      onFocus={[Function]}
-                      role="article"
-                      tabIndex={-1}
-                    >
+                    <div>
                       <div
-                        className="Hidden-root"
-                        id="comment-comment-0-label"
-                      >
-                        <span>
-                          Comment from Markus 
-                          <time
-                            className="RelativeTime-root"
-                            dateTime="2018-07-06T18:24:00.000Z"
-                            title="2018-07-06T18:24:00.000Z"
-                          >
-                            2018-07-06T18:24:00.000Z
-                          </time>
-                        </span>
-                      </div>
-                      <div
-                        className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                        aria-labelledby="comment-comment-0-label"
+                        className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                        data-key-stop={true}
+                        data-testid="comment-comment-0"
+                        id="comment-comment-0"
+                        onFocus={[Function]}
+                        role="article"
+                        tabIndex={-1}
                       >
                         <div
-                          className="coral coral-comment-collapse-toggle-indent Indent-root"
+                          className="Hidden-root"
+                          id="comment-comment-0-label"
+                        >
+                          <span>
+                            Comment from Markus 
+                            <time
+                              className="RelativeTime-root"
+                              dateTime="2018-07-06T18:24:00.000Z"
+                              title="2018-07-06T18:24:00.000Z"
+                            >
+                              2018-07-06T18:24:00.000Z
+                            </time>
+                          </span>
+                        </div>
+                        <div
+                          className="Box-root HorizontalGutter-root HorizontalGutter-full"
                         >
                           <div
-                            className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                            className="coral coral-comment-collapse-toggle-indent Indent-root"
                           >
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                              className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                             >
-                              <button
-                                aria-label="Collapse comment thread"
-                                className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                                >
-                                  remove
-                                </i>
-                              </button>
                               <div
-                                className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                                className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                               >
+                                <button
+                                  aria-label="Collapse comment thread"
+                                  className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                                  >
+                                    remove
+                                  </i>
+                                </button>
                                 <div
-                                  className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                                  className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                                 >
                                   <div
-                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                                    className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                                   >
                                     <div
-                                      className="Comment-username"
+                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                                     >
                                       <div
-                                        className="Popover-root"
+                                        className="Comment-username"
+                                      >
+                                        <div
+                                          className="Popover-root"
+                                        >
+                                          <button
+                                            aria-controls="username-popover-comment-0"
+                                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseOut={[Function]}
+                                            onMouseOver={[Function]}
+                                            onTouchEnd={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="Username-root"
+                                            >
+                                              Markus
+                                            </span>
+                                          </button>
+                                          <div
+                                            aria-hidden={true}
+                                            aria-label="A popover with more user information"
+                                            id="username-popover-comment-0"
+                                            role="dialog"
+                                          />
+                                        </div>
+                                      </div>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                                       >
                                         <button
-                                          aria-controls="username-popover-comment-0"
-                                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                          className="BaseButton-root Timestamp-root"
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onFocus={[Function]}
@@ -470,129 +498,46 @@ exports[`renders comment stream with community guidelines 1`] = `
                                           onTouchEnd={[Function]}
                                           type="button"
                                         >
-                                          <span
-                                            className="Username-root"
+                                          <time
+                                            className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                            dateTime="2018-07-06T18:24:00.000Z"
+                                            title="2018-07-06T18:24:00.000Z"
                                           >
-                                            Markus
-                                          </span>
+                                            2018-07-06T18:24:00.000Z
+                                          </time>
                                         </button>
-                                        <div
-                                          aria-hidden={true}
-                                          aria-label="A popover with more user information"
-                                          id="username-popover-comment-0"
-                                          role="dialog"
-                                        />
                                       </div>
                                     </div>
                                     <div
-                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                                     >
-                                      <button
-                                        className="BaseButton-root Timestamp-root"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <time
-                                          className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                          dateTime="2018-07-06T18:24:00.000Z"
-                                          title="2018-07-06T18:24:00.000Z"
-                                        >
-                                          2018-07-06T18:24:00.000Z
-                                        </time>
-                                      </button>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                                      />
                                     </div>
                                   </div>
                                   <div
-                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                                    className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                                   >
                                     <div
-                                      className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                                    />
-                                  </div>
-                                </div>
-                                <div
-                                  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                                >
-                                  <div
-                                    className="HTMLContent-root coral coral-content coral-comment-content"
-                                    dangerouslySetInnerHTML={
-                                      Object {
-                                        "__html": "Joining Too",
+                                      className="HTMLContent-root coral coral-content coral-comment-content"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "Joining Too",
+                                        }
                                       }
-                                    }
-                                  />
-                                  <div
-                                    className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                                  >
+                                    />
                                     <div
-                                      className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                      className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                                     >
-                                      <button
-                                        aria-label="Respect comment by Markus"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                        data-testid="comment-reaction-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                        >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReactionButton-icon"
-                                          >
-                                            thumb_up
-                                          </i>
-                                        </span>
-                                      </button>
-                                      <button
-                                        aria-label="Reply to comment by Markus"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                        data-testid="comment-reply-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        id="comments-commentContainer-replyButton-comment-0"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                        >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReplyButton-icon"
-                                          >
-                                            reply
-                                          </i>
-                                        </span>
-                                      </button>
                                       <div
-                                        className="Popover-root"
+                                        className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                       >
                                         <button
-                                          aria-controls="permalink-popover-comment-0"
-                                          aria-label="Share comment by Markus"
+                                          aria-label="Respect comment by Markus"
                                           aria-pressed={false}
-                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                          data-testid="comment-reaction-button"
                                           data-variant="flat"
                                           disabled={false}
                                           onBlur={[Function]}
@@ -608,49 +553,106 @@ exports[`renders comment stream with community guidelines 1`] = `
                                           >
                                             <i
                                               aria-hidden="true"
-                                              className="Icon-root Icon-sm PermalinkButton-icon"
+                                              className="Icon-root Icon-sm ReactionButton-icon"
                                             >
-                                              share
+                                              thumb_up
+                                            </i>
+                                          </span>
+                                        </button>
+                                        <button
+                                          aria-label="Reply to comment by Markus"
+                                          aria-pressed={false}
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                          data-testid="comment-reply-button"
+                                          data-variant="flat"
+                                          disabled={false}
+                                          id="comments-commentContainer-replyButton-comment-0"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseOut={[Function]}
+                                          onMouseOver={[Function]}
+                                          onTouchEnd={[Function]}
+                                          type="button"
+                                        >
+                                          <span
+                                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          >
+                                            <i
+                                              aria-hidden="true"
+                                              className="Icon-root Icon-sm ReplyButton-icon"
+                                            >
+                                              reply
                                             </i>
                                           </span>
                                         </button>
                                         <div
-                                          aria-hidden={true}
-                                          aria-label="A dialog showing a permalink to the comment"
-                                          id="permalink-popover-comment-0"
-                                          role="dialog"
-                                        />
-                                      </div>
-                                    </div>
-                                    <div
-                                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                                    >
-                                      <button
-                                        aria-label="Report comment by Markus"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                        data-testid="comment-report-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          className="Popover-root"
                                         >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReportButton-icon"
+                                          <button
+                                            aria-controls="permalink-popover-comment-0"
+                                            aria-label="Share comment by Markus"
+                                            aria-pressed={false}
+                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                            data-variant="flat"
+                                            disabled={false}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseOut={[Function]}
+                                            onMouseOver={[Function]}
+                                            onTouchEnd={[Function]}
+                                            type="button"
                                           >
-                                            flag
-                                          </i>
-                                        </span>
-                                      </button>
+                                            <span
+                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                            >
+                                              <i
+                                                aria-hidden="true"
+                                                className="Icon-root Icon-sm PermalinkButton-icon"
+                                              >
+                                                share
+                                              </i>
+                                            </span>
+                                          </button>
+                                          <div
+                                            aria-hidden={true}
+                                            aria-label="A dialog showing a permalink to the comment"
+                                            id="permalink-popover-comment-0"
+                                            role="dialog"
+                                          />
+                                        </div>
+                                      </div>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                      >
+                                        <button
+                                          aria-label="Report comment by Markus"
+                                          aria-pressed={false}
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                          data-testid="comment-report-button"
+                                          data-variant="flat"
+                                          disabled={false}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseOut={[Function]}
+                                          onMouseOver={[Function]}
+                                          onTouchEnd={[Function]}
+                                          type="button"
+                                        >
+                                          <span
+                                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          >
+                                            <i
+                                              aria-hidden="true"
+                                              className="Icon-root Icon-sm ReportButton-icon"
+                                            >
+                                              flag
+                                            </i>
+                                          </span>
+                                        </button>
+                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -676,79 +678,107 @@ exports[`renders comment stream with community guidelines 1`] = `
                   <div
                     className="Box-root HorizontalGutter-root HorizontalGutter-full"
                   >
-                    <div
-                      aria-labelledby="comment-comment-1-label"
-                      className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-                      data-key-stop={true}
-                      data-testid="comment-comment-1"
-                      id="comment-comment-1"
-                      onFocus={[Function]}
-                      role="article"
-                      tabIndex={-1}
-                    >
+                    <div>
                       <div
-                        className="Hidden-root"
-                        id="comment-comment-1-label"
-                      >
-                        <span>
-                          Comment from Lukas 
-                          <time
-                            className="RelativeTime-root"
-                            dateTime="2018-07-06T18:24:00.000Z"
-                            title="2018-07-06T18:24:00.000Z"
-                          >
-                            2018-07-06T18:24:00.000Z
-                          </time>
-                        </span>
-                      </div>
-                      <div
-                        className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                        aria-labelledby="comment-comment-1-label"
+                        className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                        data-key-stop={true}
+                        data-testid="comment-comment-1"
+                        id="comment-comment-1"
+                        onFocus={[Function]}
+                        role="article"
+                        tabIndex={-1}
                       >
                         <div
-                          className="coral coral-comment-collapse-toggle-indent Indent-root"
+                          className="Hidden-root"
+                          id="comment-comment-1-label"
+                        >
+                          <span>
+                            Comment from Lukas 
+                            <time
+                              className="RelativeTime-root"
+                              dateTime="2018-07-06T18:24:00.000Z"
+                              title="2018-07-06T18:24:00.000Z"
+                            >
+                              2018-07-06T18:24:00.000Z
+                            </time>
+                          </span>
+                        </div>
+                        <div
+                          className="Box-root HorizontalGutter-root HorizontalGutter-full"
                         >
                           <div
-                            className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                            className="coral coral-comment-collapse-toggle-indent Indent-root"
                           >
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                              className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                             >
-                              <button
-                                aria-label="Collapse comment thread"
-                                className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                                >
-                                  remove
-                                </i>
-                              </button>
                               <div
-                                className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                                className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                               >
+                                <button
+                                  aria-label="Collapse comment thread"
+                                  className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                                  >
+                                    remove
+                                  </i>
+                                </button>
                                 <div
-                                  className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                                  className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                                 >
                                   <div
-                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                                    className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                                   >
                                     <div
-                                      className="Comment-username"
+                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                                     >
                                       <div
-                                        className="Popover-root"
+                                        className="Comment-username"
+                                      >
+                                        <div
+                                          className="Popover-root"
+                                        >
+                                          <button
+                                            aria-controls="username-popover-comment-1"
+                                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseOut={[Function]}
+                                            onMouseOver={[Function]}
+                                            onTouchEnd={[Function]}
+                                            type="button"
+                                          >
+                                            <span
+                                              className="Username-root"
+                                            >
+                                              Lukas
+                                            </span>
+                                          </button>
+                                          <div
+                                            aria-hidden={true}
+                                            aria-label="A popover with more user information"
+                                            id="username-popover-comment-1"
+                                            role="dialog"
+                                          />
+                                        </div>
+                                      </div>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                                       >
                                         <button
-                                          aria-controls="username-popover-comment-1"
-                                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                          className="BaseButton-root Timestamp-root"
                                           onBlur={[Function]}
                                           onClick={[Function]}
                                           onFocus={[Function]}
@@ -757,129 +787,46 @@ exports[`renders comment stream with community guidelines 1`] = `
                                           onTouchEnd={[Function]}
                                           type="button"
                                         >
-                                          <span
-                                            className="Username-root"
+                                          <time
+                                            className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                            dateTime="2018-07-06T18:24:00.000Z"
+                                            title="2018-07-06T18:24:00.000Z"
                                           >
-                                            Lukas
-                                          </span>
+                                            2018-07-06T18:24:00.000Z
+                                          </time>
                                         </button>
-                                        <div
-                                          aria-hidden={true}
-                                          aria-label="A popover with more user information"
-                                          id="username-popover-comment-1"
-                                          role="dialog"
-                                        />
                                       </div>
                                     </div>
                                     <div
-                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                                     >
-                                      <button
-                                        className="BaseButton-root Timestamp-root"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <time
-                                          className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                          dateTime="2018-07-06T18:24:00.000Z"
-                                          title="2018-07-06T18:24:00.000Z"
-                                        >
-                                          2018-07-06T18:24:00.000Z
-                                        </time>
-                                      </button>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                                      />
                                     </div>
                                   </div>
                                   <div
-                                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                                    className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                                   >
                                     <div
-                                      className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                                    />
-                                  </div>
-                                </div>
-                                <div
-                                  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                                >
-                                  <div
-                                    className="HTMLContent-root coral coral-content coral-comment-content"
-                                    dangerouslySetInnerHTML={
-                                      Object {
-                                        "__html": "What's up?",
+                                      className="HTMLContent-root coral coral-content coral-comment-content"
+                                      dangerouslySetInnerHTML={
+                                        Object {
+                                          "__html": "What's up?",
+                                        }
                                       }
-                                    }
-                                  />
-                                  <div
-                                    className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                                  >
+                                    />
                                     <div
-                                      className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                      className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                                     >
-                                      <button
-                                        aria-label="Respect comment by Lukas"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                        data-testid="comment-reaction-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                        >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReactionButton-icon"
-                                          >
-                                            thumb_up
-                                          </i>
-                                        </span>
-                                      </button>
-                                      <button
-                                        aria-label="Reply to comment by Lukas"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                        data-testid="comment-reply-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        id="comments-commentContainer-replyButton-comment-1"
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                        >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReplyButton-icon"
-                                          >
-                                            reply
-                                          </i>
-                                        </span>
-                                      </button>
                                       <div
-                                        className="Popover-root"
+                                        className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                       >
                                         <button
-                                          aria-controls="permalink-popover-comment-1"
-                                          aria-label="Share comment by Lukas"
+                                          aria-label="Respect comment by Lukas"
                                           aria-pressed={false}
-                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                          data-testid="comment-reaction-button"
                                           data-variant="flat"
                                           disabled={false}
                                           onBlur={[Function]}
@@ -895,49 +842,106 @@ exports[`renders comment stream with community guidelines 1`] = `
                                           >
                                             <i
                                               aria-hidden="true"
-                                              className="Icon-root Icon-sm PermalinkButton-icon"
+                                              className="Icon-root Icon-sm ReactionButton-icon"
                                             >
-                                              share
+                                              thumb_up
+                                            </i>
+                                          </span>
+                                        </button>
+                                        <button
+                                          aria-label="Reply to comment by Lukas"
+                                          aria-pressed={false}
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                          data-testid="comment-reply-button"
+                                          data-variant="flat"
+                                          disabled={false}
+                                          id="comments-commentContainer-replyButton-comment-1"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseOut={[Function]}
+                                          onMouseOver={[Function]}
+                                          onTouchEnd={[Function]}
+                                          type="button"
+                                        >
+                                          <span
+                                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          >
+                                            <i
+                                              aria-hidden="true"
+                                              className="Icon-root Icon-sm ReplyButton-icon"
+                                            >
+                                              reply
                                             </i>
                                           </span>
                                         </button>
                                         <div
-                                          aria-hidden={true}
-                                          aria-label="A dialog showing a permalink to the comment"
-                                          id="permalink-popover-comment-1"
-                                          role="dialog"
-                                        />
-                                      </div>
-                                    </div>
-                                    <div
-                                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                                    >
-                                      <button
-                                        aria-label="Report comment by Lukas"
-                                        aria-pressed={false}
-                                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                        data-testid="comment-report-button"
-                                        data-variant="flat"
-                                        disabled={false}
-                                        onBlur={[Function]}
-                                        onClick={[Function]}
-                                        onFocus={[Function]}
-                                        onMouseOut={[Function]}
-                                        onMouseOver={[Function]}
-                                        onTouchEnd={[Function]}
-                                        type="button"
-                                      >
-                                        <span
-                                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          className="Popover-root"
                                         >
-                                          <i
-                                            aria-hidden="true"
-                                            className="Icon-root Icon-sm ReportButton-icon"
+                                          <button
+                                            aria-controls="permalink-popover-comment-1"
+                                            aria-label="Share comment by Lukas"
+                                            aria-pressed={false}
+                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                            data-variant="flat"
+                                            disabled={false}
+                                            onBlur={[Function]}
+                                            onClick={[Function]}
+                                            onFocus={[Function]}
+                                            onMouseOut={[Function]}
+                                            onMouseOver={[Function]}
+                                            onTouchEnd={[Function]}
+                                            type="button"
                                           >
-                                            flag
-                                          </i>
-                                        </span>
-                                      </button>
+                                            <span
+                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                            >
+                                              <i
+                                                aria-hidden="true"
+                                                className="Icon-root Icon-sm PermalinkButton-icon"
+                                              >
+                                                share
+                                              </i>
+                                            </span>
+                                          </button>
+                                          <div
+                                            aria-hidden={true}
+                                            aria-label="A dialog showing a permalink to the comment"
+                                            id="permalink-popover-comment-1"
+                                            role="dialog"
+                                          />
+                                        </div>
+                                      </div>
+                                      <div
+                                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                      >
+                                        <button
+                                          aria-label="Report comment by Lukas"
+                                          aria-pressed={false}
+                                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                          data-testid="comment-report-button"
+                                          data-variant="flat"
+                                          disabled={false}
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onFocus={[Function]}
+                                          onMouseOut={[Function]}
+                                          onMouseOver={[Function]}
+                                          onTouchEnd={[Function]}
+                                          type="button"
+                                        >
+                                          <span
+                                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                          >
+                                            <i
+                                              aria-hidden="true"
+                                              className="Icon-root Icon-sm ReportButton-icon"
+                                            >
+                                              flag
+                                            </i>
+                                          </span>
+                                        </button>
+                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -954,55 +958,57 @@ exports[`renders comment stream with community guidelines 1`] = `
               <div />
             </div>
           </div>
-          <nav
-            aria-label="Comments Footer"
-            className="CommentsLinks-container coral coral-streamFooter"
-          >
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of comments"
-              type="button"
+          <div>
+            <nav
+              aria-label="Comments Footer"
+              className="CommentsLinks-container coral coral-streamFooter"
             >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of comments"
+                type="button"
               >
-                forum
-              </i>
-              <span>
-                Top of comments
-              </span>
-            </button>
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of article"
-              type="button"
-            >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  forum
+                </i>
+                <span>
+                  Top of comments
+                </span>
+              </button>
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of article"
+                type="button"
               >
-                description
-              </i>
-              <span>
-                Top of article
-              </span>
-            </button>
-          </nav>
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  description
+                </i>
+                <span>
+                  Top of article
+                </span>
+              </button>
+            </nav>
+          </div>
         </div>
       </section>
     </div>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
@@ -304,55 +304,57 @@ exports[`renders message box when commenting disabled 1`] = `
               <div />
             </div>
           </div>
-          <nav
-            aria-label="Comments Footer"
-            className="CommentsLinks-container coral coral-streamFooter"
-          >
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of comments"
-              type="button"
+          <div>
+            <nav
+              aria-label="Comments Footer"
+              className="CommentsLinks-container coral coral-streamFooter"
             >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of comments"
+                type="button"
               >
-                forum
-              </i>
-              <span>
-                Top of comments
-              </span>
-            </button>
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of article"
-              type="button"
-            >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  forum
+                </i>
+                <span>
+                  Top of comments
+                </span>
+              </button>
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of article"
+                type="button"
               >
-                description
-              </i>
-              <span>
-                Top of article
-              </span>
-            </button>
-          </nav>
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  description
+                </i>
+                <span>
+                  Top of article
+                </span>
+              </button>
+            </nav>
+          </div>
         </div>
       </section>
     </div>
@@ -775,77 +777,79 @@ exports[`renders message box when logged in 1`] = `
               <div />
             </div>
           </div>
-          <nav
-            aria-label="Comments Footer"
-            className="CommentsLinks-container coral coral-streamFooter"
-          >
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-profileLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to profile and replies"
-              type="button"
+          <div>
+            <nav
+              aria-label="Comments Footer"
+              className="CommentsLinks-container coral coral-streamFooter"
             >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-profileLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to profile and replies"
+                type="button"
               >
-                account_box
-              </i>
-              <span>
-                Profile & Replies
-              </span>
-            </button>
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of comments"
-              type="button"
-            >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  account_box
+                </i>
+                <span>
+                  Profile & Replies
+                </span>
+              </button>
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of comments"
+                type="button"
               >
-                forum
-              </i>
-              <span>
-                Top of comments
-              </span>
-            </button>
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of article"
-              type="button"
-            >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  forum
+                </i>
+                <span>
+                  Top of comments
+                </span>
+              </button>
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of article"
+                type="button"
               >
-                description
-              </i>
-              <span>
-                Top of article
-              </span>
-            </button>
-          </nav>
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  description
+                </i>
+                <span>
+                  Top of article
+                </span>
+              </button>
+            </nav>
+          </div>
         </div>
       </section>
     </div>
@@ -1246,55 +1250,57 @@ exports[`renders message box when not logged in 1`] = `
               <div />
             </div>
           </div>
-          <nav
-            aria-label="Comments Footer"
-            className="CommentsLinks-container coral coral-streamFooter"
-          >
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of comments"
-              type="button"
+          <div>
+            <nav
+              aria-label="Comments Footer"
+              className="CommentsLinks-container coral coral-streamFooter"
             >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of comments"
+                type="button"
               >
-                forum
-              </i>
-              <span>
-                Top of comments
-              </span>
-            </button>
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of article"
-              type="button"
-            >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  forum
+                </i>
+                <span>
+                  Top of comments
+                </span>
+              </button>
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of article"
+                type="button"
               >
-                description
-              </i>
-              <span>
-                Top of article
-              </span>
-            </button>
-          </nav>
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  description
+                </i>
+                <span>
+                  Top of article
+                </span>
+              </button>
+            </nav>
+          </div>
         </div>
       </section>
     </div>
@@ -1596,55 +1602,57 @@ exports[`renders message box when story isClosed 1`] = `
               <div />
             </div>
           </div>
-          <nav
-            aria-label="Comments Footer"
-            className="CommentsLinks-container coral coral-streamFooter"
-          >
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of comments"
-              type="button"
+          <div>
+            <nav
+              aria-label="Comments Footer"
+              className="CommentsLinks-container coral coral-streamFooter"
             >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of comments"
+                type="button"
               >
-                forum
-              </i>
-              <span>
-                Top of comments
-              </span>
-            </button>
-            <button
-              className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
-              data-variant="textUnderlined"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseOut={[Function]}
-              onMouseOver={[Function]}
-              onTouchEnd={[Function]}
-              title="Go to top of article"
-              type="button"
-            >
-              <i
-                aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  forum
+                </i>
+                <span>
+                  Top of comments
+                </span>
+              </button>
+              <button
+                className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
+                data-variant="textUnderlined"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                title="Go to top of article"
+                type="button"
               >
-                description
-              </i>
-              <span>
-                Top of article
-              </span>
-            </button>
-          </nav>
+                <i
+                  aria-hidden="true"
+                  className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                >
+                  description
+                </i>
+                <span>
+                  Top of article
+                </span>
+              </button>
+            </nav>
+          </div>
         </div>
       </section>
     </div>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
@@ -11,83 +11,111 @@ exports[`renders reply list 1`] = `
   <div
     className="Box-root HorizontalGutter-root HorizontalGutter-full"
   >
-    <div
-      aria-labelledby="comment-comment-with-replies-label"
-      className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-      data-key-stop={true}
-      data-testid="comment-comment-with-replies"
-      id="comment-comment-with-replies"
-      onFocus={[Function]}
-      role="article"
-      tabIndex={-1}
-    >
+    <div>
       <div
-        className="Hidden-root"
-        id="comment-comment-with-replies-label"
-      >
-        <span>
-          Thread Level 1:
-        </span>
-         
-        <span>
-          Reply from Markus 
-          <time
-            className="RelativeTime-root"
-            dateTime="2018-07-06T18:24:00.000Z"
-            title="2018-07-06T18:24:00.000Z"
-          >
-            2018-07-06T18:24:00.000Z
-          </time>
-        </span>
-      </div>
-      <div
-        className="Box-root HorizontalGutter-root HorizontalGutter-full"
+        aria-labelledby="comment-comment-with-replies-label"
+        className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+        data-key-stop={true}
+        data-testid="comment-comment-with-replies"
+        id="comment-comment-with-replies"
+        onFocus={[Function]}
+        role="article"
+        tabIndex={-1}
       >
         <div
-          className="coral coral-comment-collapse-toggle-indent Indent-root"
+          className="Hidden-root"
+          id="comment-comment-with-replies-label"
+        >
+          <span>
+            Thread Level 1:
+          </span>
+           
+          <span>
+            Reply from Markus 
+            <time
+              className="RelativeTime-root"
+              dateTime="2018-07-06T18:24:00.000Z"
+              title="2018-07-06T18:24:00.000Z"
+            >
+              2018-07-06T18:24:00.000Z
+            </time>
+          </span>
+        </div>
+        <div
+          className="Box-root HorizontalGutter-root HorizontalGutter-full"
         >
           <div
-            className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
+            className="coral coral-comment-collapse-toggle-indent Indent-root"
           >
             <div
-              className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+              className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
             >
-              <button
-                aria-label="Collapse comment thread"
-                className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                onTouchEnd={[Function]}
-                type="button"
-              >
-                <i
-                  aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                >
-                  remove
-                </i>
-              </button>
               <div
-                className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
               >
+                <button
+                  aria-label="Collapse comment thread"
+                  className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  onTouchEnd={[Function]}
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                  >
+                    remove
+                  </i>
+                </button>
                 <div
-                  className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                  className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                 >
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                    className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                   >
                     <div
-                      className="Comment-username"
+                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                     >
                       <div
-                        className="Popover-root"
+                        className="Comment-username"
+                      >
+                        <div
+                          className="Popover-root"
+                        >
+                          <button
+                            aria-controls="username-popover-comment-with-replies"
+                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="Username-root"
+                            >
+                              Markus
+                            </span>
+                          </button>
+                          <div
+                            aria-hidden={true}
+                            aria-label="A popover with more user information"
+                            id="username-popover-comment-with-replies"
+                            role="dialog"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                       >
                         <button
-                          aria-controls="username-popover-comment-with-replies"
-                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                          className="BaseButton-root Timestamp-root"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -96,167 +124,84 @@ exports[`renders reply list 1`] = `
                           onTouchEnd={[Function]}
                           type="button"
                         >
-                          <span
-                            className="Username-root"
+                          <time
+                            className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                            dateTime="2018-07-06T18:24:00.000Z"
+                            title="2018-07-06T18:24:00.000Z"
                           >
-                            Markus
-                          </span>
+                            2018-07-06T18:24:00.000Z
+                          </time>
                         </button>
-                        <div
-                          aria-hidden={true}
-                          aria-label="A popover with more user information"
-                          id="username-popover-comment-with-replies"
-                          role="dialog"
-                        />
                       </div>
                     </div>
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                     >
-                      <button
-                        className="BaseButton-root Timestamp-root"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <time
-                          className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                          dateTime="2018-07-06T18:24:00.000Z"
-                          title="2018-07-06T18:24:00.000Z"
-                        >
-                          2018-07-06T18:24:00.000Z
-                        </time>
-                      </button>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                      />
                     </div>
                   </div>
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                    className="Comment-subBar"
                   >
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                    />
-                  </div>
-                </div>
-                <div
-                  className="Comment-subBar"
-                >
-                  <button
-                    className="BaseButton-root InReplyTo-button"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    onTouchEnd={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
+                    <button
+                      className="BaseButton-root InReplyTo-button"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      onTouchEnd={[Function]}
+                      type="button"
                     >
-                      <i
-                        aria-hidden="true"
-                        className="Icon-root Icon-sm InReplyTo-icon"
-                      >
-                        reply
-                      </i>
-                      <span>
-                         
-                      </span>
                       <span
-                        className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                        className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
                       >
-                        In reply to 
-                        <span
-                          className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                        <i
+                          aria-hidden="true"
+                          className="Icon-root Icon-sm InReplyTo-icon"
                         >
-                          Markus
+                          reply
+                        </i>
+                        <span>
+                           
+                        </span>
+                        <span
+                          className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                        >
+                          In reply to 
+                          <span
+                            className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                          >
+                            Markus
+                          </span>
                         </span>
                       </span>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                >
+                    </button>
+                  </div>
                   <div
-                    className="HTMLContent-root coral coral-content coral-comment-content"
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "I like yoghurt",
-                      }
-                    }
-                  />
-                  <div
-                    className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                    className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                   >
                     <div
-                      className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                      className="HTMLContent-root coral coral-content coral-comment-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "I like yoghurt",
+                        }
+                      }
+                    />
+                    <div
+                      className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                     >
-                      <button
-                        aria-label="Respect comment by Markus"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                        data-testid="comment-reaction-button"
-                        data-variant="flat"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReactionButton-icon"
-                          >
-                            thumb_up
-                          </i>
-                        </span>
-                      </button>
-                      <button
-                        aria-label="Reply to comment by Markus"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                        data-testid="comment-reply-button"
-                        data-variant="flat"
-                        disabled={false}
-                        id="comments-commentContainer-replyButton-comment-with-replies"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReplyButton-icon"
-                          >
-                            reply
-                          </i>
-                        </span>
-                      </button>
                       <div
-                        className="Popover-root"
+                        className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                       >
                         <button
-                          aria-controls="permalink-popover-comment-with-replies"
-                          aria-label="Share comment by Markus"
+                          aria-label="Respect comment by Markus"
                           aria-pressed={false}
-                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                          data-testid="comment-reaction-button"
                           data-variant="flat"
                           disabled={false}
                           onBlur={[Function]}
@@ -272,49 +217,106 @@ exports[`renders reply list 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm PermalinkButton-icon"
+                              className="Icon-root Icon-sm ReactionButton-icon"
                             >
-                              share
+                              thumb_up
+                            </i>
+                          </span>
+                        </button>
+                        <button
+                          aria-label="Reply to comment by Markus"
+                          aria-pressed={false}
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                          data-testid="comment-reply-button"
+                          data-variant="flat"
+                          disabled={false}
+                          id="comments-commentContainer-replyButton-comment-with-replies"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span
+                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ReplyButton-icon"
+                            >
+                              reply
                             </i>
                           </span>
                         </button>
                         <div
-                          aria-hidden={true}
-                          aria-label="A dialog showing a permalink to the comment"
-                          id="permalink-popover-comment-with-replies"
-                          role="dialog"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                    >
-                      <button
-                        aria-label="Report comment by Markus"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                        data-testid="comment-report-button"
-                        data-variant="flat"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          className="Popover-root"
                         >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReportButton-icon"
+                          <button
+                            aria-controls="permalink-popover-comment-with-replies"
+                            aria-label="Share comment by Markus"
+                            aria-pressed={false}
+                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                            data-variant="flat"
+                            disabled={false}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
                           >
-                            flag
-                          </i>
-                        </span>
-                      </button>
+                            <span
+                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                            >
+                              <i
+                                aria-hidden="true"
+                                className="Icon-root Icon-sm PermalinkButton-icon"
+                              >
+                                share
+                              </i>
+                            </span>
+                          </button>
+                          <div
+                            aria-hidden={true}
+                            aria-label="A dialog showing a permalink to the comment"
+                            id="permalink-popover-comment-with-replies"
+                            role="dialog"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <button
+                          aria-label="Report comment by Markus"
+                          aria-pressed={false}
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                          data-testid="comment-report-button"
+                          data-variant="flat"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span
+                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ReportButton-icon"
+                            >
+                              flag
+                            </i>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -337,83 +339,111 @@ exports[`renders reply list 1`] = `
         <div
           className="Box-root HorizontalGutter-root HorizontalGutter-full"
         >
-          <div
-            aria-labelledby="comment-comment-3-label"
-            className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-            data-key-stop={true}
-            data-testid="comment-comment-3"
-            id="comment-comment-3"
-            onFocus={[Function]}
-            role="article"
-            tabIndex={-1}
-          >
+          <div>
             <div
-              className="Hidden-root"
-              id="comment-comment-3-label"
-            >
-              <span>
-                Thread Level 2:
-              </span>
-               
-              <span>
-                Reply from Isabelle 
-                <time
-                  className="RelativeTime-root"
-                  dateTime="2018-07-06T18:24:00.000Z"
-                  title="2018-07-06T18:24:00.000Z"
-                >
-                  2018-07-06T18:24:00.000Z
-                </time>
-              </span>
-            </div>
-            <div
-              className="Box-root HorizontalGutter-root HorizontalGutter-full"
+              aria-labelledby="comment-comment-3-label"
+              className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+              data-key-stop={true}
+              data-testid="comment-comment-3"
+              id="comment-comment-3"
+              onFocus={[Function]}
+              role="article"
+              tabIndex={-1}
             >
               <div
-                className="coral coral-comment-collapse-toggle-indent Indent-root"
+                className="Hidden-root"
+                id="comment-comment-3-label"
+              >
+                <span>
+                  Thread Level 2:
+                </span>
+                 
+                <span>
+                  Reply from Isabelle 
+                  <time
+                    className="RelativeTime-root"
+                    dateTime="2018-07-06T18:24:00.000Z"
+                    title="2018-07-06T18:24:00.000Z"
+                  >
+                    2018-07-06T18:24:00.000Z
+                  </time>
+                </span>
+              </div>
+              <div
+                className="Box-root HorizontalGutter-root HorizontalGutter-full"
               >
                 <div
-                  className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level2 coral coral-indent coral-indent-2 Indent-open Indent-openPadded"
+                  className="coral coral-comment-collapse-toggle-indent Indent-root"
                 >
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                    className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level2 coral coral-indent coral-indent-2 Indent-open Indent-openPadded"
                   >
-                    <button
-                      aria-label="Collapse comment thread"
-                      className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
-                      onTouchEnd={[Function]}
-                      type="button"
-                    >
-                      <i
-                        aria-hidden="true"
-                        className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                      >
-                        remove
-                      </i>
-                    </button>
                     <div
-                      className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                      className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                     >
+                      <button
+                        aria-label="Collapse comment thread"
+                        className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        type="button"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                        >
+                          remove
+                        </i>
+                      </button>
                       <div
-                        className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                        className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                       >
                         <div
-                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                          className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                         >
                           <div
-                            className="Comment-username"
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                           >
                             <div
-                              className="Popover-root"
+                              className="Comment-username"
+                            >
+                              <div
+                                className="Popover-root"
+                              >
+                                <button
+                                  aria-controls="username-popover-comment-3"
+                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Username-root"
+                                  >
+                                    Isabelle
+                                  </span>
+                                </button>
+                                <div
+                                  aria-hidden={true}
+                                  aria-label="A popover with more user information"
+                                  id="username-popover-comment-3"
+                                  role="dialog"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                             >
                               <button
-                                aria-controls="username-popover-comment-3"
-                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                className="BaseButton-root Timestamp-root"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onFocus={[Function]}
@@ -422,167 +452,84 @@ exports[`renders reply list 1`] = `
                                 onTouchEnd={[Function]}
                                 type="button"
                               >
-                                <span
-                                  className="Username-root"
+                                <time
+                                  className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                  dateTime="2018-07-06T18:24:00.000Z"
+                                  title="2018-07-06T18:24:00.000Z"
                                 >
-                                  Isabelle
-                                </span>
+                                  2018-07-06T18:24:00.000Z
+                                </time>
                               </button>
-                              <div
-                                aria-hidden={true}
-                                aria-label="A popover with more user information"
-                                id="username-popover-comment-3"
-                                role="dialog"
-                              />
                             </div>
                           </div>
                           <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                           >
-                            <button
-                              className="BaseButton-root Timestamp-root"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <time
-                                className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                dateTime="2018-07-06T18:24:00.000Z"
-                                title="2018-07-06T18:24:00.000Z"
-                              >
-                                2018-07-06T18:24:00.000Z
-                              </time>
-                            </button>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                            />
                           </div>
                         </div>
                         <div
-                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                          className="Comment-subBar"
                         >
-                          <div
-                            className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                          />
-                        </div>
-                      </div>
-                      <div
-                        className="Comment-subBar"
-                      >
-                        <button
-                          className="BaseButton-root InReplyTo-button"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
-                          onTouchEnd={[Function]}
-                          type="button"
-                        >
-                          <span
-                            className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
+                          <button
+                            className="BaseButton-root InReplyTo-button"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
                           >
-                            <i
-                              aria-hidden="true"
-                              className="Icon-root Icon-sm InReplyTo-icon"
-                            >
-                              reply
-                            </i>
-                            <span>
-                               
-                            </span>
                             <span
-                              className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                              className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
                             >
-                              In reply to 
-                              <span
-                                className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                              <i
+                                aria-hidden="true"
+                                className="Icon-root Icon-sm InReplyTo-icon"
                               >
-                                Markus
+                                reply
+                              </i>
+                              <span>
+                                 
+                              </span>
+                              <span
+                                className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                              >
+                                In reply to 
+                                <span
+                                  className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                                >
+                                  Markus
+                                </span>
                               </span>
                             </span>
-                          </span>
-                        </button>
-                      </div>
-                      <div
-                        className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                      >
+                          </button>
+                        </div>
                         <div
-                          className="HTMLContent-root coral coral-content coral-comment-content"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Comment Body 3",
-                            }
-                          }
-                        />
-                        <div
-                          className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                         >
                           <div
-                            className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                            className="HTMLContent-root coral coral-content coral-comment-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Comment Body 3",
+                              }
+                            }
+                          />
+                          <div
+                            className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                           >
-                            <button
-                              aria-label="Respect comment by Isabelle"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                              data-testid="comment-reaction-button"
-                              data-variant="flat"
-                              disabled={false}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReactionButton-icon"
-                                >
-                                  thumb_up
-                                </i>
-                              </span>
-                            </button>
-                            <button
-                              aria-label="Reply to comment by Isabelle"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                              data-testid="comment-reply-button"
-                              data-variant="flat"
-                              disabled={false}
-                              id="comments-commentContainer-replyButton-comment-3"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReplyButton-icon"
-                                >
-                                  reply
-                                </i>
-                              </span>
-                            </button>
                             <div
-                              className="Popover-root"
+                              className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                             >
                               <button
-                                aria-controls="permalink-popover-comment-3"
-                                aria-label="Share comment by Isabelle"
+                                aria-label="Respect comment by Isabelle"
                                 aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                data-testid="comment-reaction-button"
                                 data-variant="flat"
                                 disabled={false}
                                 onBlur={[Function]}
@@ -598,49 +545,106 @@ exports[`renders reply list 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                    className="Icon-root Icon-sm ReactionButton-icon"
                                   >
-                                    share
+                                    thumb_up
+                                  </i>
+                                </span>
+                              </button>
+                              <button
+                                aria-label="Reply to comment by Isabelle"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                data-testid="comment-reply-button"
+                                data-variant="flat"
+                                disabled={false}
+                                id="comments-commentContainer-replyButton-comment-3"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReplyButton-icon"
+                                  >
+                                    reply
                                   </i>
                                 </span>
                               </button>
                               <div
-                                aria-hidden={true}
-                                aria-label="A dialog showing a permalink to the comment"
-                                id="permalink-popover-comment-3"
-                                role="dialog"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                          >
-                            <button
-                              aria-label="Report comment by Isabelle"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                              data-testid="comment-report-button"
-                              data-variant="flat"
-                              disabled={false}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                className="Popover-root"
                               >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReportButton-icon"
+                                <button
+                                  aria-controls="permalink-popover-comment-3"
+                                  aria-label="Share comment by Isabelle"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
                                 >
-                                  flag
-                                </i>
-                              </span>
-                            </button>
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                    >
+                                      share
+                                    </i>
+                                  </span>
+                                </button>
+                                <div
+                                  aria-hidden={true}
+                                  aria-label="A dialog showing a permalink to the comment"
+                                  id="permalink-popover-comment-3"
+                                  role="dialog"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                            >
+                              <button
+                                aria-label="Report comment by Isabelle"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                data-testid="comment-report-button"
+                                data-variant="flat"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReportButton-icon"
+                                  >
+                                    flag
+                                  </i>
+                                </span>
+                              </button>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -657,83 +661,111 @@ exports[`renders reply list 1`] = `
         <div
           className="Box-root HorizontalGutter-root HorizontalGutter-full"
         >
-          <div
-            aria-labelledby="comment-comment-4-label"
-            className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-            data-key-stop={true}
-            data-testid="comment-comment-4"
-            id="comment-comment-4"
-            onFocus={[Function]}
-            role="article"
-            tabIndex={-1}
-          >
+          <div>
             <div
-              className="Hidden-root"
-              id="comment-comment-4-label"
-            >
-              <span>
-                Thread Level 2:
-              </span>
-               
-              <span>
-                Reply from Isabelle 
-                <time
-                  className="RelativeTime-root"
-                  dateTime="2018-07-06T18:24:00.000Z"
-                  title="2018-07-06T18:24:00.000Z"
-                >
-                  2018-07-06T18:24:00.000Z
-                </time>
-              </span>
-            </div>
-            <div
-              className="Box-root HorizontalGutter-root HorizontalGutter-full"
+              aria-labelledby="comment-comment-4-label"
+              className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+              data-key-stop={true}
+              data-testid="comment-comment-4"
+              id="comment-comment-4"
+              onFocus={[Function]}
+              role="article"
+              tabIndex={-1}
             >
               <div
-                className="coral coral-comment-collapse-toggle-indent Indent-root"
+                className="Hidden-root"
+                id="comment-comment-4-label"
+              >
+                <span>
+                  Thread Level 2:
+                </span>
+                 
+                <span>
+                  Reply from Isabelle 
+                  <time
+                    className="RelativeTime-root"
+                    dateTime="2018-07-06T18:24:00.000Z"
+                    title="2018-07-06T18:24:00.000Z"
+                  >
+                    2018-07-06T18:24:00.000Z
+                  </time>
+                </span>
+              </div>
+              <div
+                className="Box-root HorizontalGutter-root HorizontalGutter-full"
               >
                 <div
-                  className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level2 coral coral-indent coral-indent-2 Indent-open Indent-openPadded"
+                  className="coral coral-comment-collapse-toggle-indent Indent-root"
                 >
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                    className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level2 coral coral-indent coral-indent-2 Indent-open Indent-openPadded"
                   >
-                    <button
-                      aria-label="Collapse comment thread"
-                      className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onMouseOut={[Function]}
-                      onMouseOver={[Function]}
-                      onTouchEnd={[Function]}
-                      type="button"
-                    >
-                      <i
-                        aria-hidden="true"
-                        className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                      >
-                        remove
-                      </i>
-                    </button>
                     <div
-                      className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                      className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                     >
+                      <button
+                        aria-label="Collapse comment thread"
+                        className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onMouseOut={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        type="button"
+                      >
+                        <i
+                          aria-hidden="true"
+                          className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                        >
+                          remove
+                        </i>
+                      </button>
                       <div
-                        className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                        className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                       >
                         <div
-                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                          className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                         >
                           <div
-                            className="Comment-username"
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                           >
                             <div
-                              className="Popover-root"
+                              className="Comment-username"
+                            >
+                              <div
+                                className="Popover-root"
+                              >
+                                <button
+                                  aria-controls="username-popover-comment-4"
+                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Username-root"
+                                  >
+                                    Isabelle
+                                  </span>
+                                </button>
+                                <div
+                                  aria-hidden={true}
+                                  aria-label="A popover with more user information"
+                                  id="username-popover-comment-4"
+                                  role="dialog"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                             >
                               <button
-                                aria-controls="username-popover-comment-4"
-                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                className="BaseButton-root Timestamp-root"
                                 onBlur={[Function]}
                                 onClick={[Function]}
                                 onFocus={[Function]}
@@ -742,167 +774,84 @@ exports[`renders reply list 1`] = `
                                 onTouchEnd={[Function]}
                                 type="button"
                               >
-                                <span
-                                  className="Username-root"
+                                <time
+                                  className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                  dateTime="2018-07-06T18:24:00.000Z"
+                                  title="2018-07-06T18:24:00.000Z"
                                 >
-                                  Isabelle
-                                </span>
+                                  2018-07-06T18:24:00.000Z
+                                </time>
                               </button>
-                              <div
-                                aria-hidden={true}
-                                aria-label="A popover with more user information"
-                                id="username-popover-comment-4"
-                                role="dialog"
-                              />
                             </div>
                           </div>
                           <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                           >
-                            <button
-                              className="BaseButton-root Timestamp-root"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <time
-                                className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                dateTime="2018-07-06T18:24:00.000Z"
-                                title="2018-07-06T18:24:00.000Z"
-                              >
-                                2018-07-06T18:24:00.000Z
-                              </time>
-                            </button>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                            />
                           </div>
                         </div>
                         <div
-                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                          className="Comment-subBar"
                         >
-                          <div
-                            className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                          />
-                        </div>
-                      </div>
-                      <div
-                        className="Comment-subBar"
-                      >
-                        <button
-                          className="BaseButton-root InReplyTo-button"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onMouseOut={[Function]}
-                          onMouseOver={[Function]}
-                          onTouchEnd={[Function]}
-                          type="button"
-                        >
-                          <span
-                            className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
+                          <button
+                            className="BaseButton-root InReplyTo-button"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
                           >
-                            <i
-                              aria-hidden="true"
-                              className="Icon-root Icon-sm InReplyTo-icon"
-                            >
-                              reply
-                            </i>
-                            <span>
-                               
-                            </span>
                             <span
-                              className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                              className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
                             >
-                              In reply to 
-                              <span
-                                className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                              <i
+                                aria-hidden="true"
+                                className="Icon-root Icon-sm InReplyTo-icon"
                               >
-                                Markus
+                                reply
+                              </i>
+                              <span>
+                                 
+                              </span>
+                              <span
+                                className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                              >
+                                In reply to 
+                                <span
+                                  className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                                >
+                                  Markus
+                                </span>
                               </span>
                             </span>
-                          </span>
-                        </button>
-                      </div>
-                      <div
-                        className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                      >
+                          </button>
+                        </div>
                         <div
-                          className="HTMLContent-root coral coral-content coral-comment-content"
-                          dangerouslySetInnerHTML={
-                            Object {
-                              "__html": "Comment Body 4",
-                            }
-                          }
-                        />
-                        <div
-                          className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                         >
                           <div
-                            className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                            className="HTMLContent-root coral coral-content coral-comment-content"
+                            dangerouslySetInnerHTML={
+                              Object {
+                                "__html": "Comment Body 4",
+                              }
+                            }
+                          />
+                          <div
+                            className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                           >
-                            <button
-                              aria-label="Respect comment by Isabelle"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                              data-testid="comment-reaction-button"
-                              data-variant="flat"
-                              disabled={false}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReactionButton-icon"
-                                >
-                                  thumb_up
-                                </i>
-                              </span>
-                            </button>
-                            <button
-                              aria-label="Reply to comment by Isabelle"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                              data-testid="comment-reply-button"
-                              data-variant="flat"
-                              disabled={false}
-                              id="comments-commentContainer-replyButton-comment-4"
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReplyButton-icon"
-                                >
-                                  reply
-                                </i>
-                              </span>
-                            </button>
                             <div
-                              className="Popover-root"
+                              className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                             >
                               <button
-                                aria-controls="permalink-popover-comment-4"
-                                aria-label="Share comment by Isabelle"
+                                aria-label="Respect comment by Isabelle"
                                 aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                data-testid="comment-reaction-button"
                                 data-variant="flat"
                                 disabled={false}
                                 onBlur={[Function]}
@@ -918,49 +867,106 @@ exports[`renders reply list 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                    className="Icon-root Icon-sm ReactionButton-icon"
                                   >
-                                    share
+                                    thumb_up
+                                  </i>
+                                </span>
+                              </button>
+                              <button
+                                aria-label="Reply to comment by Isabelle"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                data-testid="comment-reply-button"
+                                data-variant="flat"
+                                disabled={false}
+                                id="comments-commentContainer-replyButton-comment-4"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReplyButton-icon"
+                                  >
+                                    reply
                                   </i>
                                 </span>
                               </button>
                               <div
-                                aria-hidden={true}
-                                aria-label="A dialog showing a permalink to the comment"
-                                id="permalink-popover-comment-4"
-                                role="dialog"
-                              />
-                            </div>
-                          </div>
-                          <div
-                            className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                          >
-                            <button
-                              aria-label="Report comment by Isabelle"
-                              aria-pressed={false}
-                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                              data-testid="comment-report-button"
-                              data-variant="flat"
-                              disabled={false}
-                              onBlur={[Function]}
-                              onClick={[Function]}
-                              onFocus={[Function]}
-                              onMouseOut={[Function]}
-                              onMouseOver={[Function]}
-                              onTouchEnd={[Function]}
-                              type="button"
-                            >
-                              <span
-                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                className="Popover-root"
                               >
-                                <i
-                                  aria-hidden="true"
-                                  className="Icon-root Icon-sm ReportButton-icon"
+                                <button
+                                  aria-controls="permalink-popover-comment-4"
+                                  aria-label="Share comment by Isabelle"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
                                 >
-                                  flag
-                                </i>
-                              </span>
-                            </button>
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                    >
+                                      share
+                                    </i>
+                                  </span>
+                                </button>
+                                <div
+                                  aria-hidden={true}
+                                  aria-label="A dialog showing a permalink to the comment"
+                                  id="permalink-popover-comment-4"
+                                  role="dialog"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                            >
+                              <button
+                                aria-label="Report comment by Isabelle"
+                                aria-pressed={false}
+                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                data-testid="comment-report-button"
+                                data-variant="flat"
+                                disabled={false}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onMouseOut={[Function]}
+                                onMouseOver={[Function]}
+                                onTouchEnd={[Function]}
+                                type="button"
+                              >
+                                <span
+                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                >
+                                  <i
+                                    aria-hidden="true"
+                                    className="Icon-root Icon-sm ReportButton-icon"
+                                  >
+                                    flag
+                                  </i>
+                                </span>
+                              </button>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -980,83 +986,111 @@ exports[`renders reply list 1`] = `
   <div
     className="Box-root HorizontalGutter-root HorizontalGutter-full"
   >
-    <div
-      aria-labelledby="comment-comment-5-label"
-      className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-      data-key-stop={true}
-      data-testid="comment-comment-5"
-      id="comment-comment-5"
-      onFocus={[Function]}
-      role="article"
-      tabIndex={-1}
-    >
+    <div>
       <div
-        className="Hidden-root"
-        id="comment-comment-5-label"
-      >
-        <span>
-          Thread Level 1:
-        </span>
-         
-        <span>
-          Reply from Isabelle 
-          <time
-            className="RelativeTime-root"
-            dateTime="2018-07-06T18:24:00.000Z"
-            title="2018-07-06T18:24:00.000Z"
-          >
-            2018-07-06T18:24:00.000Z
-          </time>
-        </span>
-      </div>
-      <div
-        className="Box-root HorizontalGutter-root HorizontalGutter-full"
+        aria-labelledby="comment-comment-5-label"
+        className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+        data-key-stop={true}
+        data-testid="comment-comment-5"
+        id="comment-comment-5"
+        onFocus={[Function]}
+        role="article"
+        tabIndex={-1}
       >
         <div
-          className="coral coral-comment-collapse-toggle-indent Indent-root"
+          className="Hidden-root"
+          id="comment-comment-5-label"
+        >
+          <span>
+            Thread Level 1:
+          </span>
+           
+          <span>
+            Reply from Isabelle 
+            <time
+              className="RelativeTime-root"
+              dateTime="2018-07-06T18:24:00.000Z"
+              title="2018-07-06T18:24:00.000Z"
+            >
+              2018-07-06T18:24:00.000Z
+            </time>
+          </span>
+        </div>
+        <div
+          className="Box-root HorizontalGutter-root HorizontalGutter-full"
         >
           <div
-            className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
+            className="coral coral-comment-collapse-toggle-indent Indent-root"
           >
             <div
-              className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+              className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
             >
-              <button
-                aria-label="Collapse comment thread"
-                className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                onTouchEnd={[Function]}
-                type="button"
-              >
-                <i
-                  aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                >
-                  remove
-                </i>
-              </button>
               <div
-                className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
               >
+                <button
+                  aria-label="Collapse comment thread"
+                  className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  onTouchEnd={[Function]}
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                  >
+                    remove
+                  </i>
+                </button>
                 <div
-                  className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                  className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                 >
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                    className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                   >
                     <div
-                      className="Comment-username"
+                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                     >
                       <div
-                        className="Popover-root"
+                        className="Comment-username"
+                      >
+                        <div
+                          className="Popover-root"
+                        >
+                          <button
+                            aria-controls="username-popover-comment-5"
+                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="Username-root"
+                            >
+                              Isabelle
+                            </span>
+                          </button>
+                          <div
+                            aria-hidden={true}
+                            aria-label="A popover with more user information"
+                            id="username-popover-comment-5"
+                            role="dialog"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                       >
                         <button
-                          aria-controls="username-popover-comment-5"
-                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                          className="BaseButton-root Timestamp-root"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -1065,167 +1099,84 @@ exports[`renders reply list 1`] = `
                           onTouchEnd={[Function]}
                           type="button"
                         >
-                          <span
-                            className="Username-root"
+                          <time
+                            className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                            dateTime="2018-07-06T18:24:00.000Z"
+                            title="2018-07-06T18:24:00.000Z"
                           >
-                            Isabelle
-                          </span>
+                            2018-07-06T18:24:00.000Z
+                          </time>
                         </button>
-                        <div
-                          aria-hidden={true}
-                          aria-label="A popover with more user information"
-                          id="username-popover-comment-5"
-                          role="dialog"
-                        />
                       </div>
                     </div>
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                     >
-                      <button
-                        className="BaseButton-root Timestamp-root"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <time
-                          className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                          dateTime="2018-07-06T18:24:00.000Z"
-                          title="2018-07-06T18:24:00.000Z"
-                        >
-                          2018-07-06T18:24:00.000Z
-                        </time>
-                      </button>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                      />
                     </div>
                   </div>
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                    className="Comment-subBar"
                   >
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                    />
-                  </div>
-                </div>
-                <div
-                  className="Comment-subBar"
-                >
-                  <button
-                    className="BaseButton-root InReplyTo-button"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                    onTouchEnd={[Function]}
-                    type="button"
-                  >
-                    <span
-                      className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
+                    <button
+                      className="BaseButton-root InReplyTo-button"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onMouseOut={[Function]}
+                      onMouseOver={[Function]}
+                      onTouchEnd={[Function]}
+                      type="button"
                     >
-                      <i
-                        aria-hidden="true"
-                        className="Icon-root Icon-sm InReplyTo-icon"
-                      >
-                        reply
-                      </i>
-                      <span>
-                         
-                      </span>
                       <span
-                        className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                        className="Box-root Flex-root coral coral-comment-inReplyTo Flex-flex Flex-alignCenter"
                       >
-                        In reply to 
-                        <span
-                          className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                        <i
+                          aria-hidden="true"
+                          className="Icon-root Icon-sm InReplyTo-icon"
                         >
-                          Markus
+                          reply
+                        </i>
+                        <span>
+                           
+                        </span>
+                        <span
+                          className="InReplyTo-inReplyTo coral coral-comment-inReplyToText"
+                        >
+                          In reply to 
+                          <span
+                            className="InReplyTo-username coral coral-comment-inReplyToUsername"
+                          >
+                            Markus
+                          </span>
                         </span>
                       </span>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                >
+                    </button>
+                  </div>
                   <div
-                    className="HTMLContent-root coral coral-content coral-comment-content"
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "Comment Body 5",
-                      }
-                    }
-                  />
-                  <div
-                    className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
+                    className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                   >
                     <div
-                      className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                      className="HTMLContent-root coral coral-content coral-comment-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "Comment Body 5",
+                        }
+                      }
+                    />
+                    <div
+                      className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                     >
-                      <button
-                        aria-label="Respect comment by Isabelle"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                        data-testid="comment-reaction-button"
-                        data-variant="flat"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReactionButton-icon"
-                          >
-                            thumb_up
-                          </i>
-                        </span>
-                      </button>
-                      <button
-                        aria-label="Reply to comment by Isabelle"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                        data-testid="comment-reply-button"
-                        data-variant="flat"
-                        disabled={false}
-                        id="comments-commentContainer-replyButton-comment-5"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReplyButton-icon"
-                          >
-                            reply
-                          </i>
-                        </span>
-                      </button>
                       <div
-                        className="Popover-root"
+                        className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                       >
                         <button
-                          aria-controls="permalink-popover-comment-5"
-                          aria-label="Share comment by Isabelle"
+                          aria-label="Respect comment by Isabelle"
                           aria-pressed={false}
-                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                          data-testid="comment-reaction-button"
                           data-variant="flat"
                           disabled={false}
                           onBlur={[Function]}
@@ -1241,49 +1192,106 @@ exports[`renders reply list 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm PermalinkButton-icon"
+                              className="Icon-root Icon-sm ReactionButton-icon"
                             >
-                              share
+                              thumb_up
+                            </i>
+                          </span>
+                        </button>
+                        <button
+                          aria-label="Reply to comment by Isabelle"
+                          aria-pressed={false}
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                          data-testid="comment-reply-button"
+                          data-variant="flat"
+                          disabled={false}
+                          id="comments-commentContainer-replyButton-comment-5"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span
+                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ReplyButton-icon"
+                            >
+                              reply
                             </i>
                           </span>
                         </button>
                         <div
-                          aria-hidden={true}
-                          aria-label="A dialog showing a permalink to the comment"
-                          id="permalink-popover-comment-5"
-                          role="dialog"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                    >
-                      <button
-                        aria-label="Report comment by Isabelle"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                        data-testid="comment-report-button"
-                        data-variant="flat"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          className="Popover-root"
                         >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReportButton-icon"
+                          <button
+                            aria-controls="permalink-popover-comment-5"
+                            aria-label="Share comment by Isabelle"
+                            aria-pressed={false}
+                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                            data-variant="flat"
+                            disabled={false}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
                           >
-                            flag
-                          </i>
-                        </span>
-                      </button>
+                            <span
+                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                            >
+                              <i
+                                aria-hidden="true"
+                                className="Icon-root Icon-sm PermalinkButton-icon"
+                              >
+                                share
+                              </i>
+                            </span>
+                          </button>
+                          <div
+                            aria-hidden={true}
+                            aria-label="A dialog showing a permalink to the comment"
+                            id="permalink-popover-comment-5"
+                            role="dialog"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <button
+                          aria-label="Report comment by Isabelle"
+                          aria-pressed={false}
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                          data-testid="comment-report-button"
+                          data-variant="flat"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span
+                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ReportButton-icon"
+                            >
+                              flag
+                            </i>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderStream.spec.tsx.snap
@@ -429,79 +429,107 @@ exports[`renders comment stream 1`] = `
                       <div
                         className="Box-root HorizontalGutter-root AllCommentsTabCommentContainer-borderedCommentNotSeen HorizontalGutter-full"
                       >
-                        <div
-                          aria-labelledby="comment-comment-0-label"
-                          className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-                          data-key-stop={true}
-                          data-testid="comment-comment-0"
-                          id="comment-comment-0"
-                          onFocus={[Function]}
-                          role="article"
-                          tabIndex={-1}
-                        >
+                        <div>
                           <div
-                            className="Hidden-root"
-                            id="comment-comment-0-label"
-                          >
-                            <span>
-                              Comment from Markus 
-                              <time
-                                className="RelativeTime-root"
-                                dateTime="2018-07-06T18:24:00.000Z"
-                                title="2018-07-06T18:24:00.000Z"
-                              >
-                                2018-07-06T18:24:00.000Z
-                              </time>
-                            </span>
-                          </div>
-                          <div
-                            className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                            aria-labelledby="comment-comment-0-label"
+                            className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                            data-key-stop={true}
+                            data-testid="comment-comment-0"
+                            id="comment-comment-0"
+                            onFocus={[Function]}
+                            role="article"
+                            tabIndex={-1}
                           >
                             <div
-                              className="coral coral-comment-collapse-toggle-indent Indent-root"
+                              className="Hidden-root"
+                              id="comment-comment-0-label"
+                            >
+                              <span>
+                                Comment from Markus 
+                                <time
+                                  className="RelativeTime-root"
+                                  dateTime="2018-07-06T18:24:00.000Z"
+                                  title="2018-07-06T18:24:00.000Z"
+                                >
+                                  2018-07-06T18:24:00.000Z
+                                </time>
+                              </span>
+                            </div>
+                            <div
+                              className="Box-root HorizontalGutter-root HorizontalGutter-full"
                             >
                               <div
-                                className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                                className="coral coral-comment-collapse-toggle-indent Indent-root"
                               >
                                 <div
-                                  className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                                  className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                                 >
-                                  <button
-                                    aria-label="Collapse comment thread"
-                                    className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseOut={[Function]}
-                                    onMouseOver={[Function]}
-                                    onTouchEnd={[Function]}
-                                    type="button"
-                                  >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                                    >
-                                      remove
-                                    </i>
-                                  </button>
                                   <div
-                                    className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                                    className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                                   >
+                                    <button
+                                      aria-label="Collapse comment thread"
+                                      className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                      onTouchEnd={[Function]}
+                                      type="button"
+                                    >
+                                      <i
+                                        aria-hidden="true"
+                                        className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                                      >
+                                        remove
+                                      </i>
+                                    </button>
                                     <div
-                                      className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                                      className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                                     >
                                       <div
-                                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                                        className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                                       >
                                         <div
-                                          className="Comment-username"
+                                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                                         >
                                           <div
-                                            className="Popover-root"
+                                            className="Comment-username"
+                                          >
+                                            <div
+                                              className="Popover-root"
+                                            >
+                                              <button
+                                                aria-controls="username-popover-comment-0"
+                                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                                onTouchEnd={[Function]}
+                                                type="button"
+                                              >
+                                                <span
+                                                  className="Username-root"
+                                                >
+                                                  Markus
+                                                </span>
+                                              </button>
+                                              <div
+                                                aria-hidden={true}
+                                                aria-label="A popover with more user information"
+                                                id="username-popover-comment-0"
+                                                role="dialog"
+                                              />
+                                            </div>
+                                          </div>
+                                          <div
+                                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                                           >
                                             <button
-                                              aria-controls="username-popover-comment-0"
-                                              className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                              className="BaseButton-root Timestamp-root"
                                               onBlur={[Function]}
                                               onClick={[Function]}
                                               onFocus={[Function]}
@@ -510,129 +538,46 @@ exports[`renders comment stream 1`] = `
                                               onTouchEnd={[Function]}
                                               type="button"
                                             >
-                                              <span
-                                                className="Username-root"
+                                              <time
+                                                className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                                dateTime="2018-07-06T18:24:00.000Z"
+                                                title="2018-07-06T18:24:00.000Z"
                                               >
-                                                Markus
-                                              </span>
+                                                2018-07-06T18:24:00.000Z
+                                              </time>
                                             </button>
-                                            <div
-                                              aria-hidden={true}
-                                              aria-label="A popover with more user information"
-                                              id="username-popover-comment-0"
-                                              role="dialog"
-                                            />
                                           </div>
                                         </div>
                                         <div
-                                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                                         >
-                                          <button
-                                            className="BaseButton-root Timestamp-root"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseOut={[Function]}
-                                            onMouseOver={[Function]}
-                                            onTouchEnd={[Function]}
-                                            type="button"
-                                          >
-                                            <time
-                                              className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                              dateTime="2018-07-06T18:24:00.000Z"
-                                              title="2018-07-06T18:24:00.000Z"
-                                            >
-                                              2018-07-06T18:24:00.000Z
-                                            </time>
-                                          </button>
+                                          <div
+                                            className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                                          />
                                         </div>
                                       </div>
                                       <div
-                                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                                        className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                                       >
                                         <div
-                                          className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                                        />
-                                      </div>
-                                    </div>
-                                    <div
-                                      className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                                    >
-                                      <div
-                                        className="HTMLContent-root coral coral-content coral-comment-content"
-                                        dangerouslySetInnerHTML={
-                                          Object {
-                                            "__html": "Joining Too",
+                                          className="HTMLContent-root coral coral-content coral-comment-content"
+                                          dangerouslySetInnerHTML={
+                                            Object {
+                                              "__html": "Joining Too",
+                                            }
                                           }
-                                        }
-                                      />
-                                      <div
-                                        className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                                      >
+                                        />
                                         <div
-                                          className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                          className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                                         >
-                                          <button
-                                            aria-label="Respect comment by Markus"
-                                            aria-pressed={false}
-                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                            data-testid="comment-reaction-button"
-                                            data-variant="flat"
-                                            disabled={false}
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseOut={[Function]}
-                                            onMouseOver={[Function]}
-                                            onTouchEnd={[Function]}
-                                            type="button"
-                                          >
-                                            <span
-                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                            >
-                                              <i
-                                                aria-hidden="true"
-                                                className="Icon-root Icon-sm ReactionButton-icon"
-                                              >
-                                                thumb_up
-                                              </i>
-                                            </span>
-                                          </button>
-                                          <button
-                                            aria-label="Reply to comment by Markus"
-                                            aria-pressed={false}
-                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                            data-testid="comment-reply-button"
-                                            data-variant="flat"
-                                            disabled={false}
-                                            id="comments-commentContainer-replyButton-comment-0"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseOut={[Function]}
-                                            onMouseOver={[Function]}
-                                            onTouchEnd={[Function]}
-                                            type="button"
-                                          >
-                                            <span
-                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                            >
-                                              <i
-                                                aria-hidden="true"
-                                                className="Icon-root Icon-sm ReplyButton-icon"
-                                              >
-                                                reply
-                                              </i>
-                                            </span>
-                                          </button>
                                           <div
-                                            className="Popover-root"
+                                            className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                           >
                                             <button
-                                              aria-controls="permalink-popover-comment-0"
-                                              aria-label="Share comment by Markus"
+                                              aria-label="Respect comment by Markus"
                                               aria-pressed={false}
-                                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                              data-testid="comment-reaction-button"
                                               data-variant="flat"
                                               disabled={false}
                                               onBlur={[Function]}
@@ -648,49 +593,106 @@ exports[`renders comment stream 1`] = `
                                               >
                                                 <i
                                                   aria-hidden="true"
-                                                  className="Icon-root Icon-sm PermalinkButton-icon"
+                                                  className="Icon-root Icon-sm ReactionButton-icon"
                                                 >
-                                                  share
+                                                  thumb_up
+                                                </i>
+                                              </span>
+                                            </button>
+                                            <button
+                                              aria-label="Reply to comment by Markus"
+                                              aria-pressed={false}
+                                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                              data-testid="comment-reply-button"
+                                              data-variant="flat"
+                                              disabled={false}
+                                              id="comments-commentContainer-replyButton-comment-0"
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onFocus={[Function]}
+                                              onMouseOut={[Function]}
+                                              onMouseOver={[Function]}
+                                              onTouchEnd={[Function]}
+                                              type="button"
+                                            >
+                                              <span
+                                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                              >
+                                                <i
+                                                  aria-hidden="true"
+                                                  className="Icon-root Icon-sm ReplyButton-icon"
+                                                >
+                                                  reply
                                                 </i>
                                               </span>
                                             </button>
                                             <div
-                                              aria-hidden={true}
-                                              aria-label="A dialog showing a permalink to the comment"
-                                              id="permalink-popover-comment-0"
-                                              role="dialog"
-                                            />
-                                          </div>
-                                        </div>
-                                        <div
-                                          className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                                        >
-                                          <button
-                                            aria-label="Report comment by Markus"
-                                            aria-pressed={false}
-                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                            data-testid="comment-report-button"
-                                            data-variant="flat"
-                                            disabled={false}
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseOut={[Function]}
-                                            onMouseOver={[Function]}
-                                            onTouchEnd={[Function]}
-                                            type="button"
-                                          >
-                                            <span
-                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                              className="Popover-root"
                                             >
-                                              <i
-                                                aria-hidden="true"
-                                                className="Icon-root Icon-sm ReportButton-icon"
+                                              <button
+                                                aria-controls="permalink-popover-comment-0"
+                                                aria-label="Share comment by Markus"
+                                                aria-pressed={false}
+                                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                                data-variant="flat"
+                                                disabled={false}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                                onTouchEnd={[Function]}
+                                                type="button"
                                               >
-                                                flag
-                                              </i>
-                                            </span>
-                                          </button>
+                                                <span
+                                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                                >
+                                                  <i
+                                                    aria-hidden="true"
+                                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                                  >
+                                                    share
+                                                  </i>
+                                                </span>
+                                              </button>
+                                              <div
+                                                aria-hidden={true}
+                                                aria-label="A dialog showing a permalink to the comment"
+                                                id="permalink-popover-comment-0"
+                                                role="dialog"
+                                              />
+                                            </div>
+                                          </div>
+                                          <div
+                                            className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                          >
+                                            <button
+                                              aria-label="Report comment by Markus"
+                                              aria-pressed={false}
+                                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                              data-testid="comment-report-button"
+                                              data-variant="flat"
+                                              disabled={false}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onFocus={[Function]}
+                                              onMouseOut={[Function]}
+                                              onMouseOver={[Function]}
+                                              onTouchEnd={[Function]}
+                                              type="button"
+                                            >
+                                              <span
+                                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                              >
+                                                <i
+                                                  aria-hidden="true"
+                                                  className="Icon-root Icon-sm ReportButton-icon"
+                                                >
+                                                  flag
+                                                </i>
+                                              </span>
+                                            </button>
+                                          </div>
                                         </div>
                                       </div>
                                     </div>
@@ -716,79 +718,120 @@ exports[`renders comment stream 1`] = `
                       <div
                         className="Box-root HorizontalGutter-root HorizontalGutter-full"
                       >
-                        <div
-                          aria-labelledby="comment-comment-from-staff-0-label"
-                          className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-                          data-key-stop={true}
-                          data-testid="comment-comment-from-staff-0"
-                          id="comment-comment-from-staff-0"
-                          onFocus={[Function]}
-                          role="article"
-                          tabIndex={-1}
-                        >
+                        <div>
                           <div
-                            className="Hidden-root"
-                            id="comment-comment-from-staff-0-label"
-                          >
-                            <span>
-                              Comment from Moderator 
-                              <time
-                                className="RelativeTime-root"
-                                dateTime="2018-07-06T18:24:00.000Z"
-                                title="2018-07-06T18:24:00.000Z"
-                              >
-                                2018-07-06T18:24:00.000Z
-                              </time>
-                            </span>
-                          </div>
-                          <div
-                            className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                            aria-labelledby="comment-comment-from-staff-0-label"
+                            className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                            data-key-stop={true}
+                            data-testid="comment-comment-from-staff-0"
+                            id="comment-comment-from-staff-0"
+                            onFocus={[Function]}
+                            role="article"
+                            tabIndex={-1}
                           >
                             <div
-                              className="coral coral-comment-collapse-toggle-indent Indent-root"
+                              className="Hidden-root"
+                              id="comment-comment-from-staff-0-label"
+                            >
+                              <span>
+                                Comment from Moderator 
+                                <time
+                                  className="RelativeTime-root"
+                                  dateTime="2018-07-06T18:24:00.000Z"
+                                  title="2018-07-06T18:24:00.000Z"
+                                >
+                                  2018-07-06T18:24:00.000Z
+                                </time>
+                              </span>
+                            </div>
+                            <div
+                              className="Box-root HorizontalGutter-root HorizontalGutter-full"
                             >
                               <div
-                                className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                                className="coral coral-comment-collapse-toggle-indent Indent-root"
                               >
                                 <div
-                                  className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                                  className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                                 >
-                                  <button
-                                    aria-label="Collapse comment thread"
-                                    className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                                    onBlur={[Function]}
-                                    onClick={[Function]}
-                                    onFocus={[Function]}
-                                    onMouseOut={[Function]}
-                                    onMouseOver={[Function]}
-                                    onTouchEnd={[Function]}
-                                    type="button"
-                                  >
-                                    <i
-                                      aria-hidden="true"
-                                      className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                                    >
-                                      remove
-                                    </i>
-                                  </button>
                                   <div
-                                    className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                                    className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                                   >
+                                    <button
+                                      aria-label="Collapse comment thread"
+                                      className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onMouseOut={[Function]}
+                                      onMouseOver={[Function]}
+                                      onTouchEnd={[Function]}
+                                      type="button"
+                                    >
+                                      <i
+                                        aria-hidden="true"
+                                        className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                                      >
+                                        remove
+                                      </i>
+                                    </button>
                                     <div
-                                      className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                                      className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                                     >
                                       <div
-                                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                                        className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                                       >
                                         <div
-                                          className="Comment-username"
+                                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                                         >
                                           <div
-                                            className="Popover-root"
+                                            className="Comment-username"
                                           >
+                                            <div
+                                              className="Popover-root"
+                                            >
+                                              <button
+                                                aria-controls="username-popover-comment-from-staff-0"
+                                                className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                                onTouchEnd={[Function]}
+                                                type="button"
+                                              >
+                                                <span
+                                                  className="Username-root"
+                                                >
+                                                  Moderator
+                                                </span>
+                                              </button>
+                                              <div
+                                                aria-hidden={true}
+                                                aria-label="A popover with more user information"
+                                                id="username-popover-comment-from-staff-0"
+                                                role="dialog"
+                                              />
+                                            </div>
+                                          </div>
+                                          <div
+                                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                          >
+                                            <div
+                                              className="Box-root Flex-root Comment-tags Flex-flex Flex-alignCenter"
+                                            >
+                                              <div
+                                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                              >
+                                                <span
+                                                  className="Tag-root coral coral-userTag coral-comment-userTag BadgeTagContainer-tag Tag-colorGrey Tag-uppercase"
+                                                >
+                                                  Staff
+                                                </span>
+                                              </div>
+                                            </div>
                                             <button
-                                              aria-controls="username-popover-comment-from-staff-0"
-                                              className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                              className="BaseButton-root Timestamp-root"
                                               onBlur={[Function]}
                                               onClick={[Function]}
                                               onFocus={[Function]}
@@ -797,142 +840,46 @@ exports[`renders comment stream 1`] = `
                                               onTouchEnd={[Function]}
                                               type="button"
                                             >
-                                              <span
-                                                className="Username-root"
+                                              <time
+                                                className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                                dateTime="2018-07-06T18:24:00.000Z"
+                                                title="2018-07-06T18:24:00.000Z"
                                               >
-                                                Moderator
-                                              </span>
+                                                2018-07-06T18:24:00.000Z
+                                              </time>
                                             </button>
-                                            <div
-                                              aria-hidden={true}
-                                              aria-label="A popover with more user information"
-                                              id="username-popover-comment-from-staff-0"
-                                              role="dialog"
-                                            />
                                           </div>
                                         </div>
                                         <div
-                                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                                          className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                                         >
                                           <div
-                                            className="Box-root Flex-root Comment-tags Flex-flex Flex-alignCenter"
-                                          >
-                                            <div
-                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                            >
-                                              <span
-                                                className="Tag-root coral coral-userTag coral-comment-userTag BadgeTagContainer-tag Tag-colorGrey Tag-uppercase"
-                                              >
-                                                Staff
-                                              </span>
-                                            </div>
-                                          </div>
-                                          <button
-                                            className="BaseButton-root Timestamp-root"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseOut={[Function]}
-                                            onMouseOver={[Function]}
-                                            onTouchEnd={[Function]}
-                                            type="button"
-                                          >
-                                            <time
-                                              className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                              dateTime="2018-07-06T18:24:00.000Z"
-                                              title="2018-07-06T18:24:00.000Z"
-                                            >
-                                              2018-07-06T18:24:00.000Z
-                                            </time>
-                                          </button>
+                                            className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                                          />
                                         </div>
                                       </div>
                                       <div
-                                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                                        className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                                       >
                                         <div
-                                          className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                                        />
-                                      </div>
-                                    </div>
-                                    <div
-                                      className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                                    >
-                                      <div
-                                        className="HTMLContent-root coral coral-content coral-comment-content"
-                                        dangerouslySetInnerHTML={
-                                          Object {
-                                            "__html": "Joining Too",
+                                          className="HTMLContent-root coral coral-content coral-comment-content"
+                                          dangerouslySetInnerHTML={
+                                            Object {
+                                              "__html": "Joining Too",
+                                            }
                                           }
-                                        }
-                                      />
-                                      <div
-                                        className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                                      >
+                                        />
                                         <div
-                                          className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                          className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                                         >
-                                          <button
-                                            aria-label="Respect comment by Moderator"
-                                            aria-pressed={false}
-                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                            data-testid="comment-reaction-button"
-                                            data-variant="flat"
-                                            disabled={false}
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseOut={[Function]}
-                                            onMouseOver={[Function]}
-                                            onTouchEnd={[Function]}
-                                            type="button"
-                                          >
-                                            <span
-                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                            >
-                                              <i
-                                                aria-hidden="true"
-                                                className="Icon-root Icon-sm ReactionButton-icon"
-                                              >
-                                                thumb_up
-                                              </i>
-                                            </span>
-                                          </button>
-                                          <button
-                                            aria-label="Reply to comment by Moderator"
-                                            aria-pressed={false}
-                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                            data-testid="comment-reply-button"
-                                            data-variant="flat"
-                                            disabled={false}
-                                            id="comments-commentContainer-replyButton-comment-from-staff-0"
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseOut={[Function]}
-                                            onMouseOver={[Function]}
-                                            onTouchEnd={[Function]}
-                                            type="button"
-                                          >
-                                            <span
-                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                            >
-                                              <i
-                                                aria-hidden="true"
-                                                className="Icon-root Icon-sm ReplyButton-icon"
-                                              >
-                                                reply
-                                              </i>
-                                            </span>
-                                          </button>
                                           <div
-                                            className="Popover-root"
+                                            className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                                           >
                                             <button
-                                              aria-controls="permalink-popover-comment-from-staff-0"
-                                              aria-label="Share comment by Moderator"
+                                              aria-label="Respect comment by Moderator"
                                               aria-pressed={false}
-                                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                              data-testid="comment-reaction-button"
                                               data-variant="flat"
                                               disabled={false}
                                               onBlur={[Function]}
@@ -948,49 +895,106 @@ exports[`renders comment stream 1`] = `
                                               >
                                                 <i
                                                   aria-hidden="true"
-                                                  className="Icon-root Icon-sm PermalinkButton-icon"
+                                                  className="Icon-root Icon-sm ReactionButton-icon"
                                                 >
-                                                  share
+                                                  thumb_up
+                                                </i>
+                                              </span>
+                                            </button>
+                                            <button
+                                              aria-label="Reply to comment by Moderator"
+                                              aria-pressed={false}
+                                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                              data-testid="comment-reply-button"
+                                              data-variant="flat"
+                                              disabled={false}
+                                              id="comments-commentContainer-replyButton-comment-from-staff-0"
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onFocus={[Function]}
+                                              onMouseOut={[Function]}
+                                              onMouseOver={[Function]}
+                                              onTouchEnd={[Function]}
+                                              type="button"
+                                            >
+                                              <span
+                                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                              >
+                                                <i
+                                                  aria-hidden="true"
+                                                  className="Icon-root Icon-sm ReplyButton-icon"
+                                                >
+                                                  reply
                                                 </i>
                                               </span>
                                             </button>
                                             <div
-                                              aria-hidden={true}
-                                              aria-label="A dialog showing a permalink to the comment"
-                                              id="permalink-popover-comment-from-staff-0"
-                                              role="dialog"
-                                            />
-                                          </div>
-                                        </div>
-                                        <div
-                                          className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                                        >
-                                          <button
-                                            aria-label="Report comment by Moderator"
-                                            aria-pressed={false}
-                                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                            data-testid="comment-report-button"
-                                            data-variant="flat"
-                                            disabled={false}
-                                            onBlur={[Function]}
-                                            onClick={[Function]}
-                                            onFocus={[Function]}
-                                            onMouseOut={[Function]}
-                                            onMouseOver={[Function]}
-                                            onTouchEnd={[Function]}
-                                            type="button"
-                                          >
-                                            <span
-                                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                              className="Popover-root"
                                             >
-                                              <i
-                                                aria-hidden="true"
-                                                className="Icon-root Icon-sm ReportButton-icon"
+                                              <button
+                                                aria-controls="permalink-popover-comment-from-staff-0"
+                                                aria-label="Share comment by Moderator"
+                                                aria-pressed={false}
+                                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                                data-variant="flat"
+                                                disabled={false}
+                                                onBlur={[Function]}
+                                                onClick={[Function]}
+                                                onFocus={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
+                                                onTouchEnd={[Function]}
+                                                type="button"
                                               >
-                                                flag
-                                              </i>
-                                            </span>
-                                          </button>
+                                                <span
+                                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                                >
+                                                  <i
+                                                    aria-hidden="true"
+                                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                                  >
+                                                    share
+                                                  </i>
+                                                </span>
+                                              </button>
+                                              <div
+                                                aria-hidden={true}
+                                                aria-label="A dialog showing a permalink to the comment"
+                                                id="permalink-popover-comment-from-staff-0"
+                                                role="dialog"
+                                              />
+                                            </div>
+                                          </div>
+                                          <div
+                                            className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                                          >
+                                            <button
+                                              aria-label="Report comment by Moderator"
+                                              aria-pressed={false}
+                                              className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                              data-testid="comment-report-button"
+                                              data-variant="flat"
+                                              disabled={false}
+                                              onBlur={[Function]}
+                                              onClick={[Function]}
+                                              onFocus={[Function]}
+                                              onMouseOut={[Function]}
+                                              onMouseOver={[Function]}
+                                              onTouchEnd={[Function]}
+                                              type="button"
+                                            >
+                                              <span
+                                                className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                              >
+                                                <i
+                                                  aria-hidden="true"
+                                                  className="Icon-root Icon-sm ReportButton-icon"
+                                                >
+                                                  flag
+                                                </i>
+                                              </span>
+                                            </button>
+                                          </div>
                                         </div>
                                       </div>
                                     </div>
@@ -1007,55 +1011,57 @@ exports[`renders comment stream 1`] = `
                   <div />
                 </div>
               </div>
-              <nav
-                aria-label="Comments Footer"
-                className="CommentsLinks-container coral coral-streamFooter"
-              >
-                <button
-                  className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
-                  data-variant="textUnderlined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
-                  onTouchEnd={[Function]}
-                  title="Go to top of comments"
-                  type="button"
+              <div>
+                <nav
+                  aria-label="Comments Footer"
+                  className="CommentsLinks-container coral coral-streamFooter"
                 >
-                  <i
-                    aria-hidden="true"
-                    className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                  <button
+                    className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
+                    data-variant="textUnderlined"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    onTouchEnd={[Function]}
+                    title="Go to top of comments"
+                    type="button"
                   >
-                    forum
-                  </i>
-                  <span>
-                    Top of comments
-                  </span>
-                </button>
-                <button
-                  className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
-                  data-variant="textUnderlined"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
-                  onTouchEnd={[Function]}
-                  title="Go to top of article"
-                  type="button"
-                >
-                  <i
-                    aria-hidden="true"
-                    className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                    <i
+                      aria-hidden="true"
+                      className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                    >
+                      forum
+                    </i>
+                    <span>
+                      Top of comments
+                    </span>
+                  </button>
+                  <button
+                    className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
+                    data-variant="textUnderlined"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onMouseOut={[Function]}
+                    onMouseOver={[Function]}
+                    onTouchEnd={[Function]}
+                    title="Go to top of article"
+                    type="button"
                   >
-                    description
-                  </i>
-                  <span>
-                    Top of article
-                  </span>
-                </button>
-              </nav>
+                    <i
+                      aria-hidden="true"
+                      className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                    >
+                      description
+                    </i>
+                    <span>
+                      Top of article
+                    </span>
+                  </button>
+                </nav>
+              </div>
             </div>
           </section>
         </div>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/showAllReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/showAllReplies.spec.tsx.snap
@@ -11,83 +11,111 @@ exports[`renders comment stream 1`] = `
   <div
     className="Box-root HorizontalGutter-root HorizontalGutter-full"
   >
-    <div
-      aria-labelledby="comment-comment-1-label"
-      className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-      data-key-stop={true}
-      data-testid="comment-comment-1"
-      id="comment-comment-1"
-      onFocus={[Function]}
-      role="article"
-      tabIndex={-1}
-    >
+    <div>
       <div
-        className="Hidden-root"
-        id="comment-comment-1-label"
-      >
-        <span>
-          Thread Level 1:
-        </span>
-         
-        <span>
-          Comment from Lukas 
-          <time
-            className="RelativeTime-root"
-            dateTime="2018-07-06T18:24:00.000Z"
-            title="2018-07-06T18:24:00.000Z"
-          >
-            2018-07-06T18:24:00.000Z
-          </time>
-        </span>
-      </div>
-      <div
-        className="Box-root HorizontalGutter-root HorizontalGutter-full"
+        aria-labelledby="comment-comment-1-label"
+        className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+        data-key-stop={true}
+        data-testid="comment-comment-1"
+        id="comment-comment-1"
+        onFocus={[Function]}
+        role="article"
+        tabIndex={-1}
       >
         <div
-          className="coral coral-comment-collapse-toggle-indent Indent-root"
+          className="Hidden-root"
+          id="comment-comment-1-label"
+        >
+          <span>
+            Thread Level 1:
+          </span>
+           
+          <span>
+            Comment from Lukas 
+            <time
+              className="RelativeTime-root"
+              dateTime="2018-07-06T18:24:00.000Z"
+              title="2018-07-06T18:24:00.000Z"
+            >
+              2018-07-06T18:24:00.000Z
+            </time>
+          </span>
+        </div>
+        <div
+          className="Box-root HorizontalGutter-root HorizontalGutter-full"
         >
           <div
-            className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
+            className="coral coral-comment-collapse-toggle-indent Indent-root"
           >
             <div
-              className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+              className="CommentContainer-indentedCommentRoot CommentContainer-indented Indent-level1 coral coral-indent coral-indent-1 Indent-open Indent-openPadded"
             >
-              <button
-                aria-label="Collapse comment thread"
-                className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                onBlur={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onMouseOut={[Function]}
-                onMouseOver={[Function]}
-                onTouchEnd={[Function]}
-                type="button"
-              >
-                <i
-                  aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                >
-                  remove
-                </i>
-              </button>
               <div
-                className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
               >
+                <button
+                  aria-label="Collapse comment thread"
+                  className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                  onTouchEnd={[Function]}
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                  >
+                    remove
+                  </i>
+                </button>
                 <div
-                  className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                  className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                 >
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                    className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                   >
                     <div
-                      className="Comment-username"
+                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                     >
                       <div
-                        className="Popover-root"
+                        className="Comment-username"
+                      >
+                        <div
+                          className="Popover-root"
+                        >
+                          <button
+                            aria-controls="username-popover-comment-1"
+                            className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
+                          >
+                            <span
+                              className="Username-root"
+                            >
+                              Lukas
+                            </span>
+                          </button>
+                          <div
+                            aria-hidden={true}
+                            aria-label="A popover with more user information"
+                            id="username-popover-comment-1"
+                            role="dialog"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                       >
                         <button
-                          aria-controls="username-popover-comment-1"
-                          className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                          className="BaseButton-root Timestamp-root"
                           onBlur={[Function]}
                           onClick={[Function]}
                           onFocus={[Function]}
@@ -96,129 +124,46 @@ exports[`renders comment stream 1`] = `
                           onTouchEnd={[Function]}
                           type="button"
                         >
-                          <span
-                            className="Username-root"
+                          <time
+                            className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                            dateTime="2018-07-06T18:24:00.000Z"
+                            title="2018-07-06T18:24:00.000Z"
                           >
-                            Lukas
-                          </span>
+                            2018-07-06T18:24:00.000Z
+                          </time>
                         </button>
-                        <div
-                          aria-hidden={true}
-                          aria-label="A popover with more user information"
-                          id="username-popover-comment-1"
-                          role="dialog"
-                        />
                       </div>
                     </div>
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                      className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                     >
-                      <button
-                        className="BaseButton-root Timestamp-root"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <time
-                          className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                          dateTime="2018-07-06T18:24:00.000Z"
-                          title="2018-07-06T18:24:00.000Z"
-                        >
-                          2018-07-06T18:24:00.000Z
-                        </time>
-                      </button>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                      />
                     </div>
                   </div>
                   <div
-                    className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                    className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                   >
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                    />
-                  </div>
-                </div>
-                <div
-                  className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                >
-                  <div
-                    className="HTMLContent-root coral coral-content coral-comment-content"
-                    dangerouslySetInnerHTML={
-                      Object {
-                        "__html": "What's up?",
+                      className="HTMLContent-root coral coral-content coral-comment-content"
+                      dangerouslySetInnerHTML={
+                        Object {
+                          "__html": "What's up?",
+                        }
                       }
-                    }
-                  />
-                  <div
-                    className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                  >
+                    />
                     <div
-                      className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                      className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                     >
-                      <button
-                        aria-label="Respect comment by Lukas"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                        data-testid="comment-reaction-button"
-                        data-variant="flat"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReactionButton-icon"
-                          >
-                            thumb_up
-                          </i>
-                        </span>
-                      </button>
-                      <button
-                        aria-label="Reply to comment by Lukas"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                        data-testid="comment-reply-button"
-                        data-variant="flat"
-                        disabled={false}
-                        id="comments-commentContainer-replyButton-comment-1"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                        >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReplyButton-icon"
-                          >
-                            reply
-                          </i>
-                        </span>
-                      </button>
                       <div
-                        className="Popover-root"
+                        className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                       >
                         <button
-                          aria-controls="permalink-popover-comment-1"
-                          aria-label="Share comment by Lukas"
+                          aria-label="Respect comment by Lukas"
                           aria-pressed={false}
-                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                          data-testid="comment-reaction-button"
                           data-variant="flat"
                           disabled={false}
                           onBlur={[Function]}
@@ -234,49 +179,106 @@ exports[`renders comment stream 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm PermalinkButton-icon"
+                              className="Icon-root Icon-sm ReactionButton-icon"
                             >
-                              share
+                              thumb_up
+                            </i>
+                          </span>
+                        </button>
+                        <button
+                          aria-label="Reply to comment by Lukas"
+                          aria-pressed={false}
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                          data-testid="comment-reply-button"
+                          data-variant="flat"
+                          disabled={false}
+                          id="comments-commentContainer-replyButton-comment-1"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span
+                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ReplyButton-icon"
+                            >
+                              reply
                             </i>
                           </span>
                         </button>
                         <div
-                          aria-hidden={true}
-                          aria-label="A dialog showing a permalink to the comment"
-                          id="permalink-popover-comment-1"
-                          role="dialog"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                    >
-                      <button
-                        aria-label="Report comment by Lukas"
-                        aria-pressed={false}
-                        className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                        data-testid="comment-report-button"
-                        data-variant="flat"
-                        disabled={false}
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <span
-                          className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          className="Popover-root"
                         >
-                          <i
-                            aria-hidden="true"
-                            className="Icon-root Icon-sm ReportButton-icon"
+                          <button
+                            aria-controls="permalink-popover-comment-1"
+                            aria-label="Share comment by Lukas"
+                            aria-pressed={false}
+                            className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                            data-variant="flat"
+                            disabled={false}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onMouseOut={[Function]}
+                            onMouseOver={[Function]}
+                            onTouchEnd={[Function]}
+                            type="button"
                           >
-                            flag
-                          </i>
-                        </span>
-                      </button>
+                            <span
+                              className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                            >
+                              <i
+                                aria-hidden="true"
+                                className="Icon-root Icon-sm PermalinkButton-icon"
+                              >
+                                share
+                              </i>
+                            </span>
+                          </button>
+                          <div
+                            aria-hidden={true}
+                            aria-label="A dialog showing a permalink to the comment"
+                            id="permalink-popover-comment-1"
+                            role="dialog"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                      >
+                        <button
+                          aria-label="Report comment by Lukas"
+                          aria-pressed={false}
+                          className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                          data-testid="comment-report-button"
+                          data-variant="flat"
+                          disabled={false}
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <span
+                            className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                          >
+                            <i
+                              aria-hidden="true"
+                              className="Icon-root Icon-sm ReportButton-icon"
+                            >
+                              flag
+                            </i>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
@@ -52,79 +52,107 @@ exports[`renders app with comment stream 1`] = `
           <div
             className="Box-root HorizontalGutter-root AllCommentsTabCommentContainer-borderedCommentNotSeen HorizontalGutter-full"
           >
-            <div
-              aria-labelledby="comment-comment-2-label"
-              className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-              data-key-stop={true}
-              data-testid="comment-comment-2"
-              id="comment-comment-2"
-              onFocus={[Function]}
-              role="article"
-              tabIndex={-1}
-            >
+            <div>
               <div
-                className="Hidden-root"
-                id="comment-comment-2-label"
-              >
-                <span>
-                  Comment from Isabelle 
-                  <time
-                    className="RelativeTime-root"
-                    dateTime="2018-07-06T18:24:00.000Z"
-                    title="2018-07-06T18:24:00.000Z"
-                  >
-                    2018-07-06T18:24:00.000Z
-                  </time>
-                </span>
-              </div>
-              <div
-                className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                aria-labelledby="comment-comment-2-label"
+                className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                data-key-stop={true}
+                data-testid="comment-comment-2"
+                id="comment-comment-2"
+                onFocus={[Function]}
+                role="article"
+                tabIndex={-1}
               >
                 <div
-                  className="coral coral-comment-collapse-toggle-indent Indent-root"
+                  className="Hidden-root"
+                  id="comment-comment-2-label"
+                >
+                  <span>
+                    Comment from Isabelle 
+                    <time
+                      className="RelativeTime-root"
+                      dateTime="2018-07-06T18:24:00.000Z"
+                      title="2018-07-06T18:24:00.000Z"
+                    >
+                      2018-07-06T18:24:00.000Z
+                    </time>
+                  </span>
+                </div>
+                <div
+                  className="Box-root HorizontalGutter-root HorizontalGutter-full"
                 >
                   <div
-                    className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                    className="coral coral-comment-collapse-toggle-indent Indent-root"
                   >
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                      className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                     >
-                      <button
-                        aria-label="Collapse comment thread"
-                        className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <i
-                          aria-hidden="true"
-                          className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                        >
-                          remove
-                        </i>
-                      </button>
                       <div
-                        className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                        className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                       >
+                        <button
+                          aria-label="Collapse comment thread"
+                          className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <i
+                            aria-hidden="true"
+                            className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                          >
+                            remove
+                          </i>
+                        </button>
                         <div
-                          className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                          className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                         >
                           <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                            className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                           >
                             <div
-                              className="Comment-username"
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                             >
                               <div
-                                className="Popover-root"
+                                className="Comment-username"
+                              >
+                                <div
+                                  className="Popover-root"
+                                >
+                                  <button
+                                    aria-controls="username-popover-comment-2"
+                                    className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseOut={[Function]}
+                                    onMouseOver={[Function]}
+                                    onTouchEnd={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="Username-root"
+                                    >
+                                      Isabelle
+                                    </span>
+                                  </button>
+                                  <div
+                                    aria-hidden={true}
+                                    aria-label="A popover with more user information"
+                                    id="username-popover-comment-2"
+                                    role="dialog"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                               >
                                 <button
-                                  aria-controls="username-popover-comment-2"
-                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                  className="BaseButton-root Timestamp-root"
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}
@@ -133,129 +161,46 @@ exports[`renders app with comment stream 1`] = `
                                   onTouchEnd={[Function]}
                                   type="button"
                                 >
-                                  <span
-                                    className="Username-root"
+                                  <time
+                                    className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                    dateTime="2018-07-06T18:24:00.000Z"
+                                    title="2018-07-06T18:24:00.000Z"
                                   >
-                                    Isabelle
-                                  </span>
+                                    2018-07-06T18:24:00.000Z
+                                  </time>
                                 </button>
-                                <div
-                                  aria-hidden={true}
-                                  aria-label="A popover with more user information"
-                                  id="username-popover-comment-2"
-                                  role="dialog"
-                                />
                               </div>
                             </div>
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                             >
-                              <button
-                                className="BaseButton-root Timestamp-root"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <time
-                                  className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                  dateTime="2018-07-06T18:24:00.000Z"
-                                  title="2018-07-06T18:24:00.000Z"
-                                >
-                                  2018-07-06T18:24:00.000Z
-                                </time>
-                              </button>
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                              />
                             </div>
                           </div>
                           <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                            className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                           >
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                            />
-                          </div>
-                        </div>
-                        <div
-                          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                        >
-                          <div
-                            className="HTMLContent-root coral coral-content coral-comment-content"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Hey!",
+                              className="HTMLContent-root coral coral-content coral-comment-content"
+                              dangerouslySetInnerHTML={
+                                Object {
+                                  "__html": "Hey!",
+                                }
                               }
-                            }
-                          />
-                          <div
-                            className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                          >
+                            />
                             <div
-                              className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                              className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                             >
-                              <button
-                                aria-label="Respect comment by Isabelle"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                data-testid="comment-reaction-button"
-                                data-variant="flat"
-                                disabled={false}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReactionButton-icon"
-                                  >
-                                    thumb_up
-                                  </i>
-                                </span>
-                              </button>
-                              <button
-                                aria-label="Reply to comment by Isabelle"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                data-testid="comment-reply-button"
-                                data-variant="flat"
-                                disabled={false}
-                                id="comments-commentContainer-replyButton-comment-2"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReplyButton-icon"
-                                  >
-                                    reply
-                                  </i>
-                                </span>
-                              </button>
                               <div
-                                className="Popover-root"
+                                className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                               >
                                 <button
-                                  aria-controls="permalink-popover-comment-2"
-                                  aria-label="Share comment by Isabelle"
+                                  aria-label="Respect comment by Isabelle"
                                   aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                  data-testid="comment-reaction-button"
                                   data-variant="flat"
                                   disabled={false}
                                   onBlur={[Function]}
@@ -271,49 +216,106 @@ exports[`renders app with comment stream 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                      className="Icon-root Icon-sm ReactionButton-icon"
                                     >
-                                      share
+                                      thumb_up
+                                    </i>
+                                  </span>
+                                </button>
+                                <button
+                                  aria-label="Reply to comment by Isabelle"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                  data-testid="comment-reply-button"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  id="comments-commentContainer-replyButton-comment-2"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm ReplyButton-icon"
+                                    >
+                                      reply
                                     </i>
                                   </span>
                                 </button>
                                 <div
-                                  aria-hidden={true}
-                                  aria-label="A dialog showing a permalink to the comment"
-                                  id="permalink-popover-comment-2"
-                                  role="dialog"
-                                />
-                              </div>
-                            </div>
-                            <div
-                              className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                            >
-                              <button
-                                aria-label="Report comment by Isabelle"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                data-testid="comment-report-button"
-                                data-variant="flat"
-                                disabled={false}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  className="Popover-root"
                                 >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReportButton-icon"
+                                  <button
+                                    aria-controls="permalink-popover-comment-2"
+                                    aria-label="Share comment by Isabelle"
+                                    aria-pressed={false}
+                                    className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                    data-variant="flat"
+                                    disabled={false}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseOut={[Function]}
+                                    onMouseOver={[Function]}
+                                    onTouchEnd={[Function]}
+                                    type="button"
                                   >
-                                    flag
-                                  </i>
-                                </span>
-                              </button>
+                                    <span
+                                      className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                    >
+                                      <i
+                                        aria-hidden="true"
+                                        className="Icon-root Icon-sm PermalinkButton-icon"
+                                      >
+                                        share
+                                      </i>
+                                    </span>
+                                  </button>
+                                  <div
+                                    aria-hidden={true}
+                                    aria-label="A dialog showing a permalink to the comment"
+                                    id="permalink-popover-comment-2"
+                                    role="dialog"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                              >
+                                <button
+                                  aria-label="Report comment by Isabelle"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                  data-testid="comment-report-button"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm ReportButton-icon"
+                                    >
+                                      flag
+                                    </i>
+                                  </span>
+                                </button>
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -339,79 +341,107 @@ exports[`renders app with comment stream 1`] = `
           <div
             className="Box-root HorizontalGutter-root HorizontalGutter-full"
           >
-            <div
-              aria-labelledby="comment-comment-3-label"
-              className="CommentContainer-root coral coral-comment coral coral-reacted-0"
-              data-key-stop={true}
-              data-testid="comment-comment-3"
-              id="comment-comment-3"
-              onFocus={[Function]}
-              role="article"
-              tabIndex={-1}
-            >
+            <div>
               <div
-                className="Hidden-root"
-                id="comment-comment-3-label"
-              >
-                <span>
-                  Comment from Isabelle 
-                  <time
-                    className="RelativeTime-root"
-                    dateTime="2018-07-06T18:24:00.000Z"
-                    title="2018-07-06T18:24:00.000Z"
-                  >
-                    2018-07-06T18:24:00.000Z
-                  </time>
-                </span>
-              </div>
-              <div
-                className="Box-root HorizontalGutter-root HorizontalGutter-full"
+                aria-labelledby="comment-comment-3-label"
+                className="CommentContainer-root coral coral-comment coral coral-reacted-0"
+                data-key-stop={true}
+                data-testid="comment-comment-3"
+                id="comment-comment-3"
+                onFocus={[Function]}
+                role="article"
+                tabIndex={-1}
               >
                 <div
-                  className="coral coral-comment-collapse-toggle-indent Indent-root"
+                  className="Hidden-root"
+                  id="comment-comment-3-label"
+                >
+                  <span>
+                    Comment from Isabelle 
+                    <time
+                      className="RelativeTime-root"
+                      dateTime="2018-07-06T18:24:00.000Z"
+                      title="2018-07-06T18:24:00.000Z"
+                    >
+                      2018-07-06T18:24:00.000Z
+                    </time>
+                  </span>
+                </div>
+                <div
+                  className="Box-root HorizontalGutter-root HorizontalGutter-full"
                 >
                   <div
-                    className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
+                    className="coral coral-comment-collapse-toggle-indent Indent-root"
                   >
                     <div
-                      className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
+                      className="CommentContainer-indentedCommentRoot coral coral-indent coral-indent-0 Indent-open"
                     >
-                      <button
-                        aria-label="Collapse comment thread"
-                        className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
-                        onBlur={[Function]}
-                        onClick={[Function]}
-                        onFocus={[Function]}
-                        onMouseOut={[Function]}
-                        onMouseOver={[Function]}
-                        onTouchEnd={[Function]}
-                        type="button"
-                      >
-                        <i
-                          aria-hidden="true"
-                          className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
-                        >
-                          remove
-                        </i>
-                      </button>
                       <div
-                        className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
+                        className="Box-root Flex-root Flex-flex Flex-alignFlexStart gutter Flex-spacing-1"
                       >
+                        <button
+                          aria-label="Collapse comment thread"
+                          className="BaseButton-root IndentedComment-toggleButton coral coral-comment-collapse-toggle"
+                          onBlur={[Function]}
+                          onClick={[Function]}
+                          onFocus={[Function]}
+                          onMouseOut={[Function]}
+                          onMouseOver={[Function]}
+                          onTouchEnd={[Function]}
+                          type="button"
+                        >
+                          <i
+                            aria-hidden="true"
+                            className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                          >
+                            remove
+                          </i>
+                        </button>
                         <div
-                          className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
+                          className="Box-root HorizontalGutter-root Comment-root HorizontalGutter-half"
                         >
                           <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
+                            className="Box-root Flex-root coral coral-comment-topBar Flex-flex Flex-justifySpaceBetween Flex-alignFlexStart Flex-directionRow"
                           >
                             <div
-                              className="Comment-username"
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter"
                             >
                               <div
-                                className="Popover-root"
+                                className="Comment-username"
+                              >
+                                <div
+                                  className="Popover-root"
+                                >
+                                  <button
+                                    aria-controls="username-popover-comment-3"
+                                    className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseOut={[Function]}
+                                    onMouseOver={[Function]}
+                                    onTouchEnd={[Function]}
+                                    type="button"
+                                  >
+                                    <span
+                                      className="Username-root"
+                                    >
+                                      Isabelle
+                                    </span>
+                                  </button>
+                                  <div
+                                    aria-hidden={true}
+                                    aria-label="A popover with more user information"
+                                    id="username-popover-comment-3"
+                                    role="dialog"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
                               >
                                 <button
-                                  aria-controls="username-popover-comment-3"
-                                  className="BaseButton-root CommentContainer-usernameButton coral coral-username coral-comment-username"
+                                  className="BaseButton-root Timestamp-root"
                                   onBlur={[Function]}
                                   onClick={[Function]}
                                   onFocus={[Function]}
@@ -420,129 +450,46 @@ exports[`renders app with comment stream 1`] = `
                                   onTouchEnd={[Function]}
                                   type="button"
                                 >
-                                  <span
-                                    className="Username-root"
+                                  <time
+                                    className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
+                                    dateTime="2018-07-06T18:24:00.000Z"
+                                    title="2018-07-06T18:24:00.000Z"
                                   >
-                                    Isabelle
-                                  </span>
+                                    2018-07-06T18:24:00.000Z
+                                  </time>
                                 </button>
-                                <div
-                                  aria-hidden={true}
-                                  aria-label="A popover with more user information"
-                                  id="username-popover-comment-3"
-                                  role="dialog"
-                                />
                               </div>
                             </div>
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignCenter Flex-directionRow"
+                              className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
                             >
-                              <button
-                                className="BaseButton-root Timestamp-root"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <time
-                                  className="RelativeTime-root Timestamp-text Comment-timestamp coral coral-timestamp coral-comment-timestamp"
-                                  dateTime="2018-07-06T18:24:00.000Z"
-                                  title="2018-07-06T18:24:00.000Z"
-                                >
-                                  2018-07-06T18:24:00.000Z
-                                </time>
-                              </button>
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
+                              />
                             </div>
                           </div>
                           <div
-                            className="Box-root Flex-root Flex-flex Flex-wrap Flex-justifyFlexEnd"
+                            className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
                           >
                             <div
-                              className="Box-root Flex-root Flex-flex Flex-itemGutter Flex-justifyFlexEnd Flex-alignCenter gutter"
-                            />
-                          </div>
-                        </div>
-                        <div
-                          className="Box-root HorizontalGutter-root HorizontalGutter-oneAndAHalf"
-                        >
-                          <div
-                            className="HTMLContent-root coral coral-content coral-comment-content"
-                            dangerouslySetInnerHTML={
-                              Object {
-                                "__html": "Comment Body 3",
+                              className="HTMLContent-root coral coral-content coral-comment-content"
+                              dangerouslySetInnerHTML={
+                                Object {
+                                  "__html": "Comment Body 3",
+                                }
                               }
-                            }
-                          />
-                          <div
-                            className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
-                          >
+                            />
                             <div
-                              className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                              className="Box-root Flex-root coral coral-comment-actionBar Flex-flex Flex-justifySpaceBetween"
                             >
-                              <button
-                                aria-label="Respect comment by Isabelle"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
-                                data-testid="comment-reaction-button"
-                                data-variant="flat"
-                                disabled={false}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReactionButton-icon"
-                                  >
-                                    thumb_up
-                                  </i>
-                                </span>
-                              </button>
-                              <button
-                                aria-label="Reply to comment by Isabelle"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
-                                data-testid="comment-reply-button"
-                                data-variant="flat"
-                                disabled={false}
-                                id="comments-commentContainer-replyButton-comment-3"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
-                                >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReplyButton-icon"
-                                  >
-                                    reply
-                                  </i>
-                                </span>
-                              </button>
                               <div
-                                className="Popover-root"
+                                className="Box-root Flex-root CommentContainer-actionBar Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
                               >
                                 <button
-                                  aria-controls="permalink-popover-comment-3"
-                                  aria-label="Share comment by Isabelle"
+                                  aria-label="Respect comment by Isabelle"
                                   aria-pressed={false}
-                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-reactButton coral-comment-reactButton ReactionButton-button"
+                                  data-testid="comment-reaction-button"
                                   data-variant="flat"
                                   disabled={false}
                                   onBlur={[Function]}
@@ -558,49 +505,106 @@ exports[`renders app with comment stream 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                      className="Icon-root Icon-sm ReactionButton-icon"
                                     >
-                                      share
+                                      thumb_up
+                                    </i>
+                                  </span>
+                                </button>
+                                <button
+                                  aria-label="Reply to comment by Isabelle"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary CommentContainer-actionButton coral coral-comment-replyButton"
+                                  data-testid="comment-reply-button"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  id="comments-commentContainer-replyButton-comment-3"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm ReplyButton-icon"
+                                    >
+                                      reply
                                     </i>
                                   </span>
                                 </button>
                                 <div
-                                  aria-hidden={true}
-                                  aria-label="A dialog showing a permalink to the comment"
-                                  id="permalink-popover-comment-3"
-                                  role="dialog"
-                                />
-                              </div>
-                            </div>
-                            <div
-                              className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
-                            >
-                              <button
-                                aria-label="Report comment by Isabelle"
-                                aria-pressed={false}
-                                className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
-                                data-testid="comment-report-button"
-                                data-variant="flat"
-                                disabled={false}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onMouseOut={[Function]}
-                                onMouseOver={[Function]}
-                                onTouchEnd={[Function]}
-                                type="button"
-                              >
-                                <span
-                                  className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  className="Popover-root"
                                 >
-                                  <i
-                                    aria-hidden="true"
-                                    className="Icon-root Icon-sm ReportButton-icon"
+                                  <button
+                                    aria-controls="permalink-popover-comment-3"
+                                    aria-label="Share comment by Isabelle"
+                                    aria-pressed={false}
+                                    className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-comment-shareButton"
+                                    data-variant="flat"
+                                    disabled={false}
+                                    onBlur={[Function]}
+                                    onClick={[Function]}
+                                    onFocus={[Function]}
+                                    onMouseOut={[Function]}
+                                    onMouseOver={[Function]}
+                                    onTouchEnd={[Function]}
+                                    type="button"
                                   >
-                                    flag
-                                  </i>
-                                </span>
-                              </button>
+                                    <span
+                                      className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                    >
+                                      <i
+                                        aria-hidden="true"
+                                        className="Icon-root Icon-sm PermalinkButton-icon"
+                                      >
+                                        share
+                                      </i>
+                                    </span>
+                                  </button>
+                                  <div
+                                    aria-hidden={true}
+                                    aria-label="A dialog showing a permalink to the comment"
+                                    id="permalink-popover-comment-3"
+                                    role="dialog"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="Box-root Flex-root Flex-flex Flex-halfItemGutter Flex-justifySpaceBetween Flex-alignCenter Flex-directionRow gutter"
+                              >
+                                <button
+                                  aria-label="Report comment by Isabelle"
+                                  aria-pressed={false}
+                                  className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimarySemiBold Button-paddingSizeExtraSmall Button-colorSecondary coral coral-reportButton coral-comment-reportButton"
+                                  data-testid="comment-report-button"
+                                  data-variant="flat"
+                                  disabled={false}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseOut={[Function]}
+                                  onMouseOver={[Function]}
+                                  onTouchEnd={[Function]}
+                                  type="button"
+                                >
+                                  <span
+                                    className="Box-root Flex-root Flex-flex Flex-alignCenter"
+                                  >
+                                    <i
+                                      aria-hidden="true"
+                                      className="Icon-root Icon-sm ReportButton-icon"
+                                    >
+                                      flag
+                                    </i>
+                                  </span>
+                                </button>
+                              </div>
                             </div>
                           </div>
                         </div>
@@ -617,54 +621,56 @@ exports[`renders app with comment stream 1`] = `
       <div />
     </div>
   </div>
-  <nav
-    aria-label="Comments Footer"
-    className="CommentsLinks-container coral coral-streamFooter"
-  >
-    <button
-      className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
-      data-variant="textUnderlined"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-      onTouchEnd={[Function]}
-      title="Go to top of comments"
-      type="button"
+  <div>
+    <nav
+      aria-label="Comments Footer"
+      className="CommentsLinks-container coral coral-streamFooter"
     >
-      <i
-        aria-hidden="true"
-        className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+      <button
+        className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-commentsTopLink"
+        data-variant="textUnderlined"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+        onTouchEnd={[Function]}
+        title="Go to top of comments"
+        type="button"
       >
-        forum
-      </i>
-      <span>
-        Top of comments
-      </span>
-    </button>
-    <button
-      className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
-      data-variant="textUnderlined"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-      onTouchEnd={[Function]}
-      title="Go to top of article"
-      type="button"
-    >
-      <i
-        aria-hidden="true"
-        className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+        <i
+          aria-hidden="true"
+          className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+        >
+          forum
+        </i>
+        <span>
+          Top of comments
+        </span>
+      </button>
+      <button
+        className="BaseButton-root Button-root Button-sizeRegular CommentsLinks-sizeRegular Button-colorRegular CommentsLinks-colorRegular Button-variantTextUnderlined Button-iconLeft CommentsLinks-link coral coral-streamFooter-link coral-streamFooter-articleTopLink"
+        data-variant="textUnderlined"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseOut={[Function]}
+        onMouseOver={[Function]}
+        onTouchEnd={[Function]}
+        title="Go to top of article"
+        type="button"
       >
-        description
-      </i>
-      <span>
-        Top of article
-      </span>
-    </button>
-  </nav>
+        <i
+          aria-hidden="true"
+          className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+        >
+          description
+        </i>
+        <span>
+          Top of article
+        </span>
+      </button>
+    </nav>
+  </div>
 </div>
 `;

--- a/src/core/client/stream/test/comments/stream/closedOrDisabledCommentStream.spec.tsx
+++ b/src/core/client/stream/test/comments/stream/closedOrDisabledCommentStream.spec.tsx
@@ -97,7 +97,7 @@ it("auto close comment stream when story closed at has been reached", async () =
   );
 
   await act(async () => {
-    await jest.advanceTimersByTime(closeIn);
+    jest.advanceTimersByTime(closeIn);
   });
 
   await waitForElement(() =>

--- a/src/core/client/stream/test/comments/stream/closedOrDisabledCommentStream.spec.tsx
+++ b/src/core/client/stream/test/comments/stream/closedOrDisabledCommentStream.spec.tsx
@@ -1,3 +1,4 @@
+import { act } from "react-test-renderer";
 import sinon from "sinon";
 
 import { waitForElement, within } from "coral-framework/testHelpers";
@@ -95,7 +96,9 @@ it("auto close comment stream when story closed at has been reached", async () =
     within(testRenderer.root).getByTestID("comments-allComments-log")
   );
 
-  jest.advanceTimersByTime(closeIn);
+  await act(async () => {
+    await jest.advanceTimersByTime(closeIn);
+  });
 
   await waitForElement(() =>
     within(testRenderer.root).getByText("Story is closed", { exact: false })

--- a/src/core/client/stream/test/comments/stream/editComment.spec.tsx
+++ b/src/core/client/stream/test/comments/stream/editComment.spec.tsx
@@ -100,7 +100,9 @@ it("edit a comment", async () => {
   // Open edit form.
   act(() => within(comment).getByTestID("comment-edit-button").props.onClick());
   expect(within(comment).toJSON()).toMatchSnapshot("edit form");
-  expect(await within(comment).axe()).toHaveNoViolations();
+  await act(async () => {
+    expect(await within(comment).axe()).toHaveNoViolations();
+  });
 
   act(() =>
     testRenderer.root

--- a/src/core/client/ui/components/v2/Popover/Popover.tsx
+++ b/src/core/client/ui/components/v2/Popover/Popover.tsx
@@ -58,7 +58,6 @@ interface PopoverProps {
   eventsEnabled?: PropTypesOf<typeof Popper>["eventsEnabled"];
   positionFixed?: PropTypesOf<typeof Popper>["positionFixed"];
   dark?: boolean;
-  // window: Window;
 }
 
 const Popover: FunctionComponent<PopoverProps> = ({
@@ -74,7 +73,6 @@ const Popover: FunctionComponent<PopoverProps> = ({
   eventsEnabled,
   positionFixed,
   dark,
-  // window,
   ...rest
 }) => {
   const [visibleState, setVisibleState] = useState(false);

--- a/src/core/client/ui/components/v2/Popover/Popover.tsx
+++ b/src/core/client/ui/components/v2/Popover/Popover.tsx
@@ -3,10 +3,10 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { Manager, Popper, Reference } from "react-popper";
 
 import { oncePerFrame } from "coral-common/utils";
+import { useUIContext } from "coral-ui/components/v2/UIContext";
 import { withStyles } from "coral-ui/hocs";
 import { PropTypesOf } from "coral-ui/types";
 
-import withUIContext from "../UIContext/withUIContext";
 import Arrow from "./Arrow";
 
 import styles from "./Popover.css";
@@ -58,7 +58,7 @@ interface PopoverProps {
   eventsEnabled?: PropTypesOf<typeof Popper>["eventsEnabled"];
   positionFixed?: PropTypesOf<typeof Popper>["positionFixed"];
   dark?: boolean;
-  window: Window;
+  // window: Window;
 }
 
 const Popover: FunctionComponent<PopoverProps> = ({
@@ -74,11 +74,12 @@ const Popover: FunctionComponent<PopoverProps> = ({
   eventsEnabled,
   positionFixed,
   dark,
-  window,
+  // window,
   ...rest
 }) => {
   const [visibleState, setVisibleState] = useState(false);
   const [toggledThisFrame, setToggledThisFrame] = useState(false);
+  const { renderWindow: window } = useUIContext();
   const visible =
     controlledVisible !== undefined ? controlledVisible : visibleState;
   const includeArrow =
@@ -187,8 +188,6 @@ const Popover: FunctionComponent<PopoverProps> = ({
   );
 };
 
-const enhanced = withStyles(styles)(
-  withUIContext(({ renderWindow }) => ({ window: renderWindow }))(Popover)
-);
+const enhanced = withStyles(styles)(Popover);
 
 export default enhanced;


### PR DESCRIPTION
## What does this PR do?

These changes mark comments as seen when they are scrolled up and off the screen out of view in both the comment stream and the permalink view. They use the intersection observer to do this. These changes are for https://vmproduct.atlassian.net/browse/CORL-2573.

## What changes to the GraphQL/Database Schema does this PR introduce?

To the local schema, it adds `bottomOfCommentsInView` to know when the bottom has been reached and therefore all comments in view should be marked as read/seen.

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can go to the stream and scroll through comments. See that comments you have scrolled up and off the screen are marked as seen. If you scroll a comment down off the screen, it will not be marked as read. When you get to the bottom of the stream, check that any comments in view are marked as seen. 

Check for the same behavior in the permalink view (Click `Share` on a comment and copy the link to get there). Choose a comment that has many replies to test that comments are also marked as seen when scrolled up and off the screen and when the bottom of the comments is reached, same as in the stream.
 
## How do we deploy this PR?

They will be deployed as part of the virtualized rendering changes, after the story tree backend updates are deployed.
