### PR TITLE
Optimize tag count resolution via caching

### DIFF
--- a/src/core/server/graph/mutators/Comments.ts
+++ b/src/core/server/graph/mutators/Comments.ts
@@ -2,6 +2,7 @@ import { ERROR_CODES } from "coral-common/errors";
 import { ADDITIONAL_DETAILS_MAX_LENGTH } from "coral-common/helpers/validate";
 import GraphContext from "coral-server/graph/context";
 import { mapFieldsetToErrorCodes } from "coral-server/graph/errors";
+import { hasTag } from "coral-server/models/comment";
 import { addTag, removeTag } from "coral-server/services/comments";
 import {
   createDontAgree,
@@ -36,7 +37,6 @@ import {
   GQLUnfeatureCommentInput,
 } from "coral-server/graph/schema/__generated__/types";
 
-import { hasTag } from "coral-server/models/comment";
 import { validateUserModerationScopes } from "./helpers";
 import { validateMaximumLength, WithoutMutationID } from "./util";
 

--- a/src/core/server/graph/mutators/Comments.ts
+++ b/src/core/server/graph/mutators/Comments.ts
@@ -18,6 +18,7 @@ import {
   createComment,
   editComment,
 } from "coral-server/stacks";
+import { updateTagCommentCounts } from "coral-server/stacks/helpers/updateAllCommentCounts";
 
 import {
   GQLCOMMENT_STATUS,
@@ -205,6 +206,16 @@ export const Comments = (ctx: GraphContext) => ({
         ctx.now
       );
     }
+
+    await updateTagCommentCounts(
+      ctx.tenant.id,
+      comment.storyID,
+      ctx.site!.id,
+      ctx.mongo,
+      ctx.redis,
+      comment.tags.filter((t) => t.type !== GQLTAG.FEATURED),
+      comment.tags
+    );
 
     // Publish that the comment was featured.
     await publishCommentFeatured(ctx.broker, comment);

--- a/src/core/server/graph/mutators/Comments.ts
+++ b/src/core/server/graph/mutators/Comments.ts
@@ -211,7 +211,7 @@ export const Comments = (ctx: GraphContext) => ({
     await updateTagCommentCounts(
       ctx.tenant.id,
       comment.storyID,
-      ctx.site!.id,
+      comment.siteID,
       ctx.mongo,
       ctx.redis,
       // Create a diff where "before" tags does not have a
@@ -248,7 +248,7 @@ export const Comments = (ctx: GraphContext) => ({
       await updateTagCommentCounts(
         ctx.tenant.id,
         comment.storyID,
-        ctx.site!.id,
+        comment.siteID,
         ctx.mongo,
         ctx.redis,
         // Create a diff where "before" has the featured tag,

--- a/src/core/server/graph/mutators/Stories.ts
+++ b/src/core/server/graph/mutators/Stories.ts
@@ -3,6 +3,7 @@ import { isNull, omitBy } from "lodash";
 import { ERROR_CODES } from "coral-common/errors";
 import GraphContext from "coral-server/graph/context";
 import { mapFieldsetToErrorCodes } from "coral-server/graph/errors";
+import { initializeCommentTagCountsForStory } from "coral-server/models/comment";
 import {
   markStoryForArchiving,
   markStoryForUnarchiving,
@@ -41,7 +42,6 @@ import {
   GQLUpdateStorySettingsInput,
 } from "coral-server/graph/schema/__generated__/types";
 
-import { initializeCommentTagCountsForStory } from "coral-server/models/comment";
 import { validateUserModerationScopes } from "./helpers";
 
 export const Stories = (ctx: GraphContext) => ({

--- a/src/core/server/graph/mutators/Stories.ts
+++ b/src/core/server/graph/mutators/Stories.ts
@@ -31,6 +31,7 @@ import {
   GQLCreateStoryInput,
   GQLMergeStoriesInput,
   GQLOpenStoryInput,
+  GQLRefreshStoryCountsInput,
   GQLRemoveStoryExpertInput,
   GQLRemoveStoryInput,
   GQLScrapeStoryInput,
@@ -40,6 +41,7 @@ import {
   GQLUpdateStorySettingsInput,
 } from "coral-server/graph/schema/__generated__/types";
 
+import { initializeCommentTagCountsForStory } from "coral-server/models/comment";
 import { validateUserModerationScopes } from "./helpers";
 
 export const Stories = (ctx: GraphContext) => ({
@@ -187,5 +189,18 @@ export const Stories = (ctx: GraphContext) => ({
     }
 
     return stories;
+  },
+  refreshStoryCounts: async (input: GQLRefreshStoryCountsInput) => {
+    if (input.tags) {
+      const result = await initializeCommentTagCountsForStory(
+        ctx.mongo,
+        ctx.tenant.id,
+        input.storyID
+      );
+
+      return result.story;
+    } else {
+      return await ctx.loaders.Stories.find.load({ id: input.storyID });
+    }
   },
 });

--- a/src/core/server/graph/resolvers/Mutation.ts
+++ b/src/core/server/graph/resolvers/Mutation.ts
@@ -489,4 +489,8 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     comments: await ctx.mutators.Comments.markAsSeen(input),
     clientMutationId: input.clientMutationId,
   }),
+  refreshStoryCounts: async (source, { input }, ctx) => ({
+    story: await ctx.mutators.Stories.refreshStoryCounts(input),
+    clientMutationId: input.clientMutationId,
+  }),
 };

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -8699,6 +8699,35 @@ type MarkCommentsAsSeenPayload {
   comments: [Comment!]!
 }
 
+input RefreshStoryCountsInput {
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+
+  """
+  storyID is the story we want to update counts for.
+  """
+  storyID: String!
+
+  """
+  tags if true will update the tag counts for the story.
+  """
+  tags: Boolean!
+}
+
+type RefreshStoryCountsPayload {
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+
+  """
+  story is the story that was updated.
+  """
+  story: Story
+}
+
 ##################
 ## Mutation
 ##################
@@ -9382,6 +9411,13 @@ type Mutation {
   markCommentsAsSeen(
     input: MarkCommentsAsSeenInput!
   ): MarkCommentsAsSeenPayload!
+
+  """
+  refreshStoryCounts will recompute the cached counts for a story based on
+  which flags are set to recompute in the operation input.
+  """
+  refreshStoryCounts(input: RefreshStoryCountsInput!): RefreshStoryCountsPayload!
+    @auth(roles: [ADMIN])
 }
 
 ##################

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -1091,6 +1091,25 @@ export async function retrieveStoryCommentTagCounts(
   });
 }
 
+export async function initializeCommentTagCountsForStory(
+  mongo: MongoContext,
+  tenantID: string,
+  storyID: string
+) {
+  const story = await retrieveStory(mongo, tenantID, storyID);
+  if (story?.commentCounts.tags) {
+    return;
+  }
+
+  const tagCounts = await retrieveStoryCommentTagCounts(mongo, tenantID, [
+    storyID,
+  ]);
+
+  if (!tagCounts || tagCounts.length < 1) {
+    // TODO: generate the tag counts
+  }
+}
+
 interface StoryCommentTagCounts {
   id: string;
   counts: GQLCommentTagCounts;

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -1149,7 +1149,7 @@ export async function initializeCommentTagCountsForStory(
   }
 
   await mongo.stories().findOneAndUpdate(
-    { id: storyID },
+    { tenantID, id: storyID },
     {
       $set: {
         "commentCounts.tags": {

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -1043,14 +1043,16 @@ export async function retrieveStoryCommentTagCounts(
 ): Promise<GQLCommentTagCounts[]> {
   const stories = await retrieveManyStories(mongo, tenantID, storyIDs);
 
-  const liveStories = stories
-    .filter((s) => s !== null && s !== undefined)
-    .filter((s) => !s?.isArchived && !s?.isArchiving)
-    .map((s) => s?.id) as string[];
-  const archivedStories = stories
-    .filter((s) => s !== null && s !== undefined)
-    .filter((s) => s?.isArchived)
-    .map((s) => s?.id) as string[];
+  const liveStories: string[] = [];
+  const archivedStories: string[] = [];
+
+  for (const s of stories) {
+    if (s !== null && s !== undefined && !s.isArchived && !s.isArchiving) {
+      liveStories.push(s.id);
+    } else if (s !== null && s !== undefined && s.isArchived) {
+      archivedStories.push(s.id);
+    }
+  }
 
   const liveCounts: StoryCommentTagCounts[] =
     liveStories.length > 0
@@ -1096,12 +1098,135 @@ interface StoryCommentTagCounts {
   counts: GQLCommentTagCounts;
 }
 
-async function retrieveStoryCommentTagCountsFromDb(
+interface CompareResult {
+  elapsed: number;
+  value: StoryCommentTagCounts[];
+}
+
+async function retrieveWithCursor(
   mongo: MongoContext,
   tenantID: string,
   storyIDs: ReadonlyArray<string>,
   isArchived: boolean
-): Promise<StoryCommentTagCounts[]> {
+): Promise<CompareResult> {
+  // Build up the $match query.
+  const $match: FilterQuery<Comment> = {
+    tenantID,
+    // ensure we are using the tags.type index, this
+    // currently includes FEATURED and UNANSWERED tags
+    "tags.type": { $exists: true },
+    // Only show published comment's tag counts.
+    status: { $in: PUBLISHED_STATUSES },
+  };
+  if (storyIDs.length > 1) {
+    $match.storyID = { $in: storyIDs };
+  } else {
+    $match.storyID = storyIDs[0];
+  }
+
+  // Get the start time.
+  const timer = createTimer();
+
+  const aggregation = [
+    { $match },
+    { $unwind: "$tags" },
+    {
+      $group: {
+        _id: { tag: "$tags.type", storyID: "$storyID" },
+        total: { $sum: 1 },
+      },
+    },
+  ];
+
+  // Load the counts from the database for this particular tag query.
+  const cursor =
+    isArchived && mongo.archive
+      ? mongo
+          .archivedComments()
+          .aggregate<{
+            _id: { tag: GQLTAG; storyID: string };
+            total: number;
+          }>(aggregation)
+          .batchSize(1001)
+      : mongo
+          .comments()
+          .aggregate<{
+            _id: { tag: GQLTAG; storyID: string };
+            total: number;
+          }>(aggregation)
+          .batchSize(1001);
+
+  const storyCounts = new Map<
+    string,
+    {
+      id: string;
+      counts: {
+        FEATURED: number;
+        UNANSWERED: number;
+        REVIEW: number;
+        QUESTION: number;
+        ADMIN: number;
+        MODERATOR: number;
+        STAFF: number;
+        MEMBER: number;
+        EXPERT: number;
+      };
+    }
+  >();
+
+  while (await cursor.hasNext()) {
+    const tag = await cursor.next();
+    if (!tag) {
+      continue;
+    }
+
+    if (!storyCounts.has(tag._id.storyID)) {
+      storyCounts.set(tag._id.storyID, {
+        id: tag._id.storyID,
+        counts: {
+          FEATURED: 0,
+          UNANSWERED: 0,
+          REVIEW: 0,
+          QUESTION: 0,
+          ADMIN: 0,
+          MODERATOR: 0,
+          STAFF: 0,
+          MEMBER: 0,
+          EXPERT: 0,
+        },
+      });
+    }
+
+    if (storyCounts.has(tag._id.storyID)) {
+      const storyCount = storyCounts.get(tag._id.storyID);
+      if (!storyCount) {
+        continue;
+      }
+
+      storyCount.counts[tag._id.tag] += tag.total;
+    }
+  }
+
+  const result = Array.from(storyCounts.values());
+
+  const elapsed = timer();
+
+  // Logging at the info level here to ensure we track any degrading performance
+  // issues from this query.
+  logger.info({ responseTime: elapsed, filter: $match }, "counting tags");
+
+  return {
+    elapsed,
+    value: result,
+  };
+}
+
+async function retrieveWithoutCursor(
+  mongo: MongoContext,
+  tenantID: string,
+  storyIDs: ReadonlyArray<string>,
+  isArchived: boolean
+): Promise<CompareResult> {
   // Build up the $match query.
   const $match: FilterQuery<Comment> = {
     tenantID,
@@ -1146,12 +1271,8 @@ async function retrieveStoryCommentTagCountsFromDb(
   // Get all of the counts.
   const tags = await cursor.toArray();
 
-  // Logging at the info level here to ensure we track any degrading performance
-  // issues from this query.
-  logger.info({ responseTime: timer(), filter: $match }, "counting tags");
-
   // For each of the storyIDs...
-  return storyIDs.map((storyID) => {
+  const result = storyIDs.map((storyID) => {
     // Get the tags associated with this storyID.
     const tagCounts = tags.filter(({ _id }) => _id.storyID === storyID) || [];
 
@@ -1176,6 +1297,44 @@ async function retrieveStoryCommentTagCountsFromDb(
       counts: reducedCounts,
     };
   });
+
+  const elapsed = timer();
+
+  // Logging at the info level here to ensure we track any degrading performance
+  // issues from this query.
+  logger.info({ responseTime: elapsed, filter: $match }, "counting tags");
+
+  return {
+    elapsed,
+    value: result,
+  };
+}
+
+async function retrieveStoryCommentTagCountsFromDb(
+  mongo: MongoContext,
+  tenantID: string,
+  storyIDs: ReadonlyArray<string>,
+  isArchived: boolean
+): Promise<StoryCommentTagCounts[]> {
+  const newRet = await retrieveWithCursor(
+    mongo,
+    tenantID,
+    storyIDs,
+    isArchived
+  );
+  const old = await retrieveWithoutCursor(
+    mongo,
+    tenantID,
+    storyIDs,
+    isArchived
+  );
+
+  logger.info(
+    { newRet: newRet.elapsed, old: old.elapsed },
+    "comparing count scripts"
+  );
+
+  return old.value;
 }
 
 export async function retrieveManyRecentStatusCounts(

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -42,6 +42,7 @@ import { PUBLISHED_STATUSES } from "./constants";
 import {
   CommentCountsPerTag,
   CommentStatusCounts,
+  createEmptyCommentCountsPerTag,
   createEmptyCommentStatusCounts,
 } from "./counts";
 import { hasAncestors } from "./helpers";
@@ -1069,17 +1070,7 @@ export async function retrieveStoryCommentTagCounts(
   return storyIDs.map((id) => {
     const tags = result.get(id);
     if (!tags) {
-      return {
-        [GQLTAG.ADMIN]: 0,
-        [GQLTAG.EXPERT]: 0,
-        [GQLTAG.FEATURED]: 0,
-        [GQLTAG.MEMBER]: 0,
-        [GQLTAG.MODERATOR]: 0,
-        [GQLTAG.QUESTION]: 0,
-        [GQLTAG.REVIEW]: 0,
-        [GQLTAG.STAFF]: 0,
-        [GQLTAG.UNANSWERED]: 0,
-      };
+      return createEmptyCommentCountsPerTag();
     }
 
     return tags;
@@ -1131,17 +1122,7 @@ export async function calculateCommentTagCounts(
     } else if (archivedCount && !isCountEmpty(archivedCount.counts)) {
       return archivedCount.counts;
     } else {
-      return {
-        [GQLTAG.ADMIN]: 0,
-        [GQLTAG.EXPERT]: 0,
-        [GQLTAG.FEATURED]: 0,
-        [GQLTAG.MEMBER]: 0,
-        [GQLTAG.MODERATOR]: 0,
-        [GQLTAG.QUESTION]: 0,
-        [GQLTAG.REVIEW]: 0,
-        [GQLTAG.STAFF]: 0,
-        [GQLTAG.UNANSWERED]: 0,
-      };
+      return createEmptyCommentCountsPerTag();
     }
   });
 }
@@ -1254,17 +1235,7 @@ async function retrieveStoryCommentTagCountsFromDb(
       // Keep this collection of empty tag counts up to date to ensure we
       // provide an accurate model. The type system should warn you if there is
       // missing/extra tags here.
-      {
-        [GQLTAG.ADMIN]: 0,
-        [GQLTAG.EXPERT]: 0,
-        [GQLTAG.FEATURED]: 0,
-        [GQLTAG.MEMBER]: 0,
-        [GQLTAG.MODERATOR]: 0,
-        [GQLTAG.QUESTION]: 0,
-        [GQLTAG.REVIEW]: 0,
-        [GQLTAG.STAFF]: 0,
-        [GQLTAG.UNANSWERED]: 0,
-      }
+      createEmptyCommentCountsPerTag()
     );
 
     return {

--- a/src/core/server/models/comment/counts/counts.ts
+++ b/src/core/server/models/comment/counts/counts.ts
@@ -15,6 +15,7 @@ import {
 import {
   createEmptyCommentModerationQueueCounts,
   createEmptyCommentStatusCounts,
+  createEmptyCommentTagCounts,
   createEmptyRelatedCommentCounts,
 } from "./empty";
 
@@ -157,6 +158,27 @@ export function mergeCommentModerationQueueCount(
     merged.queues.unmoderated += moderationQueue.queues.unmoderated;
     merged.queues.pending += moderationQueue.queues.pending;
     merged.queues.reported += moderationQueue.queues.reported;
+  }
+
+  return merged;
+}
+
+export function mergeCommentTagCounts(
+  ...tags: CommentTagCounts[]
+): CommentTagCounts {
+  const merged = createEmptyCommentTagCounts();
+
+  for (const tagSet of tags) {
+    merged.total += tagSet.total;
+
+    merged.tags.EXPERT += tagSet.tags.EXPERT;
+    merged.tags.FEATURED += tagSet.tags.FEATURED;
+    merged.tags.MEMBER += tagSet.tags.MEMBER;
+    merged.tags.MODERATOR += tagSet.tags.MODERATOR;
+    merged.tags.QUESTION += tagSet.tags.QUESTION;
+    merged.tags.REVIEW += tagSet.tags.REVIEW;
+    merged.tags.STAFF += tagSet.tags.STAFF;
+    merged.tags.UNANSWERED += tagSet.tags.UNANSWERED;
   }
 
   return merged;

--- a/src/core/server/models/comment/counts/counts.ts
+++ b/src/core/server/models/comment/counts/counts.ts
@@ -171,6 +171,7 @@ export function mergeCommentTagCounts(
   for (const tagSet of tags) {
     merged.total += tagSet.total;
 
+    merged.tags.ADMIN += tagSet.tags.ADMIN;
     merged.tags.EXPERT += tagSet.tags.EXPERT;
     merged.tags.FEATURED += tagSet.tags.FEATURED;
     merged.tags.MEMBER += tagSet.tags.MEMBER;

--- a/src/core/server/models/comment/counts/counts.ts
+++ b/src/core/server/models/comment/counts/counts.ts
@@ -7,7 +7,10 @@ import logger from "coral-server/logger";
 import { EncodedCommentActionCounts } from "coral-server/models/action/comment";
 import { PUBLISHED_STATUSES } from "coral-server/models/comment/constants";
 
-import { GQLCOMMENT_STATUS } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLCOMMENT_STATUS,
+  GQLTAG,
+} from "coral-server/graph/schema/__generated__/types";
 
 import {
   createEmptyCommentModerationQueueCounts,
@@ -69,6 +72,24 @@ export interface CommentStatusCounts {
   [GQLCOMMENT_STATUS.SYSTEM_WITHHELD]: number;
 }
 
+export interface CommentTagCounts {
+  total: number;
+
+  tags: CommentCountsPerTag;
+}
+
+export interface CommentCountsPerTag {
+  [GQLTAG.ADMIN]: number;
+  [GQLTAG.EXPERT]: number;
+  [GQLTAG.FEATURED]: number;
+  [GQLTAG.MEMBER]: number;
+  [GQLTAG.MODERATOR]: number;
+  [GQLTAG.QUESTION]: number;
+  [GQLTAG.REVIEW]: number;
+  [GQLTAG.STAFF]: number;
+  [GQLTAG.UNANSWERED]: number;
+}
+
 /**
  * RelatedCommentCounts stores all the Comment Counts that will be stored on
  * each related document (like a Story, or a Site).
@@ -91,6 +112,8 @@ export interface RelatedCommentCounts {
    * ModerationQueue's on this related document.
    */
   moderationQueue: CommentModerationQueueCounts;
+
+  tags: CommentTagCounts;
 }
 
 /**

--- a/src/core/server/models/comment/counts/empty.ts
+++ b/src/core/server/models/comment/counts/empty.ts
@@ -1,9 +1,13 @@
-import { GQLCOMMENT_STATUS } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLCOMMENT_STATUS,
+  GQLTAG,
+} from "coral-server/graph/schema/__generated__/types";
 
 import {
   CommentModerationCountsPerQueue,
   CommentModerationQueueCounts,
   CommentStatusCounts,
+  CommentTagCounts,
   RelatedCommentCounts,
 } from "./counts";
 
@@ -32,10 +36,28 @@ export function createEmptyCommentStatusCounts(): CommentStatusCounts {
   };
 }
 
+export function createEmptyCommentTagCounts(): CommentTagCounts {
+  return {
+    total: 0,
+    tags: {
+      [GQLTAG.ADMIN]: 0,
+      [GQLTAG.EXPERT]: 0,
+      [GQLTAG.FEATURED]: 0,
+      [GQLTAG.MEMBER]: 0,
+      [GQLTAG.MODERATOR]: 0,
+      [GQLTAG.QUESTION]: 0,
+      [GQLTAG.REVIEW]: 0,
+      [GQLTAG.STAFF]: 0,
+      [GQLTAG.UNANSWERED]: 0,
+    },
+  };
+}
+
 export function createEmptyRelatedCommentCounts(): RelatedCommentCounts {
   return {
     action: {},
     status: createEmptyCommentStatusCounts(),
     moderationQueue: createEmptyCommentModerationQueueCounts(),
+    tags: createEmptyCommentTagCounts(),
   };
 }

--- a/src/core/server/models/comment/counts/empty.ts
+++ b/src/core/server/models/comment/counts/empty.ts
@@ -4,6 +4,7 @@ import {
 } from "coral-server/graph/schema/__generated__/types";
 
 import {
+  CommentCountsPerTag,
   CommentModerationCountsPerQueue,
   CommentModerationQueueCounts,
   CommentStatusCounts,
@@ -36,20 +37,24 @@ export function createEmptyCommentStatusCounts(): CommentStatusCounts {
   };
 }
 
+export function createEmptyCommentCountsPerTag(): CommentCountsPerTag {
+  return {
+    [GQLTAG.ADMIN]: 0,
+    [GQLTAG.EXPERT]: 0,
+    [GQLTAG.FEATURED]: 0,
+    [GQLTAG.MEMBER]: 0,
+    [GQLTAG.MODERATOR]: 0,
+    [GQLTAG.QUESTION]: 0,
+    [GQLTAG.REVIEW]: 0,
+    [GQLTAG.STAFF]: 0,
+    [GQLTAG.UNANSWERED]: 0,
+  };
+}
+
 export function createEmptyCommentTagCounts(): CommentTagCounts {
   return {
     total: 0,
-    tags: {
-      [GQLTAG.ADMIN]: 0,
-      [GQLTAG.EXPERT]: 0,
-      [GQLTAG.FEATURED]: 0,
-      [GQLTAG.MEMBER]: 0,
-      [GQLTAG.MODERATOR]: 0,
-      [GQLTAG.QUESTION]: 0,
-      [GQLTAG.REVIEW]: 0,
-      [GQLTAG.STAFF]: 0,
-      [GQLTAG.UNANSWERED]: 0,
-    },
+    tags: createEmptyCommentCountsPerTag(),
   };
 }
 

--- a/src/core/server/services/migrate/migrations/1579189174931_create_sites.ts
+++ b/src/core/server/services/migrate/migrations/1579189174931_create_sites.ts
@@ -11,6 +11,7 @@ import {
   createEmptyRelatedCommentCounts,
   mergeCommentModerationQueueCount,
   mergeCommentStatusCount,
+  mergeCommentTagCounts,
 } from "coral-server/models/comment";
 import {
   createSite,
@@ -237,6 +238,11 @@ export default class extends Migration {
       counts.moderationQueue = mergeCommentModerationQueueCount(
         counts.moderationQueue,
         story.commentCounts.moderationQueue
+      );
+
+      counts.tags = mergeCommentTagCounts(
+        counts.tags,
+        story.commentCounts.tags
       );
     }
 

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -23,6 +23,7 @@ import {
   calculateTotalCommentCount,
   mergeCommentModerationQueueCount,
   mergeCommentStatusCount,
+  mergeCommentTagCounts,
   mergeManyCommentStories,
   removeStoryComments,
 } from "coral-server/models/comment";
@@ -482,6 +483,9 @@ export async function merge(
     ),
     action: mergeCommentActionCounts(
       ...sourceStories.map((s) => s.commentCounts.action)
+    ),
+    tags: mergeCommentTagCounts(
+      ...sourceStories.map((s) => s.commentCounts.tags)
     ),
   };
 

--- a/src/core/server/stacks/createComment.ts
+++ b/src/core/server/stacks/createComment.ts
@@ -142,19 +142,20 @@ const markCommentAsAnswered = async (
       author.id,
       now
     ),
-    updateTagCommentCounts(
-      tenant.id,
-      comment.storyID,
-      comment.siteID,
-      mongo,
-      redis,
-      // Since we removed the UNANSWERED tag, we need to recreate the
-      // before after state of having an UNANSWERED tag followed by
-      // not having an unanswered tag
-      [...parent.tags, { type: GQLTAG.UNANSWERED, createdAt: new Date() }],
-      parent.tags
-    ),
   ]);
+
+  await updateTagCommentCounts(
+    tenant.id,
+    comment.storyID,
+    comment.siteID,
+    mongo,
+    redis,
+    // Since we removed the UNANSWERED tag, we need to recreate the
+    // before after state of having an UNANSWERED tag followed by
+    // not having an unanswered tag
+    parent.tags,
+    parent.tags.filter((t) => t.type !== GQLTAG.UNANSWERED)
+  );
 };
 
 const RatingSchema = Joi.number().min(1).max(5).integer();

--- a/src/core/server/stacks/createComment.ts
+++ b/src/core/server/stacks/createComment.ts
@@ -7,6 +7,7 @@ import { MongoContext } from "coral-server/data/context";
 import {
   AuthorAlreadyHasRatedStory,
   CannotCreateCommentOnArchivedStory,
+  CommentNotFoundError,
   CoralError,
   StoryNotFoundError,
   UserSiteBanned,
@@ -68,6 +69,7 @@ import {
   retrieveParent,
   updateAllCommentCounts,
 } from "./helpers";
+import { updateTagCommentCounts } from "./helpers/updateAllCommentCounts";
 
 export type CreateComment = Omit<
   CreateCommentInput,
@@ -117,6 +119,14 @@ const markCommentAsAnswered = async (
     return;
   }
 
+  const parent = await retrieveParent(mongo, tenant.id, {
+    parentID: comment.parentID,
+    parentRevisionID: comment.parentRevisionID,
+  });
+  if (!parent) {
+    throw new CommentNotFoundError(comment.parentID);
+  }
+
   // We need to mark the parent question as answered.
   // - Remove the unanswered tag.
   // - Approve it since an expert has replied to it.
@@ -131,6 +141,18 @@ const markCommentAsAnswered = async (
       comment.parentRevisionID,
       author.id,
       now
+    ),
+    updateTagCommentCounts(
+      tenant.id,
+      comment.storyID,
+      comment.siteID,
+      mongo,
+      redis,
+      // Since we removed the UNANSWERED tag, we need to recreate the
+      // before after state of having an UNANSWERED tag followed by
+      // not having an unanswered tag
+      [...parent.tags, { type: GQLTAG.UNANSWERED, createdAt: new Date() }],
+      parent.tags
     ),
   ]);
 };

--- a/src/core/server/stacks/helpers/updateAllCommentCounts.ts
+++ b/src/core/server/stacks/helpers/updateAllCommentCounts.ts
@@ -1,11 +1,15 @@
 import { MongoContext } from "coral-server/data/context";
+import { GQLTAG } from "coral-server/graph/schema/__generated__/types";
 import { EncodedCommentActionCounts } from "coral-server/models/action/comment";
 import {
   Comment,
+  CommentCountsPerTag,
   CommentModerationQueueCounts,
   CommentStatusCounts,
+  CommentTagCounts,
   updateSharedCommentCounts,
 } from "coral-server/models/comment";
+import { CommentTag } from "coral-server/models/comment/tag";
 import { updateSiteCounts } from "coral-server/models/site";
 import { updateStoryCounts } from "coral-server/models/story";
 import { Tenant } from "coral-server/models/tenant";
@@ -62,6 +66,62 @@ function calculateStatus(
   };
 }
 
+const tagChanged = (
+  before: CommentTag[] | null | undefined,
+  after: CommentTag[],
+  tag: GQLTAG
+) => {
+  const afterTag = after.find((t: CommentTag) => t.type === tag);
+
+  // If we don't have a before, then this is a new comment and the
+  // result will be that any new tags, if present are to be incremented
+  // to the totals on the story
+  if (!before && after.find((t: CommentTag) => t.type === tag)) {
+    return 1;
+  }
+
+  const beforeTag = before?.find((t: CommentTag) => t.type === tag);
+
+  if (beforeTag && !afterTag) {
+    return -1;
+  }
+  if (beforeTag && afterTag) {
+    return 0;
+  }
+  if (!beforeTag && afterTag) {
+    return 1;
+  }
+
+  return 0;
+};
+
+export const calculateTags = (
+  before: CommentTag[] | null | undefined,
+  after: CommentTag[]
+): CommentTagCounts => {
+  const tags: CommentCountsPerTag = {
+    [GQLTAG.ADMIN]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.EXPERT]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.FEATURED]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.MEMBER]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.MODERATOR]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.QUESTION]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.REVIEW]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.STAFF]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.UNANSWERED]: tagChanged(before, after, GQLTAG.ADMIN),
+  };
+
+  let total = 0;
+  for (const [, value] of Object.entries(tags)) {
+    total += value;
+  }
+
+  return {
+    total,
+    tags,
+  };
+};
+
 interface UpdateAllCommentCountsOptions {
   updateStory?: boolean;
   updateSite?: boolean;
@@ -87,6 +147,8 @@ export default async function updateAllCommentCounts(
   // Compute the status changes as a result of the change to the comment status.
   const status = calculateStatus(input);
 
+  const tags = calculateTags(input.before?.tags, input.after.tags);
+
   // Pull out some params from the input for easier usage.
   const {
     tenant,
@@ -100,6 +162,7 @@ export default async function updateAllCommentCounts(
       action,
       status,
       moderationQueue,
+      tags,
     });
   }
 
@@ -108,6 +171,7 @@ export default async function updateAllCommentCounts(
       action,
       status,
       moderationQueue,
+      tags,
     });
   }
 
@@ -123,6 +187,7 @@ export default async function updateAllCommentCounts(
       action,
       status,
       moderationQueue,
+      tags,
     });
   }
 
@@ -131,4 +196,48 @@ export default async function updateAllCommentCounts(
     status,
     moderationQueue,
   };
+}
+
+export async function updateTagCommentCounts(
+  tenantID: string,
+  storyID: string,
+  siteID: string,
+  mongo: MongoContext,
+  redis: AugmentedRedis,
+  before: CommentTag[] | null | undefined,
+  after: CommentTag[]
+) {
+  const tags = calculateTags(before, after);
+
+  // Update the story, site, and user comment counts.
+  await updateStoryCounts(mongo, tenantID, storyID, {
+    action: {},
+    status: {},
+    moderationQueue: {
+      total: 0,
+      queues: {},
+    },
+    tags,
+  });
+
+  await updateSiteCounts(mongo, tenantID, siteID, {
+    action: {},
+    status: {},
+    moderationQueue: {
+      total: 0,
+      queues: {},
+    },
+    tags,
+  });
+
+  // Update the shared counts.
+  await updateSharedCommentCounts(redis, tenantID, {
+    action: {},
+    status: {},
+    moderationQueue: {
+      total: 0,
+      queues: {},
+    },
+    tags,
+  });
 }

--- a/src/core/server/stacks/helpers/updateAllCommentCounts.ts
+++ b/src/core/server/stacks/helpers/updateAllCommentCounts.ts
@@ -101,14 +101,14 @@ export const calculateTags = (
 ): CommentTagCounts => {
   const tags: CommentCountsPerTag = {
     [GQLTAG.ADMIN]: tagChanged(before, after, GQLTAG.ADMIN),
-    [GQLTAG.EXPERT]: tagChanged(before, after, GQLTAG.ADMIN),
-    [GQLTAG.FEATURED]: tagChanged(before, after, GQLTAG.ADMIN),
-    [GQLTAG.MEMBER]: tagChanged(before, after, GQLTAG.ADMIN),
-    [GQLTAG.MODERATOR]: tagChanged(before, after, GQLTAG.ADMIN),
-    [GQLTAG.QUESTION]: tagChanged(before, after, GQLTAG.ADMIN),
-    [GQLTAG.REVIEW]: tagChanged(before, after, GQLTAG.ADMIN),
-    [GQLTAG.STAFF]: tagChanged(before, after, GQLTAG.ADMIN),
-    [GQLTAG.UNANSWERED]: tagChanged(before, after, GQLTAG.ADMIN),
+    [GQLTAG.EXPERT]: tagChanged(before, after, GQLTAG.EXPERT),
+    [GQLTAG.FEATURED]: tagChanged(before, after, GQLTAG.FEATURED),
+    [GQLTAG.MEMBER]: tagChanged(before, after, GQLTAG.MEMBER),
+    [GQLTAG.MODERATOR]: tagChanged(before, after, GQLTAG.MODERATOR),
+    [GQLTAG.QUESTION]: tagChanged(before, after, GQLTAG.QUESTION),
+    [GQLTAG.REVIEW]: tagChanged(before, after, GQLTAG.REVIEW),
+    [GQLTAG.STAFF]: tagChanged(before, after, GQLTAG.STAFF),
+    [GQLTAG.UNANSWERED]: tagChanged(before, after, GQLTAG.UNANSWERED),
   };
 
   let total = 0;


### PR DESCRIPTION
## What does this PR do?

Updates the logic for calculating the tag counts on a story to retrieve them from a cache of counts on the story document.

Also adds logic to generate the tag counts on the story document if they're not available (migrates existing stories).

## What changes to the GraphQL/Database Schema does this PR introduce?

No changes.

## Does this PR introduce any new environment variables or feature flags? 

No.

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Go to a story that you have used before
- Load the page
- Open your MongoDB compass, VS Code Mongo tools, etc and find the story document
- Confirm that a new field for `tags` has shown up under `commentCounts` on the story document
- Check that the counts are correct for how many comments are featured, written by an admin, moderator, staff, etc
- Use a Q&A and a Ratings & Review story and confirm the tags are accurate there as well while reviewing, asking questions, answering, experts, etc... 
 
## How do we deploy this PR?

No special considerations to deploy.
