### PR TITLE
[CORL-2614] Add development host and cdn testing environments to Coral

### DIFF
--- a/dev/cdn/.gitignore
+++ b/dev/cdn/.gitignore
@@ -1,0 +1,4 @@
+output/
+
+.env
+.DS_Store

--- a/dev/cdn/README.md
+++ b/dev/cdn/README.md
@@ -1,0 +1,33 @@
+# CDN Test Suite
+
+This is a useful test CDN for ensuring that the `STATIC_URI` works properly with Coral. In the wild, Coral is serving its static assets (the client js, css, and other assets) via a CDN. This emulates that behavior.
+
+## Initialize the repo
+
+This should have been done when you initialized the upper root Coral repo. If not, at the root of the repository, run:
+
+```
+npm install
+```
+
+## Setting `STATIC_URI`
+
+In your Coral root `.env` file, set the `STATIC_URI` value to `http://localhost:3001`.
+
+Example:
+```
+...
+STATIC_URI=http://localhost:3001
+...
+```
+
+## Changing the port of the CDN
+
+In your Coral root `.env` file, set the `CDN_PORT` value to whatever you want the port to be.
+
+Example for port 7000:
+```
+...
+STATIC_URI=http://localhost:7000
+CDN_PORT=7000
+```

--- a/dev/cdn/build/cdn.esbuild.js
+++ b/dev/cdn/build/cdn.esbuild.js
@@ -1,0 +1,14 @@
+const esbuild = require("esbuild");
+const nativeNodeModulesPlugin = require("./nativeNodeModules");
+
+esbuild.build({
+  entryPoints: ["dev/cdn/src/index.ts"],
+  bundle: true,
+  outdir: "dev/cdn/output/",
+  minify: false,
+  sourcemap: true,
+  platform: "node",
+  target: "esnext",
+  tsconfig: "dev/cdn/tsconfig.json",
+  plugins: [nativeNodeModulesPlugin],
+});

--- a/dev/cdn/build/nativeNodeModules.js
+++ b/dev/cdn/build/nativeNodeModules.js
@@ -1,0 +1,37 @@
+const nativeNodeModulesPlugin = {
+  name: "native-node-modules",
+  setup(build) {
+    // If a ".node" file is imported within a module in the "file" namespace, resolve
+    // it to an absolute path and put it into the "node-file" virtual namespace.
+    build.onResolve({ filter: /\.node$/, namespace: "file" }, (args) => ({
+      path: require.resolve(args.path, { paths: [args.resolveDir] }),
+      namespace: "node-file",
+    }));
+
+    // Files in the "node-file" virtual namespace call "require()" on the
+    // path from esbuild of the ".node" file in the output directory.
+    build.onLoad({ filter: /.*/, namespace: "node-file" }, (args) => ({
+      contents: `
+        import path from ${JSON.stringify(args.path)}
+        try { module.exports = require(path) }
+        catch {}
+      `,
+    }));
+
+    // If a ".node" file is imported within a module in the "node-file" namespace, put
+    // it in the "file" namespace where esbuild's default loading behavior will handle
+    // it. It is already an absolute path since we resolved it to one above.
+    build.onResolve({ filter: /\.node$/, namespace: "node-file" }, (args) => ({
+      path: args.path,
+      namespace: "file",
+    }));
+
+    // Tell esbuild's default loading behavior to use the "file" loader for
+    // these ".node" files.
+    const opts = build.initialOptions;
+    opts.loader = opts.loader || {};
+    opts.loader[".node"] = "file";
+  },
+};
+
+module.exports = nativeNodeModulesPlugin;

--- a/dev/cdn/src/index.ts
+++ b/dev/cdn/src/index.ts
@@ -2,11 +2,11 @@ import Logger from "bunyan";
 import cors from "cors";
 import express from "express";
 
-const PORT = 3001;
+import { config } from "dotenv";
 
 const createLogger = () => {
   return Logger.createLogger({
-    name: "coral-dev-host",
+    name: "coral-dev-cdn",
     src: true,
     level: "debug",
     color: true,
@@ -14,6 +14,10 @@ const createLogger = () => {
 };
 
 const run = () => {
+  config();
+
+  const port = process.env.CDN_PORT ? parseInt(process.env.CDN_PORT, 10) : 3001;
+
   const logger = createLogger();
   const app = express();
 
@@ -25,8 +29,8 @@ const run = () => {
     res.send("coral:fakeCDN");
   });
 
-  app.listen(PORT, () => {
-    logger.info({ port: PORT }, "server is listening");
+  app.listen(port, () => {
+    logger.info({ port }, "server is listening");
   });
 };
 

--- a/dev/cdn/src/index.ts
+++ b/dev/cdn/src/index.ts
@@ -29,7 +29,7 @@ const run = () => {
     res.send("coral:fakeCDN");
   });
 
-  app.listen(port, () => {
+  app.listen(port, "0.0.0.0", () => {
     logger.info({ port }, "server is listening");
   });
 };

--- a/dev/cdn/src/index.ts
+++ b/dev/cdn/src/index.ts
@@ -1,0 +1,33 @@
+import Logger from "bunyan";
+import cors from "cors";
+import express from "express";
+
+const PORT = 3001;
+
+const createLogger = () => {
+  return Logger.createLogger({
+    name: "coral-dev-host",
+    src: true,
+    level: "debug",
+    color: true,
+  });
+};
+
+const run = () => {
+  const logger = createLogger();
+  const app = express();
+
+  app.use(cors());
+
+  app.use("/", express.static("dist/static"));
+
+  app.get("/up", (req, res) => {
+    res.send("coral:fakeCDN");
+  });
+
+  app.listen(PORT, () => {
+    logger.info({ port: PORT }, "server is listening");
+  });
+};
+
+run();

--- a/dev/cdn/tsconfig.json
+++ b/dev/cdn/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "outDir": "./output",
+    "sourceMap": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/dev/host/.gitignore
+++ b/dev/host/.gitignore
@@ -1,0 +1,5 @@
+output/
+
+config.json
+.env
+.DS_Store

--- a/dev/host/README.md
+++ b/dev/host/README.md
@@ -1,0 +1,143 @@
+# Host Site Test Suite
+
+This is a useful test bed for creating multiple sites to host Coral embeds.
+
+## Initialize the repo
+
+This should have been done when you initialized the upper root Coral repo. If not, at the root of the repository, run:
+
+```
+npm install
+```
+
+## Config JSON for your sites
+
+Create a file named `config.json` at the root of your repo. Don't worry, it's already ignored in the `.gitignore`.
+
+Here is an example file with two sites with 2 stories for each site.
+
+```
+{
+  "sites": [
+    {
+      "port": 8000,
+      "coralURL": "http://localhost:3000",
+      "stories": [
+        {
+          "id": "1"
+        },
+        {
+          "id": "2",
+          "mode": "RATINGS_AND_REVIEWS"
+        }
+      ]
+    },
+    {
+      "port": 8001,
+      "coralURL": "http://localhost:3000",
+      "stories": [
+        {
+          "id": "3"
+        },
+        {
+          "id": "4",
+          "mode": "QA"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Testing SSO with a site
+
+You can also login with SSO users when testing with multi-site. An example of a SSO site looks as follows:
+
+```
+    {
+      "port": 8002,
+      "coralURL": "http://localhost:3000",
+      "sso": {
+        "secret": "<YOUR_SSO_SECRET_FROM_CORAL>",
+        "users": [
+          {
+            "id": "5e9e2816-f56e-42e2-a843-23f6b01d97f3",
+            "username": "sso-user",
+            "email": "sso-user@test.com",
+            "role": "COMMENTER"
+          },
+          {
+            "id": "58aa68f4-9435-4166-8147-ed8a2ede7e6b",
+            "username": "sso-user-admin",
+            "email": "sso-user-admin@test.com",
+            "role": "ADMIN"
+          }
+        ]
+      },
+      "stories": [
+        {
+          "id": "d6d44713-e032-406d-8b44-f4a9f53c95d6"
+        }
+      ]
+    }
+```
+
+NOTE: Unless specified in the URL via a URL parameter `userID=<USER_ID>`, the system will use the first SSO user for all requests.
+
+You can append to the story URL like so to specify which SSO user you would like to use.
+
+`http://localhost:8000/story/d6d44713-e032-406d-8b44-f4a9f53c95d6?userID=58aa68f4-9435-4166-8147-ed8a2ede7e6b`
+
+In this example, the story would load with the `sso-user-admin` user instead of the default (first) `sso-user`.
+
+#### SSO Secret
+
+Notice the `sso` section with a secret set to `<YOUR_SSO_SECRET_FROM_CORAL>` and the user details.
+
+To get the `<YOUR_SSO_SECRET_FROM_CORAL>` go to your Coral instance (likely at http://localhost:3000 or http://localhost:8080) and head over to `Configure > Authentication > Login with Single Sign On`.
+
+Enable `Login with Single Sign On` and also check `Allow Registration`.
+
+Copy the `Active` key's `Secret` field and use it for `<YOUR_SSO_SECRET_FROM_CORAL>` in your config.json.
+
+#### SSO User
+
+The user has an `id`, `username`, and `email`. These are all required fields.
+
+The user also has a `role` which can be `COMMENTER`, `MODERATOR`, or `ADMIN` as you choose. If you don't set it, Coral will defaul the user to be a `COMMENTER`.
+
+## Testing custom CSS with a site
+
+Multi-site test supports overriding the `containerClassName` and passing a `customCSSURL` as well as a `customFontsCSSURL` to the embed. If you place your custom CSS files in the `static` folder (try not to commit them though), you'll be able to host them directly from the multi-site-test bed using a URL like `http://localhost:8000/static/<YOUR_CSS_FILE_HERE>.css`.
+
+Example site config in `config.json` setting all 3 parameters:
+
+```
+{
+      "port": 8000,
+      "coralURL": "http://localhost:3000",
+      "customCSSURL": "http://localhost:8000/static/custom.css",
+      "customFontsCSSURL": "http://localhost:8000/static/font.css",
+      "containerClassName": "coral-container",
+      ...
+}
+```
+
+## Start it up
+
+```
+npm run start:host
+```
+
+When it completes, navigate to the URL you set in the `config.json` (likely http://localhost:8000 or similar).
+
+You'll need to run Coral with:
+
+```
+npm run build
+npm run start
+```
+
+NOTE: you can do a debuggable dev build via `build:development` and `start:development`.
+
+NOTE: If you are using `npm run watch` to start up Coral, you can change the `coralURL` to `http://localhost:8080` in your `config.json`.

--- a/dev/host/README.md
+++ b/dev/host/README.md
@@ -123,6 +123,26 @@ Example site config in `config.json` setting all 3 parameters:
 }
 ```
 
+## Testing `STATIC_URI` with a site
+
+If you specify the `STATIC_URI` in your Coral environment variables, you can do so here on the host test bed to ensure you're fully testing the capabilities of a CDN loading Coral onto the page.
+
+To do so, simply set the `STATIC_URI` value via the `staticURI` property on a site in the `config.json`.
+
+```
+{
+  "sites": [
+    {
+      "port": 8000,
+      "coralURL": "http://localhost:3000",
+      "staticURI": "http://localhost:3001", <-- your static URI here
+      "stories": [
+        ...
+      ]
+    }
+}
+```
+
 ## Start it up
 
 ```

--- a/dev/host/README.md
+++ b/dev/host/README.md
@@ -143,6 +143,8 @@ To do so, simply set the `STATIC_URI` value via the `staticURI` property on a si
 }
 ```
 
+NOTE: the value of `http://localhost:3001` is the default CDN value hosted by the testing CDN found under `dev/cdn` in the Coral repo.
+
 ## Start it up
 
 ```

--- a/dev/host/build/host.esbuild.js
+++ b/dev/host/build/host.esbuild.js
@@ -1,0 +1,14 @@
+const esbuild = require("esbuild");
+const nativeNodeModulesPlugin = require("./nativeNodeModules");
+
+esbuild.build({
+  entryPoints: ["dev/host/src/index.ts"],
+  bundle: true,
+  outdir: "dev/host/output/",
+  minify: false,
+  sourcemap: true,
+  platform: "node",
+  target: "esnext",
+  tsconfig: "dev/host/tsconfig.json",
+  plugins: [nativeNodeModulesPlugin],
+});

--- a/dev/host/build/nativeNodeModules.js
+++ b/dev/host/build/nativeNodeModules.js
@@ -1,0 +1,37 @@
+const nativeNodeModulesPlugin = {
+  name: "native-node-modules",
+  setup(build) {
+    // If a ".node" file is imported within a module in the "file" namespace, resolve
+    // it to an absolute path and put it into the "node-file" virtual namespace.
+    build.onResolve({ filter: /\.node$/, namespace: "file" }, (args) => ({
+      path: require.resolve(args.path, { paths: [args.resolveDir] }),
+      namespace: "node-file",
+    }));
+
+    // Files in the "node-file" virtual namespace call "require()" on the
+    // path from esbuild of the ".node" file in the output directory.
+    build.onLoad({ filter: /.*/, namespace: "node-file" }, (args) => ({
+      contents: `
+        import path from ${JSON.stringify(args.path)}
+        try { module.exports = require(path) }
+        catch {}
+      `,
+    }));
+
+    // If a ".node" file is imported within a module in the "node-file" namespace, put
+    // it in the "file" namespace where esbuild's default loading behavior will handle
+    // it. It is already an absolute path since we resolved it to one above.
+    build.onResolve({ filter: /\.node$/, namespace: "node-file" }, (args) => ({
+      path: args.path,
+      namespace: "file",
+    }));
+
+    // Tell esbuild's default loading behavior to use the "file" loader for
+    // these ".node" files.
+    const opts = build.initialOptions;
+    opts.loader = opts.loader || {};
+    opts.loader[".node"] = "file";
+  },
+};
+
+module.exports = nativeNodeModulesPlugin;

--- a/dev/host/src/index.ts
+++ b/dev/host/src/index.ts
@@ -233,7 +233,7 @@ const startServer = async (logger: Logger, site: Site) => {
     res.send(render);
   });
 
-  app.listen(port, () => {
+  app.listen(port, "0.0.0.0", () => {
     logger.info({ port }, "host server is listening");
   });
 };

--- a/dev/host/src/index.ts
+++ b/dev/host/src/index.ts
@@ -1,0 +1,253 @@
+import Logger from "bunyan";
+import cors from "cors";
+import express from "express";
+import { readFileSync } from "fs";
+import jwt from "jsonwebtoken";
+import nunjucks from "nunjucks";
+import { v4 as uuid } from "uuid";
+
+interface Story {
+  id: string;
+  section?: string;
+  mode?: string;
+  amp?: boolean;
+}
+
+interface SSOUser {
+  id: string;
+  username: string;
+  email: string;
+  role?: string;
+}
+
+interface SSOConfig {
+  secret: string;
+  users: SSOUser[];
+}
+
+interface Site {
+  port: number;
+  coralURL: string;
+  stories: Story[];
+  sso?: SSOConfig;
+  customCSSURL?: string;
+  customFontsCSSURL?: string;
+  containerClassName?: string;
+}
+
+interface Config {
+  sites: Site[];
+}
+
+const computeStoryURL = (req: any, story: Story) => {
+  const url = new URL(`/story/${story.id}`, `http://${req.headers.host}`);
+
+  return url;
+};
+
+interface SSOTokenParams {
+  jti: string;
+  user: {
+    id: string;
+    email: string;
+    username: string;
+    role?: string;
+  };
+  iat: number;
+  exp: number;
+}
+
+const createSSOToken = (secret: string, params: SSOTokenParams) => {
+  const payload = {
+    jti: params.jti,
+    iat: params.iat,
+    exp: params.exp,
+    user: params.user,
+  };
+
+  const token = jwt.sign(payload, secret);
+
+  return {
+    token,
+    payload,
+  };
+};
+
+const createIdentifier = (length: number, lettersOnly = false) => {
+  let result = "";
+  const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  for (let i = 0; i < length; i++) {
+    if (i % 2 === 0 && !lettersOnly) {
+      const pick = Math.floor(Math.random() * 10);
+      result += pick;
+    } else {
+      const index = Math.floor(Math.random() * alphabet.length);
+      const pick = alphabet[index];
+
+      result += pick;
+    }
+  }
+
+  return result;
+};
+
+const getUser = (site: Site, userID: string) => {
+  const user = site.sso?.users?.find((u) => u.id === userID);
+  if (!user && site.sso?.users?.length > 0) {
+    return site.sso?.users[0];
+  }
+
+  return user;
+};
+
+const computeIn30DaysSecs = (): number => {
+  const nowSecs = Math.floor(Date.now() / 1000);
+  const i30DaysSecs = 30 * 24 * 60 * 60;
+
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+  const in30Days = nowSecs + i30DaysSecs;
+
+  return in30Days;
+};
+
+const startServer = async (logger: Logger, site: Site) => {
+  const { port, coralURL } = site;
+  const app = express();
+
+  nunjucks.configure("dev/host/src/views", { autoescape: true });
+
+  app.use(cors());
+
+  app.use("/static", express.static("dev/host/static"));
+
+  app.get("/", (req, res) => {
+    const render = nunjucks.render("index.html", {
+      title: `mst:${site.port}`,
+      port: site.port,
+      coralURL: site.coralURL,
+      stories: site.stories.map((s) => {
+        return {
+          url: computeStoryURL(req, s).href,
+          name: `Story ${s.id}`,
+          id: s.id,
+          mode: s.mode ?? "COMMENTS",
+        };
+      }),
+      ssoEnabled: site.sso,
+    });
+    res.send(render);
+  });
+
+  app.get("/ssotoken", (req, res) => {
+    const now = Math.floor(Date.now() / 1000);
+    const in30Days = computeIn30DaysSecs();
+
+    const id = createIdentifier(12);
+    const domain = createIdentifier(8, true);
+
+    const user: SSOUser = {
+      id: uuid(),
+      username: `sso-user-${id}`,
+      email: `sso-user-${id}@${domain}.com`,
+      role: "COMMENTER",
+    };
+
+    const secret = site.sso ? site.sso.secret : "secret";
+    const options = {
+      jti: uuid(),
+      iat: now,
+      exp: in30Days,
+      user,
+    };
+
+    const { token, payload } = createSSOToken(secret, options);
+
+    const render = nunjucks.render("ssotoken.html", {
+      title: `mst:${site.port} - ssoToken`,
+      secret,
+      token,
+      tokenPayload: JSON.stringify(payload, null, 2),
+      iat: new Date(now * 1000).toISOString(),
+      exp: new Date(in30Days * 1000).toISOString(),
+    });
+
+    res.send(render);
+  });
+
+  app.get("/story/:storyID", (req, res) => {
+    const userID = req.query.userID as string;
+    const storyID = req.params.storyID;
+    const story = site.stories.find((s) => s.id === storyID);
+    if (!story) {
+      res.sendStatus(404);
+      return;
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const in30Days = computeIn30DaysSecs();
+
+    const ssoEnabled =
+      site.sso &&
+      site.sso.secret &&
+      site.sso.users &&
+      site.sso.users.length > 0;
+    const user = getUser(site, userID);
+
+    const ssoToken = ssoEnabled
+      ? createSSOToken(site.sso.secret, {
+          jti: uuid(),
+          iat: now,
+          exp: in30Days,
+          user,
+        })
+      : null;
+
+    const coralSrcURL = new URL("/assets/js/embed.js", coralURL);
+    const url = computeStoryURL(req, story);
+
+    const template = story.amp ? "amp.html" : "story.html";
+    const render = nunjucks.render(template, {
+      title: `mst:${port}/stories/${storyID}`,
+      storyID: story.id,
+      url: url.href,
+      coralURL,
+      coralSrcURL: coralSrcURL.href,
+      storyMode: story.mode ?? "COMMENTS",
+      ssoEnabled,
+      ssoUser: user,
+      ssoUsers: site.sso?.users,
+      accessToken: ssoEnabled ? ssoToken.token : undefined,
+      customCSSURL: site.customCSSURL,
+      customFontsCSSURL: site.customFontsCSSURL,
+      containerClassName: site.containerClassName,
+      section: story.section,
+    });
+    res.send(render);
+  });
+
+  app.listen(port, () => {
+    logger.info({ port }, "host server is listening");
+  });
+};
+
+const createLogger = () => {
+  return Logger.createLogger({
+    name: "coral-dev-host",
+    src: true,
+    level: "debug",
+    color: true,
+  });
+};
+
+const run = () => {
+  const logger = createLogger();
+  const configRaw = readFileSync("dev/host/config.json").toString();
+  const config = JSON.parse(configRaw) as Config;
+
+  config.sites.forEach((s) => {
+    startServer(logger, s);
+  });
+};
+
+run();

--- a/dev/host/src/views/amp.html
+++ b/dev/host/src/views/amp.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title }} - AMP</title>
+    {%if section %}
+      <meta data-rh="true" property="article:section" content="{{ section }}" />
+    {% endif %}
+  </head>
+  <body>
+    <amp-iframe
+      width=600
+      height=360
+      layout="responsive"
+      sandbox="allow-scripts allow-same-origin allow-modals allow-popups allow-forms"
+      resizable
+      src="{{ coralURL }}/embed/stream/amp?storyURL={{ url }}"
+    >
+      <div placeholder>Loading...</div>
+      <div overflow tabindex=0 role=button aria-label="Read more">Read more</div></amp-iframe>
+  </body>
+</html>

--- a/dev/host/src/views/index.html
+++ b/dev/host/src/views/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/static/index.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script class="coral-script" src="{{ coralURL }}/assets/js/count.js" defer></script>
+  </head>
+  <body>
+    <h2>Port: {{ port }}</h2>
+
+    {% if ssoEnabled %}
+    <div class="section">
+      <a href="/ssotoken">Create SSO Token</a>
+    </div>
+    {% endif %}
+
+    <div>Coral URL: <a href="{{ coralURL }}">{{ coralURL }}</a></div>
+
+    <h3>Stories:</h3>
+      {% for story in stories %}
+        <div class="item">
+          <div>
+            <a href="{{ story.url }}">{{ story.name }}</a>
+          </div>
+          <div>ID: {{ story.id }}</div>
+          <div>Mode: {{ story.mode }}</div>
+          <div>
+            <span class="coral-count" data-coral-url="{{ story.url }}" data-coral-id="{{ story.id }}"></span>
+          </div>
+        </div>
+      {% else %}
+        <div>No stories found</div>
+      {% endfor %}
+  </body>
+</html>

--- a/dev/host/src/views/index.html
+++ b/dev/host/src/views/index.html
@@ -4,7 +4,7 @@
     <title>{{ title }}</title>
     <link rel="stylesheet" href="/static/index.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script class="coral-script" src="{{ coralURL }}/assets/js/count.js" defer></script>
+    <script class="coral-script" src="{{ countScriptURL }}" type="text/javascript" defer></script>
   </head>
   <body>
     <h2>Port: {{ port }}</h2>

--- a/dev/host/src/views/ssotoken.html
+++ b/dev/host/src/views/ssotoken.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/static/ssouser.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <h2>New SSO Token w/ User</h2>
+    <div class="section"><b>Secret:</b> {{ secret }}</div>
+    <div class="section">
+      <div>
+        <b>Token:</b>
+      </div>
+      <textarea class="tokenTextArea" readonly>
+        {{ token }}
+      </textarea>
+    </div>
+    <div>
+      <b>Payload:</b>
+    </div>
+    <div class="section">
+      <pre><code>{{ tokenPayload }}</code></pre>
+    </div>
+    <div class="section">
+      <div>
+        <b>iat:</b> {{ iat }}
+      </div>
+      <div>
+        <b>exp:</b> {{ exp }}
+      </div>
+    </div>
+  </body>
+</html>

--- a/dev/host/src/views/story.html
+++ b/dev/host/src/views/story.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ title }}</title>
+    <link rel="stylesheet" href="/static/story.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script class="coral-script" src="{{ coralURL }}/assets/js/count.js" defer></script>
+    {%if section %}
+      <meta data-rh="true" property="article:section" content="{{ section }}" />
+    {% endif %}
+  </head>
+  <body>
+    <h2>Story: {{ storyID }}</h2>
+    <div>Story URL: <a href="{{ url }}">{{ url }}</a></div>
+    <div class="section">Coral URL: <a href="{{ coralURL }}">{{ coralURL }}</a></div>
+    {%if ssoEnabled %}
+    <div>Current SSO User: {{ ssoUser.username }} ({{ ssoUser.email }})</div>
+    <div class="section">
+      <div>Current SSO Token:</div>
+      <textarea class="tokenTextArea" readonly>
+        {{ accessToken }}
+      </textarea>
+    </div>
+    <div class="section">
+      <div>Switch SSO User:</div>
+      {% for user in ssoUsers %}
+        <a href="{{ url }}?userID={{ user.id }}">[ {{ user.username }} ]</a>
+      {% else %}
+        <div>No SSO users available</div>
+      {% endfor %}
+    </div>
+    {% endif %}
+    <div></div>
+    <br/>
+    <span class="coral-count" data-coral-url="{{ url }}"></span>
+    <br/><br/>
+    <div id="coral_thread"></div>
+    <script type="text/javascript">
+      (function() {
+          var d = document, s = d.createElement("script");
+          s.src = "{{ coralSrcURL }}";
+          s.async = false;
+          s.defer = true;
+          s.onload = function() {
+              Coral.createStreamEmbed({
+                  id: "coral_thread",
+                  autoRender: true,
+                  {% if ssoEnabled %}
+                  accessToken: "{{ accessToken }}",
+                  {% endif %}
+                  rootURL: "{{ coralURL }}",
+                  storyID: "{{ storyID }}",
+                  storyURL: "{{ url }}",
+                  storyMode: "{{ storyMode }}",
+                  {% if customCSSURL %}
+                  customCSSURL: "{{ customCSSURL }}",
+                  {% endif %}
+                  {% if customFontsCSSURL %}
+                  customFontsCSSURL: "{{ customFontsCSSURL }}",
+                  {% endif %}
+                  {% if containerClassName %}
+                  containerClassName: "{{ containerClassName }}",
+                  {% endif %}
+              });
+          };
+          (d.head || d.body).appendChild(s);
+      })();
+    </script>
+  </body>
+</html>

--- a/dev/host/static/index.css
+++ b/dev/host/static/index.css
@@ -1,0 +1,13 @@
+.section {
+  margin-bottom: 16px;
+}
+
+.item {
+  border-radius: 3px;
+  border-style: solid;
+  border-width: 2px;
+  border-color: lightblue;
+  
+  margin-bottom: 8px;
+  padding: 8px;
+}

--- a/dev/host/static/ssouser.css
+++ b/dev/host/static/ssouser.css
@@ -1,0 +1,8 @@
+.section {
+  margin-bottom: 16px;
+}
+
+.tokenTextArea {
+  min-width: 450px;
+  min-height: 200px;
+}

--- a/dev/host/static/story.css
+++ b/dev/host/static/story.css
@@ -1,0 +1,8 @@
+.section {
+  margin-bottom: 16px;
+}
+
+.tokenTextArea {
+  min-width: 640px;
+  min-height: 100px;
+}

--- a/dev/host/tsconfig.json
+++ b/dev/host/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "outDir": "./output",
+    "sourceMap": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "tscheck:scripts": "tsc --project ./tsconfig.json --noEmit",
     "tscheck:server": "tsc --project ./src/tsconfig.json --noEmit",
     "tscheck": "npm-run-all --parallel tscheck:*",
-    "watch": "NODE_ENV=development ts-node --transpile-only ./scripts/watcher/bin/watcher.ts --config ./config/watcher.ts"
+    "watch": "NODE_ENV=development ts-node --transpile-only ./scripts/watcher/bin/watcher.ts --config ./config/watcher.ts",
+    "start:cdn": "node dev/cdn/build/cdn.esbuild.js && node dev/cdn/output/index.js",
+    "start:host": "node dev/host/build/host.esbuild.js && node dev/host/output/index.js"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -102,6 +104,7 @@
     "dotenv": "^8.2.0",
     "emailjs": "^3.4.0",
     "env-rewrite": "^1.0.2",
+    "esbuild": "^0.14.54",
     "express": "^4.17.1",
     "express-enforces-ssl": "^1.1.0",
     "express-static-gzip": "^2.0.6",

--- a/src/core/client/embed/index.html
+++ b/src/core/client/embed/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Coral – Embed Stream</title>
+    <title>Coral Watch</title>
     <meta charset="utf-8" />
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width" />
@@ -14,30 +14,12 @@
   </head>
 
   <body>
-    <p style="text-align: center;">
-      <a href="/admin">Admin</a> | <a href="/story.html">Story</a> |
-      <a href="/storyButton.html">Story With Button</a> |
-      <a href="http://127.0.0.1:8080/storyAMP.html"> AMP</a>
-    </p>
-    <h1 style="text-align: center">Coral – Embed Stream</h1>
-    <div id="coralStreamEmbed" style="max-width: 640px; margin: 0 auto"></div>
+    Loading...
     <script>
-      const CoralStreamEmbed = Coral.createStreamEmbed({
-        id: "coralStreamEmbed",
-        rootURL: "http://localhost:8080",
-        /**
-         *  You can listen to events.
-         *  The argument passed is the event emitter from
-         *  https://github.com/asyncly/EventEmitter2
-         */
-        events: function(events) {
-          events.onAny(function(eventName, data) {
-            console.debug(eventName, data);
-          });
-        },
-      });
-      window.CoralStreamEmbed = CoralStreamEmbed;
-      CoralStreamEmbed.render();
+      function redirect() {
+        window.location.href = "http://localhost:8000";
+      }
+      document.addEventListener("DOMContentLoaded", redirect);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## What does this PR do?

Adds a host and CDN test tooling to the Coral repo so we can duplicate production similar behaviour when testing locally with full STATIC_URI, hosted in a separate web app page, while using production builds.

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

Open a terminal:
```
npm run start:cdn
``` 

Create a `config.json` under `dev/host`:

```
{
  "sites": [
    {
      "port": 8000,
      "coralURL": "http://localhost:3000",
      "staticURI": "http://localhost:3001",
      "stories": [
        {
          "id": "67be7381-6233-443f-a568-0f8e696edbc3"
        }
      ]
    }
  ]
}
```

Open another terminal:
```
npm run start:host
```

Set the following environment variables in `.env` file:
```
SIGNING_SECRET=secret
STATIC_URI=http://localhost:3001
```

Open a third terminal:
```
npm run build
npm run start
```

Add `http://localhost:8000` to a site in Coral. (visit http://localhost:3000 to do this)

Visit `http://localhost:8000` and visit the story matching the one you created in the `config.json`.

Use the stream and test things out.

## How do we deploy this PR?

No special considerations.