### PR TITLE
[CORL-2639]: fix Z key going to new replies to new comment subscriptions

### DIFF
--- a/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -792,7 +792,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
               nextUnseenComment.virtuosoIndex === 0)
           ) {
             const rootComment = root.getElementById(
-              computeCommentElementID(nextUnseenComment.rootCommentID!)
+              computeCommentElementID(nextUnseenComment.rootCommentID)
             );
             if (rootComment) {
               setFocusAndMarkSeen(nextUnseenComment.rootCommentID);

--- a/src/core/client/stream/tabs/Comments/Stream/Subscriptions/CommentEnteredSubscription.ts
+++ b/src/core/client/stream/tabs/Comments/Stream/Subscriptions/CommentEnteredSubscription.ts
@@ -163,8 +163,10 @@ function insertReply(
   const replyAncestorID =
     ancestorID || (getReplyAncestorID(comment, depth) as string);
   const ancestorProxy = store.get(replyAncestorID);
-  const allChildCommentsAncestor = ancestorProxy?.getLinkedRecord(
-    "allChildComments"
+  const allChildCommentsAncestor = ancestorProxy?.getOrCreateLinkedRecord(
+    "allChildComments",
+    "allChildComments",
+    []
   );
   if (allChildCommentsAncestor) {
     const allChildEdges =


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue of Z key not finding new replies to new comments that have been loaded in via subscription. It creates `allChildComments` in the `CommentEnteredSubscription` when it doesn't already exist, to ensure that new replies get added to be found in the next unseen comment search.

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Have two comment streams open. Stream 1 should have all comments already read. Add new top-level comments on Stream 2. Press Z key / Next unread to navigate to these new comments on Stream 1. Leave a reply to one of the new comments on Stream 2. On Stream 1, press Z key again and see that you are taken to the new reply(ies) that you left. Test in both Newest first and Oldest first sort.
 
## How do we deploy this PR?

n/a
