### PR TITLE
Check for and repair invalid comment tag counts

### DIFF
--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -3577,14 +3577,34 @@ CommentTagCounts provides count data for Tags made against Comment's.
 """
 type CommentTagCounts {
   """
+  ADMIN is the count of Comment's with the ADMIN tag.
+  """
+  ADMIN: Int!
+
+  """
+  EXPERT is the count of Comment's with the EXPERT tag.
+  """
+  EXPERT: Int!
+
+  """
   FEATURED is the count of Comment's with the FEATURED tag.
   """
   FEATURED: Int!
 
   """
-  UNANSWERED is the count of Comment's with the UNANSWERED tag.
+  MEMBER is the count of Comment's with the MEMBER tag.
   """
-  UNANSWERED: Int!
+  MEMBER: Int!
+
+  """
+  MODERATOR is the count of Comment's with the MODERATOR tag.
+  """
+  MODERATOR: Int!
+
+  """
+  QUESTION is the count of Comment's with the QUESTION tag.
+  """
+  QUESTION: Int!
 
   """
   REVIEW is the count of Comment's with the REVIEW tag.
@@ -3592,9 +3612,14 @@ type CommentTagCounts {
   REVIEW: Int!
 
   """
-  QUESTION is the count of Comment's with the QUESTION tag.
+  STAFF is the count of Comment's with the STAFF tag.
   """
-  QUESTION: Int!
+  STAFF: Int!
+
+  """
+  UNANSWERED is the count of Comment's with the UNANSWERED tag.
+  """
+  UNANSWERED: Int!
 }
 
 """

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -1150,6 +1150,11 @@ export async function initializeCommentTagCountsForStory(
   tenantID: string,
   storyID: string
 ): Promise<InitializeCommentTagCountsResult> {
+  logger.info(
+    { tenantID, storyID },
+    "initializing comment tag counts for story"
+  );
+
   const story = await retrieveStory(mongo, tenantID, storyID);
   if (!story) {
     throw new StoryNotFoundError(storyID);

--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -40,10 +40,9 @@ import {
 import { retrieveManyStories, retrieveStory, Story } from "../story";
 import { PUBLISHED_STATUSES } from "./constants";
 import {
-  CommentCountsPerTag,
   CommentStatusCounts,
-  createEmptyCommentCountsPerTag,
   createEmptyCommentStatusCounts,
+  createEmptyGQLCommentTagCounts,
   hasInvalidCommentTagCounts,
   hasInvalidGQLCommentTagCounts,
 } from "./counts";
@@ -1076,14 +1075,14 @@ export async function retrieveStoryCommentTagCounts(
         { tenantID, storyID: id },
         "found undefined/null comment count tags"
       );
-      return createEmptyCommentCountsPerTag();
+      return createEmptyGQLCommentTagCounts();
     }
     if (hasInvalidGQLCommentTagCounts(tags)) {
       logger.warn(
         { tenantID, storyID: id },
         "found invalid comment count tags"
       );
-      return createEmptyCommentCountsPerTag();
+      return createEmptyGQLCommentTagCounts();
     }
 
     return tags;
@@ -1094,7 +1093,7 @@ export async function calculateCommentTagCounts(
   mongo: MongoContext,
   tenantID: string,
   storyIDs: ReadonlyArray<string>
-): Promise<CommentCountsPerTag[]> {
+): Promise<GQLCommentTagCounts[]> {
   const stories = await retrieveManyStories(mongo, tenantID, storyIDs);
 
   const liveStories = stories
@@ -1135,14 +1134,14 @@ export async function calculateCommentTagCounts(
     } else if (archivedCount && !isCountEmpty(archivedCount.counts)) {
       return archivedCount.counts;
     } else {
-      return createEmptyCommentCountsPerTag();
+      return createEmptyGQLCommentTagCounts();
     }
   });
 }
 
 interface InitializeCommentTagCountsResult {
   story: Readonly<Story>;
-  tagCounts: CommentCountsPerTag;
+  tagCounts: GQLCommentTagCounts;
 }
 
 export async function initializeCommentTagCountsForStory(
@@ -1195,7 +1194,7 @@ export async function initializeCommentTagCountsForStory(
 
 interface StoryCommentTagCounts {
   id: string;
-  counts: CommentCountsPerTag;
+  counts: GQLCommentTagCounts;
 }
 
 async function retrieveStoryCommentTagCountsFromDb(
@@ -1265,7 +1264,7 @@ async function retrieveStoryCommentTagCountsFromDb(
       // Keep this collection of empty tag counts up to date to ensure we
       // provide an accurate model. The type system should warn you if there is
       // missing/extra tags here.
-      createEmptyCommentCountsPerTag()
+      createEmptyGQLCommentTagCounts()
     );
 
     return {

--- a/src/core/server/models/comment/counts/counts.ts
+++ b/src/core/server/models/comment/counts/counts.ts
@@ -9,7 +9,7 @@ import { PUBLISHED_STATUSES } from "coral-server/models/comment/constants";
 
 import {
   GQLCOMMENT_STATUS,
-  GQLTAG,
+  GQLCommentTagCounts,
 } from "coral-server/graph/schema/__generated__/types";
 
 import {
@@ -76,19 +76,7 @@ export interface CommentStatusCounts {
 export interface CommentTagCounts {
   total: number;
 
-  tags: CommentCountsPerTag;
-}
-
-export interface CommentCountsPerTag {
-  [GQLTAG.ADMIN]: number;
-  [GQLTAG.EXPERT]: number;
-  [GQLTAG.FEATURED]: number;
-  [GQLTAG.MEMBER]: number;
-  [GQLTAG.MODERATOR]: number;
-  [GQLTAG.QUESTION]: number;
-  [GQLTAG.REVIEW]: number;
-  [GQLTAG.STAFF]: number;
-  [GQLTAG.UNANSWERED]: number;
+  tags: GQLCommentTagCounts;
 }
 
 /**

--- a/src/core/server/models/comment/counts/empty.ts
+++ b/src/core/server/models/comment/counts/empty.ts
@@ -5,7 +5,6 @@ import {
 } from "coral-server/graph/schema/__generated__/types";
 
 import {
-  CommentCountsPerTag,
   CommentModerationCountsPerQueue,
   CommentModerationQueueCounts,
   CommentStatusCounts,
@@ -39,25 +38,8 @@ export function createEmptyCommentStatusCounts(): CommentStatusCounts {
 }
 
 export function hasInvalidGQLCommentTagCounts(
-  tags: GQLCommentTagCounts
+  counts: GQLCommentTagCounts
 ): boolean {
-  if (tags.FEATURED === null || tags.FEATURED === undefined) {
-    return true;
-  }
-  if (tags.UNANSWERED === null || tags.UNANSWERED === undefined) {
-    return true;
-  }
-  if (tags.REVIEW === null || tags.REVIEW === undefined) {
-    return true;
-  }
-  if (tags.QUESTION === null || tags.QUESTION === undefined) {
-    return true;
-  }
-
-  return false;
-}
-
-export function hasInvalidCommentTagCounts(tags: CommentTagCounts): boolean {
   const keys = [
     GQLTAG.ADMIN,
     GQLTAG.EXPERT,
@@ -70,16 +52,8 @@ export function hasInvalidCommentTagCounts(tags: CommentTagCounts): boolean {
     GQLTAG.UNANSWERED,
   ];
 
-  if (!tags) {
-    return true;
-  }
-
-  if (tags.total === undefined || tags.total === null) {
-    return true;
-  }
-
   for (const key of keys) {
-    const val = tags.tags[key];
+    const val = counts[key];
     if (val === undefined || val === null) {
       return true;
     }
@@ -88,7 +62,19 @@ export function hasInvalidCommentTagCounts(tags: CommentTagCounts): boolean {
   return false;
 }
 
-export function createEmptyCommentCountsPerTag(): CommentCountsPerTag {
+export function hasInvalidCommentTagCounts(tags: CommentTagCounts): boolean {
+  if (!tags) {
+    return true;
+  }
+
+  if (tags.total === undefined || tags.total === null) {
+    return true;
+  }
+
+  return hasInvalidGQLCommentTagCounts(tags.tags);
+}
+
+export function createEmptyGQLCommentTagCounts(): GQLCommentTagCounts {
   return {
     [GQLTAG.ADMIN]: 0,
     [GQLTAG.EXPERT]: 0,
@@ -105,7 +91,7 @@ export function createEmptyCommentCountsPerTag(): CommentCountsPerTag {
 export function createEmptyCommentTagCounts(): CommentTagCounts {
   return {
     total: 0,
-    tags: createEmptyCommentCountsPerTag(),
+    tags: createEmptyGQLCommentTagCounts(),
   };
 }
 

--- a/src/core/server/models/comment/counts/empty.ts
+++ b/src/core/server/models/comment/counts/empty.ts
@@ -1,5 +1,6 @@
 import {
   GQLCOMMENT_STATUS,
+  GQLCommentTagCounts,
   GQLTAG,
 } from "coral-server/graph/schema/__generated__/types";
 
@@ -35,6 +36,56 @@ export function createEmptyCommentStatusCounts(): CommentStatusCounts {
     [GQLCOMMENT_STATUS.REJECTED]: 0,
     [GQLCOMMENT_STATUS.SYSTEM_WITHHELD]: 0,
   };
+}
+
+export function hasInvalidGQLCommentTagCounts(
+  tags: GQLCommentTagCounts
+): boolean {
+  if (tags.FEATURED === null || tags.FEATURED === undefined) {
+    return true;
+  }
+  if (tags.UNANSWERED === null || tags.UNANSWERED === undefined) {
+    return true;
+  }
+  if (tags.REVIEW === null || tags.REVIEW === undefined) {
+    return true;
+  }
+  if (tags.QUESTION === null || tags.QUESTION === undefined) {
+    return true;
+  }
+
+  return false;
+}
+
+export function hasInvalidCommentTagCounts(tags: CommentTagCounts): boolean {
+  const keys = [
+    GQLTAG.ADMIN,
+    GQLTAG.EXPERT,
+    GQLTAG.FEATURED,
+    GQLTAG.MEMBER,
+    GQLTAG.MODERATOR,
+    GQLTAG.QUESTION,
+    GQLTAG.REVIEW,
+    GQLTAG.STAFF,
+    GQLTAG.UNANSWERED,
+  ];
+
+  if (!tags) {
+    return true;
+  }
+
+  if (tags.total === undefined || tags.total === null) {
+    return true;
+  }
+
+  for (const key of keys) {
+    const val = tags.tags[key];
+    if (val === undefined || val === null) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function createEmptyCommentCountsPerTag(): CommentCountsPerTag {

--- a/src/core/server/stacks/helpers/updateAllCommentCounts.ts
+++ b/src/core/server/stacks/helpers/updateAllCommentCounts.ts
@@ -1,9 +1,7 @@
 import { MongoContext } from "coral-server/data/context";
-import { GQLTAG } from "coral-server/graph/schema/__generated__/types";
 import { EncodedCommentActionCounts } from "coral-server/models/action/comment";
 import {
   Comment,
-  CommentCountsPerTag,
   CommentModerationQueueCounts,
   CommentStatusCounts,
   CommentTagCounts,
@@ -19,6 +17,11 @@ import {
   calculateCountsDiff,
 } from "coral-server/services/comments/moderation";
 import { AugmentedRedis } from "coral-server/services/redis";
+
+import {
+  GQLCommentTagCounts,
+  GQLTAG,
+} from "coral-server/graph/schema/__generated__/types";
 
 interface UpdateAllCommentCountsInput {
   tenant: Readonly<Tenant>;
@@ -99,7 +102,7 @@ export const calculateTags = (
   before: CommentTag[] | null | undefined,
   after: CommentTag[]
 ): CommentTagCounts => {
-  const tags: CommentCountsPerTag = {
+  const tags: GQLCommentTagCounts = {
     [GQLTAG.ADMIN]: tagChanged(before, after, GQLTAG.ADMIN),
     [GQLTAG.EXPERT]: tagChanged(before, after, GQLTAG.EXPERT),
     [GQLTAG.FEATURED]: tagChanged(before, after, GQLTAG.FEATURED),


### PR DESCRIPTION
## What does this PR do?

Instead of just checking if the tag counts field exists, check that all its sub fields and values are valid, otherwise we regenerate it.

Also checks on the GQL generated tag count types returned via GraphQL to ensure they're valid, or else it falls back to an empty tag counts to ensure the stream is always available even if a story is in a bad state. Also, if these are found, it logs warnings in the logs so we can catch these misbehaving stories.

## What changes to the GraphQL/Database Schema does this PR introduce?

Adding all the `GQLTag` types to the `tags` counts under `Story.commentCounts`. Now we have access to counts for `MODERATOR`, `ADMIN`, `STAFF`, etc... as well as the previous `FEATURED`, `QUESTION`, `REVIEW`, and `UNANSWERED`.

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- Modify an existing stories tag counts to be broken.
   - If we have a story that looks like this in its `commentCounts.tags`:
     ```
      "tags": {
        "total": 12,
        "tags": {
          "ADMIN": 0,
          "EXPERT": 0,
          "FEATURED": 2,
          "MEMBER": 0,
          "MODERATOR": 10,
          "QUESTION": 0,
          "REVIEW": 0,
          "STAFF": 0,
          "UNANSWERED": 0
        }
      }
      ```
    - Ruin the structure by deleting some fields, say make it look like this:
      ```
      "tags": {
        "total": 12,
        "tags": {
          "MODERATOR": 3
        }
      }
      ```
- Visit the story
- Check the document in the DB again, make sure it has regenerated and is back to what it originally should have been
- You can also try deleting the `total`, deleting the `tags` entirely, etc, upgrading stories without `tags` in the the `commentCounts`, etc
 
## How do we deploy this PR?

No special considerations.
