### PR TITLE
[fix CORL-2728] make focus configurable on MDE

### DIFF
--- a/src/core/client/framework/components/loadables/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/core/client/framework/components/loadables/MarkdownEditor/MarkdownEditor.tsx
@@ -47,6 +47,7 @@ interface Props {
   onChange: (value: string) => void;
   value: string;
   toolbar?: ToolbarItem[];
+  autoFocus?: boolean;
 }
 
 const MarkdownEditor: FunctionComponent<Props> = ({
@@ -55,6 +56,7 @@ const MarkdownEditor: FunctionComponent<Props> = ({
   onChange,
   value,
   toolbar,
+  autoFocus = false,
   ...rest
 }) => {
   const getMessage = useGetMessage();
@@ -193,7 +195,7 @@ const MarkdownEditor: FunctionComponent<Props> = ({
       const editorSetup = new SimpleMDE({
         ...config,
         element: textarea,
-        autofocus: true,
+        autofocus: autoFocus,
       });
       // Don't trap the key, to stay accessible.
       editorSetup.codemirror.options.extraKeys.Tab = false;

--- a/src/core/client/stream/tabs/Configure/AddMessage/MessageBoxConfig.tsx
+++ b/src/core/client/stream/tabs/Configure/AddMessage/MessageBoxConfig.tsx
@@ -153,6 +153,8 @@ const MessageBoxConfig: FunctionComponent = () => (
                 <Suspense fallback={<Spinner />}>
                   <MarkdownEditor
                     id="configure-messageBox-content"
+                    /* eslint-disable-next-line jsx-a11y/no-autofocus*/
+                    autoFocus={true}
                     data-testid="configure-messageBox-content"
                     name={contentInput.name}
                     onChange={contentInput.onChange}


### PR DESCRIPTION
## What does this PR do?
This PR addresses a bug where loading any page with a MarkdownEditor on it immediately focused on the markdown editor. This arose from an earlier feature request to have focus move to the editor in some circumstances. This PR makes that an optional behavior and sets it where appropriate. 
## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. As an admin or moderator, navigate to the stream > Configure tab.
2. Click on the "Add a Message" button under the "Add a message or question" section
3. Observe that the Markdown Editor has focus when it appears
4. As an admin, navigate to /admin/configure/general
5. Observe that the Markdown Editor **does not** receive focus immediately
 
 
## How do we deploy this PR?
No special considerations should be required.
