### PR TITLE
don't throw TenantNotFound in csp middleware

### DIFF
--- a/src/core/server/app/middleware/csp.ts
+++ b/src/core/server/app/middleware/csp.ts
@@ -139,19 +139,23 @@ export const cspSiteMiddleware =
     const {
       coral: { tenant },
     } = req;
-    if (!tenant) {
-      throw new TenantNotFoundError(req.hostname);
+
+    // if we have a tenant (should come through on all admin pages)
+    // then we can pull our domain for admin handlers and set it in
+    // our CSP headers.
+    const domains: string[] = [];
+    if (tenant) {
+      const domain =
+        config.get("env") === "development"
+          ? `http://${tenant.domain}:${config.get("port")}`
+          : tenant.domain;
+      domains.push(domain);
     }
 
-    const domain =
-      config.get("env") === "development"
-        ? `http://${tenant.domain}:${config.get("port")}`
-        : tenant.domain;
-
-    // If the frame ancestors is being set to deny, then use our tenant domain,
-    // otherwise look it up from the request.
+    // If the frame ancestors is being set to deny (admin pages), then
+    // use our domains, otherwise look it up from the request (stream).
     const origins = frameAncestorsDeny
-      ? [domain]
+      ? domains
       : await retrieveOriginsFromRequest(mongo, config, req);
 
     const frameOptions = generateFrameOptions(req, origins);

--- a/src/core/server/app/middleware/csp.ts
+++ b/src/core/server/app/middleware/csp.ts
@@ -6,7 +6,6 @@ import { AppOptions } from "coral-server/app";
 import { getOrigin, prefixSchemeIfRequired } from "coral-server/app/url";
 import { Config } from "coral-server/config";
 import { MongoContext } from "coral-server/data/context";
-import { TenantNotFoundError } from "coral-server/errors";
 import {
   retrieveSite,
   retrieveSiteByOrigin,


### PR DESCRIPTION
## What does this PR do?

Fix issue where some handlers for Coral do not provide a tenant by the time we get to the csp middleware and threw a TenantNotFound error. In that case, use an empty list of domains (or compute it for the hosting stream site) and use that. For the times when tenant is set (admin pages), use the tenant domain.

## These changes will impact:

- [X] commenters
- [X] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Visit admin and make sure the CSP header is set in the network requests
- Visit stream and see that it has a different CSP header but is set
- Visit admin login, install, and other handlers to make sure they don't crash the Coral instance

## How do we deploy this PR?

No special considerations.
