### PR TITLE
Fix/corl 2593 spoiler links

### DIFF
--- a/src/core/client/stream/common/HTMLContent/HTMLContent.tsx
+++ b/src/core/client/stream/common/HTMLContent/HTMLContent.tsx
@@ -61,6 +61,8 @@ function registerSpoilerTagHandler(window: Window) {
     el: HTMLElement,
     event: MouseEvent | KeyboardEvent
   ) => {
+    // in case text is a link
+    event.preventDefault();
     if (
       "key" in event &&
       event.key !== " " &&

--- a/src/core/client/stream/shared/htmlContent.css
+++ b/src/core/client/stream/shared/htmlContent.css
@@ -50,7 +50,7 @@ $commentsLinkColorHovered: var(--palette-primary-700);
     opacity: 1;
     color: var(--palette-text-900);
     background-color: transparent;
-    cursor: text;
+    cursor: inherit;
   }
   & :global(.coral-rte-sarcasm) {
     font-family: monospace;


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug where links hidden behind spoiler tags are immediately followed when people click to reveal them.

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. create a comment with a link in it
2. highlight the link and mark it as a spoiler
3. click on the spoiler in the created comment, note that the link is not followed when it is revealed, but can be followed with subsequent clicks (or touches if on mobile)
 
 
## How do we deploy this PR?
No special considerations should be needed.
