### PR TITLE
Add a reload function for Coral article count scripts

### DIFF
--- a/src/core/client/count/injectJSONPCallback.ts
+++ b/src/core/client/count/injectJSONPCallback.ts
@@ -135,6 +135,7 @@ function injectJSONPCallback(getCount: GetCountFunction) {
       });
     },
     getCount,
+    reload: () => getCount(),
   };
 }
 


### PR DESCRIPTION
## What does this PR do?

This adds a reload function to `window.CoralCounts` which is the API interface we use for article counts.

This is to allow our clients to be able to lazy load their article listings and tell the counts script to reload counts for them as they appear on the page instead of just once when the counts script loads.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Pull down multi-site-test to work with Coral
- Set up the multi-site test to host a site with some stories
     - There is a readme for how to setup the `config.json` if you're unfamiliar or haven't used multi-site-test in a while
- Set the property `"delayMs": 5000` for a story in the `config.json`
     - This will allow that story to load in 5 seconds (5000 ms) after the main index page of stories loads all the other stories
- Make sure Coral is set up to allow the domain your multi-site-test is hosting on locally
- Spin up coral after building the code (`npm run start:development` will do)
- Head to your multi-site-test page
- See the list of stories
- See that they have the `X comments` text (or similar) next to each story
- See that after 5 seconds the new story that comes in also has `X comments` text
- Done!
 
## How do we deploy this PR?

No special considerations.

**NOTE: this is a priority feature internally, so should be pushed out in next release ASAP.**