### PR TITLE
[6.18.2 HotFix: CORL-2561] Update scraper to also pull section from `meta[itemprop="articleSection"]`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ filter_release: &filter_release
     branches:
       only:
         - main
+        - main-6x
     tags:
       only: /^v.*/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "6.18.1",
+  "version": "6.18.2",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/src/core/server/services/stories/scraper/rules/section.ts
+++ b/src/core/server/services/stories/scraper/rules/section.ts
@@ -7,6 +7,7 @@ export const sectionScraper = (): RuleBundle => ({
   section: [
     // From: http://ogp.me/#type_article
     wrap($jsonld("articleSection")),
+    wrap(($) => $('meta[itemprop="articleSection"]').attr("content")),
     wrap(($) => $('meta[property="article:section"]').attr("content")),
   ],
 });


### PR DESCRIPTION
## What does this PR do?

Update scraper to also pull section from `meta[itemprop="articleSection"]` to be in-line with the schema.org recommendations.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Create a site in multi-site test and set `"section": "some section"` on a story in your `config.json`
- Change `<meta data-rh="true" property="article:section" content="{{ section }}" />` to `<meta itemprop="articleSection" content="{{ section }}" />` in `src/views/story.html`
- Load up the story and make sure its stream is working and hooked up to your local Coral
- Set a break point in `src/core/server/services/scraper/scraper.ts` on line 71 at `log.debug("extracted metadata");` inside the `parse(...)` method
- Head to `Coral admin > Stories` and find your story
- Attach debugger to Coral
- Rescrape the story
- Make sure that the `metadata.section` property is set to the section value you specified in `config.json`
 
## How do we deploy this PR?

This is intended for a 6.18.2 hotfix, so this will be deployed to the `main-6x` branch, built in CI from there and deployed to Docker Hub so that SaaS customers can obtain this fix without updating to 7.0+.
