### PR TITLE
[CORL-2791] Redis cache expiry improvements

### DIFF
--- a/src/core/server/data/cache/commentCache.spec.ts
+++ b/src/core/server/data/cache/commentCache.spec.ts
@@ -44,7 +44,6 @@ const createFixtures = async (
   const commentCache = new CommentCache(
     mongo,
     redis,
-    null,
     logger,
     false,
     options?.expirySeconds ? options.expirySeconds : 5 * 60

--- a/src/core/server/data/cache/commentCache.ts
+++ b/src/core/server/data/cache/commentCache.ts
@@ -96,7 +96,7 @@ export class CommentCache {
     const lockKey = this.computeLockKey(tenantID, storyID);
     const hasCommentsInRedis = await this.redis.exists(lockKey);
 
-    return hasCommentsInRedis;
+    return hasCommentsInRedis > 0;
   }
 
   public async invalidateCache(tenantID: string, storyID: string) {
@@ -250,7 +250,8 @@ export class CommentCache {
     const cmd = this.redis.multi();
 
     const lockKey = this.computeLockKey(tenantID, storyID);
-    cmd.set(lockKey, now.getTime(), "ex", this.expirySeconds);
+    cmd.set(lockKey, now.getTime());
+    cmd.expire(lockKey, this.expirySeconds);
 
     const allCommentsKey = this.computeStoryAllCommentsKey(tenantID, storyID);
     if (comments.length > 0) {
@@ -287,7 +288,8 @@ export class CommentCache {
       const key = this.computeDataKey(tenantID, storyID, comment.id);
       const value = this.serializeObject(comment);
 
-      cmd.set(key, value, "ex", this.expirySeconds);
+      cmd.set(key, value);
+      cmd.expire(key, this.expirySeconds);
     }
 
     // Create the parent to child key-value look ups

--- a/src/core/server/data/cache/dataCache.ts
+++ b/src/core/server/data/cache/dataCache.ts
@@ -1,6 +1,5 @@
 import { MongoContext } from "coral-server/data/context";
 import { Logger } from "coral-server/logger";
-import { LoadCacheQueue } from "coral-server/queue/tasks/loadCache";
 import { AugmentedRedis } from "coral-server/services/redis";
 import { CommentActionsCache } from "./commentActionsCache";
 
@@ -12,7 +11,6 @@ export const DEFAULT_DATA_EXPIRY_SECONDS = 24 * 60 * 60;
 export class DataCache {
   private mongo: MongoContext;
   private redis: AugmentedRedis;
-  private queue: LoadCacheQueue | null;
   private logger: Logger;
 
   private expirySeconds: number;
@@ -26,21 +24,18 @@ export class DataCache {
   constructor(
     mongo: MongoContext,
     redis: AugmentedRedis,
-    queue: LoadCacheQueue | null,
     logger: Logger,
     disableCaching?: boolean,
     expirySeconds: number = DEFAULT_DATA_EXPIRY_SECONDS
   ) {
     this.mongo = mongo;
     this.redis = redis;
-    this.queue = queue;
     this.logger = logger.child({ traceID: this.traceID });
     this.expirySeconds = expirySeconds;
 
     this.comments = new CommentCache(
       this.mongo,
       this.redis,
-      this.queue,
       this.logger,
       Boolean(disableCaching),
       this.expirySeconds

--- a/src/core/server/graph/context.ts
+++ b/src/core/server/graph/context.ts
@@ -140,7 +140,6 @@ export default class GraphContext {
     this.cache = new DataCache(
       this.mongo,
       this.redis,
-      this.loadCacheQueue,
       this.logger,
       this.disableCaching,
       this.config.get("redis_cache_expiry") / 1000

--- a/src/core/server/graph/loaders/Stories.ts
+++ b/src/core/server/graph/loaders/Stories.ts
@@ -180,6 +180,7 @@ export default (ctx: GraphContext) => ({
       findOrCreate(
         ctx.mongo,
         ctx.tenant,
+        ctx.cache.comments,
         ctx.loadCacheQueue,
         ctx.broker,
         input,

--- a/src/core/server/queue/tasks/loadCache.ts
+++ b/src/core/server/queue/tasks/loadCache.ts
@@ -46,7 +46,6 @@ const createJobProcessor =
     const { comments, commentActions, users } = new DataCache(
       mongo,
       redis,
-      null,
       log,
       false,
       config.get("redis_cache_expiry") / 1000

--- a/src/core/server/queue/tasks/rejector.ts
+++ b/src/core/server/queue/tasks/rejector.ts
@@ -223,7 +223,6 @@ const createJobProcessor =
     const cache = new DataCache(
       mongo,
       redis,
-      null,
       log,
       false,
       config.get("redis_cache_expiry") / 1000

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -147,11 +147,9 @@ export async function findOrCreate(
     });
   }
 
-  if (
-    !cache.isCached(tenant.id, story.id) &&
-    !story.isArchived &&
-    !story.isArchiving
-  ) {
+  const storyIsCached = await cache.isCached(tenant.id, story.id);
+
+  if (!storyIsCached && !story.isArchived && !story.isArchiving) {
     await queue.add({ tenantID: tenant.id, storyID: story.id });
   }
 


### PR DESCRIPTION
## What does this PR do?

- Consolidate cache generation into one place (`findOrCreate` story functions)
    - Ensure that only non-cached and un-archived stories are queued for caching
- Utilize only one form of setting expiry for Redis cache keys so that there is no confusion about how expiry is set for keys

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indexes.

## How do I test this PR?

- set `REDIS_CACHE_EXPIRY=60s` in your `.env` file
- run Coral with `npm run start:development:withJobs`
- enter your redis instance via `docker exec -it redis redis-cli`
- execute `FLUSHALL`
- load up a comment stream with some comments
- execute `KEYS *:lock`
- see that the key for the story you loaded are there (format: `<tenantID:storyID:lock`)
- wait a minute (60s you set in `.env` file)
- execute `KEYS *:lock`
- see that the key for the story you loaded is no longer there
    - you can also use `KEYS *` and see all the comment, sort, and lock keys are all gone too
- reload the stream, see that it loads fine and all comments are there
- execute `KEYS *:lock`
- see that the story key is back again

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Ensure this is deployed to an 8.0+ capable instance connected a Redis service with enough resources to handle caching.
