### PR TITLE
[CORL-2654] Cropped Youtube previews

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/MediaConfirmation/MediaPreview.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MediaConfirmation/MediaPreview.tsx
@@ -71,7 +71,7 @@ const MediaPreview: FunctionComponent<Props> = ({
             ) : media.type === "twitter" ? (
               <TwitterMedia url={media.url} siteID={siteID} />
             ) : media.type === "youtube" ? (
-              <YouTubeMedia url={media.url} siteID={siteID} />
+              <YouTubeMedia url={media.url} siteID={siteID} isToggled={true} />
             ) : null}
           </HorizontalGutter>
 


### PR DESCRIPTION
## What does this PR do?
This PR causes Youtube video previews (that appear after pasting a link to a Youtube video into the comment form, but before submitting) to initially render as "toggled" open, so they are not cropped.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Make sure Youtube embeds are enabled
2. While writing a comment, paste a valid youtube link into the comment body
3. Click "ADD VIDEO" in the confirm prompt
4. Observe that the full video preview is visible
 
## How do we deploy this PR?
No special considerations should be required.
