### PR TITLE
set sentry sample rate to 0.2

### DIFF
--- a/src/core/client/framework/lib/errors/reporter/sentry/sentry.tsx
+++ b/src/core/client/framework/lib/errors/reporter/sentry/sentry.tsx
@@ -67,7 +67,8 @@ export class SentryErrorReporter implements ErrorReporter {
       release: `coral@${process.env.TALK_VERSION}`,
       debug: Boolean(options.offlineDebug),
       transport: options.offlineDebug ? FakeDebugTransport : undefined,
-      whitelistUrls,
+      allowUrls: whitelistUrls,
+      sampleRate: 0.2,
       beforeSend: (event) => {
         // Drop all events if query string includes `fbclid` string
         // See: https://github.com/getsentry/sentry-javascript/issues/1811.

--- a/src/core/server/services/errors/sentry/sentry.ts
+++ b/src/core/server/services/errors/sentry/sentry.ts
@@ -44,6 +44,7 @@ export class SentryErrorReporter extends ErrorReporter {
       dsn,
       release: `coral@${version}`,
       debug: Boolean(options.offlineDebug),
+      sampleRate: 0.2,
       transport: options.offlineDebug ? FakeDebugTransport : undefined,
       integrations: [
         ...Sentry.defaultIntegrations,


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/main/CONTRIBUTING.md

-->

## What does this PR do?

Sets the sample rate for sentry to 20% so we don't blow up the sentry quota. 


## What changes to the GraphQL/Database Schema does this PR introduce?
none

## How do we deploy this PR?
Once deployed, we need to re-enable error reporting on coral through the Sentry admin. 