### PR TITLE
[CORL-2706] expand media by default to avoid cropping

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/MediaSection/MediaSectionContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MediaSection/MediaSectionContainer.tsx
@@ -40,7 +40,7 @@ const MediaSectionContainer: FunctionComponent<Props> = ({
         }
       }
     `);
-  const [isToggled, setIsToggled] = useState(false);
+  const [isToggled, setIsToggled] = useState(true);
   const onToggleExpand = useCallback(() => {
     const initialMediaSettings = expandedMediaSettings ?? { commentIDs: [] };
     const indexOfComment = initialMediaSettings.commentIDs.indexOf(comment.id);


### PR DESCRIPTION
## What does this PR do?
This fixes a bug in which external media are cropped by default when a user has their preferences set to always show media on comments.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. As a commenter, create a comment with attached media (a youtube video or a gif)
2. Update your preferences so that external media is always shown
3. View the stream and note that all external media is expanded and is not cropped
 
 
## How do we deploy this PR?
No special considerations should be required.
