### PR TITLE
[CORL-2696] Accessible label for Manage button in ignored users

### DIFF
--- a/src/core/client/stream/tabs/Profile/Preferences/IgnoreUserSettingsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Preferences/IgnoreUserSettingsContainer.tsx
@@ -91,6 +91,7 @@ const IgnoreUserSettingsContainer: FunctionComponent<Props> = ({ viewer }) => {
         <Localized
           id="profile-account-ignoredCommenters-manage"
           key="toggleButton"
+          attrs={{ "aria-label": true }}
         >
           <Button
             variant="outlined"
@@ -101,6 +102,7 @@ const IgnoreUserSettingsContainer: FunctionComponent<Props> = ({ viewer }) => {
               styles.manageButton,
               CLASSES.ignoredCommenters.manageButton
             )}
+            aria-label="Manage ignored commenters"
           >
             Manage
           </Button>

--- a/src/core/client/stream/test/profile/preferences.spec.tsx
+++ b/src/core/client/stream/test/profile/preferences.spec.tsx
@@ -144,7 +144,7 @@ it("render empty ignored users list", async () => {
     "profile-account-ignoredCommenters"
   );
   const editButton = within(ignoredCommenters).getByRole("button", {
-    name: "Manage",
+    name: "Manage ignored commenters",
   });
   userEvent.click(editButton);
   expect(
@@ -177,7 +177,7 @@ it("render ignored users list", async () => {
     "profile-account-ignoredCommenters"
   );
   const editButton = within(ignoredCommenters).getByRole("button", {
-    name: "Manage",
+    name: "Manage ignored commenters",
   });
   userEvent.click(editButton);
   within(ignoredCommenters).getByText(commenters[0].username!);

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -518,6 +518,7 @@ profile-account-ignoredCommenters-stopIgnoring = Stop ignoring
 profile-account-ignoredCommenters-youAreNoLonger =
   You are no longer ignoring
 profile-account-ignoredCommenters-manage = Manage
+  .aria-label = Manage ignored commenters
 profile-account-ignoredCommenters-cancel = Cancel
 profile-account-ignoredCommenters-close = Close
 


### PR DESCRIPTION
## What does this PR do?
This PR makes the "Manage" button under Ignored Users settings more accessible.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
Noe.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Using a screen reader, navigate to Stream -> My Profile -> Preferences -> Ignored Users, and tab to the button that says "Manage"
2. Observe the the screen reader says "Manage ignored users" rather than just "Manage"
 
 
## How do we deploy this PR?
No special considerations should be nessecary