### PR TITLE
[CORL 2735] reversed site mod promotion bugfix

### DIFF
--- a/src/core/client/admin/components/UserRole/SiteRoleActions.tsx
+++ b/src/core/client/admin/components/UserRole/SiteRoleActions.tsx
@@ -177,13 +177,12 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
     .filter((s) => userMembershipSites.find(({ id }) => id === s.id))
     .map(({ id }) => id);
 
-  // (BOOKMAR) might need to split this into canPromoteToMember + canPromoteToSiteMember
   const canPromoteToMember = validatePermissionsAction({
     viewer,
     user,
     newUserRole: GQLUSER_ROLE.MEMBER,
     scopeAdditions: membershipSitesToGive,
-    scoped: true, // TODO: marcus check this
+    scoped: true,
   });
 
   const canPromoteToModerator = validatePermissionsAction({

--- a/src/core/client/admin/components/UserRole/SiteRoleActions.tsx
+++ b/src/core/client/admin/components/UserRole/SiteRoleActions.tsx
@@ -108,6 +108,7 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
     await changeRole({
       userID: user.id,
       role: GQLUSER_ROLE.COMMENTER,
+      scoped: false,
     });
 
     setIsPopoverVisible(false);
@@ -156,6 +157,7 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
     viewer,
     user,
     newUserRole: GQLUSER_ROLE.COMMENTER,
+    scoped: false,
   });
 
   // These are sites that only the viewer can moderate, and not the user.
@@ -175,11 +177,13 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
     .filter((s) => userMembershipSites.find(({ id }) => id === s.id))
     .map(({ id }) => id);
 
+  // (BOOKMAR) might need to split this into canPromoteToMember + canPromoteToSiteMember
   const canPromoteToMember = validatePermissionsAction({
     viewer,
     user,
     newUserRole: GQLUSER_ROLE.MEMBER,
     scopeAdditions: membershipSitesToGive,
+    scoped: true, // TODO: marcus check this
   });
 
   const canPromoteToModerator = validatePermissionsAction({
@@ -187,6 +191,7 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
     user,
     newUserRole: GQLUSER_ROLE.MODERATOR,
     scopeAdditions: moderationSitesToGive,
+    scoped: true,
   });
 
   // If the user is a site moderator and some of the sites on the user are the
@@ -198,6 +203,7 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
       user,
       newUserRole: GQLUSER_ROLE.MODERATOR,
       scopeDeletions: moderationSitesToRemove,
+      scoped: true,
     });
 
   // If the user is a site moderator, staff, or commenter and some of the sites
@@ -209,6 +215,7 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
       user,
       newUserRole: GQLUSER_ROLE.MODERATOR,
       scopeAdditions: moderationSitesToGive,
+      scoped: true,
     });
 
   const canPromoteMember =
@@ -218,6 +225,7 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
       user,
       newUserRole: GQLUSER_ROLE.MEMBER,
       scopeAdditions: membershipSitesToGive,
+      scoped: true,
     });
   const canDemoteMember =
     !!membershipSitesToRemove.length &&
@@ -226,6 +234,7 @@ const SiteRoleActions: FunctionComponent<Props> = ({ viewer, user }) => {
       user,
       newUserRole: GQLUSER_ROLE.MEMBER,
       scopeDeletions: membershipSitesToRemove,
+      scoped: true,
     });
 
   const canPerformActions =

--- a/src/core/client/admin/components/UserRole/UpdateUserRoleMutation.ts
+++ b/src/core/client/admin/components/UserRole/UpdateUserRoleMutation.ts
@@ -25,12 +25,14 @@ const UpdateUserRoleMutation = createMutation(
                 scoped
                 sites {
                   id
+                  name
                 }
               }
               membershipScopes {
                 scoped
                 sites {
                   id
+                  name
                 }
               }
             }
@@ -44,12 +46,12 @@ const UpdateUserRoleMutation = createMutation(
             id: input.userID,
             role: input.role,
             moderationScopes: {
-              scoped: !!input.siteIDs?.length,
-              sites: input.siteIDs?.map((id) => ({ id })) || [],
+              scoped: !!input.scoped,
+              sites: [],
             },
             membershipScopes: {
-              scoped: !!input.siteIDs?.length,
-              sites: input.siteIDs?.map((id) => ({ id })) || [],
+              scoped: input.scoped,
+              sites: [],
             },
           },
           clientMutationId: clientMutationId.toString(),

--- a/src/core/client/admin/components/UserRole/UserRoleChange.tsx
+++ b/src/core/client/admin/components/UserRole/UserRoleChange.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { Localized } from "@fluent/react/compat";
 import React, {
   FunctionComponent,
@@ -28,7 +29,11 @@ import styles from "./UserRoleChange.css";
 
 interface Props {
   user: UserRoleChangeContainer_user;
-  onChangeRole: (role: GQLUSER_ROLE_RL, siteIDs?: string[]) => Promise<void>;
+  onChangeRole: (
+    role: GQLUSER_ROLE_RL,
+    scoped: boolean,
+    siteIDs?: string[]
+  ) => Promise<void>;
   onChangeModerationScopes: (siteIDs: string[]) => Promise<void>;
   onChangeMembershipScopes: (siteIDs: string[]) => Promise<void>;
   moderationScopesEnabled?: boolean;
@@ -66,7 +71,8 @@ const UserRoleChange: FunctionComponent<Props> = ({
    */
   const handleChangeRole = useCallback(
     async (r: GQLUSER_ROLE_RL, siteIDs: string[] = []) => {
-      await onChangeRole(r, siteIDs);
+      console.log("changing role, scoped?", !!siteIDs.length);
+      await onChangeRole(r, !!siteIDs.length, siteIDs);
     },
     [onChangeRole]
   );

--- a/src/core/client/admin/components/UserRole/UserRoleChange.tsx
+++ b/src/core/client/admin/components/UserRole/UserRoleChange.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { Localized } from "@fluent/react/compat";
 import React, {
   FunctionComponent,
@@ -71,7 +70,6 @@ const UserRoleChange: FunctionComponent<Props> = ({
    */
   const handleChangeRole = useCallback(
     async (r: GQLUSER_ROLE_RL, siteIDs: string[] = []) => {
-      console.log("changing role, scoped?", !!siteIDs.length);
       await onChangeRole(r, !!siteIDs.length, siteIDs);
     },
     [onChangeRole]

--- a/src/core/client/admin/components/UserRole/UserRoleChangeContainer.tsx
+++ b/src/core/client/admin/components/UserRole/UserRoleChangeContainer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { FunctionComponent, useCallback } from "react";
 import { graphql } from "react-relay";
 
@@ -57,7 +56,7 @@ const UserRoleChangeContainer: FunctionComponent<Props> = ({
         isSiteModerator(currentUser) || isSiteMember(currentUser);
       const updateRole =
         newRole !== currentUser.role || scoped !== userIsScoped;
-      console.log("need to update role");
+
       if (updateRole) {
         const {
           user: { id, role, moderationScopes, membershipScopes },

--- a/src/core/client/admin/components/UserRole/UserRoleChangeContainer.tsx
+++ b/src/core/client/admin/components/UserRole/UserRoleChangeContainer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, { FunctionComponent, useCallback } from "react";
 import { graphql } from "react-relay";
 
@@ -8,7 +9,11 @@ import { GQLUSER_ROLE, GQLUSER_ROLE_RL } from "coral-framework/schema";
 import { UserRoleChangeContainer_settings } from "coral-admin/__generated__/UserRoleChangeContainer_settings.graphql";
 import { UserRoleChangeContainer_user } from "coral-admin/__generated__/UserRoleChangeContainer_user.graphql";
 import { UserRoleChangeContainer_viewer } from "coral-admin/__generated__/UserRoleChangeContainer_viewer.graphql";
-import { isOrgModerator } from "coral-common/permissions/types";
+import {
+  isOrgModerator,
+  isSiteMember,
+  isSiteModerator,
+} from "coral-common/permissions/types";
 
 import ButtonPadding from "../ButtonPadding";
 import SiteRoleActions from "./SiteRoleActions";
@@ -24,6 +29,11 @@ interface Props {
   settings: UserRoleChangeContainer_settings;
 }
 
+type RoleUser = Pick<
+  UserRoleChangeContainer_user,
+  "moderationScopes" | "membershipScopes" | "role" | "id"
+>;
+
 const UserRoleChangeContainer: FunctionComponent<Props> = ({
   user,
   viewer,
@@ -36,17 +46,78 @@ const UserRoleChangeContainer: FunctionComponent<Props> = ({
   const updateUserMembershipScopes = useMutation(
     UpdateUserMembershipScopesMutation
   );
-  const handleOnChangeRole = useCallback(
-    async (role: GQLUSER_ROLE_RL, siteIDs?: string[]) => {
-      await updateUserRole({ userID: user.id, role, siteIDs });
+
+  const maybeUpdateRole = useCallback(
+    async (
+      currentUser: RoleUser,
+      newRole: GQLUSER_ROLE_RL,
+      scoped: boolean
+    ) => {
+      const userIsScoped =
+        isSiteModerator(currentUser) || isSiteMember(currentUser);
+      const updateRole =
+        newRole !== currentUser.role || scoped !== userIsScoped;
+      console.log("need to update role");
+      if (updateRole) {
+        const {
+          user: { id, role, moderationScopes, membershipScopes },
+        } = await updateUserRole({
+          userID: currentUser.id,
+          role: newRole,
+          scoped,
+        });
+        return { id, role, moderationScopes, membershipScopes };
+      }
+      const { id, role, moderationScopes, membershipScopes } = currentUser;
+      return { id, role, moderationScopes, membershipScopes };
     },
-    [user, updateUserRole]
+    [updateUserRole]
+  );
+
+  const maybeUpdateScopes = useCallback(
+    async (initialUser: RoleUser, siteIDs?: string[]) => {
+      if (
+        initialUser.role !== GQLUSER_ROLE.MODERATOR &&
+        initialUser.role !== GQLUSER_ROLE.MEMBER &&
+        !initialUser.moderationScopes?.scoped &&
+        !initialUser.membershipScopes?.scoped
+      ) {
+        return;
+      }
+
+      await (initialUser.role === GQLUSER_ROLE.MODERATOR
+        ? updateUserModerationScopes({
+            userID: initialUser.id,
+            moderationScopes: {
+              scoped: true,
+              siteIDs: siteIDs || [],
+            },
+          })
+        : updateUserMembershipScopes({
+            userID: initialUser.id,
+            membershipScopes: {
+              scoped: true,
+              siteIDs: siteIDs || [],
+            },
+          }));
+    },
+    [updateUserMembershipScopes, updateUserModerationScopes]
+  );
+  const handleOnChangeRole = useCallback(
+    async (role: GQLUSER_ROLE_RL, scoped: boolean, siteIDs?: string[]) => {
+      const updatedUser = await maybeUpdateRole(user, role, scoped);
+      if (scoped) {
+        await maybeUpdateScopes(updatedUser, siteIDs);
+      }
+    },
+    [user, maybeUpdateRole, maybeUpdateScopes]
   );
   const handleOnChangeModerationScopes = useCallback(
     async (siteIDs: string[]) => {
+      await maybeUpdateRole(user, GQLUSER_ROLE.MODERATOR, true);
       await updateUserModerationScopes({
         userID: user.id,
-        moderationScopes: { siteIDs },
+        moderationScopes: { siteIDs, scoped: true },
       });
     },
     [updateUserModerationScopes, user.id]
@@ -59,6 +130,7 @@ const UserRoleChangeContainer: FunctionComponent<Props> = ({
       await updateUserMembershipScopes({
         userID: user.id,
         membershipScopes: {
+          scoped: true,
           siteIDs,
         },
       });

--- a/src/core/client/admin/test/community/community-rtl.spec.tsx
+++ b/src/core/client/admin/test/community/community-rtl.spec.tsx
@@ -297,7 +297,7 @@ it("org mods may allocate site mods", async () => {
     },
     Mutation: {
       updateUserRole: ({ variables }) => {
-        expectAndFail(variables.siteIDs).toContain(sites[0].id);
+        expectAndFail(variables.scoped).toBeTruthy();
         return {
           user: {
             ...commenter,
@@ -588,7 +588,7 @@ it("allows admins to promote site mods to org mod", async () => {
     },
     Mutation: {
       updateUserRole: ({ variables }) => {
-        expectAndFail(variables.siteIDs).toEqual([]);
+        expectAndFail(variables.scoped).toEqual(false);
         const userRecord = pureMerge<typeof siteModeratorUser>(
           siteModeratorUser,
           {
@@ -625,6 +625,7 @@ it("allows admins to promote site mods to org mod", async () => {
   );
 });
 
+// BOOKMARK: marcus, i think we just need to add a new field to these fixtures, maybe scopes.sites.id?
 it("load more", async () => {
   await createTestRenderer({
     resolvers: createResolversStub<GQLResolver>({

--- a/src/core/common/permissions/isSiteModerationScoped.ts
+++ b/src/core/common/permissions/isSiteModerationScoped.ts
@@ -1,4 +1,5 @@
 export interface UserModerationScopes {
+  scoped?: boolean | null;
   siteIDs?: Readonly<string[]> | null;
   sites?: Readonly<any[]> | null;
 }
@@ -8,5 +9,5 @@ export function isSiteModerationScoped(
 ): moderationScopes is Required<UserModerationScopes> {
   const scopeSites = moderationScopes?.siteIDs || moderationScopes?.sites;
 
-  return !!scopeSites && scopeSites.length > 0;
+  return moderationScopes?.scoped || (!!scopeSites && scopeSites.length > 0);
 }

--- a/src/core/common/permissions/predicates.ts
+++ b/src/core/common/permissions/predicates.ts
@@ -1,4 +1,5 @@
 import {
+  isOrgModerator,
   isSiteMember,
   isSiteModerator,
   PermissionsActionPredicate,
@@ -35,15 +36,18 @@ const onlyAdminsCanDemoteStaffDirectly: PermissionsActionPredicate = ({
  * remove scopes the viewer does not posses.
  */
 const scopedUsersCantIndirectlyRemoveScopesTheyDontPosses: PermissionsActionPredicate =
-  ({ viewer, user, newUserRole }) => {
+  ({ viewer, user, newUserRole, scoped }) => {
     const reason =
       "This role change would remove scopes outside of the viewers authorization";
 
     const changingAwayFromCurrentScopedRole =
-      (isSiteModerator(user) && !!newUserRole && newUserRole !== "MODERATOR") ||
-      (isSiteMember(user) && !!newUserRole && newUserRole !== "MEMBER");
+      (isSiteModerator(user) || isSiteMember(user)) && !scoped;
 
-    if (!isSiteModerator(viewer) || !changingAwayFromCurrentScopedRole) {
+    if (
+      viewer.role === "ADMIN" ||
+      isOrgModerator(viewer) ||
+      !changingAwayFromCurrentScopedRole
+    ) {
       return {
         pass: true,
         reason,

--- a/src/core/common/permissions/types.ts
+++ b/src/core/common/permissions/types.ts
@@ -93,6 +93,7 @@ export const isLTESiteModerator = (
 export interface PermissionsAction {
   viewer: Readonly<User>;
   user: Readonly<User>;
+  scoped: boolean;
   newUserRole?: UserRole;
   scopeAdditions?: string[];
   scopeDeletions?: string[];

--- a/src/core/common/permissions/types.ts
+++ b/src/core/common/permissions/types.ts
@@ -29,7 +29,7 @@ export type SiteModerator = Moderator & {
   role: "MODERATOR";
   moderationScopes: {
     scoped: true;
-    siteIDs: string[];
+    siteIDs?: string[];
   };
 };
 
@@ -37,7 +37,7 @@ export type SiteMember = User & {
   role: "MEMBER";
   membershipScopes: {
     scoped: true;
-    siteIDs: string[];
+    siteIDs?: string[];
   };
 };
 

--- a/src/core/server/graph/mutators/Users.ts
+++ b/src/core/server/graph/mutators/Users.ts
@@ -254,7 +254,7 @@ export const Users = (ctx: GraphContext) => ({
       ctx.user!,
       input.userID,
       input.role,
-      input.siteIDs
+      input.scoped
     ),
   promoteModerator: async (input: GQLPromoteModeratorInput) =>
     promoteModerator(

--- a/src/core/server/graph/resolvers/UserMembershipScopes.ts
+++ b/src/core/server/graph/resolvers/UserMembershipScopes.ts
@@ -4,7 +4,7 @@ import { GQLUserMembershipScopesTypeResolver } from "core/server/graph/schema/__
 
 export const UserMembershipScopes: GQLUserMembershipScopesTypeResolver<user.UserMembershipScopes> =
   {
-    scoped: ({ siteIDs }) => !!siteIDs?.length,
+    scoped: ({ scoped, siteIDs }) => scoped || !!siteIDs?.length,
     sites: ({ siteIDs }, _, ctx) => {
       if (siteIDs) {
         return ctx.loaders.Sites.site.loadMany(siteIDs);

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -7472,10 +7472,17 @@ could be assigned.
 """
 input ModerationScopesInput {
   """
+  scoped is whether or not the user's moderation
+  priveledges are limited to specified sites
+  """
+
+  scoped: Boolean!
+
+  """
   siteIDs is an array of ID's that should be the list of sites that a moderator
   is limited to. If none are passed, it will remove the scoping for this User.
   """
-  siteIDs: [ID!]
+  siteIDs: [ID!]!
 }
 
 input UpdateUserModerationScopesInput {
@@ -7512,6 +7519,11 @@ type UpdateUserModerationScopesPayload {
 # updateUserMembershipScopes
 ############################
 input MembershipScopesInput {
+  """
+  scoped is whether or not a user's membership is limited to specific sites.
+  """
+  scoped: Boolean!
+
   """
   siteIDs are the ids of the sites on which to scope a user's membership to.
   """
@@ -7563,10 +7575,9 @@ input UpdateUserRoleInput {
   role: USER_ROLE!
 
   """
-  siteIDs is a list of sites on which the user has this role. if empty,
-  the user has this role on all sites in the organization.
+  scoped is whether or not the role will be limited to specific sites or not.
   """
-  siteIDs: [ID!]
+  scoped: Boolean!
 
   """
   clientMutationId is required for Relay support.

--- a/src/core/server/models/user/user.ts
+++ b/src/core/server/models/user/user.ts
@@ -887,8 +887,8 @@ export async function updateUserRole(
   scoped: boolean
 ) {
   const update: Partial<User> = { role };
+  const scopes = { scoped };
   if (scoped) {
-    const scopes = { scoped: true };
     if (role === GQLUSER_ROLE.MODERATOR) {
       update.moderationScopes = scopes;
     } else if (role === GQLUSER_ROLE.MEMBER) {
@@ -896,6 +896,12 @@ export async function updateUserRole(
     } else {
       throw new Error(`Site scopes may not be applied to role ${role}`);
     }
+  } else {
+    // This may seem odd, but is a result of us
+    // storing scopes for multiple roles when a user
+    // can only have a single role at a time
+    update.moderationScopes = scopes;
+    update.membershipScopes = scopes;
   }
 
   const result = await mongo.users().findOneAndUpdate(
@@ -959,6 +965,7 @@ export async function pullUserSiteModerationScopes(
       returnOriginal: false,
     }
   );
+
   if (!result.value) {
     throw new UserNotFoundError(id);
   }

--- a/src/core/server/models/user/user.ts
+++ b/src/core/server/models/user/user.ts
@@ -447,6 +447,7 @@ export interface UserCommentCounts {
 }
 
 export interface UserModerationScopes {
+  scoped: boolean;
   /**
    * siteIDs is the array of site ID's that this User can moderate. If not
    * provided the user can moderate all sites.
@@ -455,6 +456,11 @@ export interface UserModerationScopes {
 }
 
 export interface UserMembershipScopes {
+  /**
+   * scoped is whether or not the user's membership is limited to specific sites.
+   */
+  scoped: boolean;
+
   /**
    * siteIDs is the array of ID's for sites on which this user is a member.
    * If not present (and user has role of MEMBER), user is a member on all sites.
@@ -878,13 +884,11 @@ export async function updateUserRole(
   tenantID: string,
   id: string,
   role: GQLUSER_ROLE,
-  siteIDs?: string[]
+  scoped: boolean
 ) {
   const update: Partial<User> = { role };
-  if (siteIDs?.length) {
-    const scopes = {
-      siteIDs,
-    };
+  if (scoped) {
+    const scopes = { scoped: true };
     if (role === GQLUSER_ROLE.MODERATOR) {
       update.moderationScopes = scopes;
     } else if (role === GQLUSER_ROLE.MEMBER) {

--- a/src/core/server/services/comments/pipeline/phases/tagMember.spec.ts
+++ b/src/core/server/services/comments/pipeline/phases/tagMember.spec.ts
@@ -47,17 +47,17 @@ const siteBStory = createStoryFixture({ tenantID, siteID: siteB.id });
 const siteAMember = createUserFixture({
   tenantID,
   role: GQLUSER_ROLE.MEMBER,
-  membershipScopes: { siteIDs: [siteA.id] },
+  membershipScopes: { siteIDs: [siteA.id], scoped: true },
 });
 const siteBMember = createUserFixture({
   tenantID,
   role: GQLUSER_ROLE.MEMBER,
-  membershipScopes: { siteIDs: [siteB.id] },
+  membershipScopes: { siteIDs: [siteB.id], scoped: true },
 });
 const sitesABMember = createUserFixture({
   tenantID,
   role: GQLUSER_ROLE.MEMBER,
-  membershipScopes: { siteIDs: [siteA.id, siteB.id] },
+  membershipScopes: { siteIDs: [siteA.id, siteB.id], scoped: true },
 });
 
 it("members get badges on sites within their scope", async () => {

--- a/src/core/server/services/comments/pipeline/phases/tagStaff.spec.ts
+++ b/src/core/server/services/comments/pipeline/phases/tagStaff.spec.ts
@@ -65,11 +65,11 @@ orgModUser.role = GQLUSER_ROLE.MODERATOR;
 
 const siteAModUser = createUserFixture({ tenantID });
 siteAModUser.role = GQLUSER_ROLE.MODERATOR;
-siteAModUser.moderationScopes = { siteIDs: [siteA.id] };
+siteAModUser.moderationScopes = { siteIDs: [siteA.id], scoped: true };
 
 const siteBModUser = createUserFixture({ tenantID });
 siteBModUser.role = GQLUSER_ROLE.MODERATOR;
-siteBModUser.moderationScopes = { siteIDs: [siteB.id] };
+siteBModUser.moderationScopes = { siteIDs: [siteB.id], scoped: true };
 
 const commenter = createUserFixture({ tenantID, role: GQLUSER_ROLE.COMMENTER });
 

--- a/src/core/server/services/users/permissions/index.ts
+++ b/src/core/server/services/users/permissions/index.ts
@@ -22,11 +22,7 @@ const userShouldBeDemotedToCommenter: PermissionsActionSideEffectTest = ({
   newUserRole,
   scopeDeletions,
 }) => {
-  if (
-    !scopeDeletions ||
-    (newUserRole !== GQLUSER_ROLE.MODERATOR &&
-      newUserRole !== GQLUSER_ROLE.MEMBER)
-  ) {
+  if (!newUserRole || !scopeDeletions) {
     return;
   }
 
@@ -40,23 +36,31 @@ const userShouldBeDemotedToCommenter: PermissionsActionSideEffectTest = ({
   );
 
   if (noneRemaining) {
-    return (mongo: MongoContext, tenantID: string) =>
-      updateUserRole(mongo, tenantID, user.id, GQLUSER_ROLE.COMMENTER);
+    const demoteToCommenter = (mongo: MongoContext, tenantID: string) =>
+      updateUserRole(mongo, tenantID, user.id, GQLUSER_ROLE.COMMENTER, false);
+    return demoteToCommenter;
   }
 
   return async () => null;
 };
 
 const userShouldHaveModerationScopesRemoved: PermissionsActionSideEffectTest =
-  ({ user, newUserRole }) => {
-    if (isSiteModerator(user) && newUserRole !== GQLUSER_ROLE.MODERATOR) {
-      return (mongo: MongoContext, tenantID: string) =>
+  ({ user, newUserRole, scopeDeletions }) => {
+    const isSiteMod = isSiteModerator(user);
+    const newRole = newUserRole !== GQLUSER_ROLE.MODERATOR;
+    const allScopesDeleted = !!user.moderationScopes?.siteIDs?.every((id) =>
+      scopeDeletions?.includes(id)
+    );
+    if (isSiteMod && (newRole || allScopesDeleted)) {
+      const removeModerationScopes = (mongo: MongoContext, tenantID: string) =>
         pullUserSiteModerationScopes(
           mongo,
           tenantID,
           user.id,
-          user.moderationScopes.siteIDs
+          user.moderationScopes!.siteIDs!
         );
+
+      return removeModerationScopes;
     }
 
     return undefined;
@@ -65,13 +69,15 @@ const userShouldHaveModerationScopesRemoved: PermissionsActionSideEffectTest =
 const userShouldHaveMembershipScopesRemoved: PermissionsActionSideEffectTest =
   ({ user, newUserRole }) => {
     if (isSiteMember(user) && newUserRole !== GQLUSER_ROLE.MEMBER) {
-      return (mongo: MongoContext, tenantID: string) =>
+      const removeMembershipScopes = (mongo: MongoContext, tenantID: string) =>
         pullUserMembershipScopes(
           mongo,
           tenantID,
           user.id,
           user.membershipScopes.siteIDs
         );
+
+      return removeMembershipScopes;
     }
 
     return async () => null;

--- a/src/core/server/services/users/permissions/index.ts
+++ b/src/core/server/services/users/permissions/index.ts
@@ -51,7 +51,8 @@ const userShouldHaveModerationScopesRemoved: PermissionsActionSideEffectTest =
     const allScopesDeleted = !!user.moderationScopes?.siteIDs?.every((id) =>
       scopeDeletions?.includes(id)
     );
-    if (isSiteMod && (newRole || allScopesDeleted)) {
+    const userHadScopes = !!user.moderationScopes?.siteIDs;
+    if (isSiteMod && (newRole || allScopesDeleted) && userHadScopes) {
       const removeModerationScopes = (mongo: MongoContext, tenantID: string) =>
         pullUserSiteModerationScopes(
           mongo,
@@ -68,13 +69,17 @@ const userShouldHaveModerationScopesRemoved: PermissionsActionSideEffectTest =
 
 const userShouldHaveMembershipScopesRemoved: PermissionsActionSideEffectTest =
   ({ user, newUserRole }) => {
-    if (isSiteMember(user) && newUserRole !== GQLUSER_ROLE.MEMBER) {
+    if (
+      isSiteMember(user) &&
+      newUserRole !== GQLUSER_ROLE.MEMBER &&
+      !!user.membershipScopes.siteIDs
+    ) {
       const removeMembershipScopes = (mongo: MongoContext, tenantID: string) =>
         pullUserMembershipScopes(
           mongo,
           tenantID,
           user.id,
-          user.membershipScopes.siteIDs
+          user.membershipScopes.siteIDs!
         );
 
       return removeMembershipScopes;

--- a/src/core/server/services/users/users.spec.ts
+++ b/src/core/server/services/users/users.spec.ts
@@ -83,6 +83,7 @@ describe("updateUserBan", () => {
       tenantID: tenant.id,
       moderationScopes: {
         siteIDs: [siteA.id],
+        scoped: true,
       },
     });
 
@@ -272,7 +273,8 @@ describe("updateRole", () => {
         tenant,
         commenterA,
         commenterA.id,
-        GQLUSER_ROLE.MODERATOR
+        GQLUSER_ROLE.MODERATOR,
+        false
       );
     }).rejects.toThrow(Error);
   });
@@ -292,6 +294,7 @@ describe("promote/demoteMember", () => {
     role: GQLUSER_ROLE.MODERATOR,
     moderationScopes: {
       siteIDs: [siteA.id, siteB.id],
+      scoped: true,
     },
   });
   const siteCMod = createUserFixture({
@@ -299,6 +302,7 @@ describe("promote/demoteMember", () => {
     role: GQLUSER_ROLE.MODERATOR,
     moderationScopes: {
       siteIDs: [siteC.id],
+      scoped: true,
     },
   });
   const member = createUserFixture({
@@ -308,12 +312,12 @@ describe("promote/demoteMember", () => {
   const promotedMember = createUserFixture({
     tenantID,
     role: GQLUSER_ROLE.MEMBER,
-    membershipScopes: { siteIDs: [siteA.id, siteB.id] },
+    membershipScopes: { siteIDs: [siteA.id, siteB.id], scoped: true },
   });
   const siteAMember = createUserFixture({
     tenantID,
     role: GQLUSER_ROLE.MEMBER,
-    membershipScopes: { siteIDs: [siteA.id] },
+    membershipScopes: { siteIDs: [siteA.id], scoped: true },
   });
 
   const users = [siteABMod, siteCMod, member, promotedMember, siteAMember];

--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -1082,6 +1082,11 @@ export async function updateModerationScopes(
     throw new Error("no sites specified in the moderation scopes");
   }
 
+  const user = await retrieveUser(mongo, tenant.id, userID);
+  if (!user?.moderationScopes?.scoped) {
+    throw new Error("User is not moderation scoped");
+  }
+
   const sites = await retrieveManySites(
     mongo,
     tenant.id,

--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -13,6 +13,7 @@ import {
   isSiteModerationScoped,
   validatePermissionsAction,
 } from "coral-common/permissions";
+import { PermissionsAction } from "coral-common/permissions/types";
 import { Config } from "coral-server/config";
 import { MongoContext } from "coral-server/data/context";
 import {
@@ -784,7 +785,7 @@ export async function updateRole(
   viewer: Pick<User, "id">,
   userID: string,
   role: GQLUSER_ROLE,
-  siteIDs?: string[]
+  scoped: boolean
 ) {
   const fullViewer = await retrieveUser(mongo, tenant.id, viewer.id);
   const user = await retrieveUser(mongo, tenant.id, userID);
@@ -795,11 +796,19 @@ export async function updateRole(
     throw new UserNotFoundError(userID);
   }
 
-  const action = {
+  if (
+    role !== GQLUSER_ROLE.MODERATOR &&
+    role !== GQLUSER_ROLE.MEMBER &&
+    scoped
+  ) {
+    throw new Error(`${role} cannot be scoped`);
+  }
+
+  const action: PermissionsAction = {
     viewer: fullViewer,
     user,
     newUserRole: role,
-    scopeAdditions: siteIDs,
+    scoped,
   };
 
   const validUpdate = validatePermissionsAction(action);
@@ -816,7 +825,7 @@ export async function updateRole(
 
   await Promise.all(sideEffects.map((se) => se(mongo, tenant.id)));
 
-  return updateUserRole(mongo, tenant.id, userID, role, siteIDs);
+  return updateUserRole(mongo, tenant.id, userID, role, scoped);
 }
 
 export async function promoteModerator(
@@ -826,6 +835,11 @@ export async function promoteModerator(
   userID: string,
   siteIDs: string[]
 ) {
+  // TODO: make sure this logic is represented
+  // scopeAdditions: siteIDs,
+  //   scopeDeletions: relevantScopes?.siteIDs?.filter(
+  //     (id) => !siteIDs?.includes(id)
+  //   ),
   if (viewer.id === userID) {
     throw new Error("cannot promote yourself");
   }
@@ -858,7 +872,7 @@ export async function promoteModerator(
     user.role === GQLUSER_ROLE.MODERATOR &&
     !isSiteModerationScoped(user.moderationScopes)
   ) {
-    throw new Error("user can't be an organization moderator");
+    throw new Error("User is already an organization moderator");
   }
 
   // Merge the site moderation scopes.
@@ -875,7 +889,8 @@ export async function promoteModerator(
       mongo,
       tenant.id,
       user.id,
-      GQLUSER_ROLE.MODERATOR
+      GQLUSER_ROLE.MODERATOR,
+      true
     );
   }
 
@@ -939,7 +954,8 @@ export async function demoteModerator(
       mongo,
       tenant.id,
       user.id,
-      GQLUSER_ROLE.COMMENTER
+      GQLUSER_ROLE.COMMENTER,
+      false
     );
   }
 
@@ -1001,7 +1017,8 @@ export async function promoteMember(
       mongo,
       tenant.id,
       updated.id,
-      GQLUSER_ROLE.MEMBER
+      GQLUSER_ROLE.MEMBER,
+      true
     );
   }
 
@@ -1034,7 +1051,8 @@ export async function demoteMember(
       mongo,
       tenant.id,
       updated.id,
-      GQLUSER_ROLE.COMMENTER
+      GQLUSER_ROLE.COMMENTER,
+      false
     );
   }
 


### PR DESCRIPTION
## What does this PR do?
This PR addresses a bug in which a promotion of a site mod to an org mod is immediately reversed.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
[bookmark]

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
As an admin and org mod:
1. Navigate to the community page
2. Promote a site moderator to an org mod
3. Demote an org mod to a site mod
4. Demote users of both roles to roles < moderator, and back again
5. Observe that the changes persist
 
 
## How do we deploy this PR?
No special considerations should be required.
