### PR TITLE
[CORL-2596] Handle users with a known missing email

### DIFF
--- a/src/core/server/queue/tasks/mailer/index.ts
+++ b/src/core/server/queue/tasks/mailer/index.ts
@@ -59,9 +59,9 @@ export class MailerQueue {
     // and did not provide an email. This is common on older
     // host sites that don't attach an email after the 3rd
     // party sign-on provider has finished validating their
-    // credentials. So we putting an email similar to:
+    // credentials. So we put an email similar to:
     //
-    // missing-601057
+    // missing-{{userID}}
     //
     // It's easy to check for since it's missing an '@' and
     // has their id embedded into it for easy debugging should

--- a/src/core/server/queue/tasks/mailer/index.ts
+++ b/src/core/server/queue/tasks/mailer/index.ts
@@ -53,13 +53,11 @@ export class MailerQueue {
       true
     );
 
-    // This is to handle users we know do not have an email
-    // because their account was made using SSO and the login
-    // provider on the host was also SSO (Google/FB/Twitter)
-    // and did not provide an email. This is common on older
-    // host sites that don't attach an email after the 3rd
-    // party sign-on provider has finished validating their
-    // credentials. So we put an email similar to:
+    // This is to handle sbn users that don't have an email.
+    // These are users who signed up with a third-party login
+    // identity (typically Google, FB, or Twitter) and that provider
+    // does not disclose that identity's email address to us for
+    // whatever reason. So we put an email similar to:
     //
     // missing-{{userID}}
     //

--- a/src/core/server/queue/tasks/mailer/index.ts
+++ b/src/core/server/queue/tasks/mailer/index.ts
@@ -53,6 +53,27 @@ export class MailerQueue {
       true
     );
 
+    // This is to handle users we know do not have an email
+    // because their account was made using SSO and the login
+    // provider on the host was also SSO (Google/FB/Twitter)
+    // and did not provide an email. This is common on older
+    // host sites that don't attach an email after the 3rd
+    // party sign-on provider has finished validating their
+    // credentials. So we putting an email similar to:
+    //
+    // missing-601057
+    //
+    // It's easy to check for since it's missing an '@' and
+    // has their id embedded into it for easy debugging should
+    // an error occur around it.
+    if (!to.includes("@") && to.startsWith("missing-")) {
+      log.error(
+        { email: to },
+        "not sending email, user does not have an email"
+      );
+      return;
+    }
+
     // All email templates require the tenant in order to insert the footer, so
     // load it from the tenant cache here.
     const tenant = await this.tenantCache.retrieveByID(tenantID);


### PR DESCRIPTION


## What does this PR do?

handle `missing-{{id}}` pattern in the mailer queue.

Prevents sending emails to users marked to never have emails since an email was never provided from the host site via SSO and never will be because they use 3rd party auth on the host site that doesn't attach an email.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- set a user's email to `missing-{{id}}`
- login as that user and attempt to do a password reset (or any email action)
- see that the logs show it ignored sending an email because the user is missing an email
- check a normal user, see that they can send emails normally
 
## How do we deploy this PR?

No special consideration.