### PR TITLE
[CORL-2578] Fix Shift + A mark all comments seen keyboard shortcut

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
@@ -73,10 +73,12 @@ const markAllAsSeenRecursive = (
       continue;
     }
 
-    const childComments =
-      repliesConnection
-        .getLinkedRecords("edges")
-        ?.map((e) => e.getLinkedRecord("node")) || [];
+    const edges = repliesConnection.getLinkedRecords("edges");
+    if (!edges || edges.length === 0) {
+      continue;
+    }
+
+    const childComments = edges.map((e) => e.getLinkedRecord("node")) || [];
     if (!childComments || childComments.length === 0) {
       continue;
     }
@@ -103,9 +105,12 @@ const markAllAsSeen = (
     return;
   }
 
-  const comments = connection
-    .getLinkedRecords("edges")
-    ?.map((e) => e.getLinkedRecord("node"));
+  const edges = connection.getLinkedRecords("edges");
+  if (!edges || edges.length === 0) {
+    return;
+  }
+
+  const comments = edges.map((e) => e.getLinkedRecord("node"));
   if (!comments) {
     return;
   }

--- a/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
@@ -52,18 +52,18 @@ const getReplies = (commentProxy: RecordProxy<{}>) => {
 
   const edges = repliesConnection.getLinkedRecords("edges");
   if (edges && edges.length > 0) {
-    allEdges.push(...edges);
+    edges.forEach((e) => allEdges.push(e));
   }
   const viewNewEdges = repliesConnection.getLinkedRecords("viewNewEdges");
   if (viewNewEdges && viewNewEdges.length > 0) {
-    allEdges.push(...viewNewEdges);
+    viewNewEdges.forEach((e) => allEdges.push(e));
   }
 
   if (!allEdges || allEdges.length === 0) {
     return [];
   }
 
-  const childComments = allEdges.map((e) => e.getLinkedRecord("node")) || [];
+  const childComments = allEdges.map((e) => e.getLinkedRecord("node"));
   if (!childComments || childComments.length === 0) {
     return [];
   }
@@ -79,21 +79,21 @@ const getKeyboardShorcutReplies = (commentProxy: RecordProxy<{}>) => {
 
   const allEdges: RecordProxy<{}>[] = [];
 
-  const edges = allChildComments.getLinkedRecords("edges") || [];
+  const edges = allChildComments.getLinkedRecords("edges");
   if (edges && edges.length > 0) {
-    allEdges.push(...edges);
+    edges.forEach((e) => allEdges.push(e));
   }
 
-  const viewNewEdges = allChildComments.getLinkedRecords("viewNewEdges") || [];
+  const viewNewEdges = allChildComments.getLinkedRecords("viewNewEdges");
   if (viewNewEdges && viewNewEdges.length > 0) {
-    allEdges.push(...viewNewEdges);
+    viewNewEdges.forEach((e) => allEdges.push(e));
   }
 
   if (!allEdges || allEdges.length === 0) {
     return [];
   }
 
-  const childComments = allEdges.map((e) => e.getLinkedRecord("node")) || [];
+  const childComments = allEdges.map((e) => e.getLinkedRecord("node"));
   if (!childComments || childComments.length === 0) {
     return [];
   }
@@ -160,11 +160,11 @@ const markAllAsSeen = (
 
   const edges = connection.getLinkedRecords("edges");
   if (edges && edges.length > 0) {
-    allEdges.push(...edges);
+    edges.forEach((e) => allEdges.push(e));
   }
   const viewNewEdges = connection.getLinkedRecords("viewNewEdges");
   if (viewNewEdges && viewNewEdges.length > 0) {
-    allEdges.push(...viewNewEdges);
+    viewNewEdges.forEach((e) => allEdges.push(e));
   }
 
   if (!allEdges || allEdges.length === 0) {

--- a/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
@@ -48,12 +48,22 @@ const getReplies = (commentProxy: RecordProxy<{}>) => {
     return [];
   }
 
+  const allEdges: RecordProxy<{}>[] = [];
+
   const edges = repliesConnection.getLinkedRecords("edges");
-  if (!edges || edges.length === 0) {
+  if (edges && edges.length > 0) {
+    allEdges.push(...edges);
+  }
+  const viewNewEdges = repliesConnection.getLinkedRecords("viewNewEdges");
+  if (viewNewEdges && viewNewEdges.length > 0) {
+    allEdges.push(...viewNewEdges);
+  }
+
+  if (!allEdges || allEdges.length === 0) {
     return [];
   }
 
-  const childComments = edges.map((e) => e.getLinkedRecord("node")) || [];
+  const childComments = allEdges.map((e) => e.getLinkedRecord("node")) || [];
   if (!childComments || childComments.length === 0) {
     return [];
   }
@@ -67,12 +77,23 @@ const getKeyboardShorcutReplies = (commentProxy: RecordProxy<{}>) => {
     return [];
   }
 
+  const allEdges: RecordProxy<{}>[] = [];
+
   const edges = allChildComments.getLinkedRecords("edges") || [];
-  if (!edges || edges.length === 0) {
+  if (edges && edges.length > 0) {
+    allEdges.push(...edges);
+  }
+
+  const viewNewEdges = allChildComments.getLinkedRecords("viewNewEdges") || [];
+  if (viewNewEdges && viewNewEdges.length > 0) {
+    allEdges.push(...viewNewEdges);
+  }
+
+  if (!allEdges || allEdges.length === 0) {
     return [];
   }
 
-  const childComments = edges.map((e) => e.getLinkedRecord("node")) || [];
+  const childComments = allEdges.map((e) => e.getLinkedRecord("node")) || [];
   if (!childComments || childComments.length === 0) {
     return [];
   }
@@ -109,7 +130,11 @@ const markAllAsSeenRecursive = (
     const replies = getReplies(c);
     const keyboardShortcutReplies = getKeyboardShorcutReplies(c);
 
-    markAllAsSeenRecursive(store, [...replies, ...keyboardShortcutReplies], seen);
+    markAllAsSeenRecursive(
+      store,
+      [...replies, ...keyboardShortcutReplies],
+      seen
+    );
   }
 };
 
@@ -131,12 +156,22 @@ const markAllAsSeen = (
     return;
   }
 
+  const allEdges: RecordProxy<{}>[] = [];
+
   const edges = connection.getLinkedRecords("edges");
-  if (!edges || edges.length === 0) {
+  if (edges && edges.length > 0) {
+    allEdges.push(...edges);
+  }
+  const viewNewEdges = connection.getLinkedRecords("viewNewEdges");
+  if (viewNewEdges && viewNewEdges.length > 0) {
+    allEdges.push(...viewNewEdges);
+  }
+
+  if (!allEdges || allEdges.length === 0) {
     return;
   }
 
-  const comments = edges.map((e) => e.getLinkedRecord("node"));
+  const comments = allEdges.map((e) => e.getLinkedRecord("node"));
   if (!comments) {
     return;
   }

--- a/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
@@ -150,7 +150,7 @@ const markAllAsSeen = (
   }
 
   const connection = ConnectionHandler.getConnection(story, "Stream_comments", {
-    orderBy: orderBy,
+    orderBy,
   });
   if (!connection) {
     return;

--- a/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
@@ -91,7 +91,6 @@ const markAllAsSeen = (
   orderBy: COMMENT_SORT | null | undefined,
   seen: boolean
 ) => {
-  console.log("markAllAsSeen");
   const story = store.get(storyID);
   if (!story) {
     return;


### PR DESCRIPTION
## What does this PR do?

Fixes Shift + A mark all comments seen keyboard shortcut to mark all comments as seen and all nested replies.

It does this by marking all as seen using recursion to walk relay's data store.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags? 

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices added.

## How do I test this PR?

- Enable `Z_KEY` and `COMMENT_SEEN`
- Login on stream
- See yellow not seen colouring (usually yellow)
- Press `Shift + A` 
- All comments should now be marked as seen (usually white)
 
## How do we deploy this PR?

No special considerations
