### PR TITLE
[CORL-2702] Rec Level Styling bug

### DIFF
--- a/src/core/client/stream/classes.ts
+++ b/src/core/client/stream/classes.ts
@@ -425,15 +425,7 @@ const CLASSES = {
     /**
      * indentation classes for the different levels.
      */
-    indent: [
-      "coral coral-indent coral-indent-0",
-      "coral coral-indent coral-indent-1",
-      "coral coral-indent coral-indent-2",
-      "coral coral-indent coral-indent-3",
-      "coral coral-indent coral-indent-4",
-      "coral coral-indent coral-indent-5",
-      "coral coral-indent coral-indent-6",
-    ],
+    indent: (level: number) => `coral coral-indent coral-indent-${level}`,
   },
 
   /**

--- a/src/core/client/stream/tabs/Comments/Indent.tsx
+++ b/src/core/client/stream/tabs/Comments/Indent.tsx
@@ -30,7 +30,7 @@ function getLevelClassName(level = 0) {
   if (!(level in levels)) {
     throw new Error(`Indent level ${level} does not exist`);
   }
-  return cn(levels[level], CLASSES.comment.indent[level]);
+  return cn(levels[level], CLASSES.comment.indent(level));
 }
 
 const Indent: FunctionComponent<IndentProps> = (props) => {


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug in which flattened replies did not receive the CSS classes necessary to allow custom style sheets to style them based on how many times they had been interacted with.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Include a custom style sheet that styles comments based on number of reactions a comment has received*
2. Enable flattened replies
3. Create a reply chain deep enough to start flattening replies
4. Give comments, both before the flattening threshold and after, enough reactions to pass the threshold (2 in the example below)
5. Observe that both comments receive the custom styling.

*example from docs
```css
.coral-comment .coral-indent {
  background-color: coral;
}

.coral-reacted-0 .coral-indent,
.coral-reacted-1 .coral-indent,
.coral-reacted-2 .coral-indent {
  background-color: transparent;
}
```
 
 
## How do we deploy this PR?
No special considerations should be nessecary.
