### PR TITLE
[CORL-2261] Use story/ancestors state to determine whether we can reply to a comment

### DIFF
--- a/src/core/server/models/comment/comment.ts
+++ b/src/core/server/models/comment/comment.ts
@@ -1644,32 +1644,3 @@ export async function retrieveFeaturedComments(
 
   return results;
 }
-
-export async function hasRejectedAncestors(
-  mongo: MongoContext,
-  tenantID: string,
-  commentID: string
-) {
-  const comment = await mongo.comments().findOne({ tenantID, id: commentID });
-  if (!comment) {
-    throw new CommentNotFoundError(commentID);
-  }
-
-  const { ancestorIDs } = comment;
-  if (!ancestorIDs || ancestorIDs.length === 0) {
-    return false;
-  }
-
-  const ancestors = await mongo
-    .comments()
-    .find({ tenantID, id: { $in: ancestorIDs } })
-    .toArray();
-
-  const rejectedAncestors = ancestors.filter(
-    (a) => a.status === GQLCOMMENT_STATUS.REJECTED
-  );
-  const hasRejectedStateAncestors =
-    rejectedAncestors && rejectedAncestors.length > 0;
-
-  return hasRejectedStateAncestors;
-}

--- a/src/core/server/stacks/approveComment.ts
+++ b/src/core/server/stacks/approveComment.ts
@@ -50,8 +50,6 @@ const approveComment = async (
     await submitCommentAsNotSpam(mongo, tenant, result.before, request);
   }
 
-  await enableRepliesToChildren(result.before.id, mongo);
-
   // If the comment hasn't been updated, skip the rest of the steps.
   if (!result.after) {
     return result.before;
@@ -69,39 +67,6 @@ const approveComment = async (
 
   // Return the resulting comment.
   return result.after;
-};
-
-const enableRepliesToChildren = async (
-  commentID: string,
-  mongo: MongoContext
-) => {
-  const children = await mongo
-    .comments()
-    .find({
-      parentID: commentID,
-    })
-    .toArray();
-
-  if (children.length === 0) {
-    return;
-  }
-
-  const nonRejectedChildIDs = children
-    .filter(({ status }) => status !== GQLCOMMENT_STATUS.REJECTED)
-    .map(({ id }) => id);
-
-  const allChildIDs = children.map(({ id }) => id);
-
-  await mongo
-    .comments()
-    .updateMany(
-      { id: { $in: allChildIDs } },
-      { $set: { rejectedAncestor: false } }
-    );
-
-  await Promise.all(
-    nonRejectedChildIDs.map((id) => enableRepliesToChildren(id, mongo))
-  );
 };
 
 export default approveComment;

--- a/src/core/server/stacks/rejectComment.ts
+++ b/src/core/server/stacks/rejectComment.ts
@@ -62,8 +62,6 @@ const rejectComment = async (
     return result.before;
   }
 
-  await disableRepliesToChildren(commentID, mongo);
-
   // TODO: (wyattjoh) (tessalt) broker cannot easily be passed to stack from tasks,
   // see CORL-935 in jira
   if (broker && counts) {
@@ -103,31 +101,6 @@ const rejectComment = async (
 
   // Return the resulting comment.
   return result.after;
-};
-
-const disableRepliesToChildren = async (
-  commentID: string,
-  mongo: MongoContext
-) => {
-  const children = await mongo
-    .comments()
-    .find({
-      ancestorIDs: commentID,
-    })
-    .toArray();
-
-  if (children.length === 0) {
-    return;
-  }
-
-  const childIDs = children.map(({ id }) => id);
-
-  await mongo
-    .comments()
-    .updateMany(
-      { id: { $in: childIDs } },
-      { $set: { rejectedAncestor: true } }
-    );
 };
 
 export default rejectComment;


### PR DESCRIPTION

## What does this PR do?

- Adds archived/is-archiving check to `canReply` resolver
- Uses retrieving ancestors by the `ancestorID`'s of a comment to determine if a parent was rejected when checking if a comment can reply.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

No changes to schema

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes

## How do I test this PR?

- Create a root comment with many replies
- Create replies to the replies using various commenter accounts
- Open single conversation view for one of the bottom most replies
- Reject a 1st (or near to root comment) reply
- Attempt to reply in the single conversation view
- See that it warns you an ancestor was rejected
- Refresh the page in single conversation view
- See that the reply buttons are greyed out below the rejected ancestor comment
- Approve the previously rejected reply/comment
- Refresh the single conversation view and see that the reply buttons are enabled again
- Make a reply and see that it is accepted
 
## How do we deploy this PR?

No special considerations