### PR TITLE
[patch:6.18.x] update unarchiving to use a job task

### DIFF
--- a/src/core/client/admin/components/StoryInfoDrawer/ArchiveStoryActionsContainer.css
+++ b/src/core/client/admin/components/StoryInfoDrawer/ArchiveStoryActionsContainer.css
@@ -1,4 +1,3 @@
 .button {
-  width: 100px;
   margin: var(--spacing-2) 0;
 }

--- a/src/core/client/admin/components/StoryInfoDrawer/ArchiveStoryActionsContainer.tsx
+++ b/src/core/client/admin/components/StoryInfoDrawer/ArchiveStoryActionsContainer.tsx
@@ -67,6 +67,16 @@ const ArchiveStoryActionsContainer: FunctionComponent<Props> = ({
     !story.isArchiving &&
     story.isArchived;
 
+  if (story.isUnarchiving) {
+    return (
+      <Localized id="stories-actions-isUnarchiving">
+        <Button className={styles.button} disabled={true} color="secondary">
+          Unarchiving
+        </Button>
+      </Localized>
+    );
+  }
+
   if (canArchive) {
     return (
       <Localized id="stories-actions-archive">
@@ -99,6 +109,7 @@ const enhanced = withFragmentContainer<Props>({
       id
       isArchiving
       isArchived
+      isUnarchiving
       isClosed
       status
       settings {

--- a/src/core/client/admin/components/StoryInfoDrawer/StoryInfoDrawerContainer.css
+++ b/src/core/client/admin/components/StoryInfoDrawer/StoryInfoDrawerContainer.css
@@ -25,8 +25,8 @@
   margin: var(--spacing-4) 0;
 }
 
-.archived {
-  width: 100px;
+.flexSizeToContentWidth {
+  width: min-content;
 }
 
 .publishInfoSection {

--- a/src/core/client/admin/components/StoryInfoDrawer/StoryInfoDrawerContainer.tsx
+++ b/src/core/client/admin/components/StoryInfoDrawer/StoryInfoDrawerContainer.tsx
@@ -51,12 +51,14 @@ const StoryInfoDrawerContainer: FunctionComponent<Props> = ({
           </TextLink>
           {story.isArchived || story.isArchiving ? (
             <Flex direction="column" className={styles.status}>
-              <Flex direction="column" className={styles.archived}>
+              <div className={styles.flexSizeToContentWidth}>
                 <ArchivedMarker />
-                {viewer && (
+              </div>
+              {viewer && (
+                <div className={styles.flexSizeToContentWidth}>
                   <ArchiveStoryActionsContainer story={story} viewer={viewer} />
-                )}
-              </Flex>
+                </div>
+              )}
             </Flex>
           ) : (
             <>
@@ -79,7 +81,9 @@ const StoryInfoDrawerContainer: FunctionComponent<Props> = ({
               </Flex>
               <RescrapeStory storyID={story.id} />
               {viewer && (
-                <ArchiveStoryActionsContainer story={story} viewer={viewer} />
+                <div className={styles.flexSizeToContentWidth}>
+                  <ArchiveStoryActionsContainer story={story} viewer={viewer} />
+                </div>
               )}
               <StorySettingsContainer
                 settings={story.settings}

--- a/src/core/client/admin/components/StoryInfoDrawer/UnarchiveStoriesMutation.ts
+++ b/src/core/client/admin/components/StoryInfoDrawer/UnarchiveStoriesMutation.ts
@@ -24,6 +24,7 @@ const UnarchiveStoriesMutation = createMutation(
               status
               isArchived
               isArchiving
+              isUnarchiving
             }
             clientMutationId
           }
@@ -37,6 +38,7 @@ const UnarchiveStoriesMutation = createMutation(
               status: GQLSTORY_STATUS.CLOSED,
               isArchived: true,
               isArchiving: false,
+              isUnarchiving: true,
             },
           ],
           clientMutationId: clientMutationId.toString(),

--- a/src/core/client/admin/components/TranslatedStoryStatus.tsx
+++ b/src/core/client/admin/components/TranslatedStoryStatus.tsx
@@ -8,6 +8,7 @@ interface Props {
   children: GQLSTORY_STATUS_RL;
   isArchiving?: boolean;
   isArchived?: boolean;
+  isUnarchiving?: boolean;
 }
 
 function createElement(
@@ -26,6 +27,14 @@ const TranslatedRole: React.FunctionComponent<Props> = (props) => {
     return (
       <Localized id="storyStatus-open">
         {createElement(props.container!, "Open")}
+      </Localized>
+    );
+  }
+
+  if (props.children === GQLSTORY_STATUS.CLOSED && props.isUnarchiving) {
+    return (
+      <Localized id="storyStatus-unarchiving">
+        {createElement(props.container!, "Unarchiving")}
       </Localized>
     );
   }

--- a/src/core/client/admin/routes/Stories/StoryStatus/StoryStatusContainer.tsx
+++ b/src/core/client/admin/routes/Stories/StoryStatus/StoryStatusContainer.tsx
@@ -16,6 +16,7 @@ const StoryStatusContainer: FunctionComponent<Props> = (props) => {
     <StoryStatusText
       isArchived={props.story.isArchived}
       isArchiving={props.story.isArchiving}
+      isUnarchiving={props.story.isUnarchiving}
     >
       {props.story.status}
     </StoryStatusText>
@@ -29,6 +30,7 @@ const enhanced = withFragmentContainer<Props>({
       status
       isArchiving
       isArchived
+      isUnarchiving
     }
   `,
 })(StoryStatusContainer);

--- a/src/core/client/admin/routes/Stories/StoryStatus/StoryStatusText.tsx
+++ b/src/core/client/admin/routes/Stories/StoryStatus/StoryStatusText.tsx
@@ -10,6 +10,7 @@ interface Props {
   children: GQLSTORY_STATUS_RL;
   isArchiving?: boolean;
   isArchived?: boolean;
+  isUnarchiving?: boolean;
 }
 
 const StoryStatusText: FunctionComponent<Props> = (props) => (
@@ -23,6 +24,7 @@ const StoryStatusText: FunctionComponent<Props> = (props) => (
     }
     isArchiving={props.isArchiving}
     isArchived={props.isArchived}
+    isUnarchiving={props.isUnarchiving}
   >
     {props.children}
   </TranslatedStoryStatus>

--- a/src/core/client/admin/test/fixtures.ts
+++ b/src/core/client/admin/test/fixtures.ts
@@ -602,6 +602,7 @@ export const stories = createFixtures<GQLStory>([
     isClosed: false,
     isArchived: false,
     isArchiving: false,
+    isUnarchiving: false,
     status: GQLSTORY_STATUS.OPEN,
     createdAt: "2018-11-29T16:01:51.897Z",
     url: "",
@@ -635,6 +636,7 @@ export const stories = createFixtures<GQLStory>([
     isClosed: false,
     isArchived: false,
     isArchiving: false,
+    isUnarchiving: false,
     status: GQLSTORY_STATUS.OPEN,
     createdAt: "2018-11-29T16:01:51.897Z",
     url: "",
@@ -669,6 +671,7 @@ export const stories = createFixtures<GQLStory>([
     isClosed: true,
     isArchived: false,
     isArchiving: false,
+    isUnarchiving: false,
     status: GQLSTORY_STATUS.CLOSED,
     url: "",
     commentCounts: {

--- a/src/core/client/stream/test/fixtures.ts
+++ b/src/core/client/stream/test/fixtures.ts
@@ -349,6 +349,7 @@ export const baseStory = createFixture<GQLStory>({
   isClosed: false,
   isArchiving: false,
   isArchived: false,
+  isUnarchiving: false,
   comments: {
     edges: [],
     pageInfo: {

--- a/src/core/server/app/index.ts
+++ b/src/core/server/app/index.ts
@@ -35,6 +35,7 @@ import { MailerQueue } from "coral-server/queue/tasks/mailer";
 import { NotifierQueue } from "coral-server/queue/tasks/notifier";
 import { RejectorQueue } from "coral-server/queue/tasks/rejector";
 import { ScraperQueue } from "coral-server/queue/tasks/scraper";
+import { UnarchiverQueue } from "coral-server/queue/tasks/unarchiver";
 import { WebhookQueue } from "coral-server/queue/tasks/webhook";
 import { ErrorReporter } from "coral-server/services/errors";
 import { I18n } from "coral-server/services/i18n";
@@ -74,6 +75,7 @@ export interface AppOptions {
   signingConfig: JWTSigningConfig;
   tenantCache: TenantCache;
   webhookQueue: WebhookQueue;
+  unarchiverQueue: UnarchiverQueue;
 }
 
 /**

--- a/src/core/server/graph/context.ts
+++ b/src/core/server/graph/context.ts
@@ -16,6 +16,7 @@ import { MailerQueue } from "coral-server/queue/tasks/mailer";
 import { NotifierQueue } from "coral-server/queue/tasks/notifier";
 import { RejectorQueue } from "coral-server/queue/tasks/rejector";
 import { ScraperQueue } from "coral-server/queue/tasks/scraper";
+import { UnarchiverQueue } from "coral-server/queue/tasks/unarchiver";
 import { WebhookQueue } from "coral-server/queue/tasks/webhook";
 import { ErrorReporter } from "coral-server/services/errors";
 import { I18n } from "coral-server/services/i18n";
@@ -48,6 +49,7 @@ export interface GraphContextOptions {
   scraperQueue: ScraperQueue;
   webhookQueue: WebhookQueue;
   notifierQueue: NotifierQueue;
+  unarchiverQueue: UnarchiverQueue;
   mongo: MongoContext;
   pubsub: RedisPubSub;
   redis: AugmentedRedis;
@@ -72,6 +74,7 @@ export default class GraphContext {
   public readonly scraperQueue: ScraperQueue;
   public readonly webhookQueue: WebhookQueue;
   public readonly notifierQueue: NotifierQueue;
+  public readonly unarchiverQueue: UnarchiverQueue;
   public readonly mongo: MongoContext;
   public readonly mutators: ReturnType<typeof mutators>;
   public readonly now: Date;
@@ -116,6 +119,7 @@ export default class GraphContext {
     this.rejectorQueue = options.rejectorQueue;
     this.notifierQueue = options.notifierQueue;
     this.webhookQueue = options.webhookQueue;
+    this.unarchiverQueue = options.unarchiverQueue;
     this.signingConfig = options.signingConfig;
     this.clientID = options.clientID;
     this.reporter = options.reporter;

--- a/src/core/server/graph/mutators/Stories.ts
+++ b/src/core/server/graph/mutators/Stories.ts
@@ -9,7 +9,7 @@ import {
   retrieveStory,
   Story,
 } from "coral-server/models/story";
-import { archiveStory, unarchiveStory } from "coral-server/services/archive";
+import { archiveStory } from "coral-server/services/archive";
 import {
   addExpert,
   close,
@@ -162,26 +162,15 @@ export const Stories = (ctx: GraphContext) => ({
     const stories: Readonly<Story>[] = [];
 
     for (const storyID of input.storyIDs) {
-      const markResult = await markStoryForUnarchiving(
+      const result = await markStoryForUnarchiving(
         ctx.mongo,
         ctx.tenant.id,
         storyID,
         ctx.now
       );
 
-      if (markResult) {
-        await unarchiveStory(
-          ctx.mongo,
-          ctx.redis,
-          ctx.tenant.id,
-          storyID,
-          ctx.logger,
-          ctx.now
-        );
-      }
-
-      const result = await retrieveStory(ctx.mongo, ctx.tenant.id, storyID);
-      if (result) {
+      if (result && result.isUnarchiving) {
+        await ctx.unarchiverQueue.add({ storyID, tenantID: ctx.tenant.id });
         stories.push(result);
       }
     }

--- a/src/core/server/graph/resolvers/Queues.ts
+++ b/src/core/server/graph/resolvers/Queues.ts
@@ -20,4 +20,5 @@ export const Queues: Required<GQLQueuesTypeResolver> = {
   notifier: get((ctx) => ctx.notifierQueue),
   webhook: get((ctx) => ctx.webhookQueue),
   rejector: get((ctx) => ctx.rejectorQueue),
+  unarchiver: get((ctx) => ctx.unarchiverQueue),
 };

--- a/src/core/server/graph/resolvers/Story.ts
+++ b/src/core/server/graph/resolvers/Story.ts
@@ -38,6 +38,7 @@ export const Story: GQLStoryTypeResolver<story.Story> = {
   closedAt: (s, input, ctx) => story.getStoryClosedAt(ctx.tenant, s) || null,
   isArchiving: (s, input, ctx) => story.isStoryArchiving(s),
   isArchived: (s, input, ctx) => story.isStoryArchived(s),
+  isUnarchiving: (s, input, ctx) => story.isStoryUnarchiving(s),
   commentActionCounts: (s) => decodeActionCounts(s.commentCounts.action),
   commentCounts: (s): CommentCountsInput => s,
   // Merge tenant settings into the story settings so we can easily inherit the

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -4100,6 +4100,12 @@ type Story @cacheControl(maxAge: 30) {
   isArchived: Boolean!
 
   """
+  isUnarchiving returns true when a story is in-between being unarchived and is
+  yet to be fully unarchived.
+  """
+  isUnarchiving: Boolean!
+
+  """
   commentCounts stores all the counts of Comments that are left on the Comment.
   """
   commentCounts: CommentCounts!
@@ -4240,6 +4246,11 @@ type Queues {
   rejector is the Queue associated with the Rejector queue.
   """
   rejector: Queue!
+
+  """
+  unarchiver is the Queue associated with unarchiving stories.
+  """
+  unarchiver: Queue!
 }
 
 ################################################################################

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -312,6 +312,7 @@ class Server {
       this.tasks.webhook.process();
       this.tasks.rejector.process();
       this.tasks.archiver.process();
+      this.tasks.unarchiver.process();
 
       // Start up the cron job processors.
       this.scheduledTasks = startScheduledTasks({
@@ -378,6 +379,7 @@ class Server {
       signingConfig: this.signingConfig,
       tenantCache: this.tenantCache,
       webhookQueue: this.tasks.webhook,
+      unarchiverQueue: this.tasks.unarchiver,
     };
 
     // Create the Coral App, branching off from the parent app.

--- a/src/core/server/models/story/helpers.ts
+++ b/src/core/server/models/story/helpers.ts
@@ -81,6 +81,10 @@ export function isStoryArchived(story: Pick<Story, "isArchived">) {
   return story.isArchived ?? false;
 }
 
+export function isStoryUnarchiving(story: Pick<Story, "isUnarchiving">) {
+  return story.isUnarchiving ?? false;
+}
+
 export function resolveStoryMode(
   storySettings: Story["settings"],
   tenant: Pick<Tenant, "featureFlags">

--- a/src/core/server/queue/index.ts
+++ b/src/core/server/queue/index.ts
@@ -16,6 +16,7 @@ import { createMailerTask, MailerQueue } from "./tasks/mailer";
 import { createNotifierTask, NotifierQueue } from "./tasks/notifier";
 import { createRejectorTask, RejectorQueue } from "./tasks/rejector";
 import { createScraperTask, ScraperQueue } from "./tasks/scraper";
+import { createUnarchiverTask, UnarchiverQueue } from "./tasks/unarchiver";
 import { createWebhookTask, WebhookQueue } from "./tasks/webhook";
 
 const createQueueOptions = (config: Config): Queue.QueueOptions => {
@@ -62,6 +63,7 @@ export interface TaskQueue {
   webhook: WebhookQueue;
   rejector: RejectorQueue;
   archiver: ArchiverQueue;
+  unarchiver: UnarchiverQueue;
 }
 
 export function createQueue(options: QueueOptions): TaskQueue {
@@ -82,6 +84,7 @@ export function createQueue(options: QueueOptions): TaskQueue {
   const webhook = createWebhookTask(queueOptions, options);
   const rejector = createRejectorTask(queueOptions, options);
   const archiver = createArchiverTask(queueOptions, options);
+  const unarchiver = createUnarchiverTask(queueOptions, options);
 
   // Return the tasks + client.
   return {
@@ -91,5 +94,6 @@ export function createQueue(options: QueueOptions): TaskQueue {
     webhook,
     rejector,
     archiver,
+    unarchiver,
   };
 }

--- a/src/core/server/queue/tasks/unarchiver.ts
+++ b/src/core/server/queue/tasks/unarchiver.ts
@@ -1,0 +1,105 @@
+import { QueueOptions } from "bull";
+
+import { MongoContext } from "coral-server/data/context";
+import { createTimer } from "coral-server/helpers";
+import logger from "coral-server/logger";
+import { retrieveStoryToBeUnarchived } from "coral-server/models/story";
+import Task, { JobProcessor } from "coral-server/queue/Task";
+import { unarchiveStory } from "coral-server/services/archive";
+import { AugmentedRedis } from "coral-server/services/redis";
+import { TenantCache } from "coral-server/services/tenant/cache";
+
+const JOB_NAME = "unarchiver";
+
+export interface UnarchiverProcessorOptions {
+  mongo: MongoContext;
+  redis: AugmentedRedis;
+  tenantCache: TenantCache;
+}
+
+export interface UnarchiverData {
+  tenantID: string;
+  storyID: string;
+}
+
+const createJobProcessor = ({
+  mongo,
+  redis,
+  tenantCache,
+}: UnarchiverProcessorOptions): JobProcessor<UnarchiverData> => {
+  return async (job) => {
+    const { storyID, tenantID } = job.data;
+
+    const log = logger.child(
+      {
+        jobID: job.id,
+        jobName: JOB_NAME,
+        storyID,
+        tenantID,
+      },
+      true
+    );
+
+    const timer = createTimer();
+
+    log.info("attempting to unarchive story");
+
+    const tenant = await tenantCache.retrieveByID(tenantID);
+    if (!tenant) {
+      log.error("referenced tenant was not found");
+      return;
+    }
+
+    const now = new Date();
+
+    const story = await retrieveStoryToBeUnarchived(
+      mongo,
+      tenantID,
+      storyID,
+      now
+    );
+    if (!story) {
+      log.warn(
+        { storyID },
+        "unarchiver was unable to lock story for unarchiving"
+      );
+      return;
+    }
+
+    log.info({ storyID }, "found story, proceeding with unarchiving");
+
+    const result = await unarchiveStory(
+      mongo,
+      redis,
+      tenant.id,
+      story.id,
+      log,
+      now
+    );
+
+    if (!result?.isArchived && !result?.isArchiving) {
+      log.info({ storyID }, "successfully unarchived story");
+    } else {
+      log.error({ storyID }, "unable to unarchive story");
+      throw new Error("unable to unarchive story");
+    }
+
+    log.debug({ took: timer() }, "attempted unarchive operation ended");
+  };
+};
+
+export type UnarchiverQueue = Task<UnarchiverData>;
+
+export function createUnarchiverTask(
+  queue: QueueOptions,
+  options: UnarchiverProcessorOptions
+) {
+  return new Task({
+    jobName: JOB_NAME,
+    jobProcessor: createJobProcessor(options),
+    queue,
+    jobIdGenerator: ({ tenantID, storyID }) =>
+      `${tenantID}:${storyID}:unarchive`,
+    attempts: 1,
+  });
+}

--- a/src/core/server/services/archive/index.ts
+++ b/src/core/server/services/archive/index.ts
@@ -49,20 +49,19 @@ export async function archiveStory(
     tenantID,
     storyID: id,
   };
+  const targetCommentModerationActions = {
+    tenantID,
+    storyID: id,
+  };
 
   logger.info("archiving comments");
-  const targetCommentIDs = await moveDocuments({
+  await moveDocuments({
     tenantID,
     source: mongo.comments(),
     filter: targetComments,
     destination: mongo.archivedComments(),
     returnMovedIDs: true,
   });
-
-  const targetCommentModerationActions = {
-    tenantID,
-    commentID: { $in: targetCommentIDs },
-  };
 
   logger.info("archiving comment actions");
   await moveDocuments({
@@ -133,20 +132,19 @@ export async function unarchiveStory(
     tenantID,
     storyID: id,
   };
+  const targetCommentModerationActions = {
+    tenantID,
+    storyID: id,
+  };
 
   logger.info("unarchiving comments");
-  const targetCommentIDs = await moveDocuments({
+  await moveDocuments({
     tenantID,
     source: mongo.archivedComments(),
     filter: targetComments,
     destination: mongo.comments(),
     returnMovedIDs: true,
   });
-
-  const targetCommentModerationActions = {
-    tenantID,
-    commentID: { $in: targetCommentIDs },
-  };
 
   logger.info("unarchiving comment actions");
   await moveDocuments({

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -11,6 +11,7 @@ storyStatus-open = Open
 storyStatus-closed = Closed
 storyStatus-archiving = Archiving
 storyStatus-archived = Archived
+storyStatus-unarchiving = Unarchiving
 
 ## Roles
 role-admin = Admin
@@ -573,6 +574,7 @@ stories-actions-close = Close story
 stories-actions-open = Open story
 stories-actions-archive = Archive story
 stories-actions-unarchive = Unarchive story
+stories-actions-isUnarchiving = Unarchiving
 
 ### Sections
 


### PR DESCRIPTION
## What does this PR do?

Moves unarchiving operations to a job task that can run independently of a mutation request. This allows long running unarchive jobs to get proper CPU resources to finish until completion.

Also updates the UI to display this unarchiving job status to the user in both the Admin > Stories table and also the Story drawer.

## These changes will impact:

- [ ] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds a `isUnarchiving: Boolean!` resolver to the `Story` type.

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Go to Admin > Stories
- Pick a story
- Archive it using the story drawer options
- Unarchive it using story drawer options
- See that it shows `Unarchiving` state
- See that it finishes unarchiving the story
- See that it shows `Closed` state (stories remain closed after unarchiving)
- See that you can open story using story drawer
- Check that story stream works and is open
 
## How do we deploy this PR?

No special considerations.
