### PR TITLE
[CORL-2598]: only traverse after loading more comments if Z key clicked button

### DIFF
--- a/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -302,6 +302,8 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({ loggedIn, storyID }) => {
   const [disableZAction, setDisableZAction] = useState<boolean>(true);
   const [disableUnmarkAction, setDisableUnmarkAction] = useState<boolean>(true);
 
+  const [zKeyClickedButton, setZKeyClickedButton] = useState(false);
+
   const updateButtonStates = useCallback(() => {
     const nextAction = getNextAction(root, relayEnvironment, {
       skipSeen: true,
@@ -439,6 +441,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({ loggedIn, storyID }) => {
             prevOrNextStop.element.focus();
           }
         }
+        setZKeyClickedButton(true);
         stop.element.click();
       } else {
         void setTraversalFocus({
@@ -561,7 +564,10 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({ loggedIn, storyID }) => {
 
         // after more comments/replies have loaded, we want to traverse
         // to the next comment/reply based on the configuration
-        if (data.keyboardShortcutsConfig) {
+        // zKeyClickedButton keeps track of whether a user just clicked on
+        // a load more, or if Z key did and we want to traverse
+        if (data.keyboardShortcutsConfig && zKeyClickedButton) {
+          setZKeyClickedButton(false);
           traverse(data.keyboardShortcutsConfig);
         }
       }
@@ -575,7 +581,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({ loggedIn, storyID }) => {
     return () => {
       eventEmitter.offAny(listener);
     };
-  }, [eventEmitter, traverse, updateButtonStates]);
+  }, [eventEmitter, traverse, updateButtonStates, zKeyClickedButton]);
 
   // Subscribe to keypress events.
   useEffect(() => {


### PR DESCRIPTION
## What does this PR do?

This addresses an issue where the keyboard shortcuts was overzealously traversing to the next unseen comment after a load more button is clicked (`Show more replies`, `Load more` or `View new comments`). It was traversing even when the button was just clicked, and we want it to only traverse if the button is clicked by the Z key.

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

## How do I test this PR?

Use Z key to interact with the stream. Set traversal focus to a comment. On another tab, create two new replies on different root comments via subscription below that comment with traversal focus. On the first tab, where the new `Show more replies` buttons showed up, click the second/bottom button. See that it reveals the new reply but does NOT affect traversal focus. However, if you then use the Z key, it should still click the topmost `Show more replies` button and reveal its new reply and set traversal focus to that reply.
 
## How do we deploy this PR?

