### PR TITLE
[CORL-2650] Fix typo in tombstone

### DIFF
--- a/src/core/client/stream/tabs/Comments/PermalinkView/RejectedTombstoneContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/PermalinkView/RejectedTombstoneContainer.tsx
@@ -31,8 +31,8 @@ const RejectedTombstoneContainer: FunctionComponent<Props> = ({
       noWrapper
     >
       <Localized id="comments-tombstone-rejected">
-        This commenter has been removed by a moderator for violating our
-        community guidelines.
+        This comment has been removed by a moderator for violating our community
+        guidelines.
       </Localized>
     </Tombstone>
   );

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -860,7 +860,7 @@ comments-tombstone-showComment = Show comment
 comments-tombstone-deleted =
   This comment is no longer available. The commenter has deleted their account.
 comments-tombstone-rejected =
-  This commenter has been removed by a moderator for violating our community guidelines.
+  This comment has been removed by a moderator for violating our community guidelines.
 
 suspendInfo-heading =
 suspendInfo-heading-yourAccountHasBeen =


### PR DESCRIPTION

## What does this PR do?
Fixes a typo in the copy for tombstones (This commenter -> this comment)

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Create a comment, as well as a reply (directly or as a grandchild).
2. Copy the link to the reply and open it in another tab
3. Report and reject the parent comment
4. View the reply in the other tab (the conversation permalink view)
5. Verify that the tombstone of the rejected parent reads "this comment has been removed" rather than "this commenter has been removed"