### PR TITLE
fix off by one error in MAX_REPLY_INDENT_DEPTH

### DIFF
--- a/src/core/client/stream/constants.ts
+++ b/src/core/client/stream/constants.ts
@@ -4,7 +4,7 @@ export const VIEWER_STATUS_CONTAINER_ID = "viewer-status";
 
 export const POST_COMMENT_FORM_ID = "post-comment-form";
 
-export const MAX_REPLY_INDENT_DEPTH = 7;
+export const MAX_REPLY_INDENT_DEPTH = 8;
 
 export const NUM_INITIAL_COMMENTS = 20;
 


### PR DESCRIPTION
## What does this PR do?
Fixes bug in which replies to deeply nested comments are incorrectly indented.

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Enable Flatten Replies
2. Create a reply chain > 8 comments long
3. Reply to a reply past the 8th level (at which point all replies should be indented at the same level) and observe that the comment is in line with the comment preceding it (as opposed to the left of it).
 

