### PR TITLE
[CORL-2754] obey count cutoff when filling the archiving queue

### DIFF
--- a/src/core/server/models/story/story.ts
+++ b/src/core/server/models/story/story.ts
@@ -892,7 +892,7 @@ export async function retrieveStoriesToBeArchived(
   const results: Readonly<Story>[] = [];
   let scanned = 0;
 
-  while ((await cursor.hasNext()) || results.length === count) {
+  while (await cursor.hasNext()) {
     const story = (await cursor.next()) as ArchiveCheckStory;
     if (!story) {
       continue;
@@ -928,6 +928,11 @@ export async function retrieveStoriesToBeArchived(
       notRatingsAndReview
     ) {
       results.push(story);
+    }
+
+    // if we have enough to meet our count quota, stop iterating the cursor
+    if (results.length >= count) {
+      break;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Properly breaks the cursor iteration when the number of found documents meets the count cutoff for searching for stories to archive during the fill archiving queue job.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.