### PR TITLE
[CORL-2636]: don't look for next unseen if there is none

### DIFF
--- a/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -1099,6 +1099,10 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
 
   const handleZKeyPress = useCallback(
     async (source: "keyboard" | "mobileToolbar") => {
+      if (disableUnreadButtons) {
+        return;
+      }
+
       // First, try to just traverse to the next unseen comment
       // if it's already loaded up in the DOM
       const traversed = await traverse(
@@ -1139,6 +1143,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
       root,
       scrollToComment,
       setLocal,
+      disableUnreadButtons,
     ]
   );
 


### PR DESCRIPTION
## What does this PR do?

This fixes the issue of the screen scrolling/flickering when Z key is pressed and there are no new comments. Instead of looking for a next unseen, in the case where there is none (which we already calculate for the `Next unread` mobile buttons), we actually should just do nothing.

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Mark all comments as read on a stream. Focus a comment. Scroll down the stream, with the comment out of view. Press Z key. Nothing should happen. 
 
## How do we deploy this PR?


