### PR TITLE
Make subscription errors stop crashing pods

### DIFF
--- a/src/core/server/graph/plugins/logger.ts
+++ b/src/core/server/graph/plugins/logger.ts
@@ -22,7 +22,7 @@ export function logAndReportError(
 
   // If there's no reporter active, then just log what we got and return now.
   if (!ctx.reporter || !ctx.reporter.shouldReport(err)) {
-    ctx.logger.error({ err, report: null }, "graphql query error");
+    logger.error({ err, report: null }, "graphql query error");
     return;
   }
 
@@ -45,7 +45,7 @@ export function logAndReportError(
   const report = ctx.reporter.report(getOriginalError(err) || err, scope);
 
   // Log that we reported an error.
-  ctx.logger.error({ err, report }, "graphql query error");
+  logger.error({ err, report }, "graphql query error");
 }
 
 export function logQuery(


### PR DESCRIPTION
## What does this PR do?

Use `logger.error` instead of `ctx.logger.error` in the graphql logger middleware's `logAndReportError` utility function.

We do this because the logger on the context has likely de-scoped by the time we hit the graphQL error middleware that is logging the error.

If we don't do this, the pod will crash as it fails to log an error with an undefined logger.

Elsewhere in this file, we use `logger.error(...)` instead of `ctx.logger.error(...)` for this very reason... this looks like a copy/paste error that has only been hit upon until now.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- Cause an error in a resolver or other part of the graphql resolvers/mutators
- See that the error is logged appropriately
 
## How do we deploy this PR?

No special considerations