### PR TITLE
[CORL-2561] Update scraper to also pull section from `meta[itemprop="articleSection"]`

### DIFF
--- a/src/core/server/services/stories/scraper/rules/section.ts
+++ b/src/core/server/services/stories/scraper/rules/section.ts
@@ -7,6 +7,7 @@ export const sectionScraper = (): RuleBundle => ({
   section: [
     // From: http://ogp.me/#type_article
     wrap($jsonld("articleSection")),
+    wrap(($) => $('meta[itemprop="articleSection"]').attr("content")),
     wrap(($) => $('meta[property="article:section"]').attr("content")),
   ],
 });


### PR DESCRIPTION
## What does this PR do?

Update scraper to also pull section from `meta[itemprop="articleSection"]`

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes

## How do I test this PR?

- Pull down multi-site test
- Modify `src/views/story.html` to do `<meta itemprop="articleSection" content="{{ section }}" />` instead of `<meta data-rh="true" property="article:section" content="{{ section }}" />` on line 8
- Set a story to have a section in your `config.json`... i.e. do `"section": "some section thing"`
- Add the multi-site site domain to your allowed domains under a Coral site
- Visit the story you just marked with a section so it's registered in Coral
- In Coral, make a break point on Line 71 of `src/core/server/services/stories/scraper/scraper.ts` in the `parse(...)` method
- Attach to Coral for debugging
- Go to your coral admin to the stories tab
- FInd the story you added a section to, rescrape it
- See that VSCode hits the break point and check that the `metadata.section` is populated and matches the value for `content` that you set.
 
## How do we deploy this PR?

No special considerations.
