### PR TITLE
[CORL-2780] add `sectionOverride` option to scraper

### DIFF
--- a/src/core/server/services/stories/scraper/rules/section.ts
+++ b/src/core/server/services/stories/scraper/rules/section.ts
@@ -5,6 +5,9 @@ import { wrap } from "./helpers";
 
 export const sectionScraper = (): RuleBundle => ({
   section: [
+    // an override for newsrooms using section differently than
+    // the default way
+    wrap(($) => $(`meta[property="sectionOverride"]`).attr("content")),
     // From: http://ogp.me/#type_article
     wrap($jsonld("articleSection")),
     wrap(($) => $('meta[itemprop="articleSection"]').attr("content")),


### PR DESCRIPTION
## What does this PR do?

Adds the `sectionOverride` optional tag to override the default section behaviour for newsrooms that use the section tag differently than the standard section flow.

## These changes will impact:

- [ ] commenters
- [X] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- Use multi-site test
    - Remember to pull down if you haven't pulled `main` on this repo in a while!
- Create a new story with the following data in the `config.json`:

```
{
    "id": "some-story",
    "section": "comedy",
    "sectionOverride": "override"
}
```

- Navigate to the stream for the newly created story so it shows up and registers with Coral
- Find it in the stories tab (might be unknown as it hasn't been scraped)
    - Open the story info drawer and re-scrape the story data
- Open up Mongo compass or a mongo shell and find the story by its id (`"some-story"`)
- Check the metadata tag and see that it its section is set to `"override"`

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.

Newsrooms that wish to override the section metadata can put the following inside their `<head>`:

```
<meta data-rh="true" property="sectionOverride" content="{{ section_override_value_they_want_to_use }}" />
```
