### PR TITLE
Fix new comment counts not showing on SBN

### DIFF
--- a/src/core/client/count/injectJSONPCallback.ts
+++ b/src/core/client/count/injectJSONPCallback.ts
@@ -45,7 +45,6 @@ function createCountElementEnhancer({
   html,
   count: currentCount,
   id: storyID,
-  showNew,
 }: CountJSONPData) {
   // Get the dataset together for setting properties on the enhancer.
   const dataset: CountElementDataset = {
@@ -58,7 +57,7 @@ function createCountElementEnhancer({
   // Update the innerHTML which contains the count and new value..
   element.innerHTML = html;
 
-  if (storyID && showNew) {
+  if (storyID) {
     const previousCount = getPreviousCount(storyID) ?? 0;
 
     // The new count is the current count subtracted from the previous

--- a/src/core/common/types/count.ts
+++ b/src/core/common/types/count.ts
@@ -3,7 +3,6 @@ export interface CountJSONPData {
   html: string;
   count: number;
   id?: string | null;
-  showNew?: boolean;
 }
 
 export interface PreviousCountData {

--- a/src/core/server/app/handlers/api/story/count.ts
+++ b/src/core/server/app/handlers/api/story/count.ts
@@ -7,15 +7,12 @@ import { MongoContext } from "coral-server/data/context";
 import { retrieveManyStoryRatings } from "coral-server/models/comment";
 import { PUBLISHED_STATUSES } from "coral-server/models/comment/constants";
 import { Story } from "coral-server/models/story";
-import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
+import { Tenant } from "coral-server/models/tenant";
 import { I18n, translate } from "coral-server/services/i18n";
 import { find } from "coral-server/services/stories";
 import { RequestHandler, TenantCoralRequest } from "coral-server/types/express";
 
-import {
-  GQLFEATURE_FLAG,
-  GQLSTORY_MODE,
-} from "coral-server/graph/schema/__generated__/types";
+import { GQLSTORY_MODE } from "coral-server/graph/schema/__generated__/types";
 
 const NUMBER_CLASS_NAME = "coral-count-number";
 const TEXT_CLASS_NAME = "coral-count-text";
@@ -82,16 +79,6 @@ function getCountHTML(
   return html;
 }
 
-function canShowNew(
-  tenant: Readonly<Tenant>,
-  storyMode: GQLSTORY_MODE | undefined | null
-) {
-  return (
-    storyMode === GQLSTORY_MODE.COMMENTS &&
-    hasFeatureFlag(tenant, GQLFEATURE_FLAG.NEW_COMMENT_COUNT)
-  );
-}
-
 /**
  * countHandler returns translated comment counts using JSONP.
  */
@@ -133,7 +120,6 @@ export const countJSONPHandler = ({
       html,
       count,
       id: story?.id || null,
-      showNew: canShowNew(tenant, story?.settings.mode),
     };
 
     // Respond using jsonp.
@@ -178,9 +164,8 @@ export const countHandler = ({
     }
 
     const count = await calculateStoryCount(mongo, story);
-    const showNew = canShowNew(req.coral.tenant, story?.settings.mode);
 
-    return res.json({ count, showNew });
+    return res.json({ count });
   } catch (err) {
     return next(err);
   }


### PR DESCRIPTION
Please ignore that I marked this as CORL-2522, I brain flubbed and used the wrong JIRA identifier.

## What does this PR do?

Remove the showNew that will frequently be false on SBN that isn't really necessary.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes added.

## How do I test this PR?

- Load up multi-site test
- Visit an article with one user
- Leave the article
- With another user, in a different browser (or use Firefox tab containers), post some comments
- With the first user, on the main page (index) of multi-site see that it shows the new comment counts
- For all other other stories, make sure it shows `X Comments / 0 New` or similar
 
## How do we deploy this PR?

No special considerations.
