### PR TITLE
[CORL-2726] fix role change display bug

### DIFF
--- a/src/core/client/admin/permissions/user.ts
+++ b/src/core/client/admin/permissions/user.ts
@@ -17,7 +17,7 @@ interface PermissionContext {
 
 const permissionMap: PermissionMap<AbilityType, PermissionContext> = {
   CHANGE_ROLE: {
-    [GQLUSER_ROLE.ADMIN]: () => true,
+    [GQLUSER_ROLE.ADMIN]: (ctx) => ctx?.user.role !== GQLUSER_ROLE.ADMIN,
     [GQLUSER_ROLE.MODERATOR]: (ctx) => {
       if (!ctx) {
         return true;


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug in which the role change dropdown is interact-able and visible (though empty) for Admin users in the community view, even though no one is able to change an Admin's role
## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Log in as any role with the ability to update other users' roles
2. Navigate to the /admin/community route
3. Find a user with the role of admin
4. observe that the user's role is just a plaintext display, rather than a dropdown button
 
## How do we deploy this PR?
No special considerations should be needed.
