### PR TITLE
[CORL-2731] Add a message screen reader fix

### DIFF
--- a/src/core/client/stream/tabs/Configure/AddMessage/AddMessageClosed.tsx
+++ b/src/core/client/stream/tabs/Configure/AddMessage/AddMessageClosed.tsx
@@ -38,6 +38,7 @@ const AddMessageClosed: FunctionComponent<Props> = ({
           disabled={disableButton}
           upperCase
           data-testid="configure-addMessage"
+          aria-label="Add message"
         >
           Add message
         </Button>

--- a/src/core/client/stream/tabs/Configure/AddMessage/AddMessageOpen.tsx
+++ b/src/core/client/stream/tabs/Configure/AddMessage/AddMessageOpen.tsx
@@ -169,19 +169,21 @@ const AddMessageOpen: FunctionComponent<Props> = ({
                 >
                   <Localized id="configure-addMessage-cancel">Cancel</Localized>
                 </Button>
-                <Button
-                  className={CLASSES.configureCommentStream.applyButton}
-                  color="primary"
-                  variant="filled"
-                  type="submit"
-                  disabled={submitting || pristine}
-                  upperCase
-                  data-testid="configure-addMessage-submitAdd"
-                >
-                  <Localized id="configure-addMessage-submitAdd">
+                <Localized id="configure-addMessage-submitAdd">
+                  <Button
+                    className={CLASSES.configureCommentStream.applyButton}
+                    color="primary"
+                    variant="filled"
+                    type="submit"
+                    disabled={submitting || pristine}
+                    upperCase
+                    data-testid="configure-addMessage-submitAdd"
+                    aria-label="Add message"
+                  >
                     Add message
-                  </Localized>
-                </Button>
+                  </Button>
+                </Localized>
+
                 {renderSuccess}
               </div>
             )}

--- a/src/core/client/stream/test/configure/__snapshots__/renderConfigure.spec.tsx.snap
+++ b/src/core/client/stream/test/configure/__snapshots__/renderConfigure.spec.tsx.snap
@@ -170,6 +170,7 @@ to pose a topic, ask a question or make announcements relating to this
 story.
         </div>
         <button
+          aria-label="Add message"
           class="BaseButton-root Button-base Button-filled Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-paddingSizeSmall Button-colorSecondary Button-upperCase coral coral-openCommentStream-openButton"
           data-testid="configure-addMessage"
           data-variant="filled"


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug in which a screen reader reads the word "Add" as "A D D" in the "Add message" buttons when configuring a stream.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
none.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Enable a screen reader
2. As a moderator or admin, navigate to the "configure" tab of a stream, to the section where you can add a message at the top of the stream
3. Tab to the Add Message button, both with the editor open and closed (it will stay open after adding and then removing a message)
4. Observe that the screen reader correctly pronoucnes "ADD A MESSAGE"

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations needed.
