### PR TITLE
[CORL-2727] Promoting site mods to org mods

### DIFF
--- a/src/core/client/admin/components/UserRole/UserRoleChangeContainer.tsx
+++ b/src/core/client/admin/components/UserRole/UserRoleChangeContainer.tsx
@@ -38,11 +38,6 @@ const UserRoleChangeContainer: FunctionComponent<Props> = ({
   );
   const handleOnChangeRole = useCallback(
     async (role: GQLUSER_ROLE_RL, siteIDs?: string[]) => {
-      if (role === user.role) {
-        // No role change is needed! User already has the selected role.
-        return;
-      }
-
       await updateUserRole({ userID: user.id, role, siteIDs });
     },
     [user, updateUserRole]


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug in which a site moderator cannot be promoted to an org moderator. 

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. As an admin user, navigate to admin/community
2. Find a site moderator user, and click their role, opening the role change dropdown
3. Click organization moderator
4. Observe that their role has been update to org mod
 
## How do we deploy this PR?
No special considerations should be needed.
