### PR TITLE
Fix validation on story tree generation jobs so they run with optional/empty inputs

### DIFF
--- a/src/core/server/app/handlers/api/jobStatus.ts
+++ b/src/core/server/app/handlers/api/jobStatus.ts
@@ -64,7 +64,7 @@ export const jobStatusHandler = ({
   const ipLimiter = new RequestLimiter({
     redis,
     ttl: "1m",
-    max: 2,
+    max: 10,
     prefix: "ip",
     config,
   });

--- a/src/core/server/app/router/api/jobStatus.ts
+++ b/src/core/server/app/router/api/jobStatus.ts
@@ -9,7 +9,7 @@ export function createJobStatusRouter(app: AppOptions): Router {
   const router = createAPIRouter();
 
   // Configure job status route.
-  router.get("/", jobStatusHandler(app));
+  router.post("/", jobStatusHandler(app));
 
   return router;
 }

--- a/src/core/server/queue/tasks/regenerateStoryTrees/processor.ts
+++ b/src/core/server/queue/tasks/regenerateStoryTrees/processor.ts
@@ -35,7 +35,7 @@ const RegenerateStoryTreeDataSchema = Joi.object().keys({
   tenantID: Joi.string(),
   jobID: Joi.string(),
   disableCommenting: Joi.boolean(),
-  disableCommentingMessage: Joi.string().optional(),
+  disableCommentingMessage: Joi.string().optional().allow(""),
 });
 
 export const createJobProcessor = (


### PR DESCRIPTION
## What does this PR do?

- Fixes the validation in the `regenerateStoryTrees` job processor queue so that it accepts an empty/undefined string for the `
- Fixes the `/api/jobStatus` endpoint to be `POST` so it can handle a body request when running with HTTPS

## What changes to the GraphQL/Database Schema does this PR introduce?

No changes to schema.

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Start Coral up
- Get an admin token using the `login` endpoint:

    ```
    POST | <YOUR_CORAL_URL>/api/auth/local
    
    Body:
    {
	    "email": "<ADMIN_EMAIL>",
	    "password": "<ADMIN_PASS"
    }
    ```
    
- Use the admin token for the following requests as the authentication `Bearer `

- Issue the following mutation

    ```
    mutation {
      regenerateStoryTrees(input: {
       clientMutationId: "1",
	   disableCommenting: false,
	   disableCommentingMessage: ""
     }) {
        accepted
        jobID
     }
   }
   ```
- Grab the `jobID` it returns, call the following endpoint:

   ```
    POST | <YOUR_CORAL_URL>/api/jobStatus

    Body:
    {
	    "name": "regenerateStoryTrees",
	    "jobID": "<YOUR_JOB_ID_FROM_PREVIOUS_STEP>"
    }
   ```

- If you don't get a progress result, give it a few minutes and try again, it's just prepping the job so it can track progress accurately. It should show a `started` date though with 0 `total` and 0 `percentage` but eventually you'll see something similar to this returned:

    ```
    {
	   "name": "regenerateStoryTrees",
	   "processed": 279175,
	   "total": 793357,
	   "percentage": 35.189076292261866,
	   "started": "Tue, 28 Jun 2022 18:01:06 GMT",
	   "ended": null
    }
    ```
 
## How do we deploy this PR?

- See previous story tree deployment and migration docs for how to use these features.
