### PR TITLE
make E-Mail notifications and Ignored Commenters h1s

### DIFF
--- a/src/core/client/stream/tabs/Profile/Preferences/IgnoreUserSettingsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Preferences/IgnoreUserSettingsContainer.tsx
@@ -56,12 +56,12 @@ const IgnoreUserSettingsContainer: FunctionComponent<Props> = ({ viewer }) => {
       aria-labelledby="profile-account-ignoredCommenters-title"
     >
       <Localized id="profile-account-ignoredCommenters">
-        <div
+        <h1
           className={styles.title}
           id="profile-account-ignoredCommenters-title"
         >
           Ignored Commenters
-        </div>
+        </h1>
       </Localized>
       <Localized id="profile-account-ignoredCommenters-description">
         <div className={styles.description}>

--- a/src/core/client/stream/tabs/Profile/Preferences/NotificationSettingsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Preferences/NotificationSettingsContainer.tsx
@@ -85,12 +85,12 @@ const NotificationSettingsContainer: FunctionComponent<Props> = ({
             <HorizontalGutter>
               <HorizontalGutter>
                 <Localized id="profile-account-notifications-emailNotifications">
-                  <div
+                  <h1
                     className={styles.title}
                     id="profile-account-notifications-emailNotifications-title"
                   >
                     Email Notifications
-                  </div>
+                  </h1>
                 </Localized>
               </HorizontalGutter>
               <HorizontalGutter>


### PR DESCRIPTION
## What does this PR do?
Makes the titles for "E-Mail Notifications" and "Ignored Users" under My Profile > Preferences `<h1>`s rather than `<div>`s.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. In the stream, navigate to the "My Profile" tab
2. Navigate to the "Preferences" pane
3. Note that "E-Mail Notifications" and "Ignored Users" are h1 elements
 
## How do we deploy this PR?
No special considerations should be required.
