### PR TITLE
only focus on message box after clicking button

### DIFF
--- a/src/core/client/stream/tabs/Configure/AddMessage/AddMessageContainer.tsx
+++ b/src/core/client/stream/tabs/Configure/AddMessage/AddMessageContainer.tsx
@@ -20,8 +20,10 @@ interface Props {
 const AddMessageContainer: FunctionComponent<Props> = ({ story }) => {
   const [open, setOpen] = useState(story.settings.messageBox.enabled);
   const [removed, setRemoved] = useState(false);
+  const [focusOnEditor, setFocusOnEditor] = useState(false);
 
   const onOpen = useCallback(() => {
+    setFocusOnEditor(true);
     setOpen(true);
   }, [setOpen]);
   const onClose = useCallback(() => {
@@ -43,6 +45,8 @@ const AddMessageContainer: FunctionComponent<Props> = ({ story }) => {
           storySettings={story.settings}
           onCancel={onClose}
           onRemove={onRemove}
+          /* eslint-disable-next-line jsx-a11y/no-autofocus*/
+          autoFocus={focusOnEditor}
         />
       </section>
     );

--- a/src/core/client/stream/tabs/Configure/AddMessage/AddMessageOpen.tsx
+++ b/src/core/client/stream/tabs/Configure/AddMessage/AddMessageOpen.tsx
@@ -24,6 +24,7 @@ interface Props {
   storySettings: any;
   onCancel: () => void;
   onRemove: () => void;
+  autoFocus?: boolean;
 }
 
 const AddMessageOpen: FunctionComponent<Props> = ({
@@ -31,6 +32,7 @@ const AddMessageOpen: FunctionComponent<Props> = ({
   storySettings,
   onCancel,
   onRemove,
+  autoFocus,
 }) => {
   const updateMutation = useMutation(UpdateMessageBoxMutation);
 
@@ -118,7 +120,8 @@ const AddMessageOpen: FunctionComponent<Props> = ({
             id="message-box-form"
             data-testid="configure-addMessage-form"
           >
-            <MessageBoxConfig />
+            {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+            <MessageBoxConfig autoFocus={autoFocus} />
             {storySettings.messageBox.content ? (
               <div className={styles.actions}>
                 <Button

--- a/src/core/client/stream/tabs/Configure/AddMessage/MessageBoxConfig.tsx
+++ b/src/core/client/stream/tabs/Configure/AddMessage/MessageBoxConfig.tsx
@@ -28,6 +28,10 @@ import {
 
 import styles from "./MessageBoxConfig.css";
 
+export interface Props {
+  autoFocus?: boolean;
+}
+
 // eslint-disable-next-line no-unused-expressions
 graphql`
   fragment MessageBoxConfig_formValues on StorySettings {
@@ -39,7 +43,7 @@ graphql`
   }
 `;
 
-const MessageBoxConfig: FunctionComponent = () => (
+const MessageBoxConfig: FunctionComponent<Props> = ({ autoFocus }) => (
   <HorizontalGutter size="oneAndAHalf">
     <Field name="messageBox.icon" parse={parseEmptyAsNull} format={formatEmpty}>
       {({ input: iconInput }) => (
@@ -154,7 +158,7 @@ const MessageBoxConfig: FunctionComponent = () => (
                   <MarkdownEditor
                     id="configure-messageBox-content"
                     /* eslint-disable-next-line jsx-a11y/no-autofocus*/
-                    autoFocus={true}
+                    autoFocus={autoFocus}
                     data-testid="configure-messageBox-content"
                     name={contentInput.name}
                     onChange={contentInput.onChange}


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug in which the MDE autofocuses after switching to the configure tab in stream just because a story has a message configured.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. As a moderator or admin, navigate to a stream
2. Cick on the configure tab
3. If the story currently has a message configured, observe that focus begins at the top of the tab as expected
4. If the story does not have a message configured, click on the "Add Message" button, and observe that focus shifts to the markdown editor.
 
 
## How do we deploy this PR?
No special considerations needed.
