### PR TITLE
Fix Docker builds for Apple M-series mac's

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:14-alpine
 ENV NODE_OPTIONS=--max-old-space-size=8192
 
 # Install build dependancies.
-RUN apk --no-cache add git python3
+RUN apk --no-cache add git python3 gcc g++ libc-dev musl musl-dev make
 
 RUN npm install -g npm@8.0.0
 


### PR DESCRIPTION
## What does this PR do?

Add container dependencies so docker builds can run on M1 macs (or any Docker host tbh).

Alpine linux relies on host OS having the right binaries for it to build our node app. Since it sees the pre-build x86 libs, it panics and tries to find/build them locally.

They aren't there cause none of this pre-built for Apple M1. By installing them, we ensure they are available for building our apps dependencies no matter which platform we are on.

Please note, this is only for our dependencies to build the app, this does not affect our runtime dependencies such as re2 for our wordlist detection which is pulled in as an x86 lib for use on our cloud systems which are x86 based.

Note: adds about 80 MB of size to the container image.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Use an M1/M2 mac
- `docker build -t <TAG>`
- See it succeeds
 
## How do we deploy this PR?

No special considerations.
