### PR TITLE
[CORL-2649] fix 'raw error' bug when replying to ancestor of rejected comment

### DIFF
--- a/src/core/common/errors.ts
+++ b/src/core/common/errors.ts
@@ -221,6 +221,12 @@ export enum ERROR_CODES {
   PARENT_COMMENT_REJECTED = "PARENT_COMMENT_REJECTED",
 
   /**
+   * ANCESTOR_REJECTED is returned when a Comment's ancestor
+   * has been rejected.
+   */
+  ANCESTOR_REJECTED = "ANCESTOR_REJECTED",
+
+  /**
    * AUTHENTICATION_ERROR is returned when a general authentication error has
    * occurred and the request can not be processed.
    */
@@ -395,13 +401,6 @@ export enum ERROR_CODES {
    * or replies on archived comment data.
    */
   CANNOT_CREATE_COMMENT_ON_ARCHIVED_STORY = "CANNOT_CREATE_COMMENT_ON_ARCHIVED_STORY",
-
-  /**
-   * CANNOT_REPLY_TO_REJECTED_COMMENT is thrown when a user attempts to publish
-   * a reply to a comment that has been rejected, or is a descendent of a rejected
-   * comment.
-   */
-  CANNOT_REPLY_TO_REJECTED_COMMENT = "CANNOT_REPLY_TO_REJECTED_COMMENT",
 
   /**
    * CANNOT_OPEN_AN_ARCHIVED_STORY is thrown when a user attempts to open a

--- a/src/core/server/errors/index.ts
+++ b/src/core/server/errors/index.ts
@@ -526,6 +526,15 @@ export class ParentCommentRejectedError extends CoralError {
   }
 }
 
+export class AncestorRejectedError extends CoralError {
+  constructor(tenantID: string, commentID: string) {
+    super({
+      code: ERROR_CODES.ANCESTOR_REJECTED,
+      context: { tenantID, pub: { commentID }, pvt: { commentID } },
+    });
+  }
+}
+
 export class AuthorAlreadyHasRatedStory extends CoralError {
   constructor(userID: string, storyID: string) {
     super({
@@ -947,16 +956,6 @@ export class CannotMergeAnArchivedStory extends CoralError {
       code: ERROR_CODES.CANNOT_MERGE_AN_ARCHIVED_STORY,
       status: 400,
       context: { tenantID, pub: { storyID }, pvt: { tenantID, storyID } },
-    });
-  }
-}
-
-export class CannotReplyToRejectedComment extends CoralError {
-  constructor(tenantID: string, commentID: string) {
-    super({
-      code: ERROR_CODES.CANNOT_REPLY_TO_REJECTED_COMMENT,
-      status: 400,
-      context: { tenantID, pub: { commentID }, pvt: { commentID } },
     });
   }
 }

--- a/src/core/server/errors/translations.ts
+++ b/src/core/server/errors/translations.ts
@@ -1,12 +1,12 @@
 import { ERROR_CODES } from "coral-common/errors";
 
 export const ERROR_TRANSLATIONS: Record<ERROR_CODES, string> = {
-  CANNOT_REPLY_TO_REJECTED_COMMENT: "error-cannotReplyToRejectedComment",
   COMMENT_BODY_EXCEEDS_MAX_LENGTH: "error-commentBodyExceedsMaxLength",
   COMMENT_BODY_TOO_SHORT: "error-commentBodyTooShort",
   COMMENT_NOT_FOUND: "error-commentNotFound",
   COMMENT_REVISION_NOT_FOUND: "error-commentRevisionNotFound",
   PARENT_COMMENT_REJECTED: "error-parentCommentRejected",
+  ANCESTOR_REJECTED: "error-ancestorRejected",
   COMMENTING_DISABLED: "error-commentingDisabled",
   DUPLICATE_EMAIL: "error-duplicateEmail",
   DUPLICATE_EMAIL_DOMAIN: "error-duplicateEmailDomain",

--- a/src/core/server/locales/en-US/errors.ftl
+++ b/src/core/server/locales/en-US/errors.ftl
@@ -2,6 +2,7 @@ error-commentingDisabled = Commenting has been disabled tenant wide.
 error-storyClosed = Story is currently closed for commenting.
 error-commentBodyTooShort = Comment body must have at least {$min} characters.
 error-parentCommentRejected = The comment you are replying to has been rejected by a moderator.
+error-ancestorRejected = The comment you are replying to is an ancestor of a rejected comment.
 error-commentBodyExceedsMaxLength =
   Comment body exceeds maximum length of {$max} characters.
 error-storyURLNotPermitted =

--- a/src/core/server/stacks/createComment.ts
+++ b/src/core/server/stacks/createComment.ts
@@ -5,9 +5,9 @@ import { ERROR_TYPES } from "coral-common/errors";
 import { Config } from "coral-server/config";
 import { MongoContext } from "coral-server/data/context";
 import {
+  AncestorRejectedError,
   AuthorAlreadyHasRatedStory,
   CannotCreateCommentOnArchivedStory,
-  CannotReplyToRejectedComment,
   CommentNotFoundError,
   CoralError,
   StoryNotFoundError,
@@ -282,7 +282,7 @@ export default async function create(
     );
 
     if (rejectedAncestor) {
-      throw new CannotReplyToRejectedComment(tenant.id, rejectedAncestor.id);
+      throw new AncestorRejectedError(tenant.id, rejectedAncestor.id);
     }
   }
 


### PR DESCRIPTION
## What does this PR do?
Fixes bug where raw error is displayed when replying to ancestor of rejected comment/

## What changes to the GraphQL/Database Schema does this PR introduce?
None

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Create a comment (A) and a reply (B)
2. Open a permalink view to B
3. As a moderator, reject A
4. Without refreshing permalink view, submit reply to B
5. Verify that you see a friendly error message as opposed to screaming snake case error code.
 
