### PR TITLE
Add stable classnames to more DOM elements in stream

### DIFF
--- a/src/core/client/admin/test/auth/__snapshots__/addEmailAddress.spec.tsx.snap
+++ b/src/core/client/admin/test/auth/__snapshots__/addEmailAddress.spec.tsx.snap
@@ -67,7 +67,7 @@ exports[`accepts valid email 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>
@@ -134,7 +134,7 @@ exports[`checks for invalid email 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>
@@ -173,7 +173,7 @@ exports[`checks for invalid email 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>
@@ -363,7 +363,7 @@ exports[`shows error when submitting empty form 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>
@@ -402,7 +402,7 @@ exports[`shows error when submitting empty form 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>

--- a/src/core/client/admin/test/auth/__snapshots__/createPassword.spec.tsx.snap
+++ b/src/core/client/admin/test/auth/__snapshots__/createPassword.spec.tsx.snap
@@ -55,7 +55,7 @@ we require users to create a password.
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               visibility
             </i>
@@ -67,7 +67,7 @@ we require users to create a password.
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>
@@ -182,7 +182,7 @@ we require users to create a password.
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm"
+                            className="Icon-root Icon-sm coral coral-icon"
                           >
                             visibility
                           </i>
@@ -269,7 +269,7 @@ we require users to create a password.
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               visibility
             </i>
@@ -281,7 +281,7 @@ we require users to create a password.
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>
@@ -377,7 +377,7 @@ GraphQL request:4:3
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               visibility
             </i>
@@ -457,7 +457,7 @@ we require users to create a password.
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               visibility
             </i>

--- a/src/core/client/admin/test/auth/__snapshots__/createUsername.spec.tsx.snap
+++ b/src/core/client/admin/test/auth/__snapshots__/createUsername.spec.tsx.snap
@@ -46,7 +46,7 @@ exports[`checks for invalid username 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>
@@ -218,7 +218,7 @@ exports[`shows error when submitting empty form 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm MessageIcon-root"
+          className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
         >
           warning
         </i>

--- a/src/core/client/admin/test/auth/__snapshots__/linkAccount.spec.tsx.snap
+++ b/src/core/client/admin/test/auth/__snapshots__/linkAccount.spec.tsx.snap
@@ -94,7 +94,7 @@ link these enter your password.
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm"
+                              className="Icon-root Icon-sm coral coral-icon"
                             >
                               visibility
                             </i>

--- a/src/core/client/admin/test/auth/__snapshots__/restricted.spec.tsx.snap
+++ b/src/core/client/admin/test/auth/__snapshots__/restricted.spec.tsx.snap
@@ -41,7 +41,7 @@ exports[`show restricted screen for commenters and staff 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-lg Restricted-lockIcon"
+              className="Icon-root Icon-lg coral coral-icon Restricted-lockIcon"
             >
               lock
             </i>
@@ -133,7 +133,7 @@ exports[`show restricted screen for commenters and staff 2`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-lg Restricted-lockIcon"
+              className="Icon-root Icon-lg coral coral-icon Restricted-lockIcon"
             >
               lock
             </i>

--- a/src/core/client/admin/test/configure/__snapshots__/advanced.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/advanced.spec.tsx.snap
@@ -761,7 +761,7 @@ scrape request.
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm"
+                          className="Icon-root Icon-sm coral coral-icon"
                         >
                           visibility
                         </i>
@@ -809,7 +809,7 @@ scrape request.
                       AMP
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-xs TextLink-icon"
+                        className="Icon-root Icon-xs coral coral-icon TextLink-icon"
                       >
                         open_in_new
                       </i>
@@ -825,7 +825,7 @@ template. See our
                       documentation
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-xs TextLink-icon"
+                        className="Icon-root Icon-xs coral coral-icon TextLink-icon"
                       >
                         open_in_new
                       </i>

--- a/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/auth.spec.tsx.snap
@@ -518,7 +518,7 @@ address from the site and the database.
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm"
+                          className="Icon-root Icon-sm coral coral-icon"
                         >
                           expand_more
                         </i>
@@ -769,7 +769,7 @@ integration to register for a new account.
                       https://openid.net/connect/
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-xs TextLink-icon"
+                        className="Icon-root Icon-xs coral coral-icon TextLink-icon"
                       >
                         open_in_new
                       </i>
@@ -934,7 +934,7 @@ needs to be displayed, e.g. “Log in with &lt;Facebook&gt;”.
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm"
+                            className="Icon-root Icon-sm coral coral-icon"
                           >
                             visibility
                           </i>
@@ -1379,7 +1379,7 @@ more about creating a JWT Token with
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm"
+                                    className="Icon-root Icon-sm coral coral-icon"
                                   >
                                     visibility
                                   </i>
@@ -1400,7 +1400,7 @@ more about creating a JWT Token with
                               <i
                                 aria-hidden="true"
                                 aria-label="Copy Secret"
-                                className="Icon-root Icon-md"
+                                className="Icon-root Icon-md coral coral-icon"
                               >
                                 content_copy
                               </i>
@@ -1472,7 +1472,7 @@ more about creating a JWT Token with
                             </span>
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm"
+                              className="Icon-root Icon-sm coral coral-icon"
                             >
                               arrow_drop_down
                             </i>
@@ -1673,7 +1673,7 @@ to create and set up a web application. For more information visit:
                       https://developers.google.com/identity/protocols/OAuth2WebServer#creatingcred
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-xs TextLink-icon"
+                        className="Icon-root Icon-xs coral coral-icon TextLink-icon"
                       >
                         open_in_new
                       </i>
@@ -1795,7 +1795,7 @@ to create and set up a web application. For more information visit:
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm"
+                            className="Icon-root Icon-sm coral coral-icon"
                           >
                             visibility
                           </i>
@@ -1989,7 +1989,7 @@ For more information visit:
                       https://developers.facebook.com/docs/facebook-login/web
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-xs TextLink-icon"
+                        className="Icon-root Icon-xs coral coral-icon TextLink-icon"
                       >
                         open_in_new
                       </i>
@@ -2111,7 +2111,7 @@ For more information visit:
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm"
+                            className="Icon-root Icon-sm coral coral-icon"
                           >
                             visibility
                           </i>

--- a/src/core/client/admin/test/configure/__snapshots__/webhooks.spec.tsx.snap
+++ b/src/core/client/admin/test/configure/__snapshots__/webhooks.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`displays a list of webhook endpoints that have been configured 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-md ExperimentalCallOut-icon"
+          className="Icon-root Icon-md coral coral-icon ExperimentalCallOut-icon"
         >
           new_releases
         </i>
@@ -94,7 +94,7 @@ about webhook signing, visit our
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-md"
+            className="Icon-root Icon-md coral coral-icon"
           >
             add
           </i>
@@ -171,7 +171,7 @@ about webhook signing, visit our
                     Details 
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-sm"
+                      className="Icon-root Icon-sm coral coral-icon"
                     >
                       keyboard_arrow_right
                     </i>
@@ -218,7 +218,7 @@ about webhook signing, visit our
                     Details 
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-sm"
+                      className="Icon-root Icon-sm coral coral-icon"
                     >
                       keyboard_arrow_right
                     </i>
@@ -250,7 +250,7 @@ exports[`goes to add new webhook endpoint when clicking add 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-md ExperimentalCallOut-icon"
+          className="Icon-root Icon-md coral coral-icon ExperimentalCallOut-icon"
         >
           new_releases
         </i>
@@ -328,7 +328,7 @@ about webhook signing, visit our
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-md"
+            className="Icon-root Icon-md coral coral-icon"
           >
             add
           </i>
@@ -370,7 +370,7 @@ exports[`goes to the webhook endpoint configuration page when selected 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-md ExperimentalCallOut-icon"
+          className="Icon-root Icon-md coral coral-icon ExperimentalCallOut-icon"
         >
           new_releases
         </i>
@@ -448,7 +448,7 @@ about webhook signing, visit our
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-md"
+            className="Icon-root Icon-md coral coral-icon"
           >
             add
           </i>
@@ -525,7 +525,7 @@ about webhook signing, visit our
                     Details 
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-sm"
+                      className="Icon-root Icon-sm coral coral-icon"
                     >
                       keyboard_arrow_right
                     </i>
@@ -557,7 +557,7 @@ exports[`renders webhooks 1`] = `
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-md ExperimentalCallOut-icon"
+          className="Icon-root Icon-md coral coral-icon ExperimentalCallOut-icon"
         >
           new_releases
         </i>
@@ -635,7 +635,7 @@ about webhook signing, visit our
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-md"
+            className="Icon-root Icon-md coral coral-icon"
           >
             add
           </i>

--- a/src/core/client/admin/test/moderate/__snapshots__/rejectedQueue.spec.tsx.snap
+++ b/src/core/client/admin/test/moderate/__snapshots__/rejectedQueue.spec.tsx.snap
@@ -115,7 +115,7 @@ exports[`approves comment in rejected queue: dangling 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root"
             >
               question_answer
             </i>
@@ -260,7 +260,7 @@ exports[`approves comment in rejected queue: dangling 1`] = `
                 </span>
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root"
+                  className="Icon-root Icon-sm coral coral-icon ButtonIcon-root"
                 >
                   arrow_drop_down
                 </i>
@@ -295,7 +295,7 @@ exports[`approves comment in rejected queue: dangling 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-lg RejectButton-icon"
+            className="Icon-root Icon-lg coral coral-icon RejectButton-icon"
           >
             close
           </i>
@@ -314,7 +314,7 @@ exports[`approves comment in rejected queue: dangling 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-lg ApproveButton-icon"
+            className="Icon-root Icon-lg coral coral-icon ApproveButton-icon"
           >
             done
           </i>
@@ -437,7 +437,7 @@ exports[`renders rejected queue with comments 1`] = `
                 >
                   <i
                     aria-hidden="true"
-                    className="Icon-root Icon-sm ButtonIcon-root"
+                    className="Icon-root Icon-sm coral coral-icon ButtonIcon-root"
                   >
                     question_answer
                   </i>
@@ -582,7 +582,7 @@ exports[`renders rejected queue with comments 1`] = `
                       </span>
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ButtonIcon-root"
+                        className="Icon-root Icon-sm coral coral-icon ButtonIcon-root"
                       >
                         arrow_drop_down
                       </i>
@@ -617,7 +617,7 @@ exports[`renders rejected queue with comments 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-lg RejectButton-icon"
+                  className="Icon-root Icon-lg coral coral-icon RejectButton-icon"
                 >
                   close
                 </i>
@@ -636,7 +636,7 @@ exports[`renders rejected queue with comments 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-lg ApproveButton-icon"
+                  className="Icon-root Icon-lg coral coral-icon ApproveButton-icon"
                 >
                   done
                 </i>
@@ -729,7 +729,7 @@ exports[`renders rejected queue with comments 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm InReplyTo-icon"
+                  className="Icon-root Icon-sm coral coral-icon InReplyTo-icon"
                 >
                   reply
                 </i>
@@ -791,7 +791,7 @@ exports[`renders rejected queue with comments 1`] = `
                 >
                   <i
                     aria-hidden="true"
-                    className="Icon-root Icon-sm ButtonIcon-root"
+                    className="Icon-root Icon-sm coral coral-icon ButtonIcon-root"
                   >
                     question_answer
                   </i>
@@ -888,7 +888,7 @@ exports[`renders rejected queue with comments 1`] = `
                       </span>
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ButtonIcon-root"
+                        className="Icon-root Icon-sm coral coral-icon ButtonIcon-root"
                       >
                         arrow_drop_down
                       </i>
@@ -923,7 +923,7 @@ exports[`renders rejected queue with comments 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-lg RejectButton-icon"
+                  className="Icon-root Icon-lg coral coral-icon RejectButton-icon"
                 >
                   close
                 </i>
@@ -942,7 +942,7 @@ exports[`renders rejected queue with comments 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-lg ApproveButton-icon"
+                  className="Icon-root Icon-lg coral coral-icon ApproveButton-icon"
                 >
                   done
                 </i>
@@ -1068,7 +1068,7 @@ exports[`renders rejected queue with comments and load more 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root"
             >
               question_answer
             </i>
@@ -1178,7 +1178,7 @@ exports[`renders rejected queue with comments and load more 1`] = `
                 </span>
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root"
+                  className="Icon-root Icon-sm coral coral-icon ButtonIcon-root"
                 >
                   arrow_drop_down
                 </i>
@@ -1213,7 +1213,7 @@ exports[`renders rejected queue with comments and load more 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-lg RejectButton-icon"
+            className="Icon-root Icon-lg coral coral-icon RejectButton-icon"
           >
             close
           </i>
@@ -1232,7 +1232,7 @@ exports[`renders rejected queue with comments and load more 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-lg ApproveButton-icon"
+            className="Icon-root Icon-lg coral coral-icon ApproveButton-icon"
           >
             done
           </i>

--- a/src/core/client/admin/test/moderate/__snapshots__/searchBar.spec.tsx.snap
+++ b/src/core/client/admin/test/moderate/__snapshots__/searchBar.spec.tsx.snap
@@ -35,7 +35,7 @@ exports[`all stories active search with no results 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-md Field-searchIcon"
+                className="Icon-root Icon-md coral coral-icon Field-searchIcon"
               >
                 search
               </i>
@@ -173,7 +173,7 @@ exports[`all stories active search with too many results 1`] = `
     </span>
     <i
       aria-hidden="true"
-      className="Icon-root Icon-md SeeAllOption-icon"
+      className="Icon-root Icon-md coral coral-icon SeeAllOption-icon"
     >
       keyboard_arrow_right
     </i>
@@ -216,7 +216,7 @@ exports[`all stories renders search bar 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-md Field-searchIcon"
+                className="Icon-root Icon-md coral coral-icon Field-searchIcon"
               >
                 search
               </i>

--- a/src/core/client/admin/test/moderate/__snapshots__/tabBar.spec.tsx.snap
+++ b/src/core/client/admin/test/moderate/__snapshots__/tabBar.spec.tsx.snap
@@ -24,7 +24,7 @@ exports[`tab bar renders tab bar (empty queues) 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               flag
             </i>
@@ -53,7 +53,7 @@ exports[`tab bar renders tab bar (empty queues) 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               access_time
             </i>
@@ -82,7 +82,7 @@ exports[`tab bar renders tab bar (empty queues) 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               forum
             </i>
@@ -111,7 +111,7 @@ exports[`tab bar renders tab bar (empty queues) 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               check_circle
             </i>
@@ -130,7 +130,7 @@ exports[`tab bar renders tab bar (empty queues) 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               cancel
             </i>
@@ -171,7 +171,7 @@ exports[`tab bar renders tab bar (empty queues) 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm"
+            className="Icon-root Icon-sm coral coral-icon"
           >
             expand_more
           </i>

--- a/src/core/client/auth/test/__snapshots__/addEmailAddress.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/addEmailAddress.spec.tsx.snap
@@ -836,7 +836,7 @@ Your email address will be used to:
     className="coral coral-login-errorContainer AddEmailAddress-error"
   >
     <div
-      className="CallOut-root CallOut-error CallOut-leftBorder c/nooral coral-login-error"
+      className="CallOut-root CallOut-error CallOut-leftBorder coral coral-login-error"
     >
       <div
         className="CallOut-container"

--- a/src/core/client/auth/test/__snapshots__/addEmailAddress.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/addEmailAddress.spec.tsx.snap
@@ -22,7 +22,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -44,7 +44,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -65,7 +65,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -146,7 +146,7 @@ Your email address will be used to:
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -199,7 +199,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -221,7 +221,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -242,7 +242,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -293,7 +293,7 @@ Your email address will be used to:
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -341,7 +341,7 @@ Your email address will be used to:
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -417,7 +417,7 @@ Your email address will be used to:
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm"
+                  className="Icon-root Icon-sm coral coral-icon"
                 >
                   done
                 </i>
@@ -439,7 +439,7 @@ Your email address will be used to:
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm"
+                  className="Icon-root Icon-sm coral coral-icon"
                 >
                   done
                 </i>
@@ -460,7 +460,7 @@ Your email address will be used to:
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm"
+                  className="Icon-root Icon-sm coral coral-icon"
                 >
                   done
                 </i>
@@ -580,7 +580,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -602,7 +602,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -623,7 +623,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -674,7 +674,7 @@ Your email address will be used to:
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -722,7 +722,7 @@ Your email address will be used to:
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -775,7 +775,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -797,7 +797,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -818,7 +818,7 @@ Your email address will be used to:
       >
         <i
           aria-hidden="true"
-          className="Icon-root Icon-sm"
+          className="Icon-root Icon-sm coral coral-icon"
         >
           done
         </i>
@@ -836,7 +836,7 @@ Your email address will be used to:
     className="coral coral-login-errorContainer AddEmailAddress-error"
   >
     <div
-      className="CallOut-root CallOut-error CallOut-leftBorder coral coral-login-error"
+      className="CallOut-root CallOut-error CallOut-leftBorder c/nooral coral-login-error"
     >
       <div
         className="CallOut-container"
@@ -846,7 +846,7 @@ Your email address will be used to:
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm"
+            className="Icon-root Icon-sm coral coral-icon"
           >
             error
           </i>

--- a/src/core/client/auth/test/__snapshots__/createPassword.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/createPassword.spec.tsx.snap
@@ -336,7 +336,7 @@ we require users to create a password.
     className="coral coral-login-errorContainer CreatePassword-error"
   >
     <div
-      className="CallOut-root CallOut-error CallOut-leftBorder c/nooral coral-login-error"
+      className="CallOut-root CallOut-error CallOut-leftBorder coral coral-login-error"
     >
       <div
         className="CallOut-container"

--- a/src/core/client/auth/test/__snapshots__/createPassword.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/createPassword.spec.tsx.snap
@@ -57,7 +57,7 @@ we require users to create a password.
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               visibility
             </i>
@@ -73,7 +73,7 @@ we require users to create a password.
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -184,7 +184,7 @@ we require users to create a password.
                   >
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-sm"
+                      className="Icon-root Icon-sm coral coral-icon"
                     >
                       visibility
                     </i>
@@ -274,7 +274,7 @@ we require users to create a password.
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               visibility
             </i>
@@ -290,7 +290,7 @@ we require users to create a password.
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -336,7 +336,7 @@ we require users to create a password.
     className="coral coral-login-errorContainer CreatePassword-error"
   >
     <div
-      className="CallOut-root CallOut-error CallOut-leftBorder coral coral-login-error"
+      className="CallOut-root CallOut-error CallOut-leftBorder c/nooral coral-login-error"
     >
       <div
         className="CallOut-container"
@@ -346,7 +346,7 @@ we require users to create a password.
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm"
+            className="Icon-root Icon-sm coral coral-icon"
           >
             error
           </i>
@@ -418,7 +418,7 @@ GraphQL request:4:3
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               visibility
             </i>
@@ -504,7 +504,7 @@ we require users to create a password.
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               visibility
             </i>

--- a/src/core/client/auth/test/__snapshots__/createUsername.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/createUsername.spec.tsx.snap
@@ -272,7 +272,7 @@ exports[`shows server error 1`] = `
     className="coral coral-login-errorContainer CreateUsername-error"
   >
     <div
-      className="CallOut-root CallOut-error CallOut-leftBorder c/nooral coral-login-error"
+      className="CallOut-root CallOut-error CallOut-leftBorder coral coral-login-error"
     >
       <div
         className="CallOut-container"

--- a/src/core/client/auth/test/__snapshots__/createUsername.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/createUsername.spec.tsx.snap
@@ -52,7 +52,7 @@ exports[`checks for invalid username 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -227,7 +227,7 @@ exports[`shows error when submitting empty form 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm ValidationMessage-icon"
+            className="Icon-root Icon-sm coral coral-icon ValidationMessage-icon"
           >
             error
           </i>
@@ -272,7 +272,7 @@ exports[`shows server error 1`] = `
     className="coral coral-login-errorContainer CreateUsername-error"
   >
     <div
-      className="CallOut-root CallOut-error CallOut-leftBorder coral coral-login-error"
+      className="CallOut-root CallOut-error CallOut-leftBorder c/nooral coral-login-error"
     >
       <div
         className="CallOut-container"
@@ -282,7 +282,7 @@ exports[`shows server error 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm"
+            className="Icon-root Icon-sm coral coral-icon"
           >
             error
           </i>

--- a/src/core/client/auth/test/__snapshots__/linkAccount.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/linkAccount.spec.tsx.snap
@@ -82,7 +82,7 @@ link these enter your password.
                   >
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-sm"
+                      className="Icon-root Icon-sm coral coral-icon"
                     >
                       visibility
                     </i>

--- a/src/core/client/auth/test/__snapshots__/signIn.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/signIn.spec.tsx.snap
@@ -83,7 +83,7 @@ exports[`auth configuration renders all auth enabled 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm"
+                  className="Icon-root Icon-sm coral coral-icon"
                 >
                   visibility
                 </i>
@@ -133,7 +133,7 @@ exports[`auth configuration renders all auth enabled 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-md SignInWithEmail-icon"
+              className="Icon-root Icon-md coral coral-icon SignInWithEmail-icon"
             >
               email
             </i>
@@ -462,7 +462,7 @@ exports[`renders sign in view 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm"
+                        className="Icon-root Icon-sm coral coral-icon"
                       >
                         visibility
                       </i>
@@ -512,7 +512,7 @@ exports[`renders sign in view 1`] = `
                 >
                   <i
                     aria-hidden="true"
-                    className="Icon-root Icon-md SignInWithEmail-icon"
+                    className="Icon-root Icon-md coral coral-icon SignInWithEmail-icon"
                   >
                     email
                   </i>

--- a/src/core/client/auth/test/__snapshots__/signUp.spec.tsx.snap
+++ b/src/core/client/auth/test/__snapshots__/signUp.spec.tsx.snap
@@ -120,7 +120,7 @@ exports[`auth configuration renders all auth enabled 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm"
+                className="Icon-root Icon-sm coral coral-icon"
               >
                 visibility
               </i>
@@ -148,7 +148,7 @@ exports[`auth configuration renders all auth enabled 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-md SignUpWithEmail-icon"
+            className="Icon-root Icon-md coral coral-icon SignUpWithEmail-icon"
           >
             email
           </i>
@@ -513,7 +513,7 @@ exports[`renders sign up form 1`] = `
                   >
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-sm"
+                      className="Icon-root Icon-sm coral coral-icon"
                     >
                       visibility
                     </i>
@@ -541,7 +541,7 @@ exports[`renders sign up form 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-md SignUpWithEmail-icon"
+                  className="Icon-root Icon-md coral coral-icon SignUpWithEmail-icon"
                 >
                   email
                 </i>

--- a/src/core/client/auth/views/SignIn/__snapshots__/SignIn.spec.tsx.snap
+++ b/src/core/client/auth/views/SignIn/__snapshots__/SignIn.spec.tsx.snap
@@ -187,7 +187,7 @@ exports[`renders error 1`] = `
       className="coral coral-login-errorContainer"
     >
       <withPropsOnChange(CallOut)
-        className="c/nooral coral-login-error"
+        className="coral coral-login-error"
         color="error"
         title="Server Error"
       />

--- a/src/core/client/auth/views/SignIn/__snapshots__/SignIn.spec.tsx.snap
+++ b/src/core/client/auth/views/SignIn/__snapshots__/SignIn.spec.tsx.snap
@@ -187,7 +187,7 @@ exports[`renders error 1`] = `
       className="coral coral-login-errorContainer"
     >
       <withPropsOnChange(CallOut)
-        className="coral coral-login-error"
+        className="c/nooral coral-login-error"
         color="error"
         title="Server Error"
       />

--- a/src/core/client/stream/classes.ts
+++ b/src/core/client/stream/classes.ts
@@ -47,6 +47,7 @@ const CLASSES = {
     placeholder: "coral coral-rte-placeholder",
     toolbar: "coral coral-rte-toolbar",
     container: "coral coral-rte-container",
+    fakeContainer: "coral coral-rte-fake-container",
   },
 
   /**
@@ -82,6 +83,7 @@ const CLASSES = {
    * tabBarComments is all the components in the comments secondary tab bar selector.
    */
   tabBarComments: {
+    row: "coral coral-tabBarSecondary-row",
     /**
      * $root represents the container for the tab buttons.
      */
@@ -398,29 +400,41 @@ const CLASSES = {
        * reactButton is the reaction button.
        */
       reactButton: "coral coral-reactButton coral-comment-reactButton",
+
+      reactButtonIcon:
+        "coral coral-reactButton-icon coral-comment-reactButton-icon",
       /**
        * reactedButton is the class added to the reaction button
        * when the viewer has already reacted to the comment.
        */
       reactedButton: "coral-reactedButton coral-comment-reactedButton",
+
       /**
        * replyButton is button that triggers the reply form.
        */
       replyButton: "coral coral-comment-replyButton",
+      replyButtonIcon: "coral coral-comment-replyButton-icon",
       /**
        * shareButton is the button that will show the permalink popover.
        */
       shareButton: "coral coral-comment-shareButton",
+      shareButtonIcon: "coral coral-comment-shareButton-icon",
       /**
        * reportButton is the button that triggers the report feature.
        */
       reportButton: "coral coral-reportButton coral-comment-reportButton",
+      reportButtonIcon:
+        "coral coral-reportButton-icon coral-comment-reportButton-icon",
       /**
        * reportedButton is added to report button when the viewer
        * has already reported the comment.
        */
       reportedButton: "coral-reportedButton coral-comment-reportedButton",
+      reportedButtonIcon:
+        "coral-reportedButtonIcon coral-comment-reportedButtonIcon",
     },
+
+    avatar: "coral coral-comment-avatar",
 
     /**
      * indentation classes for the different levels.
@@ -667,6 +681,10 @@ const CLASSES = {
     signInButton: "coral coral-viewerBox-signInButton",
     registerButton: "coral coral-viewerBox-registerButton",
     username: "coral coral-viewerBox-username",
+    joinText: "coral coral-viewerBox-joinText",
+    actionButtons: "coral coral-viewerBox-actionButtons",
+    usernameLabel: "coral coral-viewerBox-usernameLabel",
+    usernameContainer: "coral coral-viewerBox-usernameContainer",
   },
 
   /**
@@ -686,7 +704,6 @@ const CLASSES = {
      */
     unauthenticated: "coral coral-unauthenticated",
   },
-
   /**
    * allCommentsTabPane is the tab pane that shows all comments.
    */
@@ -1075,6 +1092,20 @@ const CLASSES = {
   },
 
   mobileToolbar: "coral coral-mobileToolbar",
+
+  viewersWatching: {
+    $root: "coral coral-viewersWatching",
+  },
+
+  modMessage: {
+    $root: "coral coral-modMessage",
+  },
+
+  bannedInfo: {
+    $root: "coral coral-bannedInfo",
+  },
+
+  icon: "coral coral-icon",
 };
 
 export default CLASSES;

--- a/src/core/client/stream/classes.ts
+++ b/src/core/client/stream/classes.ts
@@ -1052,7 +1052,7 @@ const CLASSES = {
     description: "coral coral-login-description",
     field: "coral coral-login-field",
     errorContainer: "coral coral-login-errorContainer",
-    error: "c/nooral coral-login-error",
+    error: "coral coral-login-error",
     facebookButton: "coral coral-login-facebookButton",
     googleButton: "coral coral-login-googleButton",
     oidcButton: "coral coral-login-oidcButton",

--- a/src/core/client/stream/classes.ts
+++ b/src/core/client/stream/classes.ts
@@ -400,38 +400,28 @@ const CLASSES = {
        * reactButton is the reaction button.
        */
       reactButton: "coral coral-reactButton coral-comment-reactButton",
-
-      reactButtonIcon:
-        "coral coral-reactButton-icon coral-comment-reactButton-icon",
       /**
        * reactedButton is the class added to the reaction button
        * when the viewer has already reacted to the comment.
        */
       reactedButton: "coral-reactedButton coral-comment-reactedButton",
-
       /**
        * replyButton is button that triggers the reply form.
        */
       replyButton: "coral coral-comment-replyButton",
-      replyButtonIcon: "coral coral-comment-replyButton-icon",
       /**
        * shareButton is the button that will show the permalink popover.
        */
       shareButton: "coral coral-comment-shareButton",
-      shareButtonIcon: "coral coral-comment-shareButton-icon",
       /**
        * reportButton is the button that triggers the report feature.
        */
       reportButton: "coral coral-reportButton coral-comment-reportButton",
-      reportButtonIcon:
-        "coral coral-reportButton-icon coral-comment-reportButton-icon",
       /**
        * reportedButton is added to report button when the viewer
        * has already reported the comment.
        */
       reportedButton: "coral-reportedButton coral-comment-reportedButton",
-      reportedButtonIcon:
-        "coral-reportedButtonIcon coral-comment-reportedButtonIcon",
     },
 
     avatar: "coral coral-comment-avatar",
@@ -892,10 +882,16 @@ const CLASSES = {
    */
   ignoredCommenters: {
     $root: "coral coral-ignoredCommenters",
+    heading: "coral coral-ignoredCommenters-heading",
     list: "coral coral-ignoredCommenters-list",
     manageButton: "coral coral-ignoredComments-manageButton",
     username: "coral coral-ignoredCommenters-username",
     stopIgnoreButton: "coral coral-ignoredCommenters-stopIgnoreButton",
+  },
+
+  myBio: {
+    $root: "coral coral-myBio",
+    heading: "coral coral-myBio-heading",
   },
 
   /**
@@ -1017,10 +1013,14 @@ const CLASSES = {
 
   emailNotifications: {
     $root: "coral coral-emailNotifications",
+    heading: "coral coral-emailNotifications-heading",
+    label: "coral coral-emailNotifications-label",
     updateButton: "coral coral-emailNotifications-updateButton",
   },
 
   mediaPreferences: {
+    $root: "coral coral-mediaPreferences",
+    heading: "coral coral-mediaPreferences-heading",
     updateButton: "coral coral-mediaPreferences-updateButton",
   },
 
@@ -1052,7 +1052,7 @@ const CLASSES = {
     description: "coral coral-login-description",
     field: "coral coral-login-field",
     errorContainer: "coral coral-login-errorContainer",
-    error: "coral coral-login-error",
+    error: "c/nooral coral-login-error",
     facebookButton: "coral coral-login-facebookButton",
     googleButton: "coral coral-login-googleButton",
     oidcButton: "coral coral-login-oidcButton",
@@ -1103,6 +1103,10 @@ const CLASSES = {
 
   bannedInfo: {
     $root: "coral coral-bannedInfo",
+  },
+
+  accountSettings: {
+    $root: "coral coral-accountSettings",
   },
 
   icon: "coral coral-icon",

--- a/src/core/client/stream/common/MessageBox/__snapshots__/MessageBox.spec.tsx.snap
+++ b/src/core/client/stream/common/MessageBox/__snapshots__/MessageBox.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`renders icon 1`] = `
 >
   <i
     aria-hidden="true"
-    className="Icon-root Icon-md MessageBoxIcon-root"
+    className="Icon-root Icon-md coral coral-icon MessageBoxIcon-root"
   >
     alert
   </i>

--- a/src/core/client/stream/common/UserBox/UserBoxAuthenticated.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxAuthenticated.tsx
@@ -30,9 +30,15 @@ const UserBoxAuthenticated: FunctionComponent<UserBoxAuthenticatedProps> = (
     >
       <section className={CLASSES.viewerBox.$root} aria-label="Authentication">
         <Localized id="general-userBoxAuthenticated-signedIn">
-          <div className={styles.text}>Signed in as</div>
+          <div className={cn(styles.text, CLASSES.viewerBox.usernameLabel)}>
+            Signed in as
+          </div>
         </Localized>
-        <Flex alignItems="flex-end" wrap>
+        <Flex
+          alignItems="flex-end"
+          wrap
+          className={CLASSES.viewerBox.usernameContainer}
+        >
           <Username />
           {props.showLogoutButton && (
             <Localized

--- a/src/core/client/stream/common/UserBox/UserBoxUnauthenticated.tsx
+++ b/src/core/client/stream/common/UserBox/UserBoxUnauthenticated.tsx
@@ -30,9 +30,11 @@ const UserBoxUnauthenticated: FunctionComponent<UserBoxUnauthenticatedProps> = (
         aria-label="Authentication"
       >
         <Localized id="general-userBoxUnauthenticated-joinTheConversation">
-          <span className={styles.joinText}>Join the conversation</span>
+          <span className={cn(styles.joinText, CLASSES.viewerBox.joinText)}>
+            Join the conversation
+          </span>
         </Localized>
-        <div className={styles.actions}>
+        <div className={cn(styles.actions, CLASSES.viewerBox.actionButtons)}>
           {props.showRegisterButton && (
             <Localized id="general-userBoxUnauthenticated-register">
               <Button

--- a/src/core/client/stream/common/UserBox/__snapshots__/UserBoxAuthenticated.spec.tsx.snap
+++ b/src/core/client/stream/common/UserBox/__snapshots__/UserBoxAuthenticated.spec.tsx.snap
@@ -17,13 +17,14 @@ exports[`renders correctly with logout button 1`] = `
       id="general-userBoxAuthenticated-signedIn"
     >
       <div
-        className="UserBoxAuthenticated-text"
+        className="UserBoxAuthenticated-text coral coral-viewerBox-usernameLabel"
       >
         Signed in as
       </div>
     </Localized>
     <ForwardRef(forwardRef)
       alignItems="flex-end"
+      className="coral coral-viewerBox-usernameContainer"
       wrap={true}
     >
       <Username />
@@ -72,13 +73,14 @@ exports[`renders correctly without logout button 1`] = `
       id="general-userBoxAuthenticated-signedIn"
     >
       <div
-        className="UserBoxAuthenticated-text"
+        className="UserBoxAuthenticated-text coral coral-viewerBox-usernameLabel"
       >
         Signed in as
       </div>
     </Localized>
     <ForwardRef(forwardRef)
       alignItems="flex-end"
+      className="coral coral-viewerBox-usernameContainer"
       wrap={true}
     >
       <Username />

--- a/src/core/client/stream/common/UserBox/__snapshots__/UserBoxUnauthenticated.spec.tsx.snap
+++ b/src/core/client/stream/common/UserBox/__snapshots__/UserBoxUnauthenticated.spec.tsx.snap
@@ -20,13 +20,13 @@ exports[`renders correctly 1`] = `
       id="general-userBoxUnauthenticated-joinTheConversation"
     >
       <span
-        className="UserBoxUnauthenticated-joinText"
+        className="UserBoxUnauthenticated-joinText coral coral-viewerBox-joinText"
       >
         Join the conversation
       </span>
     </Localized>
     <div
-      className="UserBoxUnauthenticated-actions"
+      className="UserBoxUnauthenticated-actions coral coral-viewerBox-actionButtons"
     >
       <Localized
         id="general-userBoxUnauthenticated-register"
@@ -83,13 +83,13 @@ exports[`renders correctly hides showRegisterButton 1`] = `
       id="general-userBoxUnauthenticated-joinTheConversation"
     >
       <span
-        className="UserBoxUnauthenticated-joinText"
+        className="UserBoxUnauthenticated-joinText coral coral-viewerBox-joinText"
       >
         Join the conversation
       </span>
     </Localized>
     <div
-      className="UserBoxUnauthenticated-actions"
+      className="UserBoxUnauthenticated-actions coral coral-viewerBox-actionButtons"
     >
       <Localized
         id="general-userBoxUnauthenticated-signIn"

--- a/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/CommentContainer.tsx
@@ -619,7 +619,12 @@ export const CommentContainer: FunctionComponent<Props> = ({
                         </Button>
                       )}
                       {showAvatar && comment.author?.avatar && (
-                        <div className={styles.avatarContainer}>
+                        <div
+                          className={cn(
+                            styles.avatarContainer,
+                            CLASSES.comment.avatar
+                          )}
+                        >
                           <Localized
                             id="comments-commentContainer-avatar"
                             attrs={{ alt: true }}

--- a/src/core/client/stream/tabs/Comments/Comment/ReactionButton/ReactionButton.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReactionButton/ReactionButton.tsx
@@ -20,6 +20,7 @@ interface ReactionButtonProps {
   className?: string;
   isQA?: boolean;
   author?: string | null;
+  iconClassName?: string | null;
 }
 
 function render(props: ReactionButtonProps) {
@@ -33,6 +34,7 @@ function render(props: ReactionButtonProps) {
     label,
     icon,
     iconActive,
+    iconClassName,
   } = props;
 
   return (
@@ -56,7 +58,7 @@ function render(props: ReactionButtonProps) {
         {props.isQA ? (
           <Icon className={styles.icon}>arrow_upward</Icon>
         ) : (
-          <Icon className={styles.icon}>
+          <Icon className={cn(styles.icon, iconClassName)}>
             {reacted ? (iconActive ? iconActive : icon) : icon}
           </Icon>
         )}

--- a/src/core/client/stream/tabs/Comments/Comment/ReactionButton/ReactionButtonContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReactionButton/ReactionButtonContainer.tsx
@@ -126,7 +126,7 @@ const ReactionButtonContainer: FunctionComponent<Props> = ({
       readOnly={readOnly}
       isQA={isQA}
       author={comment.author?.username}
-      iconClassName={CLASSES.comment.actionBar.reactButtonIcon}
+      iconClassName={CLASSES.comment.actionBar.reactButton}
     />
   );
 };

--- a/src/core/client/stream/tabs/Comments/Comment/ReactionButton/ReactionButtonContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReactionButton/ReactionButtonContainer.tsx
@@ -16,6 +16,7 @@ import { ReactionButtonContainer_comment as CommentData } from "coral-stream/__g
 import { ReactionButtonContainer_settings as SettingsData } from "coral-stream/__generated__/ReactionButtonContainer_settings.graphql";
 import { ReactionButtonContainer_viewer as ViewerData } from "coral-stream/__generated__/ReactionButtonContainer_viewer.graphql";
 
+import CLASSES from "coral-stream/classes";
 import { shouldTriggerViewerRefresh } from "../../helpers";
 import RefreshViewerFetch from "../../RefreshViewerFetch";
 import CreateCommentReactionMutation from "./CreateCommentReactionMutation";
@@ -125,6 +126,7 @@ const ReactionButtonContainer: FunctionComponent<Props> = ({
       readOnly={readOnly}
       isQA={isQA}
       author={comment.author?.username}
+      iconClassName={CLASSES.comment.actionBar.reactButtonIcon}
     />
   );
 };

--- a/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.tsx
@@ -56,7 +56,7 @@ class ReportCommentForm extends React.Component<Props> {
     const { onCancel, onSubmit, id } = this.props;
     return (
       <div
-        className={styles.root}
+        className={cn(styles.root, CLASSES.reportPopover.$root)}
         data-testid="report-comment-form"
         role="none"
       >

--- a/src/core/client/stream/tabs/Comments/Stream/BannedInfo.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/BannedInfo.tsx
@@ -1,4 +1,6 @@
 import { Localized } from "@fluent/react/compat";
+
+import CLASSES from "coral-stream/classes";
 import React, { FunctionComponent } from "react";
 
 import { Icon } from "coral-ui/components/v2";
@@ -10,6 +12,7 @@ const BannedInfo: FunctionComponent = (props) => {
   return (
     <CallOut
       color="error"
+      className={CLASSES.bannedInfo.$root}
       icon={
         <Icon size="sm" className={styles.icon}>
           block

--- a/src/core/client/stream/tabs/Comments/Stream/ModMessage/ModMessage.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/ModMessage/ModMessage.tsx
@@ -1,4 +1,5 @@
 import { Localized } from "@fluent/react/compat";
+import CLASSES from "coral-stream/classes";
 import React, { FunctionComponent } from "react";
 
 import { HorizontalGutter, Icon } from "coral-ui/components/v2";
@@ -16,6 +17,7 @@ const ModMessage: FunctionComponent<Props> = ({ message, onAcknowledge }) => {
     <CallOut
       color="primary"
       iconColor="none"
+      className={CLASSES.modMessage.$root}
       icon={
         <Icon size="sm" color="stream">
           message

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentFormFake.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentFormFake.tsx
@@ -62,7 +62,7 @@ const PostCommentFormFake: FunctionComponent<Props> = ({
         />
       )}
       <HorizontalGutter className={styles.root}>
-        <div className={styles.rteContainer}>
+        <div className={cn(styles.rteContainer, CLASSES.rte.fakeContainer)}>
           <Localized
             id={
               isQA

--- a/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/__snapshots__/PostCommentFormFake.spec.tsx.snap
+++ b/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/__snapshots__/PostCommentFormFake.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`renders correctly 1`] = `
     className="PostCommentFormFake-root"
   >
     <div
-      className="PostCommentFormFake-rteContainer"
+      className="PostCommentFormFake-rteContainer coral coral-rte-fake-container"
     >
       <Localized
         attrs={

--- a/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -345,7 +345,7 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
               direction="row"
               alignItems="flex-end"
               justifyContent="space-between"
-              className={styles.tabBarRow}
+              className={cn(styles.tabBarRow, CLASSES.tabBarComments.row)}
               container="nav"
               aria-label="Secondary Tablist"
             >

--- a/src/core/client/stream/tabs/Comments/Stream/ViewersWatchingContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/ViewersWatchingContainer.tsx
@@ -1,4 +1,5 @@
 import { Localized } from "@fluent/react/compat";
+import CLASSES from "coral-stream/classes";
 import React, {
   FunctionComponent,
   useCallback,
@@ -124,7 +125,7 @@ const ViewersWatchingContainer: FunctionComponent<Props> = ({
       story.viewerCount + 1;
 
   return (
-    <div ref={intersectionRef}>
+    <div ref={intersectionRef} className={CLASSES.viewersWatching.$root}>
       <CallOut
         classes={{
           icon: styles.icon,

--- a/src/core/client/stream/tabs/Profile/Preferences/BioContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Preferences/BioContainer.tsx
@@ -1,4 +1,6 @@
 import { Localized } from "@fluent/react/compat";
+import cn from "classnames";
+import CLASSES from "coral-stream/classes";
 import { FORM_ERROR } from "final-form";
 import React, { FunctionComponent, useCallback, useState } from "react";
 import { Field, Form } from "react-final-form";
@@ -61,10 +63,17 @@ const BioContainer: FunctionComponent<Props> = ({ viewer, settings }) => {
     return null;
   }
   return (
-    <HorizontalGutter container="section" aria-labelledby="profile-bio-title">
+    <HorizontalGutter
+      container="section"
+      aria-labelledby="profile-bio-title"
+      className={CLASSES.myBio.$root}
+    >
       <HorizontalGutter spacing={1}>
         <Localized id="profile-bio-title">
-          <h2 className={styles.title} id="profile-bio-title">
+          <h2
+            className={cn(styles.title, CLASSES.myBio.heading)}
+            id="profile-bio-title"
+          >
             Bio
           </h2>
         </Localized>

--- a/src/core/client/stream/tabs/Profile/Preferences/IgnoreUserSettingsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Preferences/IgnoreUserSettingsContainer.tsx
@@ -56,12 +56,12 @@ const IgnoreUserSettingsContainer: FunctionComponent<Props> = ({ viewer }) => {
       aria-labelledby="profile-account-ignoredCommenters-title"
     >
       <Localized id="profile-account-ignoredCommenters">
-        <h1
-          className={styles.title}
+        <h2
+          className={cn(styles.title, CLASSES.ignoredCommenters.heading)}
           id="profile-account-ignoredCommenters-title"
         >
           Ignored Commenters
-        </h1>
+        </h2>
       </Localized>
       <Localized id="profile-account-ignoredCommenters-description">
         <div className={styles.description}>

--- a/src/core/client/stream/tabs/Profile/Preferences/MediaSettingsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Preferences/MediaSettingsContainer.tsx
@@ -82,6 +82,7 @@ const MediaSettingsContainer: FunctionComponent<Props> = ({
     <>
       <HorizontalGutter
         container="section"
+        className={CLASSES.mediaPreferences.$root}
         aria-labelledby="profile-preferences-mediaPreferences-title"
       >
         <Form initialValues={viewer.mediaSettings} onSubmit={onSubmit}>
@@ -94,12 +95,12 @@ const MediaSettingsContainer: FunctionComponent<Props> = ({
           }) => (
             <form className={styles.form} onSubmit={handleSubmit}>
               <Localized id="profile-preferences-mediaPreferences">
-                <div
-                  className={styles.title}
+                <h2
+                  className={cn(styles.title, CLASSES.mediaPreferences.heading)}
                   id="profile-preferences-mediaPreferences-title"
                 >
                   Media Preferences
-                </div>
+                </h2>
               </Localized>
               <div className={styles.options}>
                 <FieldSet>

--- a/src/core/client/stream/tabs/Profile/Preferences/NotificationSettingsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Preferences/NotificationSettingsContainer.tsx
@@ -85,18 +85,24 @@ const NotificationSettingsContainer: FunctionComponent<Props> = ({
             <HorizontalGutter>
               <HorizontalGutter>
                 <Localized id="profile-account-notifications-emailNotifications">
-                  <h1
-                    className={styles.title}
+                  <h2
+                    className={cn(
+                      styles.title,
+                      CLASSES.emailNotifications.heading
+                    )}
                     id="profile-account-notifications-emailNotifications-title"
                   >
                     Email Notifications
-                  </h1>
+                  </h2>
                 </Localized>
               </HorizontalGutter>
               <HorizontalGutter>
                 <Localized id="profile-account-notifications-receiveWhen">
                   <div
-                    className={styles.header}
+                    className={cn(
+                      styles.header,
+                      CLASSES.emailNotifications.label
+                    )}
                     id="profile-account-notifications-receiveWhen"
                   >
                     Receive notifications when:
@@ -170,7 +176,11 @@ const NotificationSettingsContainer: FunctionComponent<Props> = ({
                   <FormField>
                     <Localized id="profile-account-notifications-sendNotifications">
                       <label
-                        className={cn(styles.header, styles.sendNotifications)}
+                        className={cn(
+                          styles.header,
+                          styles.sendNotifications,
+                          CLASSES.emailNotifications.label
+                        )}
                         htmlFor="digestFrequency"
                       >
                         Send Notifications:

--- a/src/core/client/stream/tabs/Profile/Settings/AccountSettingsContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Settings/AccountSettingsContainer.tsx
@@ -1,8 +1,11 @@
+import cn from "classnames";
 import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import { withFragmentContainer } from "coral-framework/lib/relay";
 import { HorizontalGutter } from "coral-ui/components/v2";
+
+import CLASSES from "coral-stream/classes";
 
 import { AccountSettingsContainer_settings } from "coral-stream/__generated__/AccountSettingsContainer_settings.graphql";
 import { AccountSettingsContainer_viewer } from "coral-stream/__generated__/AccountSettingsContainer_viewer.graphql";
@@ -25,7 +28,9 @@ const AccountSettingsContainer: FunctionComponent<Props> = ({
   settings,
 }) => (
   <HorizontalGutter size="oneAndAHalf" data-testid="profile-manageAccount">
-    <HorizontalGutter className={styles.root}>
+    <HorizontalGutter
+      className={cn(styles.root, CLASSES.accountSettings.$root)}
+    >
       <ChangeUsernameContainer settings={settings} viewer={viewer} />
       <ChangeEmailContainer settings={settings} viewer={viewer} />
       <ChangePasswordContainer settings={settings} />

--- a/src/core/client/stream/test/comments/featured/__snapshots__/renderFeaturedStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/featured/__snapshots__/renderFeaturedStream.spec.tsx.snap
@@ -583,7 +583,7 @@ exports[`renders comment stream 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>
@@ -732,7 +732,7 @@ exports[`renders comment stream 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>

--- a/src/core/client/stream/test/comments/featured/__snapshots__/renderFeaturedStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/featured/__snapshots__/renderFeaturedStream.spec.tsx.snap
@@ -40,7 +40,7 @@ exports[`renders comment stream 1`] = `
           <div>
             <i
               aria-hidden="true"
-              className="Icon-root Icon-lg"
+              className="Icon-root Icon-lg coral coral-icon"
             >
               forum
             </i>
@@ -72,12 +72,12 @@ exports[`renders comment stream 1`] = `
             className="Box-root Flex-root coral coral-viewerBox Flex-flex Flex-wrap Flex-alignCenter"
           >
             <span
-              className="UserBoxUnauthenticated-joinText"
+              className="UserBoxUnauthenticated-joinText coral coral-viewerBox-joinText"
             >
               Join the conversation
             </span>
             <div
-              className="UserBoxUnauthenticated-actions"
+              className="UserBoxUnauthenticated-actions coral coral-viewerBox-actionButtons"
             >
               <button
                 className="BaseButton-root Button-base Button-filled Button-fontSizeExtraSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeExtraSmall Button-colorPrimary Button-upperCase UserBoxUnauthenticated-register coral coral-viewerBox-registerButton"
@@ -124,7 +124,7 @@ exports[`renders comment stream 1`] = `
               className="Box-root HorizontalGutter-root PostCommentFormFake-root HorizontalGutter-full"
             >
               <div
-                className="PostCommentFormFake-rteContainer"
+                className="PostCommentFormFake-rteContainer coral coral-rte-fake-container"
               >
                 <div
                   role="none"
@@ -166,7 +166,7 @@ exports[`renders comment stream 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-md"
+                          className="Icon-root Icon-md coral coral-icon"
                         >
                           format_bold
                         </i>
@@ -186,7 +186,7 @@ exports[`renders comment stream 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-md"
+                          className="Icon-root Icon-md coral coral-icon"
                         >
                           format_italic
                         </i>
@@ -206,7 +206,7 @@ exports[`renders comment stream 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-md"
+                          className="Icon-root Icon-md coral coral-icon"
                         >
                           format_quote
                         </i>
@@ -226,7 +226,7 @@ exports[`renders comment stream 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-md"
+                          className="Icon-root Icon-md coral coral-icon"
                         >
                           format_list_bulleted
                         </i>
@@ -257,7 +257,7 @@ exports[`renders comment stream 1`] = `
         >
           <nav
             aria-label="Secondary Tablist"
-            className="Box-root Flex-root StreamContainer-tabBarRow Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
+            className="Box-root Flex-root StreamContainer-tabBarRow coral coral-tabBarSecondary-row Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
           >
             <ul
               className="TabBar-root TabBar-streamSecondary coral coral-tabBarSecondary coral-tabBarComments StreamContainer-tabBarRoot"
@@ -339,7 +339,7 @@ exports[`renders comment stream 1`] = `
                   >
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-sm"
+                      className="Icon-root Icon-sm coral coral-icon"
                     >
                       info
                     </i>
@@ -453,7 +453,7 @@ exports[`renders comment stream 1`] = `
                 >
                   <i
                     aria-hidden="true"
-                    className="Icon-root Icon-sm"
+                    className="Icon-root Icon-sm coral coral-icon"
                   >
                     expand_more
                   </i>
@@ -583,7 +583,7 @@ exports[`renders comment stream 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -610,7 +610,7 @@ exports[`renders comment stream 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm FeaturedCommentContainer-icon"
+                          className="Icon-root Icon-sm coral coral-icon FeaturedCommentContainer-icon"
                         >
                           forum
                         </i>
@@ -732,7 +732,7 @@ exports[`renders comment stream 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -759,7 +759,7 @@ exports[`renders comment stream 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm FeaturedCommentContainer-icon"
+                          className="Icon-root Icon-sm coral coral-icon FeaturedCommentContainer-icon"
                         >
                           forum
                         </i>

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
@@ -15,12 +15,12 @@ exports[`renders permalink view 1`] = `
       className="Box-root Flex-root coral coral-viewerBox Flex-flex Flex-wrap Flex-alignCenter"
     >
       <span
-        className="UserBoxUnauthenticated-joinText"
+        className="UserBoxUnauthenticated-joinText coral coral-viewerBox-joinText"
       >
         Join the conversation
       </span>
       <div
-        className="UserBoxUnauthenticated-actions"
+        className="UserBoxUnauthenticated-actions coral coral-viewerBox-actionButtons"
       >
         <button
           className="BaseButton-root Button-base Button-filled Button-fontSizeExtraSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeExtraSmall Button-colorPrimary Button-upperCase UserBoxUnauthenticated-register coral coral-viewerBox-registerButton"
@@ -276,7 +276,7 @@ exports[`renders permalink view 1`] = `
                                         >
                                           <i
                                             aria-hidden="true"
-                                            className="Icon-root Icon-sm ReactionButton-icon"
+                                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                           >
                                             thumb_up
                                           </i>
@@ -303,7 +303,7 @@ exports[`renders permalink view 1`] = `
                                         >
                                           <i
                                             aria-hidden="true"
-                                            className="Icon-root Icon-sm ReplyButton-icon"
+                                            className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                           >
                                             reply
                                           </i>
@@ -332,7 +332,7 @@ exports[`renders permalink view 1`] = `
                                           >
                                             <i
                                               aria-hidden="true"
-                                              className="Icon-root Icon-sm PermalinkButton-icon"
+                                              className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                             >
                                               share
                                             </i>
@@ -369,7 +369,7 @@ exports[`renders permalink view 1`] = `
                                         >
                                           <i
                                             aria-hidden="true"
-                                            className="Icon-root Icon-sm ReportButton-icon"
+                                            className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                           >
                                             flag
                                           </i>
@@ -561,7 +561,7 @@ exports[`renders permalink view 1`] = `
                                         >
                                           <i
                                             aria-hidden="true"
-                                            className="Icon-root Icon-sm ReactionButton-icon"
+                                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                           >
                                             thumb_up
                                           </i>
@@ -588,7 +588,7 @@ exports[`renders permalink view 1`] = `
                                         >
                                           <i
                                             aria-hidden="true"
-                                            className="Icon-root Icon-sm ReplyButton-icon"
+                                            className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                           >
                                             reply
                                           </i>
@@ -617,7 +617,7 @@ exports[`renders permalink view 1`] = `
                                           >
                                             <i
                                               aria-hidden="true"
-                                              className="Icon-root Icon-sm PermalinkButton-icon"
+                                              className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                             >
                                               share
                                             </i>
@@ -654,7 +654,7 @@ exports[`renders permalink view 1`] = `
                                         >
                                           <i
                                             aria-hidden="true"
-                                            className="Icon-root Icon-sm ReportButton-icon"
+                                            className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                           >
                                             flag
                                           </i>
@@ -844,7 +844,7 @@ exports[`renders permalink view 1`] = `
                                     >
                                       <i
                                         aria-hidden="true"
-                                        className="Icon-root Icon-sm ReactionButton-icon"
+                                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                       >
                                         thumb_up
                                       </i>
@@ -871,7 +871,7 @@ exports[`renders permalink view 1`] = `
                                     >
                                       <i
                                         aria-hidden="true"
-                                        className="Icon-root Icon-sm ReplyButton-icon"
+                                        className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                       >
                                         reply
                                       </i>
@@ -900,7 +900,7 @@ exports[`renders permalink view 1`] = `
                                       >
                                         <i
                                           aria-hidden="true"
-                                          className="Icon-root Icon-sm PermalinkButton-icon"
+                                          className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                         >
                                           share
                                         </i>
@@ -937,7 +937,7 @@ exports[`renders permalink view 1`] = `
                                     >
                                       <i
                                         aria-hidden="true"
-                                        className="Icon-root Icon-sm ReportButton-icon"
+                                        className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                       >
                                         flag
                                       </i>
@@ -1023,7 +1023,7 @@ exports[`renders permalink view 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                            className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                           >
                             remove
                           </i>
@@ -1118,7 +1118,7 @@ exports[`renders permalink view 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm InReplyTo-icon"
+                                  className="Icon-root Icon-sm coral coral-icon InReplyTo-icon"
                                 >
                                   reply
                                 </i>
@@ -1175,7 +1175,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm ReactionButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                     >
                                       thumb_up
                                     </i>
@@ -1202,7 +1202,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm ReplyButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                     >
                                       reply
                                     </i>
@@ -1231,7 +1231,7 @@ exports[`renders permalink view 1`] = `
                                     >
                                       <i
                                         aria-hidden="true"
-                                        className="Icon-root Icon-sm PermalinkButton-icon"
+                                        className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                       >
                                         share
                                       </i>
@@ -1268,7 +1268,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm ReportButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                     >
                                       flag
                                     </i>
@@ -1344,7 +1344,7 @@ exports[`renders permalink view 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                            className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                           >
                             remove
                           </i>
@@ -1439,7 +1439,7 @@ exports[`renders permalink view 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm InReplyTo-icon"
+                                  className="Icon-root Icon-sm coral coral-icon InReplyTo-icon"
                                 >
                                   reply
                                 </i>
@@ -1496,7 +1496,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm ReactionButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                     >
                                       thumb_up
                                     </i>
@@ -1523,7 +1523,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm ReplyButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                     >
                                       reply
                                     </i>
@@ -1552,7 +1552,7 @@ exports[`renders permalink view 1`] = `
                                     >
                                       <i
                                         aria-hidden="true"
-                                        className="Icon-root Icon-sm PermalinkButton-icon"
+                                        className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                       >
                                         share
                                       </i>
@@ -1589,7 +1589,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm ReportButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                     >
                                       flag
                                     </i>

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkView.spec.tsx.snap
@@ -276,7 +276,7 @@ exports[`renders permalink view 1`] = `
                                         >
                                           <i
                                             aria-hidden="true"
-                                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                           >
                                             thumb_up
                                           </i>
@@ -561,7 +561,7 @@ exports[`renders permalink view 1`] = `
                                         >
                                           <i
                                             aria-hidden="true"
-                                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                           >
                                             thumb_up
                                           </i>
@@ -844,7 +844,7 @@ exports[`renders permalink view 1`] = `
                                     >
                                       <i
                                         aria-hidden="true"
-                                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                       >
                                         thumb_up
                                       </i>
@@ -1175,7 +1175,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                     >
                                       thumb_up
                                     </i>
@@ -1496,7 +1496,7 @@ exports[`renders permalink view 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                     >
                                       thumb_up
                                     </i>

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewCommentNotFound.spec.tsx.snap
@@ -15,12 +15,12 @@ exports[`renders permalink view with unknown comment 1`] = `
       className="Box-root Flex-root coral coral-viewerBox Flex-flex Flex-wrap Flex-alignCenter"
     >
       <span
-        className="UserBoxUnauthenticated-joinText"
+        className="UserBoxUnauthenticated-joinText coral coral-viewerBox-joinText"
       >
         Join the conversation
       </span>
       <div
-        className="UserBoxUnauthenticated-actions"
+        className="UserBoxUnauthenticated-actions coral coral-viewerBox-actionButtons"
       >
         <button
           className="BaseButton-root Button-base Button-filled Button-fontSizeExtraSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeExtraSmall Button-colorPrimary Button-upperCase UserBoxUnauthenticated-register coral coral-viewerBox-registerButton"

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewLoadMoreParents.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewLoadMoreParents.spec.tsx.snap
@@ -197,7 +197,7 @@ exports[`renders conversation thread 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReactionButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                 >
                                   thumb_up
                                 </i>
@@ -224,7 +224,7 @@ exports[`renders conversation thread 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReplyButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                 >
                                   reply
                                 </i>
@@ -253,7 +253,7 @@ exports[`renders conversation thread 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                   >
                                     share
                                   </i>
@@ -290,7 +290,7 @@ exports[`renders conversation thread 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReportButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                 >
                                   flag
                                 </i>
@@ -313,7 +313,7 @@ exports[`renders conversation thread 1`] = `
     >
       <i
         aria-hidden="true"
-        className="Icon-root Icon-lg ConversationThreadContainer-showMoreIcon"
+        className="Icon-root Icon-lg coral coral-icon ConversationThreadContainer-showMoreIcon"
       >
         more_vert
       </i>
@@ -507,7 +507,7 @@ exports[`renders conversation thread 1`] = `
                             >
                               <i
                                 aria-hidden="true"
-                                className="Icon-root Icon-sm ReactionButton-icon"
+                                className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                               >
                                 thumb_up
                               </i>
@@ -534,7 +534,7 @@ exports[`renders conversation thread 1`] = `
                             >
                               <i
                                 aria-hidden="true"
-                                className="Icon-root Icon-sm ReplyButton-icon"
+                                className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                               >
                                 reply
                               </i>
@@ -563,7 +563,7 @@ exports[`renders conversation thread 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm PermalinkButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                 >
                                   share
                                 </i>
@@ -600,7 +600,7 @@ exports[`renders conversation thread 1`] = `
                             >
                               <i
                                 aria-hidden="true"
-                                className="Icon-root Icon-sm ReportButton-icon"
+                                className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                               >
                                 flag
                               </i>
@@ -818,7 +818,7 @@ exports[`shows more of this conversation 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReactionButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                 >
                                   thumb_up
                                 </i>
@@ -845,7 +845,7 @@ exports[`shows more of this conversation 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReplyButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                 >
                                   reply
                                 </i>
@@ -874,7 +874,7 @@ exports[`shows more of this conversation 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                   >
                                     share
                                   </i>
@@ -911,7 +911,7 @@ exports[`shows more of this conversation 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReportButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                 >
                                   flag
                                 </i>
@@ -1106,7 +1106,7 @@ exports[`shows more of this conversation 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReactionButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                   >
                                     thumb_up
                                   </i>
@@ -1133,7 +1133,7 @@ exports[`shows more of this conversation 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReplyButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                   >
                                     reply
                                   </i>
@@ -1162,7 +1162,7 @@ exports[`shows more of this conversation 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                     >
                                       share
                                     </i>
@@ -1199,7 +1199,7 @@ exports[`shows more of this conversation 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReportButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                   >
                                     flag
                                   </i>
@@ -1389,7 +1389,7 @@ exports[`shows more of this conversation 1`] = `
                             >
                               <i
                                 aria-hidden="true"
-                                className="Icon-root Icon-sm ReactionButton-icon"
+                                className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                               >
                                 thumb_up
                               </i>
@@ -1416,7 +1416,7 @@ exports[`shows more of this conversation 1`] = `
                             >
                               <i
                                 aria-hidden="true"
-                                className="Icon-root Icon-sm ReplyButton-icon"
+                                className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                               >
                                 reply
                               </i>
@@ -1445,7 +1445,7 @@ exports[`shows more of this conversation 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm PermalinkButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                 >
                                   share
                                 </i>
@@ -1482,7 +1482,7 @@ exports[`shows more of this conversation 1`] = `
                             >
                               <i
                                 aria-hidden="true"
-                                className="Icon-root Icon-sm ReportButton-icon"
+                                className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                               >
                                 flag
                               </i>

--- a/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewLoadMoreParents.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/permalink/__snapshots__/permalinkViewLoadMoreParents.spec.tsx.snap
@@ -197,7 +197,7 @@ exports[`renders conversation thread 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                 >
                                   thumb_up
                                 </i>
@@ -507,7 +507,7 @@ exports[`renders conversation thread 1`] = `
                             >
                               <i
                                 aria-hidden="true"
-                                className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                               >
                                 thumb_up
                               </i>
@@ -818,7 +818,7 @@ exports[`shows more of this conversation 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                 >
                                   thumb_up
                                 </i>
@@ -1106,7 +1106,7 @@ exports[`shows more of this conversation 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                   >
                                     thumb_up
                                   </i>
@@ -1389,7 +1389,7 @@ exports[`shows more of this conversation 1`] = `
                             >
                               <i
                                 aria-hidden="true"
-                                className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                               >
                                 thumb_up
                               </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
@@ -51,7 +51,7 @@ exports[`cancel edit 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
             >
               remove
             </i>
@@ -143,7 +143,7 @@ exports[`cancel edit 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm CommentContainer-editIcon"
+                        className="Icon-root Icon-sm coral coral-icon CommentContainer-editIcon"
                       >
                         edit
                       </i>
@@ -190,7 +190,7 @@ exports[`cancel edit 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -217,7 +217,7 @@ exports[`cancel edit 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReplyButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                       >
                         reply
                       </i>
@@ -246,7 +246,7 @@ exports[`cancel edit 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm PermalinkButton-icon"
+                          className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                         >
                           share
                         </i>
@@ -283,7 +283,7 @@ exports[`cancel edit 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReportButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                       >
                         flag
                       </i>
@@ -392,7 +392,7 @@ exports[`edit a comment and handle server error: edit form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_bold
                       </i>
@@ -412,7 +412,7 @@ exports[`edit a comment and handle server error: edit form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_italic
                       </i>
@@ -432,7 +432,7 @@ exports[`edit a comment and handle server error: edit form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_quote
                       </i>
@@ -452,7 +452,7 @@ exports[`edit a comment and handle server error: edit form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_list_bulleted
                       </i>
@@ -467,7 +467,7 @@ exports[`edit a comment and handle server error: edit form 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm MessageIcon-root"
+              className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
             >
               alarm
             </i>
@@ -613,7 +613,7 @@ exports[`edit a comment: edit form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_bold
                       </i>
@@ -633,7 +633,7 @@ exports[`edit a comment: edit form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_italic
                       </i>
@@ -653,7 +653,7 @@ exports[`edit a comment: edit form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_quote
                       </i>
@@ -673,7 +673,7 @@ exports[`edit a comment: edit form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_list_bulleted
                       </i>
@@ -688,7 +688,7 @@ exports[`edit a comment: edit form 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm MessageIcon-root"
+              className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
             >
               alarm
             </i>
@@ -834,7 +834,7 @@ exports[`edit a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_bold
                       </i>
@@ -854,7 +854,7 @@ exports[`edit a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_italic
                       </i>
@@ -874,7 +874,7 @@ exports[`edit a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_quote
                       </i>
@@ -894,7 +894,7 @@ exports[`edit a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_list_bulleted
                       </i>
@@ -909,7 +909,7 @@ exports[`edit a comment: optimistic response 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm MessageIcon-root"
+              className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
             >
               alarm
             </i>
@@ -1014,7 +1014,7 @@ exports[`edit a comment: render comment with edit button 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
             >
               remove
             </i>
@@ -1106,7 +1106,7 @@ exports[`edit a comment: render comment with edit button 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm CommentContainer-editIcon"
+                        className="Icon-root Icon-sm coral coral-icon CommentContainer-editIcon"
                       >
                         edit
                       </i>
@@ -1153,7 +1153,7 @@ exports[`edit a comment: render comment with edit button 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -1180,7 +1180,7 @@ exports[`edit a comment: render comment with edit button 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReplyButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                       >
                         reply
                       </i>
@@ -1209,7 +1209,7 @@ exports[`edit a comment: render comment with edit button 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm PermalinkButton-icon"
+                          className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                         >
                           share
                         </i>
@@ -1246,7 +1246,7 @@ exports[`edit a comment: render comment with edit button 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReportButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                       >
                         flag
                       </i>
@@ -1314,7 +1314,7 @@ exports[`edit a comment: server response 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
             >
               remove
             </i>
@@ -1415,7 +1415,7 @@ exports[`edit a comment: server response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm CommentContainer-editIcon"
+                        className="Icon-root Icon-sm coral coral-icon CommentContainer-editIcon"
                       >
                         edit
                       </i>
@@ -1462,7 +1462,7 @@ exports[`edit a comment: server response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -1489,7 +1489,7 @@ exports[`edit a comment: server response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReplyButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                       >
                         reply
                       </i>
@@ -1518,7 +1518,7 @@ exports[`edit a comment: server response 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm PermalinkButton-icon"
+                          className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                         >
                           share
                         </i>
@@ -1555,7 +1555,7 @@ exports[`edit a comment: server response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReportButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                       >
                         flag
                       </i>
@@ -1623,7 +1623,7 @@ exports[`shows expiry message: edit form closed 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
             >
               remove
             </i>
@@ -1715,7 +1715,7 @@ exports[`shows expiry message: edit form closed 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm CommentContainer-editIcon"
+                        className="Icon-root Icon-sm coral coral-icon CommentContainer-editIcon"
                       >
                         edit
                       </i>
@@ -1762,7 +1762,7 @@ exports[`shows expiry message: edit form closed 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -1789,7 +1789,7 @@ exports[`shows expiry message: edit form closed 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReplyButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                       >
                         reply
                       </i>
@@ -1818,7 +1818,7 @@ exports[`shows expiry message: edit form closed 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm PermalinkButton-icon"
+                          className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                         >
                           share
                         </i>
@@ -1855,7 +1855,7 @@ exports[`shows expiry message: edit form closed 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReportButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                       >
                         flag
                       </i>
@@ -1964,7 +1964,7 @@ exports[`shows expiry message: edit time expired 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_bold
                       </i>
@@ -1984,7 +1984,7 @@ exports[`shows expiry message: edit time expired 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_italic
                       </i>
@@ -2004,7 +2004,7 @@ exports[`shows expiry message: edit time expired 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_quote
                       </i>
@@ -2024,7 +2024,7 @@ exports[`shows expiry message: edit time expired 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-md"
+                        className="Icon-root Icon-md coral coral-icon"
                       >
                         format_list_bulleted
                       </i>
@@ -2045,7 +2045,7 @@ exports[`shows expiry message: edit time expired 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm"
+                  className="Icon-root Icon-sm coral coral-icon"
                 >
                   error
                 </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/editComment.spec.tsx.snap
@@ -190,7 +190,7 @@ exports[`cancel edit 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>
@@ -1153,7 +1153,7 @@ exports[`edit a comment: render comment with edit button 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>
@@ -1462,7 +1462,7 @@ exports[`edit a comment: server response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>
@@ -1762,7 +1762,7 @@ exports[`shows expiry message: edit form closed 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postComment.spec.tsx.snap
@@ -190,7 +190,7 @@ exports[`post a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postComment.spec.tsx.snap
@@ -51,7 +51,7 @@ exports[`post a comment: optimistic response 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
             >
               remove
             </i>
@@ -143,7 +143,7 @@ exports[`post a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm CommentContainer-editIcon"
+                        className="Icon-root Icon-sm coral coral-icon CommentContainer-editIcon"
                       >
                         edit
                       </i>
@@ -190,7 +190,7 @@ exports[`post a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -217,7 +217,7 @@ exports[`post a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReplyButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                       >
                         reply
                       </i>
@@ -246,7 +246,7 @@ exports[`post a comment: optimistic response 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm PermalinkButton-icon"
+                          className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                         >
                           share
                         </i>
@@ -283,7 +283,7 @@ exports[`post a comment: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReportButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                       >
                         flag
                       </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
@@ -51,7 +51,7 @@ exports[`post a reply: open reply form 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
             >
               remove
             </i>
@@ -165,7 +165,7 @@ exports[`post a reply: open reply form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -192,7 +192,7 @@ exports[`post a reply: open reply form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReplyButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                       >
                         reply
                       </i>
@@ -221,7 +221,7 @@ exports[`post a reply: open reply form 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm PermalinkButton-icon"
+                          className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                         >
                           share
                         </i>
@@ -258,7 +258,7 @@ exports[`post a reply: open reply form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReportButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                       >
                         flag
                       </i>
@@ -295,7 +295,7 @@ exports[`post a reply: open reply form 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm"
+                  className="Icon-root Icon-sm coral coral-icon"
                 >
                   reply
                 </i>
@@ -357,7 +357,7 @@ exports[`post a reply: open reply form 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-md"
+                          className="Icon-root Icon-md coral coral-icon"
                         >
                           format_bold
                         </i>
@@ -377,7 +377,7 @@ exports[`post a reply: open reply form 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-md"
+                          className="Icon-root Icon-md coral coral-icon"
                         >
                           format_italic
                         </i>
@@ -397,7 +397,7 @@ exports[`post a reply: open reply form 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-md"
+                          className="Icon-root Icon-md coral coral-icon"
                         >
                           format_quote
                         </i>
@@ -417,7 +417,7 @@ exports[`post a reply: open reply form 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-md"
+                          className="Icon-root Icon-md coral coral-icon"
                         >
                           format_list_bulleted
                         </i>
@@ -531,7 +531,7 @@ exports[`post a reply: optimistic response 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                  className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                 >
                   remove
                 </i>
@@ -623,7 +623,7 @@ exports[`post a reply: optimistic response 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm CommentContainer-editIcon"
+                            className="Icon-root Icon-sm coral coral-icon CommentContainer-editIcon"
                           >
                             edit
                           </i>
@@ -651,7 +651,7 @@ exports[`post a reply: optimistic response 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm InReplyTo-icon"
+                        className="Icon-root Icon-sm coral coral-icon InReplyTo-icon"
                       >
                         reply
                       </i>
@@ -708,7 +708,7 @@ exports[`post a reply: optimistic response 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReactionButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                           >
                             thumb_up
                           </i>
@@ -735,7 +735,7 @@ exports[`post a reply: optimistic response 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReplyButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                           >
                             reply
                           </i>
@@ -764,7 +764,7 @@ exports[`post a reply: optimistic response 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm PermalinkButton-icon"
+                              className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                             >
                               share
                             </i>
@@ -801,7 +801,7 @@ exports[`post a reply: optimistic response 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReportButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                           >
                             flag
                           </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/postReply.spec.tsx.snap
@@ -165,7 +165,7 @@ exports[`post a reply: open reply form 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>
@@ -708,7 +708,7 @@ exports[`post a reply: optimistic response 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                           >
                             thumb_up
                           </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/reaction.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/reaction.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`create and remove reaction: Respected 1`] = `
   >
     <i
       aria-hidden="true"
-      className="Icon-root Icon-sm ReactionButton-icon"
+      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
     >
       thumb_up
     </i>
@@ -55,7 +55,7 @@ exports[`create and remove reaction: Unrespected 1`] = `
   >
     <i
       aria-hidden="true"
-      className="Icon-root Icon-sm ReactionButton-icon"
+      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
     >
       thumb_up
     </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/reaction.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/reaction.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`create and remove reaction: Respected 1`] = `
   >
     <i
       aria-hidden="true"
-      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
     >
       thumb_up
     </i>
@@ -55,7 +55,7 @@ exports[`create and remove reaction: Unrespected 1`] = `
   >
     <i
       aria-hidden="true"
-      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+      className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
     >
       thumb_up
     </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderMessageBox.spec.tsx.snap
@@ -18,12 +18,12 @@ exports[`renders message box when commenting disabled 1`] = `
         className="Box-root Flex-root coral coral-viewerBox Flex-flex Flex-wrap Flex-alignCenter"
       >
         <span
-          className="UserBoxUnauthenticated-joinText"
+          className="UserBoxUnauthenticated-joinText coral coral-viewerBox-joinText"
         >
           Join the conversation
         </span>
         <div
-          className="UserBoxUnauthenticated-actions"
+          className="UserBoxUnauthenticated-actions coral coral-viewerBox-actionButtons"
         >
           <button
             className="BaseButton-root Button-base Button-filled Button-fontSizeExtraSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeExtraSmall Button-colorPrimary Button-upperCase UserBoxUnauthenticated-register coral coral-viewerBox-registerButton"
@@ -76,7 +76,7 @@ exports[`renders message box when commenting disabled 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm"
+                className="Icon-root Icon-sm coral coral-icon"
               >
                 feedback
               </i>
@@ -111,7 +111,7 @@ exports[`renders message box when commenting disabled 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-md MessageBoxIcon-root"
+              className="Icon-root Icon-md coral coral-icon MessageBoxIcon-root"
             >
               chat
             </i>
@@ -133,7 +133,7 @@ exports[`renders message box when commenting disabled 1`] = `
     >
       <nav
         aria-label="Secondary Tablist"
-        className="Box-root Flex-root StreamContainer-tabBarRow Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
+        className="Box-root Flex-root StreamContainer-tabBarRow coral coral-tabBarSecondary-row Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
       >
         <ul
           className="TabBar-root TabBar-streamSecondary coral coral-tabBarSecondary coral-tabBarComments StreamContainer-tabBarRoot"
@@ -241,7 +241,7 @@ exports[`renders message box when commenting disabled 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm"
+                className="Icon-root Icon-sm coral coral-icon"
               >
                 expand_more
               </i>
@@ -322,7 +322,7 @@ exports[`renders message box when commenting disabled 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 forum
               </i>
@@ -344,7 +344,7 @@ exports[`renders message box when commenting disabled 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 description
               </i>
@@ -378,12 +378,12 @@ exports[`renders message box when logged in 1`] = `
         className="coral coral-viewerBox"
       >
         <div
-          className="UserBoxAuthenticated-text"
+          className="UserBoxAuthenticated-text coral coral-viewerBox-usernameLabel"
         >
           Signed in as
         </div>
         <div
-          className="Box-root Flex-root Flex-flex Flex-wrap Flex-alignFlexEnd"
+          className="Box-root Flex-root coral coral-viewerBox-usernameContainer Flex-flex Flex-wrap Flex-alignFlexEnd"
         >
           <div
             className="coral coral-viewerBox-username UserBoxAuthenticated-username"
@@ -430,7 +430,7 @@ exports[`renders message box when logged in 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-md MessageBoxIcon-root"
+              className="Icon-root Icon-md coral coral-icon MessageBoxIcon-root"
             >
               chat
             </i>
@@ -506,7 +506,7 @@ exports[`renders message box when logged in 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-md"
+                              className="Icon-root Icon-md coral coral-icon"
                             >
                               format_bold
                             </i>
@@ -526,7 +526,7 @@ exports[`renders message box when logged in 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-md"
+                              className="Icon-root Icon-md coral coral-icon"
                             >
                               format_italic
                             </i>
@@ -546,7 +546,7 @@ exports[`renders message box when logged in 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-md"
+                              className="Icon-root Icon-md coral coral-icon"
                             >
                               format_quote
                             </i>
@@ -566,7 +566,7 @@ exports[`renders message box when logged in 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-md"
+                              className="Icon-root Icon-md coral coral-icon"
                             >
                               format_list_bulleted
                             </i>
@@ -604,7 +604,7 @@ exports[`renders message box when logged in 1`] = `
     >
       <nav
         aria-label="Secondary Tablist"
-        className="Box-root Flex-root StreamContainer-tabBarRow Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
+        className="Box-root Flex-root StreamContainer-tabBarRow coral coral-tabBarSecondary-row Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
       >
         <ul
           className="TabBar-root TabBar-streamSecondary coral coral-tabBarSecondary coral-tabBarComments StreamContainer-tabBarRoot"
@@ -712,7 +712,7 @@ exports[`renders message box when logged in 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm"
+                className="Icon-root Icon-sm coral coral-icon"
               >
                 expand_more
               </i>
@@ -793,7 +793,7 @@ exports[`renders message box when logged in 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 account_box
               </i>
@@ -815,7 +815,7 @@ exports[`renders message box when logged in 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 forum
               </i>
@@ -837,7 +837,7 @@ exports[`renders message box when logged in 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 description
               </i>
@@ -871,12 +871,12 @@ exports[`renders message box when not logged in 1`] = `
         className="Box-root Flex-root coral coral-viewerBox Flex-flex Flex-wrap Flex-alignCenter"
       >
         <span
-          className="UserBoxUnauthenticated-joinText"
+          className="UserBoxUnauthenticated-joinText coral coral-viewerBox-joinText"
         >
           Join the conversation
         </span>
         <div
-          className="UserBoxUnauthenticated-actions"
+          className="UserBoxUnauthenticated-actions coral coral-viewerBox-actionButtons"
         >
           <button
             className="BaseButton-root Button-base Button-filled Button-fontSizeExtraSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeExtraSmall Button-colorPrimary Button-upperCase UserBoxUnauthenticated-register coral coral-viewerBox-registerButton"
@@ -924,7 +924,7 @@ exports[`renders message box when not logged in 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-md MessageBoxIcon-root"
+            className="Icon-root Icon-md coral coral-icon MessageBoxIcon-root"
           >
             chat
           </i>
@@ -942,7 +942,7 @@ exports[`renders message box when not logged in 1`] = `
           className="Box-root HorizontalGutter-root PostCommentFormFake-root HorizontalGutter-full"
         >
           <div
-            className="PostCommentFormFake-rteContainer"
+            className="PostCommentFormFake-rteContainer coral coral-rte-fake-container"
           >
             <div
               role="none"
@@ -984,7 +984,7 @@ exports[`renders message box when not logged in 1`] = `
                   >
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-md"
+                      className="Icon-root Icon-md coral coral-icon"
                     >
                       format_bold
                     </i>
@@ -1004,7 +1004,7 @@ exports[`renders message box when not logged in 1`] = `
                   >
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-md"
+                      className="Icon-root Icon-md coral coral-icon"
                     >
                       format_italic
                     </i>
@@ -1024,7 +1024,7 @@ exports[`renders message box when not logged in 1`] = `
                   >
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-md"
+                      className="Icon-root Icon-md coral coral-icon"
                     >
                       format_quote
                     </i>
@@ -1044,7 +1044,7 @@ exports[`renders message box when not logged in 1`] = `
                   >
                     <i
                       aria-hidden="true"
-                      className="Icon-root Icon-md"
+                      className="Icon-root Icon-md coral coral-icon"
                     >
                       format_list_bulleted
                     </i>
@@ -1075,7 +1075,7 @@ exports[`renders message box when not logged in 1`] = `
     >
       <nav
         aria-label="Secondary Tablist"
-        className="Box-root Flex-root StreamContainer-tabBarRow Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
+        className="Box-root Flex-root StreamContainer-tabBarRow coral coral-tabBarSecondary-row Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
       >
         <ul
           className="TabBar-root TabBar-streamSecondary coral coral-tabBarSecondary coral-tabBarComments StreamContainer-tabBarRoot"
@@ -1183,7 +1183,7 @@ exports[`renders message box when not logged in 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm"
+                className="Icon-root Icon-sm coral coral-icon"
               >
                 expand_more
               </i>
@@ -1264,7 +1264,7 @@ exports[`renders message box when not logged in 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 forum
               </i>
@@ -1286,7 +1286,7 @@ exports[`renders message box when not logged in 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 description
               </i>
@@ -1320,12 +1320,12 @@ exports[`renders message box when story isClosed 1`] = `
         className="Box-root Flex-root coral coral-viewerBox Flex-flex Flex-wrap Flex-alignCenter"
       >
         <span
-          className="UserBoxUnauthenticated-joinText"
+          className="UserBoxUnauthenticated-joinText coral coral-viewerBox-joinText"
         >
           Join the conversation
         </span>
         <div
-          className="UserBoxUnauthenticated-actions"
+          className="UserBoxUnauthenticated-actions coral coral-viewerBox-actionButtons"
         >
           <button
             className="BaseButton-root Button-base Button-filled Button-fontSizeExtraSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeExtraSmall Button-colorPrimary Button-upperCase UserBoxUnauthenticated-register coral coral-viewerBox-registerButton"
@@ -1391,7 +1391,7 @@ exports[`renders message box when story isClosed 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm"
+                className="Icon-root Icon-sm coral coral-icon"
               >
                 feedback
               </i>
@@ -1425,7 +1425,7 @@ exports[`renders message box when story isClosed 1`] = `
     >
       <nav
         aria-label="Secondary Tablist"
-        className="Box-root Flex-root StreamContainer-tabBarRow Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
+        className="Box-root Flex-root StreamContainer-tabBarRow coral coral-tabBarSecondary-row Flex-flex Flex-justifySpaceBetween Flex-alignFlexEnd Flex-directionRow"
       >
         <ul
           className="TabBar-root TabBar-streamSecondary coral coral-tabBarSecondary coral-tabBarComments StreamContainer-tabBarRoot"
@@ -1533,7 +1533,7 @@ exports[`renders message box when story isClosed 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm"
+                className="Icon-root Icon-sm coral coral-icon"
               >
                 expand_more
               </i>
@@ -1614,7 +1614,7 @@ exports[`renders message box when story isClosed 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 forum
               </i>
@@ -1636,7 +1636,7 @@ exports[`renders message box when story isClosed 1`] = `
             >
               <i
                 aria-hidden="true"
-                className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+                className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
               >
                 description
               </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
@@ -217,7 +217,7 @@ exports[`renders reply list 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                           >
                             thumb_up
                           </i>
@@ -544,7 +544,7 @@ exports[`renders reply list 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                 >
                                   thumb_up
                                 </i>
@@ -865,7 +865,7 @@ exports[`renders reply list 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                 >
                                   thumb_up
                                 </i>
@@ -1189,7 +1189,7 @@ exports[`renders reply list 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                           >
                             thumb_up
                           </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/renderReplies.spec.tsx.snap
@@ -65,7 +65,7 @@ exports[`renders reply list 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                  className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                 >
                   remove
                 </i>
@@ -160,7 +160,7 @@ exports[`renders reply list 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm InReplyTo-icon"
+                        className="Icon-root Icon-sm coral coral-icon InReplyTo-icon"
                       >
                         reply
                       </i>
@@ -217,7 +217,7 @@ exports[`renders reply list 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReactionButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                           >
                             thumb_up
                           </i>
@@ -244,7 +244,7 @@ exports[`renders reply list 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReplyButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                           >
                             reply
                           </i>
@@ -273,7 +273,7 @@ exports[`renders reply list 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm PermalinkButton-icon"
+                              className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                             >
                               share
                             </i>
@@ -310,7 +310,7 @@ exports[`renders reply list 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReportButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                           >
                             flag
                           </i>
@@ -392,7 +392,7 @@ exports[`renders reply list 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                        className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                       >
                         remove
                       </i>
@@ -487,7 +487,7 @@ exports[`renders reply list 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm InReplyTo-icon"
+                              className="Icon-root Icon-sm coral coral-icon InReplyTo-icon"
                             >
                               reply
                             </i>
@@ -544,7 +544,7 @@ exports[`renders reply list 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReactionButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                 >
                                   thumb_up
                                 </i>
@@ -571,7 +571,7 @@ exports[`renders reply list 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReplyButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                 >
                                   reply
                                 </i>
@@ -600,7 +600,7 @@ exports[`renders reply list 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                   >
                                     share
                                   </i>
@@ -637,7 +637,7 @@ exports[`renders reply list 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReportButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                 >
                                   flag
                                 </i>
@@ -713,7 +713,7 @@ exports[`renders reply list 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                        className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                       >
                         remove
                       </i>
@@ -808,7 +808,7 @@ exports[`renders reply list 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm InReplyTo-icon"
+                              className="Icon-root Icon-sm coral coral-icon InReplyTo-icon"
                             >
                               reply
                             </i>
@@ -865,7 +865,7 @@ exports[`renders reply list 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReactionButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                 >
                                   thumb_up
                                 </i>
@@ -892,7 +892,7 @@ exports[`renders reply list 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReplyButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                 >
                                   reply
                                 </i>
@@ -921,7 +921,7 @@ exports[`renders reply list 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm PermalinkButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                   >
                                     share
                                   </i>
@@ -958,7 +958,7 @@ exports[`renders reply list 1`] = `
                               >
                                 <i
                                   aria-hidden="true"
-                                  className="Icon-root Icon-sm ReportButton-icon"
+                                  className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                 >
                                   flag
                                 </i>
@@ -1037,7 +1037,7 @@ exports[`renders reply list 1`] = `
               >
                 <i
                   aria-hidden="true"
-                  className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                  className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                 >
                   remove
                 </i>
@@ -1132,7 +1132,7 @@ exports[`renders reply list 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm InReplyTo-icon"
+                        className="Icon-root Icon-sm coral coral-icon InReplyTo-icon"
                       >
                         reply
                       </i>
@@ -1189,7 +1189,7 @@ exports[`renders reply list 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReactionButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                           >
                             thumb_up
                           </i>
@@ -1216,7 +1216,7 @@ exports[`renders reply list 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReplyButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                           >
                             reply
                           </i>
@@ -1245,7 +1245,7 @@ exports[`renders reply list 1`] = `
                           >
                             <i
                               aria-hidden="true"
-                              className="Icon-root Icon-sm PermalinkButton-icon"
+                              className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                             >
                               share
                             </i>
@@ -1282,7 +1282,7 @@ exports[`renders reply list 1`] = `
                         >
                           <i
                             aria-hidden="true"
-                            className="Icon-root Icon-sm ReportButton-icon"
+                            className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                           >
                             flag
                           </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
@@ -611,7 +611,7 @@ exports[`report comment as offensive 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                       >
                         thumb_up
                       </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/reportComment.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`render popup 1`] = `
 <div
-  className="ReportCommentForm-root"
+  className="ReportCommentForm-root coral coral-reportPopover"
   data-testid="report-comment-form"
   role="none"
 >
@@ -225,7 +225,7 @@ exports[`render popup 1`] = `
 
 exports[`render popup expanded 1`] = `
 <div
-  className="ReportCommentForm-root"
+  className="ReportCommentForm-root coral coral-reportPopover"
   data-testid="report-comment-form"
   role="none"
 >
@@ -497,7 +497,7 @@ exports[`report comment as offensive 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+              className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
             >
               remove
             </i>
@@ -611,7 +611,7 @@ exports[`report comment as offensive 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReactionButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                       >
                         thumb_up
                       </i>
@@ -638,7 +638,7 @@ exports[`report comment as offensive 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReplyButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                       >
                         reply
                       </i>
@@ -667,7 +667,7 @@ exports[`report comment as offensive 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm PermalinkButton-icon"
+                          className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                         >
                           share
                         </i>
@@ -694,7 +694,7 @@ exports[`report comment as offensive 1`] = `
                     >
                       <i
                         aria-hidden="true"
-                        className="Icon-root Icon-sm ReportButton-icon"
+                        className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                       >
                         flag
                       </i>
@@ -718,7 +718,7 @@ exports[`report comment as offensive 1`] = `
         >
           <i
             aria-hidden="true"
-            className="Icon-root Icon-sm"
+            className="Icon-root Icon-sm coral coral-icon"
           >
             check_circle
           </i>
@@ -755,7 +755,7 @@ exports[`report comment as offensive 1`] = `
           >
             <i
               aria-hidden="true"
-              className="Icon-root Icon-sm"
+              className="Icon-root Icon-sm coral coral-icon"
             >
               close
             </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
@@ -216,7 +216,7 @@ exports[`renders app with comment stream 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                   >
                                     thumb_up
                                   </i>
@@ -504,7 +504,7 @@ exports[`renders app with comment stream 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon coral coral-reactButton coral-comment-reactButton"
                                   >
                                     thumb_up
                                   </i>

--- a/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
+++ b/src/core/client/stream/test/comments/stream/__snapshots__/sortStream.spec.tsx.snap
@@ -102,7 +102,7 @@ exports[`renders app with comment stream 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                          className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                         >
                           remove
                         </i>
@@ -216,7 +216,7 @@ exports[`renders app with comment stream 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReactionButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                   >
                                     thumb_up
                                   </i>
@@ -243,7 +243,7 @@ exports[`renders app with comment stream 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReplyButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                   >
                                     reply
                                   </i>
@@ -272,7 +272,7 @@ exports[`renders app with comment stream 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                     >
                                       share
                                     </i>
@@ -309,7 +309,7 @@ exports[`renders app with comment stream 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReportButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                   >
                                     flag
                                   </i>
@@ -390,7 +390,7 @@ exports[`renders app with comment stream 1`] = `
                       >
                         <i
                           aria-hidden="true"
-                          className="Icon-root Icon-sm ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
+                          className="Icon-root Icon-sm coral coral-icon ButtonIcon-root IndentedComment-icon coral coral-comment-collapse-toggle-icon"
                         >
                           remove
                         </i>
@@ -504,7 +504,7 @@ exports[`renders app with comment stream 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReactionButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReactionButton-icon"
                                   >
                                     thumb_up
                                   </i>
@@ -531,7 +531,7 @@ exports[`renders app with comment stream 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReplyButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReplyButton-icon"
                                   >
                                     reply
                                   </i>
@@ -560,7 +560,7 @@ exports[`renders app with comment stream 1`] = `
                                   >
                                     <i
                                       aria-hidden="true"
-                                      className="Icon-root Icon-sm PermalinkButton-icon"
+                                      className="Icon-root Icon-sm coral coral-icon PermalinkButton-icon"
                                     >
                                       share
                                     </i>
@@ -597,7 +597,7 @@ exports[`renders app with comment stream 1`] = `
                                 >
                                   <i
                                     aria-hidden="true"
-                                    className="Icon-root Icon-sm ReportButton-icon"
+                                    className="Icon-root Icon-sm coral coral-icon ReportButton-icon"
                                   >
                                     flag
                                   </i>
@@ -637,7 +637,7 @@ exports[`renders app with comment stream 1`] = `
     >
       <i
         aria-hidden="true"
-        className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+        className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
       >
         forum
       </i>
@@ -659,7 +659,7 @@ exports[`renders app with comment stream 1`] = `
     >
       <i
         aria-hidden="true"
-        className="Icon-root Icon-sm ButtonIcon-root CommentsLinks-icon"
+        className="Icon-root Icon-sm coral coral-icon ButtonIcon-root CommentsLinks-icon"
       >
         description
       </i>

--- a/src/core/client/stream/test/configure/__snapshots__/renderConfigure.spec.tsx.snap
+++ b/src/core/client/stream/test/configure/__snapshots__/renderConfigure.spec.tsx.snap
@@ -13,12 +13,12 @@ exports[`renders configure 1`] = `
       class="coral coral-viewerBox"
     >
       <div
-        class="UserBoxAuthenticated-text"
+        class="UserBoxAuthenticated-text coral coral-viewerBox-usernameLabel"
       >
         Signed in as
       </div>
       <div
-        class="Box-root Flex-root Flex-flex Flex-wrap Flex-alignFlexEnd"
+        class="Box-root Flex-root coral coral-viewerBox-usernameContainer Flex-flex Flex-wrap Flex-alignFlexEnd"
       >
         <div
           class="coral coral-viewerBox-username UserBoxAuthenticated-username"

--- a/src/core/client/stream/test/profile/__snapshots__/account.spec.tsx.snap
+++ b/src/core/client/stream/test/profile/__snapshots__/account.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders the empty settings pane 1`] = `
   data-testid="profile-manageAccount"
 >
   <div
-    class="Box-root HorizontalGutter-root AccountSettingsContainer-root HorizontalGutter-full"
+    class="Box-root HorizontalGutter-root AccountSettingsContainer-root coral coral-accountSettings HorizontalGutter-full"
   >
     <section
       aria-labelledby="profile-changeUsername-title"
@@ -90,7 +90,7 @@ exports[`renders the empty settings pane 1`] = `
                   <div>
                     <i
                       aria-hidden="true"
-                      class="Icon-root Icon-lg"
+                      class="Icon-root Icon-lg coral coral-icon"
                     >
                       email
                     </i>

--- a/src/core/client/ui/components/v2/Icon/Icon.tsx
+++ b/src/core/client/ui/components/v2/Icon/Icon.tsx
@@ -1,6 +1,8 @@
 import cn from "classnames";
 import React, { FunctionComponent, HTMLAttributes, Ref } from "react";
 
+import CLASSES from "coral-stream/classes";
+
 import { withForwardRef, withStyles } from "coral-ui/hocs";
 import { PropTypesOf } from "coral-ui/types";
 
@@ -35,6 +37,7 @@ const Icon: FunctionComponent<Props> = (props) => {
   const rootClassName = cn(
     classes.root,
     classes[size !== undefined ? size : "sm"],
+    CLASSES.icon,
     {
       [classes.colorPrimary]: color === "primary",
       [classes.colorError]: color === "error",

--- a/src/core/client/ui/components/v2/Icon/__snapshots__/Icon.spec.tsx.snap
+++ b/src/core/client/ui/components/v2/Icon/__snapshots__/Icon.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders correctly 1`] = `
 <i
   aria-hidden="true"
-  className="Icon-root Icon-sm"
+  className="Icon-root Icon-sm coral coral-icon"
 >
   face
 </i>
@@ -12,7 +12,7 @@ exports[`renders correctly 1`] = `
 exports[`renders correctly with specified size 1`] = `
 <i
   aria-hidden="true"
-  className="Icon-root Icon-lg"
+  className="Icon-root Icon-lg coral coral-icon"
 >
   bookmark
 </i>

--- a/src/core/client/ui/components/v2/Message/__snapshots__/Message.spec.tsx.snap
+++ b/src/core/client/ui/components/v2/Message/__snapshots__/Message.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`renders icon 1`] = `
 >
   <i
     aria-hidden="true"
-    className="Icon-root Icon-sm MessageIcon-root"
+    className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
   >
     alert
   </i>

--- a/src/core/client/ui/components/v2/SelectField/__snapshots__/SelectField.spec.tsx.snap
+++ b/src/core/client/ui/components/v2/SelectField/__snapshots__/SelectField.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`renders correctly 1`] = `
   >
     <i
       aria-hidden="true"
-      className="Icon-root Icon-sm"
+      className="Icon-root Icon-sm coral coral-icon"
     >
       expand_more
     </i>

--- a/src/core/client/ui/components/v2/ValidationMessage/__snapshots__/ValidationMessage.spec.tsx.snap
+++ b/src/core/client/ui/components/v2/ValidationMessage/__snapshots__/ValidationMessage.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders correctly 1`] = `
 >
   <i
     aria-hidden="true"
-    className="Icon-root Icon-sm MessageIcon-root"
+    className="Icon-root Icon-sm coral coral-icon MessageIcon-root"
   >
     warning
   </i>

--- a/src/core/client/ui/components/v3/CallOut/CallOut.tsx
+++ b/src/core/client/ui/components/v3/CallOut/CallOut.tsx
@@ -1,5 +1,6 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
+
 import React, { FunctionComponent, HTMLAttributes, useCallback } from "react";
 
 import { BaseButton, Icon } from "coral-ui/components/v2";


### PR DESCRIPTION
## What does this PR do?

Adds more stable classnames to stream DOM elements to prevent usage of attribute selectors in custom stylesheets, making the DOM more future-proof and making customization simpler and more reliable. I tried to be conservative and base my additions on the custom stylesheets we maintain at Vox Media. The one exception is the addition of the `coral-icon` class to all icons. This somewhat contradicts vinh's initial direction of adding stable classnames to specific instances rather than components, which i assume was to encourage authors of custom stylesheets to use css variables where possible. I've made this exception for icons because they account for a large number of the attribute selectors i've seen at Vox Media and in the wild, as changing icons is a very common customization. In combination with the container classes already in place and that have been added here, this one classname should provide enough specificity to enable simple customization. 

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## How do I test this PR?

View the stream and inspect impacted elements to see new classnames. Inspect the DOM in the "preferences" tab to see new classnames for all headings and sections.  
 