### PR TITLE
Multiple fixes for Akismet integration

### DIFF
--- a/src/core/server/services/comments/actions.ts
+++ b/src/core/server/services/comments/actions.ts
@@ -37,7 +37,6 @@ import {
   publishCommentFlagCreated,
   publishCommentReactionCreated,
 } from "../events";
-import { submitCommentAsSpam } from "../spam";
 
 export type CreateAction = CreateActionInput;
 
@@ -417,16 +416,6 @@ export async function createFlag(
     ).catch((err) => {
       logger.error({ err }, "could not publish comment flag created");
     });
-
-    const revision = getLatestRevision(comment);
-    if (
-      revision &&
-      tenant.integrations.akismet.enabled &&
-      action.actionType === ACTION_TYPE.FLAG &&
-      action.reason === GQLCOMMENT_FLAG_REPORTED_REASON.COMMENT_REPORTED_SPAM
-    ) {
-      await submitCommentAsSpam(mongo, tenant, comment, request);
-    }
   }
 
   return comment;

--- a/src/core/server/services/comments/pipeline/phases/spam.ts
+++ b/src/core/server/services/comments/pipeline/phases/spam.ts
@@ -1,29 +1,15 @@
-import fetch from "node-fetch";
-
 import { SpamCommentError } from "coral-server/errors";
 import { ACTION_TYPE } from "coral-server/models/action/comment";
 import {
   IntermediateModerationPhase,
   IntermediatePhaseResult,
 } from "coral-server/services/comments/pipeline";
+import { checkCommentIsSpam } from "coral-server/services/spam";
 
 import {
   GQLCOMMENT_FLAG_REASON,
   GQLCOMMENT_STATUS,
 } from "coral-server/graph/schema/__generated__/types";
-
-interface AkismetParameters {
-  api_key: string;
-  blog: string;
-  user_ip: string;
-  user_agent: string;
-  referrer: string;
-  permalink: string;
-  comment_type: string;
-  comment_author: string;
-  comment_content: string;
-  recheck_reason?: string;
-}
 
 export const spam: IntermediateModerationPhase = async ({
   story,
@@ -34,138 +20,43 @@ export const spam: IntermediateModerationPhase = async ({
   nudge,
   log,
 }): Promise<IntermediatePhaseResult | void> => {
-  const integration = tenant.integrations.akismet;
-
-  // We can only check for spam if this comment originated from a graphql
-  // request via an HTTP call.
-  if (!req) {
-    log.debug("request was not available");
-    return;
+  let recheck;
+  if (comment.id) {
+    // We only have a comment ID already at this point if this comment is being
+    // edited.
+    recheck = "edit";
   }
+  const isSpam = await checkCommentIsSpam(
+    tenant,
+    comment,
+    req,
+    story,
+    author,
+    recheck
+  );
+  log.trace("checking comment for spam");
+  if (isSpam) {
+    log.trace({ isSpam }, "comment contained spam");
 
-  if (!integration.enabled) {
-    log.debug("akismet integration was disabled");
-    return;
-  }
-
-  if (!integration.key) {
-    log.error(
-      "akismet integration was enabled but the key configuration was missing"
-    );
-    return;
-  }
-
-  if (!integration.site) {
-    log.error(
-      "akismet integration was enabled but the site configuration was missing"
-    );
-    return;
-  }
-
-  // If the comment doesn't have a body, it can't be spam!
-  if (!comment.body) {
-    return;
-  }
-
-  // Grab the properties we need.
-  let userIP = "";
-
-  // Only use the ip address if ipBased is enabled. This property is by default
-  // not set, that's why we're explicitly checking if it is false before using
-  // it.
-  if (integration.ipBased !== false) {
-    if (req.ip) {
-      userIP = req.ip;
-    } else {
-      log.debug(
-        "request did not contain ip address, continue spam check with empty ip address"
-      );
+    // Throw an error if we're nudging instead of recording.
+    if (nudge) {
+      throw new SpamCommentError();
     }
-  } else {
-    log.trace("not adding ip address to request due to configuration");
-  }
 
-  const userAgent = req.get("User-Agent") || "";
-
-  const referrer = req.get("Referrer") || "";
-
-  try {
-    log.trace("checking comment for spam");
-
-    const params: AkismetParameters = {
-      api_key: integration.key,
-      blog: integration.site,
-      user_ip: userIP,
-      user_agent: userAgent,
-      referrer,
-      permalink: story.url,
-      comment_type: "comment",
-      comment_author: author.username || "",
-      comment_content: comment.body,
-    };
-    if (comment.id) {
-      params.recheck_reason = "edit";
-    }
-    // Check the comment for spam.
-    const isSpam = await checkSpam(params);
-    if (isSpam) {
-      log.trace({ isSpam }, "comment contained spam");
-
-      // Throw an error if we're nudging instead of recording.
-      if (nudge) {
-        throw new SpamCommentError();
-      }
-
-      return {
-        status: GQLCOMMENT_STATUS.SYSTEM_WITHHELD,
-        actions: [
-          {
-            actionType: ACTION_TYPE.FLAG,
-            reason: GQLCOMMENT_FLAG_REASON.COMMENT_DETECTED_SPAM,
-          },
-        ],
-        metadata: {
-          // Store the spam result from Akismet in the Comment metadata.
-          akismet: isSpam,
+    return {
+      status: GQLCOMMENT_STATUS.SYSTEM_WITHHELD,
+      actions: [
+        {
+          actionType: ACTION_TYPE.FLAG,
+          reason: GQLCOMMENT_FLAG_REASON.COMMENT_DETECTED_SPAM,
         },
-      };
-    }
-
-    log.trace({ isSpam }, "comment did not contain spam");
-  } catch (err) {
-    // Rethrow any SpamCommentError.
-    if (err instanceof SpamCommentError) {
-      throw err;
-    }
-
-    log.error({ err }, "could not determine if comment contained spam");
+      ],
+      metadata: {
+        // Store the spam result from Akismet in the Comment metadata.
+        akismet: isSpam,
+      },
+    };
   }
-};
 
-const checkSpam = async (params: AkismetParameters) => {
-  const url = "https://rest.akismet.com/1.1/comment-check";
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: new URLSearchParams(Object.entries(params)).toString(),
-  });
-
-  const body = await response.text();
-  if (body === "true") {
-    return true;
-  }
-  if (body === "false") {
-    return false;
-  }
-  if (body === "invalid") {
-    throw new Error("Invalid Akismet API key");
-  }
-  const help = response.headers.get("x-akismet-debug-help");
-  if (help) {
-    throw new Error(help);
-  }
-  throw new Error(body);
+  log.trace({ isSpam }, "comment did not contain spam");
 };

--- a/src/core/server/services/spam/index.ts
+++ b/src/core/server/services/spam/index.ts
@@ -52,8 +52,6 @@ const createBody = (params: Parameters) => {
     api_key: apiKey,
     blog,
     user_ip: userIP || "",
-    user_agent: userAgent || "",
-    referrer: referrer || "",
 
     permalink: story.url,
 
@@ -71,6 +69,13 @@ const createBody = (params: Parameters) => {
   // This key has to be missing if it's not a recheck, we can't just leave it blank
   if (recheckReason) {
     res.recheck_reason = recheckReason;
+  }
+  // Only send these if we had a request object so we know them
+  if (userAgent !== undefined) {
+    res.user_agent = userAgent;
+  }
+  if (referrer !== undefined) {
+    res.referrer = referrer;
   }
   return new URLSearchParams(res);
 };
@@ -189,8 +194,12 @@ const prepareParams = (
   if (tenant.integrations.akismet.ipBased !== false) {
     userIP = request?.ip || "";
   }
-  const userAgent = request?.get("User-Agent") || "";
-  const referrer = request?.get("Referrer") || "";
+  let userAgent;
+  let referrer;
+  if (request) {
+    userAgent = request.get("User-Agent") || "";
+    referrer = request.get("Referrer") || "";
+  }
 
   return {
     apiKey,

--- a/src/core/server/services/spam/index.ts
+++ b/src/core/server/services/spam/index.ts
@@ -9,163 +9,235 @@ import { Tenant } from "coral-server/models/tenant";
 import { retrieveUser } from "coral-server/models/user";
 import { Request } from "coral-server/types/express";
 
+interface PartialComment {
+  // An in-flight comment has a pretty ugly type, but this is the important bit
+  body: string;
+}
+
 export interface Parameters {
   apiKey: string;
-  comment: Readonly<Comment>;
+  blog: string;
+  comment: Readonly<Comment> | PartialComment;
   story: Readonly<Story>;
   author: Readonly<User>;
   userIP: string | undefined;
   userAgent: string | undefined;
   referrer: string | undefined;
+  recheckReason?: string | undefined;
 }
 
 const createBody = (params: Parameters) => {
-  const { comment, story, author, userIP, userAgent, referrer } = params;
-  const latestRevision = getLatestRevision(comment);
-  const username = author ? (author.username ? author.username : "") : "";
-
-  return {
-    user_ip: userIP,
-    user_agent: userAgent,
+  const {
+    apiKey,
+    blog,
+    comment,
+    story,
+    author,
+    userIP,
+    userAgent,
     referrer,
+    recheckReason,
+  } = params;
+  let body = "";
+  let date;
+  if ("revisions" in comment) {
+    const latestRevision = getLatestRevision(comment);
+    body = latestRevision.body;
+    date = latestRevision.createdAt.toISOString();
+  } else {
+    body = comment.body;
+  }
+
+  const res: Record<string, string> = {
+    api_key: apiKey,
+    blog,
+    user_ip: userIP || "",
+    user_agent: userAgent || "",
+    referrer: referrer || "",
 
     permalink: story.url,
 
     comment_type: "comment",
-    comment_author: username,
-    comment_content: latestRevision ? latestRevision.body : "",
-    comment_date_gmt: latestRevision
-      ? latestRevision.createdAt.toISOString()
-      : "",
+    comment_author: author.username || "",
+    comment_content: body,
 
-    is_test: false,
+    // is_test: "true", // set this if testing to avoid the test account ending
+    // up on the naughty list...
   };
+  // current time will be used if this is missing
+  if (date) {
+    res.comment_date_gmt = date;
+  }
+  // This key has to be missing if it's not a recheck, we can't just leave it blank
+  if (recheckReason) {
+    res.recheck_reason = recheckReason;
+  }
+  return new URLSearchParams(res);
+};
+
+const makeAkismetRequest = async (
+  params: Parameters,
+  url: string,
+  expect: string[]
+) => {
+  const body = createBody(params);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: body.toString(),
+  });
+
+  const content = await response.text();
+  if (!expect.includes(content)) {
+    const help = response.headers.get("x-akismet-debug-help");
+    throw new Error(`Akismet API error: ${content}, ${help}`);
+  }
+  return content;
 };
 
 const submitSpam = async (params: Parameters) => {
-  const { apiKey } = params;
-  const url = `https://${apiKey}.rest.akismet.com/1.1/submit-spam`;
-  const body = createBody(params);
-
   try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
-
-    return response.ok;
+    await makeAkismetRequest(
+      params,
+      "https://rest.akismet.com/1.1/submit-spam",
+      ["Thanks for making the web a better place."]
+    );
   } catch (err) {
     logger.error({ err }, "unable to submit spam to Akismet");
     return false;
   }
+  return true;
 };
 
 const submitNotSpam = async (params: Parameters) => {
-  const { apiKey } = params;
-  const url = `https://${apiKey}.rest.akismet.com/1.1/submit-ham`;
-  const body = createBody(params);
-
   try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
-
-    return response.ok;
+    await makeAkismetRequest(
+      params,
+      "https://rest.akismet.com/1.1/submit-ham",
+      ["Thanks for making the web a better place."]
+    );
   } catch (err) {
-    logger.error({ err }, "unable to submit non-spam to Akismet");
+    logger.error({ err }, "unable to submit not-spam to Akismet");
     return false;
   }
+  return true;
+};
+
+const checkSpam = async (params: Parameters) => {
+  try {
+    const res = await makeAkismetRequest(
+      params,
+      "https://rest.akismet.com/1.1/comment-check",
+      ["true", "false"]
+    );
+    if (res === "true") {
+      return true;
+    }
+    return false;
+  } catch (err) {
+    logger.error({ err }, "unable to check Akismet for spam");
+    return false;
+  }
+};
+
+const prepareParamsMongo = async (
+  mongo: MongoContext,
+  tenant: Tenant,
+  comment: Readonly<Comment>
+) => {
+  // this is checked in prepareParams as well, but it saves some DB hits here
+  if (!tenant.integrations.akismet.enabled) {
+    return;
+  }
+  const story = await retrieveStory(mongo, tenant.id, comment.storyID);
+  if (!story) {
+    return;
+  }
+  const author = comment.authorID
+    ? await retrieveUser(mongo, tenant.id, comment.authorID)
+    : undefined;
+  if (!author) {
+    return;
+  }
+
+  return prepareParams(tenant, comment, story, author);
+};
+
+const prepareParams = (
+  tenant: Tenant,
+  comment: Readonly<Comment> | PartialComment,
+  story: Readonly<Story>,
+  author: Readonly<User>,
+  request?: Readonly<Request> | undefined
+): Parameters | undefined => {
+  if (!tenant.integrations.akismet.enabled) {
+    return;
+  }
+  const apiKey = tenant.integrations.akismet.key;
+  const blog = tenant.integrations.akismet.site;
+  if (!apiKey || !blog) {
+    logger.error("Akismet not configured");
+    return;
+  }
+
+  // Only use the ip address if ipBased is enabled. This property is by default
+  // not set, that's why we're explicitly checking if it is false before using
+  // it.
+  let userIP = "";
+  if (tenant.integrations.akismet.ipBased !== false) {
+    userIP = request?.ip || "";
+  }
+  const userAgent = request?.get("User-Agent") || "";
+  const referrer = request?.get("Referrer") || "";
+
+  return {
+    apiKey,
+    blog,
+    comment,
+    story,
+    author,
+    userIP,
+    userAgent,
+    referrer,
+  };
 };
 
 export const submitCommentAsNotSpam = async (
   mongo: MongoContext,
   tenant: Tenant,
-  comment: Readonly<Comment>,
-  request?: Request | undefined
+  comment: Readonly<Comment>
 ) => {
-  const story = await retrieveStory(mongo, tenant.id, comment.storyID);
-  if (!story) {
-    return;
+  const params = await prepareParamsMongo(mongo, tenant, comment);
+  if (params) {
+    await submitNotSpam(params);
   }
-
-  const author = comment.authorID
-    ? await retrieveUser(mongo, tenant.id, comment.authorID)
-    : null;
-  if (!author) {
-    return;
-  }
-
-  const userIP = request?.ip || "";
-
-  const userAgent = request?.get("User-Agent");
-  if (!userAgent || userAgent.length === 0) {
-    return;
-  }
-
-  const referrer = request?.get("Referrer");
-  if (!referrer || referrer.length === 0) {
-    return;
-  }
-
-  await submitNotSpam({
-    apiKey: tenant.integrations.akismet.key
-      ? tenant.integrations.akismet.key
-      : "",
-    comment,
-    story,
-    author,
-    userIP,
-    userAgent,
-    referrer,
-  });
 };
 
 export const submitCommentAsSpam = async (
   mongo: MongoContext,
   tenant: Tenant,
-  comment: Readonly<Comment>,
-  request?: Request | undefined
+  comment: Readonly<Comment>
 ) => {
-  const story = await retrieveStory(mongo, tenant.id, comment.storyID);
-  if (!story) {
-    return;
+  const params = await prepareParamsMongo(mongo, tenant, comment);
+  if (params) {
+    await submitSpam(params);
   }
+};
 
-  const author = comment.authorID
-    ? await retrieveUser(mongo, tenant.id, comment.authorID)
-    : null;
-  if (!author) {
-    return;
+export const checkCommentIsSpam = async (
+  tenant: Tenant,
+  comment: PartialComment,
+  request: Readonly<Request> | undefined,
+  story: Readonly<Story>,
+  author: Readonly<User>,
+  recheck: string | undefined
+) => {
+  const params = prepareParams(tenant, comment, story, author, request);
+  if (params) {
+    params.recheckReason = recheck;
+    return await checkSpam(params);
   }
-
-  const userIP = request?.ip || "";
-
-  const userAgent = request?.get("User-Agent");
-  if (!userAgent || userAgent.length === 0) {
-    return;
-  }
-
-  const referrer = request?.get("Referrer");
-  if (!referrer || referrer.length === 0) {
-    return;
-  }
-
-  await submitSpam({
-    apiKey: tenant.integrations.akismet.key
-      ? tenant.integrations.akismet.key
-      : "",
-    comment,
-    story,
-    author,
-    userIP,
-    userAgent,
-    referrer,
-  });
+  return false;
 };

--- a/src/core/server/stacks/approveComment.ts
+++ b/src/core/server/stacks/approveComment.ts
@@ -49,7 +49,7 @@ const approveComment = async (
       (actionCounts.flag.reasons.COMMENT_REPORTED_SPAM > 0 ||
         actionCounts.flag.reasons.COMMENT_DETECTED_SPAM > 0)
     ) {
-      await submitCommentAsNotSpam(mongo, tenant, result.before, request);
+      await submitCommentAsNotSpam(mongo, tenant, result.before);
     }
   }
 

--- a/src/core/server/stacks/approveComment.ts
+++ b/src/core/server/stacks/approveComment.ts
@@ -1,5 +1,6 @@
 import { MongoContext } from "coral-server/data/context";
 import { CoralEventPublisherBroker } from "coral-server/events/publisher";
+import { decodeActionCounts } from "coral-server/models/action/comment";
 import { getLatestRevision } from "coral-server/models/comment";
 import { Tenant } from "coral-server/models/tenant";
 import { moderate } from "coral-server/services/comments/moderation";
@@ -41,13 +42,15 @@ const approveComment = async (
   );
 
   const revision = getLatestRevision(result.before);
-  if (
-    revision &&
-    tenant.integrations.akismet.enabled &&
-    (revision.actionCounts.COMMENT_REPORTED_SPAM > 0 ||
-      revision.actionCounts.COMMENT_DETECTED_SPAM > 0)
-  ) {
-    await submitCommentAsNotSpam(mongo, tenant, result.before, request);
+  if (revision) {
+    const actionCounts = decodeActionCounts(revision.actionCounts);
+    if (
+      tenant.integrations.akismet.enabled &&
+      (actionCounts.flag.reasons.COMMENT_REPORTED_SPAM > 0 ||
+        actionCounts.flag.reasons.COMMENT_DETECTED_SPAM > 0)
+    ) {
+      await submitCommentAsNotSpam(mongo, tenant, result.before, request);
+    }
   }
 
   // If the comment hasn't been updated, skip the rest of the steps.

--- a/src/core/server/stacks/rejectComment.ts
+++ b/src/core/server/stacks/rejectComment.ts
@@ -56,7 +56,7 @@ const rejectComment = async (
       (actionCounts.flag.reasons.COMMENT_REPORTED_SPAM > 0 ||
         actionCounts.flag.reasons.COMMENT_DETECTED_SPAM > 0)
     ) {
-      await submitCommentAsSpam(mongo, tenant, result.before, request);
+      await submitCommentAsSpam(mongo, tenant, result.before);
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

This fixes a number of issues with the Akismet integration. This started as an attempt to fix #4122, but I ran into a number of other problems while I was working on it. Also, it doesn't seem to entirely fix that issue, but it does seem to have helped. Some of the other fixes here (successfully telling the Akismet API that something is not spam, for example) should also help. Hard to test definitively because spam detection is such a dark art.

Background: there are two separate parts of the flow in Coral that integrate with Akismet. When a comment is submitted, it's sent to Akismet for spam checking, and the results may affect what happens to the comment. Secondly, comments can be approved/unapproved, and the results of this for possible-spam comments will be sent to Akismet. Prior to this PR, these two sections are implemented entirely separately.

Here are the issues I've encountered, and fixes applied. Firstly, on the spam _checking_:
1. If the user-agent or referrer fields are not provided in the request or are empty, spam checking is abandoned. This means that you can bypass the spam filter by simply not supplying a user-agent; correct behaviour here is to tell Akismet that the user-agent was empty.
2. The recheck_reason field in the Akismet API request was not being populated for rechecked comments (for example, on edit), which seems to contribute to edited comments being marked as spam where their original versions were not. Annoyingly, the Akismet library used by this half of the integration does not correctly support the recheck_reason field, and it didn't look particularly actively maintained. I have instead merged this half with the direct Akismet API request made by the other half (it's not a particularly complicated API and most of the code is just argument marshalling we have to do anyway, so I didn't think the library was buying much).

There were more issues with the spam/not-spam submission, which I've ended up heavily rewriting:
1. Comments would be sent to Akismet as spam upon _user report_ of spam. This means that a random user can train the spam filter to block another target user, for example, which is clearly undesirable: submission should only happen on moderator confirmation. I've just disabled this hook.
2. Moderation approve/reject comment actions are intended to submit to Akismet if the comment was either detected as spam by Akismet, or reported as spam by a user. The checking of flag counts was incorrect and would never trigger. This is fixed.
3. The API requests sent to Akismet were invalid and would never be accepted, and the results were not checked. I have fixed the API requests, and added checks that the responses are as expected.
4. The approval path was confusing the request object of the _moderator_ making the request with the request object that created the comment, and would therefore submit the moderator's user-agent and referrer to Akismet as if they belonged to the spam comment. We don't store these for the comment, so don't know them in this situation. I have just removed sending them. (I don't know why this didn't happen on the near-identical reject path as well and resisted trying to work it out.)

There's quite a bit going on here, so I anticipate some review comments!

## These changes will impact:

- [x] commenters
- [x] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

Add some comments, edit those comments, report those comments as spam, and approve/reject them in the moderation panel. Verify that correct requests are generated to Akismet when this happens: added comments are spam checked; approved/rejected comments that were marked as possible spam are submitted; requests are not made in other situations. You may want to debug log the outgoing requests, and turn on the is_test API parameter to avoid accidentally banning yourself. You can set your username to "viagra-test-123" to force Akismet to declare you as spam.
 
## How do we deploy this PR?

No special requirements
