### PR TITLE
[CORL-2751] Legacy site moderators bug fix

### DIFF
--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -1083,7 +1083,7 @@ export async function updateModerationScopes(
   }
 
   const user = await retrieveUser(mongo, tenant.id, userID);
-  if (!user?.moderationScopes?.scoped) {
+  if (!isSiteModerationScoped(user?.moderationScopes)) {
     throw new Error("User is not moderation scoped");
   }
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug in which users who were promoted to Site Moderators before the most recent change to scoped roles were unable to have sites added to or removed from their moderation scopes.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags? 
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Checkout the previous release of coral. 
2. As an admin or org mod, promote a commenter to a site moderator
3. Checkout this PR
4. Try to add or remove scopes to/from the previous user, observe that it is successful (and persists).
 
## How do we deploy this PR?
No special considerations should be required.
