### PR TITLE
[CORL-2791] create an admin control panel

### DIFF
--- a/src/core/client/admin/routeConfig.tsx
+++ b/src/core/client/admin/routeConfig.tsx
@@ -30,6 +30,7 @@ import {
 } from "./routes/Configure/sections";
 import AddSiteRoute from "./routes/Configure/sections/Sites/AddSiteRoute";
 import SiteRoute from "./routes/Configure/sections/Sites/SiteRoute";
+import ControlPanelRoute from "./routes/ControlPanel";
 import DashboardRoute from "./routes/Dashboard";
 import SiteDashboardRoute from "./routes/Dashboard/SiteDashboardRoute";
 import ForgotPasswordRoute from "./routes/ForgotPassword";
@@ -179,6 +180,11 @@ export default makeRouteConfig(
             <Route path="new" {...AddSiteRoute.routeConfig} />
             <Route path=":siteID" {...SiteRoute.routeConfig} />
           </Route>
+        </Route>
+        <Route
+          {...createAuthCheckRoute({ role: GQLUSER_ROLE.ADMIN }).routeConfig}
+        >
+          <Route path="controlpanel" {...ControlPanelRoute.routeConfig} />
         </Route>
       </Route>
     </Route>

--- a/src/core/client/admin/routes/ControlPanel/ControlPanel.css
+++ b/src/core/client/admin/routes/ControlPanel/ControlPanel.css
@@ -1,0 +1,5 @@
+.root {
+  max-width: 950px;
+  margin-top: calc(3 * var(--mini-unit));
+  margin-bottom: calc(3 * var(--mini-unit));
+}

--- a/src/core/client/admin/routes/ControlPanel/ControlPanel.tsx
+++ b/src/core/client/admin/routes/ControlPanel/ControlPanel.tsx
@@ -1,0 +1,49 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent, useCallback, useState } from "react";
+
+import MainLayout from "coral-admin/components/MainLayout";
+import { useMutation } from "coral-framework/lib/relay";
+import { FieldSet, FormField, Label } from "coral-ui/components/v2";
+import { Button } from "coral-ui/components/v3";
+
+import ConfigBox from "../Configure/ConfigBox";
+import Header from "../Configure/Header";
+import FlushRedisMutation from "./FlushRedisMutation";
+
+import styles from "./ControlPanel.css";
+
+const ControlPanel: FunctionComponent = () => {
+  const [isTriggered, setTriggered] = useState<boolean>(false);
+  const flushRedis = useMutation(FlushRedisMutation);
+
+  const onFlush = useCallback(async () => {
+    await flushRedis();
+    setTriggered(true);
+  }, [flushRedis]);
+
+  return (
+    <MainLayout className={styles.root} data-testid="controlPanel-container">
+      <ConfigBox
+        title={
+          <Localized id="controlPanel-redis-redis ">
+            <Header container="h2">Redis</Header>
+          </Localized>
+        }
+      >
+        <FormField container={<FieldSet />}>
+          <Localized id="controlPanel-redis-flushRedis">
+            <Label>Flush Redis</Label>
+          </Localized>
+
+          <Localized id="controlPanel-redis-flush">
+            <Button disabled={isTriggered} onClick={onFlush}>
+              Flush
+            </Button>
+          </Localized>
+        </FormField>
+      </ConfigBox>
+    </MainLayout>
+  );
+};
+
+export default ControlPanel;

--- a/src/core/client/admin/routes/ControlPanel/ControlPanelRoute.tsx
+++ b/src/core/client/admin/routes/ControlPanel/ControlPanelRoute.tsx
@@ -1,0 +1,39 @@
+import React, { FunctionComponent } from "react";
+import { graphql } from "react-relay";
+
+import { withRouteConfig } from "coral-framework/lib/router";
+import { GQLUSER_ROLE } from "coral-framework/schema";
+
+import { ControlPanelRouteQueryResponse } from "coral-admin/__generated__/ControlPanelRouteQuery.graphql";
+
+import ControlPanel from "./ControlPanel";
+
+interface Props {
+  data: ControlPanelRouteQueryResponse | null;
+}
+
+const ControlPanelRoute: FunctionComponent<Props> = ({ data }) => {
+  if (!data) {
+    return null;
+  }
+
+  const { viewer } = data;
+
+  if (!viewer || viewer.role !== GQLUSER_ROLE.ADMIN) {
+    return null;
+  }
+
+  return <ControlPanel />;
+};
+
+const enhanced = withRouteConfig<Props>({
+  query: graphql`
+    query ControlPanelRouteQuery {
+      viewer {
+        role
+      }
+    }
+  `,
+})(ControlPanelRoute);
+
+export default enhanced;

--- a/src/core/client/admin/routes/ControlPanel/FlushRedisMutation.ts
+++ b/src/core/client/admin/routes/ControlPanel/FlushRedisMutation.ts
@@ -12,7 +12,7 @@ import { FlushRedisMutation as MutationTypes } from "coral-admin/__generated__/F
 let clientMutationId = 0;
 
 const FlushRedisMutation = createMutation(
-  "invalidateCachedStory",
+  "flushRedis",
   (environment: Environment, input: MutationInput<MutationTypes>) =>
     commitMutationPromiseNormalized<MutationTypes>(environment, {
       mutation: graphql`

--- a/src/core/client/admin/routes/ControlPanel/FlushRedisMutation.ts
+++ b/src/core/client/admin/routes/ControlPanel/FlushRedisMutation.ts
@@ -1,0 +1,34 @@
+import { graphql } from "react-relay";
+import { Environment } from "relay-runtime";
+
+import {
+  commitMutationPromiseNormalized,
+  createMutation,
+  MutationInput,
+} from "coral-framework/lib/relay";
+
+import { FlushRedisMutation as MutationTypes } from "coral-admin/__generated__/FlushRedisMutation.graphql";
+
+let clientMutationId = 0;
+
+const FlushRedisMutation = createMutation(
+  "invalidateCachedStory",
+  (environment: Environment, input: MutationInput<MutationTypes>) =>
+    commitMutationPromiseNormalized<MutationTypes>(environment, {
+      mutation: graphql`
+        mutation FlushRedisMutation($input: FlushRedisInput!) {
+          flushRedis(input: $input) {
+            clientMutationId
+          }
+        }
+      `,
+      variables: {
+        input: {
+          ...input,
+          clientMutationId: (clientMutationId++).toString(),
+        },
+      },
+    })
+);
+
+export default FlushRedisMutation;

--- a/src/core/client/admin/routes/ControlPanel/index.ts
+++ b/src/core/client/admin/routes/ControlPanel/index.ts
@@ -1,0 +1,1 @@
+export { default, default as ControlPanelRoute } from "./ControlPanelRoute";

--- a/src/core/server/graph/mutators/Redis.ts
+++ b/src/core/server/graph/mutators/Redis.ts
@@ -1,0 +1,7 @@
+import GraphContext from "../context";
+
+export const Redis = (ctx: GraphContext) => ({
+  flush: async (): Promise<"OK"> => {
+    return ctx.redis.flushall();
+  },
+});

--- a/src/core/server/graph/mutators/index.ts
+++ b/src/core/server/graph/mutators/index.ts
@@ -2,6 +2,7 @@ import GraphContext from "coral-server/graph/context";
 
 import { Actions } from "./Actions";
 import { Comments } from "./Comments";
+import { Redis } from "./Redis";
 import { Settings } from "./Settings";
 import { Sites } from "./Sites";
 import { Stories } from "./Stories";
@@ -14,4 +15,5 @@ export default (ctx: GraphContext) => ({
   Stories: Stories(ctx),
   Users: Users(ctx),
   Sites: Sites(ctx),
+  Redis: Redis(ctx),
 });

--- a/src/core/server/graph/resolvers/Mutation.ts
+++ b/src/core/server/graph/resolvers/Mutation.ts
@@ -502,4 +502,11 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     story: await ctx.mutators.Stories.invalidateCachedStory(input),
     clientMutationId: input.clientMutationId,
   }),
+  flushRedis: async (source, { input: { clientMutationId } }, ctx) => {
+    await ctx.mutators.Redis.flush();
+
+    return {
+      clientMutationId,
+    };
+  },
 };

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -7480,7 +7480,6 @@ input ModerationScopesInput {
   scoped is whether or not the user's moderation
   priveledges are limited to specified sites
   """
-
   scoped: Boolean!
 
   """
@@ -8861,6 +8860,21 @@ type InvalidateCachedStoryPayload {
 }
 
 ##################
+## Redis
+##################
+
+input FlushRedisInput {
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+type FlushRedisPayload {
+  clientMutationId: String!
+}
+
+##################
 ## Mutation
 ##################
 
@@ -9548,8 +9562,9 @@ type Mutation {
   refreshStoryCounts will recompute the cached counts for a story based on
   which flags are set to recompute in the operation input.
   """
-  refreshStoryCounts(input: RefreshStoryCountsInput!): RefreshStoryCountsPayload!
-    @auth(roles: [ADMIN])
+  refreshStoryCounts(
+    input: RefreshStoryCountsInput!
+  ): RefreshStoryCountsPayload! @auth(roles: [ADMIN])
 
   """
   cacheStory will cache the given Story and its comments into redis for fast
@@ -9562,8 +9577,14 @@ type Mutation {
   invalidateCachedStory will invalidate any cached data for a story whose stream
   may be cached in redis.
   """
-  invalidateCachedStory(input: InvalidateCachedStoryInput!): InvalidateCachedStoryPayload!
-    @auth(roles: [ADMIN, MODERATOR])
+  invalidateCachedStory(
+    input: InvalidateCachedStoryInput!
+  ): InvalidateCachedStoryPayload! @auth(roles: [ADMIN, MODERATOR])
+
+  """
+  flushRedis flushes the redis instance.
+  """
+  flushRedis(input: FlushRedisInput!): FlushRedisPayload! @auth(roles: [ADMIN])
 }
 
 ##################

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -1759,3 +1759,9 @@ conversation-modal-commentNotFound = Comment not found.
 conversation-modal-showMoreReplies = Show more replies
 conversation-modal-header-title = Conversation on:
 conversation-modal-header-moderate-link = Moderate story
+
+# Control panel
+
+controlPanel-redis-redis = Redis
+controlPanel-redis-flushRedis = Flush Redis
+controlPanel-redis-flush = Flush


### PR DESCRIPTION
## What does this PR do?

- creates an admin only control panel located at `http[s]://<url>/admin/controlpanel`
- adds a `Flush Redis` action to the control panel so you can flush Redis whenever you feel like it

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

- adds a `flushRedis` mutation to the schema

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- enter your Redis instance via `docker exec -it redis redis-cli`
- execute `SET hello hiya`
- execute `KEYS *`
- see your `hello` key (as well as likely other keys)
- go to `/admin/controlpanel` and click to `Flush Redis`
- execute `KEYS *`
- Redis should return `(empty list or set)`

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations, though it would be useful for this to go out with the other `CORL-2791` Redis cache improvements!
