### PR TITLE
[CORL-2707] Go to comment username

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/FeaturedComments/FeaturedCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/FeaturedComments/FeaturedCommentContainer.tsx
@@ -72,7 +72,6 @@ const FeaturedCommentContainer: FunctionComponent<Props> = (props) => {
     [emitViewConversationEvent, comment.id, setCommentID]
   );
 
-  // TEMPORARY MARCUS
   const gotoConvAriaLabelId = comment.author?.username
     ? "comments-featured-gotoConversation-label-with-username"
     : "comments-featured-gotoConversation-label-without-username";

--- a/src/core/client/stream/tabs/Comments/Stream/FeaturedComments/FeaturedCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/FeaturedComments/FeaturedCommentContainer.tsx
@@ -177,7 +177,7 @@ const FeaturedCommentContainer: FunctionComponent<Props> = (props) => {
               <Localized
                 id={gotoConvAriaLabelId}
                 attrs={{ "aria-label": true }}
-                vars={{ username: undefined }}
+                vars={{ username: comment.author?.username }}
               >
                 <Button
                   className={cn(

--- a/src/core/client/stream/test/comments/featured/__snapshots__/renderFeaturedStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/featured/__snapshots__/renderFeaturedStream.spec.tsx.snap
@@ -596,7 +596,7 @@ exports[`renders comment stream 1`] = `
                       className="Box-root Flex-root Flex-flex Flex-alignCenter"
                     >
                       <a
-                        aria-label="Go to this featured comment by user {$username} in the main comment stream"
+                        aria-label="Go to this featured comment by user Markus in the main comment stream"
                         className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold coral coral-featuredComment-goToConversationButton FeaturedCommentContainer-gotoConversation"
                         data-variant="flat"
                         disabled={false}
@@ -745,7 +745,7 @@ exports[`renders comment stream 1`] = `
                       className="Box-root Flex-root Flex-flex Flex-alignCenter"
                     >
                       <a
-                        aria-label="Go to this featured comment by user {$username} in the main comment stream"
+                        aria-label="Go to this featured comment by user Lukas in the main comment stream"
                         className="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold coral coral-featuredComment-goToConversationButton FeaturedCommentContainer-gotoConversation"
                         data-variant="flat"
                         disabled={false}


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug in which the aria label for the "Go to Conversation" button on a featured comment does not have the username of the comment's author populated

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. As a moderator, feature a comment
2. Inspect the button in the lower right hand corner of the featured comment that says "Go to conversation"
3. Observe that it has an aria label in the form of "Go to this featured comment by user { $username } in the main comment stream" (or "Go to this featured comment in the main comment stream" in the case that the user has no username)
 
 
## How do we deploy this PR?
No special considerations should be required

