### PR TITLE
fix disappearing collapse button bug

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/flattenReplies/index.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/flattenReplies/index.ts
@@ -7,6 +7,6 @@ export const isReplyFlattened = (
   return (
     flattenedRepliesEnabled &&
     indentLevel &&
-    indentLevel >= MAX_REPLY_INDENT_DEPTH
+    indentLevel > MAX_REPLY_INDENT_DEPTH
   );
 };

--- a/src/core/client/stream/tabs/Comments/Comment/flattenReplies/index.ts
+++ b/src/core/client/stream/tabs/Comments/Comment/flattenReplies/index.ts
@@ -1,4 +1,4 @@
-export const FlattenRepliesIndentLevel = 4 as const;
+import { MAX_REPLY_INDENT_DEPTH } from "coral-stream/constants";
 
 export const isReplyFlattened = (
   flattenedRepliesEnabled?: boolean | null,
@@ -7,6 +7,6 @@ export const isReplyFlattened = (
   return (
     flattenedRepliesEnabled &&
     indentLevel &&
-    indentLevel >= FlattenRepliesIndentLevel
+    indentLevel >= MAX_REPLY_INDENT_DEPTH
   );
 };


### PR DESCRIPTION
## What does this PR do?
Fixes bug where collapse button disappears after level 5 of nested comments.

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Create a reply chain longer than 8 comments long
2. Observe that collapse buttons are present on all comments until they start being flattened (in flatten replies mode)
 