### PR TITLE
Log story parameters when we upsert a story into mongo

### DIFF
--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -120,9 +120,15 @@ export async function findOrCreate(
   if (wasUpserted) {
     logger.info(
       {
-        storyID: input.id,
-        storyURL: input.url,
-        storyMode: input.mode,
+        upserted: {
+          id: story.id,
+          url: story.url,
+        },
+        input: {
+          id: input.id,
+          url: input.url,
+          mode: input.mode,
+        },
       },
       "story upserted"
     );

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -120,9 +120,9 @@ export async function findOrCreate(
   if (wasUpserted) {
     logger.info(
       {
-        storyID: story.id,
-        storyURL: story.url,
-        siteID: story.siteID,
+        storyID: input.id,
+        storyURL: input.url,
+        storyMode: input.mode,
       },
       "story upserted"
     );

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -1,4 +1,3 @@
-import Logger from "bunyan";
 import { defaultTo, uniq } from "lodash";
 import { DateTime } from "luxon";
 

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -1,3 +1,4 @@
+import Logger from "bunyan";
 import { defaultTo, uniq } from "lodash";
 import { DateTime } from "luxon";
 
@@ -118,6 +119,15 @@ export async function findOrCreate(
   }
 
   if (wasUpserted) {
+    logger.info(
+      {
+        storyID: story.id,
+        storyURL: story.url,
+        siteID: story.siteID,
+      },
+      "story upserted"
+    );
+
     StoryCreatedCoralEvent.publish(broker, {
       storyID: story.id,
       storyURL: story.url,


### PR DESCRIPTION
## What does this PR do?

Logs the story creation parameters when we upsert the story into Mongo during story creation/update.

We will use this to determine if sometimes we're not getting a storyID from certain clients when they call `Coral.createStreamEmbed(...)`.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Start up coral
- Create a new story via lazy story creation (new embed loading for the first time)
- Check your CLI logs for a record message of `story upserted`
- See that it has the `storyID`, `storyURL`, and `siteID` listed in the log parameters
 
## How do we deploy this PR?

No special considerations.
