### PR TITLE
[CORL-2657]: add customScrollContainer stream embed option and update scrolling

### DIFF
--- a/src/core/client/embed/Coral.ts
+++ b/src/core/client/embed/Coral.ts
@@ -38,7 +38,7 @@ export interface Config {
   customFontsCSSURL?: string;
   disableDefaultFonts?: boolean;
   amp?: boolean;
-  customScrollContainer?: React.RefObject<any>;
+  customScrollContainer?: HTMLElement;
 }
 
 export function createStreamEmbed(config: Config): StreamEmbed {

--- a/src/core/client/embed/Coral.ts
+++ b/src/core/client/embed/Coral.ts
@@ -38,6 +38,7 @@ export interface Config {
   customFontsCSSURL?: string;
   disableDefaultFonts?: boolean;
   amp?: boolean;
+  customScrollParent?: React.RefObject<any>;
 }
 
 export function createStreamEmbed(config: Config): StreamEmbed {
@@ -76,5 +77,6 @@ export function createStreamEmbed(config: Config): StreamEmbed {
     autoRender: config.autoRender,
     enableDeprecatedEvents: config.enableDeprecatedEvents,
     containerClassName: config.containerClassName || config.bodyClassName,
+    customScrollParent: config.customScrollParent || undefined,
   });
 }

--- a/src/core/client/embed/Coral.ts
+++ b/src/core/client/embed/Coral.ts
@@ -38,7 +38,7 @@ export interface Config {
   customFontsCSSURL?: string;
   disableDefaultFonts?: boolean;
   amp?: boolean;
-  customScrollParent?: React.RefObject<any>;
+  customScrollContainer?: React.RefObject<any>;
 }
 
 export function createStreamEmbed(config: Config): StreamEmbed {
@@ -77,6 +77,6 @@ export function createStreamEmbed(config: Config): StreamEmbed {
     autoRender: config.autoRender,
     enableDeprecatedEvents: config.enableDeprecatedEvents,
     containerClassName: config.containerClassName || config.bodyClassName,
-    customScrollParent: config.customScrollParent || undefined,
+    customScrollContainer: config.customScrollContainer || undefined,
   });
 }

--- a/src/core/client/embed/StreamEmbed.ts
+++ b/src/core/client/embed/StreamEmbed.ts
@@ -48,6 +48,7 @@ export interface StreamEmbedConfig {
   refreshAccessToken?: RefreshAccessTokenCallback;
   amp?: boolean;
   graphQLSubscriptionURI?: string;
+  customScrollParent?: React.RefObject<any>;
 }
 export class StreamEmbed {
   /**
@@ -371,6 +372,7 @@ export class StreamEmbed {
       // the stream will cause stream pages to cache bust.
       version: process.env.TALK_VERSION ? process.env.TALK_VERSION : "dev",
       defaultFontsCSSURL: this.defaultFontsCSSURL,
+      customScrollParent: this.config.customScrollParent,
     });
   }
 

--- a/src/core/client/embed/StreamEmbed.ts
+++ b/src/core/client/embed/StreamEmbed.ts
@@ -48,7 +48,7 @@ export interface StreamEmbedConfig {
   refreshAccessToken?: RefreshAccessTokenCallback;
   amp?: boolean;
   graphQLSubscriptionURI?: string;
-  customScrollContainer?: React.RefObject<any>;
+  customScrollContainer?: HTMLElement;
 }
 export class StreamEmbed {
   /**

--- a/src/core/client/embed/StreamEmbed.ts
+++ b/src/core/client/embed/StreamEmbed.ts
@@ -48,7 +48,7 @@ export interface StreamEmbedConfig {
   refreshAccessToken?: RefreshAccessTokenCallback;
   amp?: boolean;
   graphQLSubscriptionURI?: string;
-  customScrollParent?: React.RefObject<any>;
+  customScrollContainer?: React.RefObject<any>;
 }
 export class StreamEmbed {
   /**
@@ -372,7 +372,7 @@ export class StreamEmbed {
       // the stream will cause stream pages to cache bust.
       version: process.env.TALK_VERSION ? process.env.TALK_VERSION : "dev",
       defaultFontsCSSURL: this.defaultFontsCSSURL,
-      customScrollParent: this.config.customScrollParent,
+      customScrollContainer: this.config.customScrollContainer,
     });
   }
 

--- a/src/core/client/embed/test/basic.spec.ts
+++ b/src/core/client/embed/test/basic.spec.ts
@@ -74,6 +74,7 @@ describe("Basic integration test", () => {
           ],
           "customCSSURL": undefined,
           "customFontsCSSURL": undefined,
+          "customScrollParent": undefined,
           "defaultFontsCSSURL": undefined,
           "disableDefaultFonts": undefined,
           "element": <div

--- a/src/core/client/embed/test/basic.spec.ts
+++ b/src/core/client/embed/test/basic.spec.ts
@@ -74,7 +74,7 @@ describe("Basic integration test", () => {
           ],
           "customCSSURL": undefined,
           "customFontsCSSURL": undefined,
-          "customScrollParent": undefined,
+          "customScrollContainer": undefined,
           "defaultFontsCSSURL": undefined,
           "disableDefaultFonts": undefined,
           "element": <div

--- a/src/core/client/framework/lib/bootstrap/CoralContext.tsx
+++ b/src/core/client/framework/lib/bootstrap/CoralContext.tsx
@@ -95,10 +95,10 @@ export interface CoralContext {
   /** rootURL to the Coral Server */
   rootURL: string;
 
-  /** Supports a custom scroll container ref if Coral is rendered outside
+  /** Supports a custom scroll container element if Coral is rendered outside
    * of the render window
    */
-  customScrollContainer?: React.RefObject<any>;
+  customScrollContainer?: HTMLElement;
 }
 
 export const CoralReactContext = React.createContext<CoralContext>({} as any);

--- a/src/core/client/framework/lib/bootstrap/CoralContext.tsx
+++ b/src/core/client/framework/lib/bootstrap/CoralContext.tsx
@@ -95,7 +95,10 @@ export interface CoralContext {
   /** rootURL to the Coral Server */
   rootURL: string;
 
-  customScrollParent?: React.RefObject<any>;
+  /** Supports a custom scroll container ref if Coral is rendered outside
+   * of the render window
+   */
+  customScrollContainer?: React.RefObject<any>;
 }
 
 export const CoralReactContext = React.createContext<CoralContext>({} as any);

--- a/src/core/client/framework/lib/bootstrap/CoralContext.tsx
+++ b/src/core/client/framework/lib/bootstrap/CoralContext.tsx
@@ -94,6 +94,8 @@ export interface CoralContext {
 
   /** rootURL to the Coral Server */
   rootURL: string;
+
+  customScrollParent?: React.RefObject<any>;
 }
 
 export const CoralReactContext = React.createContext<CoralContext>({} as any);

--- a/src/core/client/framework/lib/bootstrap/createManaged.tsx
+++ b/src/core/client/framework/lib/bootstrap/createManaged.tsx
@@ -107,7 +107,10 @@ interface CreateContextArguments {
   /** Static Config from the server necessary to start the client*/
   staticConfig?: StaticConfig | null;
 
-  customScrollParent?: React.RefObject<any>;
+  /** Supports a custom scroll container ref if Coral is rendered outside
+   * of the render window
+   */
+  customScrollContainer?: React.RefObject<any>;
 }
 
 /**
@@ -398,7 +401,7 @@ export default async function createManaged({
   graphQLSubscriptionURI,
   refreshAccessTokenPromise,
   staticConfig = getStaticConfig(window),
-  customScrollParent,
+  customScrollContainer,
 }: CreateContextArguments): Promise<ComponentType> {
   if (!staticConfig) {
     // eslint-disable-next-line no-console
@@ -497,7 +500,7 @@ export default async function createManaged({
     window,
     renderWindow: window,
     rootURL,
-    customScrollParent,
+    customScrollContainer,
   };
 
   // Initialize local state.

--- a/src/core/client/framework/lib/bootstrap/createManaged.tsx
+++ b/src/core/client/framework/lib/bootstrap/createManaged.tsx
@@ -106,6 +106,8 @@ interface CreateContextArguments {
 
   /** Static Config from the server necessary to start the client*/
   staticConfig?: StaticConfig | null;
+
+  customScrollParent?: React.RefObject<any>;
 }
 
 /**
@@ -396,6 +398,7 @@ export default async function createManaged({
   graphQLSubscriptionURI,
   refreshAccessTokenPromise,
   staticConfig = getStaticConfig(window),
+  customScrollParent,
 }: CreateContextArguments): Promise<ComponentType> {
   if (!staticConfig) {
     // eslint-disable-next-line no-console
@@ -494,6 +497,7 @@ export default async function createManaged({
     window,
     renderWindow: window,
     rootURL,
+    customScrollParent,
   };
 
   // Initialize local state.

--- a/src/core/client/framework/lib/bootstrap/createManaged.tsx
+++ b/src/core/client/framework/lib/bootstrap/createManaged.tsx
@@ -107,10 +107,10 @@ interface CreateContextArguments {
   /** Static Config from the server necessary to start the client*/
   staticConfig?: StaticConfig | null;
 
-  /** Supports a custom scroll container ref if Coral is rendered outside
+  /** Supports a custom scroll container element if Coral is rendered outside
    * of the render window
    */
-  customScrollContainer?: React.RefObject<any>;
+  customScrollContainer?: HTMLElement;
 }
 
 /**

--- a/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -474,15 +474,9 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
     [setTraversalFocus, markSeen, commentSeenEnabled, storyID]
   );
 
-  const scrollToComment = useCallback(
-    (comment) => {
-      const offset =
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        comment.getBoundingClientRect().top + renderWindow.pageYOffset - 150;
-      renderWindow.scrollTo({ top: offset });
-    },
-    [renderWindow]
-  );
+  const scrollToComment = useCallback((comment) => {
+    comment.scrollIntoView();
+  }, []);
 
   const findViewNewCommentButtonAndClick = useCallback(() => {
     const newCommentsButtonInRoot = root.getElementById(
@@ -1025,12 +1019,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
       if (stop.id === "comments-loadAll" || stop.id === "comments-loadMore") {
         return false;
       }
-      const offset =
-        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-        stopElement.getBoundingClientRect().top +
-        renderWindow.pageYOffset -
-        150;
-      renderWindow.scrollTo({ top: offset });
+      stopElement.scrollIntoView();
 
       if (stop.isLoadMore) {
         if (!stop.isViewNew) {
@@ -1058,7 +1047,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
       } else {
         setFocusAndMarkSeen(parseCommentElementID(stop.id));
         setTimeout(() => {
-          renderWindow.scrollTo({ top: offset });
+          stopElement.scrollIntoView();
         }, 0);
         return true;
       }

--- a/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -284,6 +284,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
     renderWindow,
     eventEmitter,
     browserInfo,
+    customScrollContainer,
   } = useCoralContext();
   const root = useShadowRootOrDocument();
   const [toolbarClosed, setToolbarClosed] = useInMemoryState(
@@ -474,9 +475,19 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
     [setTraversalFocus, markSeen, commentSeenEnabled, storyID]
   );
 
-  const scrollToComment = useCallback((comment) => {
-    comment.scrollIntoView();
-  }, []);
+  const scrollToComment = useCallback(
+    (comment) => {
+      if (customScrollContainer) {
+        comment.scrollIntoView();
+      } else {
+        const offset =
+          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+          comment.getBoundingClientRect().top + renderWindow.pageYOffset - 150;
+        renderWindow.scrollTo({ top: offset });
+      }
+    },
+    [renderWindow, customScrollContainer]
+  );
 
   const findViewNewCommentButtonAndClick = useCallback(() => {
     const newCommentsButtonInRoot = root.getElementById(
@@ -1019,7 +1030,16 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
       if (stop.id === "comments-loadAll" || stop.id === "comments-loadMore") {
         return false;
       }
-      stopElement.scrollIntoView();
+      const offset =
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        stopElement.getBoundingClientRect().top +
+        renderWindow.pageYOffset -
+        150;
+      if (customScrollContainer) {
+        stopElement.scrollIntoView();
+      } else {
+        renderWindow.scrollTo({ top: offset });
+      }
 
       if (stop.isLoadMore) {
         if (!stop.isViewNew) {
@@ -1047,7 +1067,11 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
       } else {
         setFocusAndMarkSeen(parseCommentElementID(stop.id));
         setTimeout(() => {
-          stopElement.scrollIntoView();
+          if (customScrollContainer) {
+            stopElement.scrollIntoView();
+          } else {
+            renderWindow.scrollTo({ top: offset });
+          }
         }, 0);
         return true;
       }
@@ -1065,6 +1089,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
       findAndNavigateToNextUnseen,
       setZKeyClickedButton,
       commentsFullyLoaded,
+      customScrollContainer,
     ]
   );
 

--- a/src/core/client/stream/common/scrollToBeginning.ts
+++ b/src/core/client/stream/common/scrollToBeginning.ts
@@ -3,10 +3,10 @@ import getElementWindowTopOffset from "coral-ui/helpers/getElementWindowTopOffse
 function scrollToBeginning(
   root: ShadowRoot | Document,
   window: Window,
-  customScrollParent?: React.RefObject<any>
+  customScrollContainer?: React.RefObject<any>
 ) {
   const tab = root.getElementById("tab-COMMENTS");
-  const scrollContainer = customScrollParent?.current ?? window;
+  const scrollContainer = customScrollContainer?.current ?? window;
   if (tab) {
     scrollContainer.scrollTo({
       top: getElementWindowTopOffset(scrollContainer, tab),

--- a/src/core/client/stream/common/scrollToBeginning.ts
+++ b/src/core/client/stream/common/scrollToBeginning.ts
@@ -3,10 +3,10 @@ import getElementWindowTopOffset from "coral-ui/helpers/getElementWindowTopOffse
 function scrollToBeginning(
   root: ShadowRoot | Document,
   window: Window,
-  customScrollContainer?: React.RefObject<any>
+  customScrollContainer?: HTMLElement
 ) {
   const tab = root.getElementById("tab-COMMENTS");
-  const scrollContainer = customScrollContainer?.current ?? window;
+  const scrollContainer = customScrollContainer ?? window;
   if (tab) {
     scrollContainer.scrollTo({
       top: getElementWindowTopOffset(scrollContainer, tab),

--- a/src/core/client/stream/common/scrollToBeginning.ts
+++ b/src/core/client/stream/common/scrollToBeginning.ts
@@ -1,9 +1,16 @@
 import getElementWindowTopOffset from "coral-ui/helpers/getElementWindowTopOffset";
 
-function scrollToBeginning(root: ShadowRoot | Document, window: Window) {
+function scrollToBeginning(
+  root: ShadowRoot | Document,
+  window: Window,
+  customScrollParent?: React.RefObject<any>
+) {
   const tab = root.getElementById("tab-COMMENTS");
+  const scrollContainer = customScrollParent?.current ?? window;
   if (tab) {
-    window.scrollTo({ top: getElementWindowTopOffset(window, tab) });
+    scrollContainer.scrollTo({
+      top: getElementWindowTopOffset(scrollContainer, tab),
+    });
   }
 }
 

--- a/src/core/client/stream/stream.tsx
+++ b/src/core/client/stream/stream.tsx
@@ -52,7 +52,7 @@ export interface AttachOptions {
   defaultFontsCSSURL?: string;
   disableDefaultFonts?: boolean;
   containerClassName?: string;
-  customScrollContainer?: React.RefObject<null>;
+  customScrollContainer?: HTMLElement;
 }
 
 function extractBundleConfig() {

--- a/src/core/client/stream/stream.tsx
+++ b/src/core/client/stream/stream.tsx
@@ -52,6 +52,7 @@ export interface AttachOptions {
   defaultFontsCSSURL?: string;
   disableDefaultFonts?: boolean;
   containerClassName?: string;
+  customScrollParent?: React.RefObject<null>;
 }
 
 function extractBundleConfig() {
@@ -109,6 +110,7 @@ export async function attach(options: AttachOptions) {
     eventEmitter: options.eventEmitter,
     refreshAccessTokenPromise,
     staticConfig: options.staticConfig,
+    customScrollParent: options.customScrollParent,
   });
 
   // Amount of initial css files to be loaded.

--- a/src/core/client/stream/stream.tsx
+++ b/src/core/client/stream/stream.tsx
@@ -52,7 +52,7 @@ export interface AttachOptions {
   defaultFontsCSSURL?: string;
   disableDefaultFonts?: boolean;
   containerClassName?: string;
-  customScrollParent?: React.RefObject<null>;
+  customScrollContainer?: React.RefObject<null>;
 }
 
 function extractBundleConfig() {
@@ -110,7 +110,7 @@ export async function attach(options: AttachOptions) {
     eventEmitter: options.eventEmitter,
     refreshAccessTokenPromise,
     staticConfig: options.staticConfig,
-    customScrollParent: options.customScrollParent,
+    customScrollContainer: options.customScrollContainer,
   });
 
   // Amount of initial css files to be loaded.

--- a/src/core/client/stream/tabs/Comments/Comment/InReplyTo.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/InReplyTo.tsx
@@ -23,10 +23,10 @@ const InReplyTo: FunctionComponent<Props> = ({
   parent,
   enableJumpToParent,
 }) => {
-  const { renderWindow, customScrollParent } = useCoralContext();
+  const { renderWindow, customScrollContainer } = useCoralContext();
   const scrollContainer = useMemo(() => {
-    return customScrollParent?.current ?? renderWindow;
-  }, [renderWindow, customScrollParent]);
+    return customScrollContainer?.current ?? renderWindow;
+  }, [renderWindow, customScrollContainer]);
   const root = useShadowRootOrDocument();
 
   const navigateToParent = useCallback(() => {
@@ -46,7 +46,7 @@ const InReplyTo: FunctionComponent<Props> = ({
         `Assertion Error: Expected to find parent comment with id ${parent?.id} but could not`
       );
     }
-  }, [parent, root, renderWindow, customScrollParent]);
+  }, [parent, root, scrollContainer]);
 
   const Username = () => (
     <span className={cn(styles.username, CLASSES.comment.inReplyTo.username)}>

--- a/src/core/client/stream/tabs/Comments/Comment/InReplyTo.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/InReplyTo.tsx
@@ -1,6 +1,6 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
-import React, { FunctionComponent, useCallback } from "react";
+import React, { FunctionComponent, useCallback, useMemo } from "react";
 
 import { useCoralContext } from "coral-framework/lib/bootstrap";
 import { globalErrorReporter } from "coral-framework/lib/errors";
@@ -23,7 +23,10 @@ const InReplyTo: FunctionComponent<Props> = ({
   parent,
   enableJumpToParent,
 }) => {
-  const { renderWindow } = useCoralContext();
+  const { renderWindow, customScrollParent } = useCoralContext();
+  const scrollContainer = useMemo(() => {
+    return customScrollParent?.current ?? renderWindow;
+  }, [renderWindow, customScrollParent]);
   const root = useShadowRootOrDocument();
 
   const navigateToParent = useCallback(() => {
@@ -34,8 +37,8 @@ const InReplyTo: FunctionComponent<Props> = ({
     const elemID = computeCommentElementID(parent.id);
     const elem = root.getElementById(elemID);
     if (elem) {
-      renderWindow.scrollTo({
-        top: getElementWindowTopOffset(renderWindow, elem),
+      scrollContainer.scrollTo({
+        top: getElementWindowTopOffset(scrollContainer, elem),
       });
       elem.focus();
     } else {
@@ -43,7 +46,7 @@ const InReplyTo: FunctionComponent<Props> = ({
         `Assertion Error: Expected to find parent comment with id ${parent?.id} but could not`
       );
     }
-  }, [parent, root, renderWindow]);
+  }, [parent, root, renderWindow, customScrollParent]);
 
   const Username = () => (
     <span className={cn(styles.username, CLASSES.comment.inReplyTo.username)}>

--- a/src/core/client/stream/tabs/Comments/Comment/InReplyTo.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/InReplyTo.tsx
@@ -1,14 +1,12 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
-import React, { FunctionComponent, useCallback, useMemo } from "react";
+import React, { FunctionComponent, useCallback } from "react";
 
-import { useCoralContext } from "coral-framework/lib/bootstrap";
 import { globalErrorReporter } from "coral-framework/lib/errors";
 import CLASSES from "coral-stream/classes";
 import computeCommentElementID from "coral-stream/tabs/Comments/Comment/computeCommentElementID";
 import { BaseButton, Flex, Icon } from "coral-ui/components/v2";
 import { useShadowRootOrDocument } from "coral-ui/encapsulation";
-import getElementWindowTopOffset from "coral-ui/helpers/getElementWindowTopOffset";
 
 import { CommentContainer_comment as CommentData } from "coral-stream/__generated__/CommentContainer_comment.graphql";
 
@@ -23,10 +21,6 @@ const InReplyTo: FunctionComponent<Props> = ({
   parent,
   enableJumpToParent,
 }) => {
-  const { renderWindow, customScrollContainer } = useCoralContext();
-  const scrollContainer = useMemo(() => {
-    return customScrollContainer?.current ?? renderWindow;
-  }, [renderWindow, customScrollContainer]);
   const root = useShadowRootOrDocument();
 
   const navigateToParent = useCallback(() => {
@@ -37,16 +31,14 @@ const InReplyTo: FunctionComponent<Props> = ({
     const elemID = computeCommentElementID(parent.id);
     const elem = root.getElementById(elemID);
     if (elem) {
-      scrollContainer.scrollTo({
-        top: getElementWindowTopOffset(scrollContainer, elem),
-      });
+      elem.scrollIntoView();
       elem.focus();
     } else {
       globalErrorReporter.report(
         `Assertion Error: Expected to find parent comment with id ${parent?.id} but could not`
       );
     }
-  }, [parent, root, scrollContainer]);
+  }, [parent, root]);
 
   const Username = () => (
     <span className={cn(styles.username, CLASSES.comment.inReplyTo.username)}>

--- a/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/ReplyCommentFormContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/ReplyCommentFormContainer.tsx
@@ -65,7 +65,12 @@ const ReplyCommentFormContainer: FunctionComponent<Props> = ({
   settings,
 }) => {
   const root = useShadowRootOrDocument();
-  const { renderWindow, sessionStorage, browserInfo } = useCoralContext();
+  const {
+    renderWindow,
+    sessionStorage,
+    browserInfo,
+    customScrollParent,
+  } = useCoralContext();
   // Disable autofocus on ios and enable for the rest.
   const autofocus = !browserInfo.ios;
   const commentSeenEnabled = useCommentSeenEnabled();
@@ -245,16 +250,27 @@ const ReplyCommentFormContainer: FunctionComponent<Props> = ({
     setTimeout(() => {
       const elem = root.getElementById(elementID);
       if (elem) {
-        const offset =
-          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-          elem.getBoundingClientRect().top +
-          renderWindow.pageYOffset -
-          (commentSeenEnabled ? 150 : 0);
-        renderWindow.scrollTo({ top: offset });
+        if (customScrollParent) {
+          elem.scrollIntoView();
+        } else {
+          const offset =
+            // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+            elem.getBoundingClientRect().top +
+            renderWindow.pageYOffset -
+            (commentSeenEnabled ? 150 : 0);
+          renderWindow.scrollTo({ top: offset });
+        }
         elem.focus();
       }
     }, 300);
-  }, [commentSeenEnabled, jumpToCommentID, onClose, renderWindow, root]);
+  }, [
+    commentSeenEnabled,
+    jumpToCommentID,
+    onClose,
+    renderWindow,
+    root,
+    customScrollParent,
+  ]);
 
   if (!initialized) {
     return null;

--- a/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/ReplyCommentFormContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReplyCommentForm/ReplyCommentFormContainer.tsx
@@ -69,7 +69,7 @@ const ReplyCommentFormContainer: FunctionComponent<Props> = ({
     renderWindow,
     sessionStorage,
     browserInfo,
-    customScrollParent,
+    customScrollContainer,
   } = useCoralContext();
   // Disable autofocus on ios and enable for the rest.
   const autofocus = !browserInfo.ios;
@@ -250,7 +250,7 @@ const ReplyCommentFormContainer: FunctionComponent<Props> = ({
     setTimeout(() => {
       const elem = root.getElementById(elementID);
       if (elem) {
-        if (customScrollParent) {
+        if (customScrollContainer) {
           elem.scrollIntoView();
         } else {
           const offset =
@@ -269,7 +269,7 @@ const ReplyCommentFormContainer: FunctionComponent<Props> = ({
     onClose,
     renderWindow,
     root,
-    customScrollParent,
+    customScrollContainer,
   ]);
 
   if (!initialized) {

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
@@ -47,7 +47,12 @@ interface Props {
 const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
   const { comment, story, viewer, settings } = props;
   const setCommentID = useMutation(SetCommentIDMutation);
-  const { renderWindow, eventEmitter, window } = useCoralContext();
+  const {
+    renderWindow,
+    eventEmitter,
+    window,
+    customScrollParent,
+  } = useCoralContext();
   const root = useShadowRootOrDocument();
 
   const subscribeToCommentEntered = useSubscription(CommentEnteredSubscription);
@@ -71,8 +76,11 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
     if (!renderWindow) {
       return;
     }
-    setTimeout(() => scrollToBeginning(root, renderWindow), 100);
-  }, [root, renderWindow]);
+    setTimeout(
+      () => scrollToBeginning(root, renderWindow, customScrollParent),
+      100
+    );
+  }, [root, renderWindow, customScrollParent]);
 
   const onShowAllComments = useCallback(
     (e: MouseEvent<any>) => {

--- a/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/PermalinkViewContainer.tsx
@@ -51,7 +51,7 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
     renderWindow,
     eventEmitter,
     window,
-    customScrollParent,
+    customScrollContainer,
   } = useCoralContext();
   const root = useShadowRootOrDocument();
 
@@ -77,10 +77,10 @@ const PermalinkViewContainer: FunctionComponent<Props> = (props) => {
       return;
     }
     setTimeout(
-      () => scrollToBeginning(root, renderWindow, customScrollParent),
+      () => scrollToBeginning(root, renderWindow, customScrollContainer),
       100
     );
-  }, [root, renderWindow, customScrollParent]);
+  }, [root, renderWindow, customScrollContainer]);
 
   const onShowAllComments = useCallback(
     (e: MouseEvent<any>) => {

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
@@ -214,7 +214,7 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
               key: comments.length,
             }
           : {})}
-        customScrollParent={customScrollContainer?.current}
+        customScrollParent={customScrollContainer}
         useWindowScroll
         ref={currentScrollRef}
         style={{ height: comments.length > 0 ? virtuosoHeight : 0 }}

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
@@ -4,6 +4,7 @@ import React, { FunctionComponent, useCallback, useMemo } from "react";
 import { graphql } from "react-relay";
 import { Virtuoso } from "react-virtuoso";
 
+import { useCoralContext } from "coral-framework/lib/bootstrap";
 import { useViewerNetworkEvent } from "coral-framework/lib/events";
 import { useLocal } from "coral-framework/lib/relay";
 import { GQLCOMMENT_SORT } from "coral-framework/schema";
@@ -70,6 +71,8 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
       }
     }
   `);
+
+  const { customScrollParent } = useCoralContext();
 
   // This determines if there are more comments to display than the initial 20.
   // It also takes into account the initial comments loaded since if we start
@@ -211,6 +214,7 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
               key: comments.length,
             }
           : {})}
+        customScrollParent={customScrollParent?.current}
         useWindowScroll
         ref={currentScrollRef}
         style={{ height: comments.length > 0 ? virtuosoHeight : 0 }}

--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabVirtualizedComments.tsx
@@ -72,7 +72,7 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
     }
   `);
 
-  const { customScrollParent } = useCoralContext();
+  const { customScrollContainer } = useCoralContext();
 
   // This determines if there are more comments to display than the initial 20.
   // It also takes into account the initial comments loaded since if we start
@@ -214,7 +214,7 @@ const AllCommentsTabVirtualizedComments: FunctionComponent<Props> = ({
               key: comments.length,
             }
           : {})}
-        customScrollParent={customScrollParent?.current}
+        customScrollParent={customScrollContainer?.current}
         useWindowScroll
         ref={currentScrollRef}
         style={{ height: comments.length > 0 ? virtuosoHeight : 0 }}

--- a/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
@@ -45,14 +45,14 @@ const CommentsLinks: FunctionComponent<Props> = ({
   showGoToDiscussions,
   showGoToProfile,
 }) => {
-  const { renderWindow } = useCoralContext();
+  const { renderWindow, customScrollParent } = useCoralContext();
   const root = useShadowRootOrDocument();
   const onGoToArticleTop = useCallback(() => {
     renderWindow.scrollTo({ top: 0 });
   }, [renderWindow]);
   const onGoToCommentsTop = useCallback(() => {
-    scrollToBeginning(root, renderWindow);
-  }, [root, renderWindow]);
+    scrollToBeginning(root, renderWindow, customScrollParent);
+  }, [root, renderWindow, customScrollParent]);
 
   const setActiveTab = useMutation(SetActiveTabMutation);
 

--- a/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
@@ -45,14 +45,14 @@ const CommentsLinks: FunctionComponent<Props> = ({
   showGoToDiscussions,
   showGoToProfile,
 }) => {
-  const { renderWindow, customScrollParent } = useCoralContext();
+  const { renderWindow, customScrollContainer } = useCoralContext();
   const root = useShadowRootOrDocument();
   const onGoToArticleTop = useCallback(() => {
     renderWindow.scrollTo({ top: 0 });
   }, [renderWindow]);
   const onGoToCommentsTop = useCallback(() => {
-    scrollToBeginning(root, renderWindow, customScrollParent);
-  }, [root, renderWindow, customScrollParent]);
+    scrollToBeginning(root, renderWindow, customScrollContainer);
+  }, [root, renderWindow, customScrollContainer]);
 
   const setActiveTab = useMutation(SetActiveTabMutation);
 

--- a/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
 } from "react";
 import { graphql } from "react-relay";
+import { VirtuosoHandle } from "react-virtuoso";
 
 import { useCoralContext } from "coral-framework/lib/bootstrap";
 import { useViewerEvent } from "coral-framework/lib/events";
@@ -207,7 +208,7 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
     // If we aren't warned.
     !warned;
 
-  const currentScrollRef = useRef<null | HTMLElement>(null);
+  const currentScrollRef = useRef<VirtuosoHandle>(null);
 
   // Emit comment count event.
   useCommentCountEvent(

--- a/src/core/client/ui/helpers/getElementWindowTopOffset.ts
+++ b/src/core/client/ui/helpers/getElementWindowTopOffset.ts
@@ -1,7 +1,11 @@
 /**
  * Get elements top offset relative to the window.
  */
-function getElementWindowTopOffset(window: Window, element: Element) {
+function getElementWindowTopOffset(
+  window: Window | React.RefObject<any>["current"],
+  element: Element
+) {
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
   return element.getBoundingClientRect().top + window.scrollY;
 }
 


### PR DESCRIPTION
## What does this PR do?

It adds a custom scroll container that can be passed through to the stream embed. This is an HTML element. It is then used by both Virtuoso as its `customScrollParent` as well as for scrolling in other places throughout the stream. This `customScrollContainer` is needed in cases where Coral is embedded outside of the main render window (for example, if it slides out in its own drawer).
 
## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags? 

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test this PR by ensuring that scrolling and everything still works as expected when the `customScrollContainer` is not provided to the embed. So, check that keyboard shortcuts (Z key) work as expected, `Top of comments` link in the footer, `In reply to` button in comments, `Jump to comment` link, etc.

To check with `customScrollContainer` provided, check with me and I can either help you get setup where you can test it or I can walk you through it working. Then check the same things, in addition to that there are no spacing issues when there is a `Load all comments` button and more than 20ish comments.
 
## How do we deploy this PR?


