### PR TITLE
Don't redis cache archived stories

### DIFF
--- a/src/core/server/graph/loaders/Comments.ts
+++ b/src/core/server/graph/loaders/Comments.ts
@@ -324,7 +324,13 @@ export default (ctx: GraphContext) => ({
       throw new StoryNotFoundError(storyID);
     }
 
-    if (isRatingsAndReviews(ctx.tenant, story) || isQA(ctx.tenant, story)) {
+    const isArchived = !!(story.isArchived || story.isArchiving);
+
+    if (
+      isRatingsAndReviews(ctx.tenant, story) ||
+      isQA(ctx.tenant, story) ||
+      isArchived
+    ) {
       const connection = await retrieveCommentStoryConnection(
         ctx.mongo,
         ctx.tenant.id,
@@ -347,7 +353,6 @@ export default (ctx: GraphContext) => ({
       return connection;
     }
 
-    const isArchived = !!(story.isArchived || story.isArchiving);
     const { userIDs } = await ctx.cache.comments.primeCommentsForStory(
       ctx.tenant.id,
       storyID,
@@ -380,7 +385,13 @@ export default (ctx: GraphContext) => ({
       throw new StoryNotFoundError(storyID);
     }
 
-    if (isRatingsAndReviews(ctx.tenant, story) || isQA(ctx.tenant, story)) {
+    const isArchived = !!(story.isArchived || story.isArchiving);
+
+    if (
+      isRatingsAndReviews(ctx.tenant, story) ||
+      isQA(ctx.tenant, story) ||
+      isArchived
+    ) {
       const connection = await retrieveCommentRepliesConnection(
         ctx.mongo,
         ctx.tenant.id,


### PR DESCRIPTION
## What does this PR do?

Bypasses caching for archived story comments avoiding those stories from being placed into the redis cache.

This keeps the redis cache focused for live stories that are of highest priority.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes added.

## How do I test this PR?

- Hook into your redis via `docker exec -it <your_redis_instance_name> redis-cli`
- Start Coral up with jobs enabled
    - run `npm run start:development:withJobs`
- In your Redis CLI run the command `FLUSHALL` to empty Redis
- Visit an archived story
- Visit the archived story's stream
- Run `KEYS *` in your Redis CLI and see that only user data is cached
   - only keys with format `<tenantID>:<userID>:userData` are present
   - may see `{queue}:*` keys for jobs that ran
   - may see `<tenantID>:lastUsedSSOSigningSecret` keys for auth middleware caching
- Run the command `FLUSHALL` to empty Redis again
- Visit a live (open, non-archived) story's stream
- Run `KEYS *` in your Redis CLI and see that story, comments, commentActions, and user data is loaded into the cache
   - keys with format `<tenantID>:<storyID>:<commentID>:data` are present
   - keys with format `<tenantID>:<storyID>:lock` are present

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
