### PR TITLE
[CORL-2730] give buttons clearer labels for screen readers

### DIFF
--- a/src/core/client/stream/tabs/Profile/Settings/ChangeEmail/ChangeEmailContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Settings/ChangeEmail/ChangeEmailContainer.tsx
@@ -297,12 +297,16 @@ const ChangeEmailContainer: FunctionComponent<Props> = ({
             [styles.changeButtonMessage]: showSuccessMessage,
           })}
         >
-          <Localized id="profile-changeEmail-change">
+          <Localized
+            id="profile-changeEmail-change"
+            attrs={{ "aria-lable": true }}
+          >
             <Button
               className={CLASSES.myEmail.editButton}
               variant="flat"
               paddingSize="none"
               onClick={toggleEditForm}
+              aria-label="Change email"
             >
               Change
             </Button>

--- a/src/core/client/stream/tabs/Profile/Settings/ChangePassword.tsx
+++ b/src/core/client/stream/tabs/Profile/Settings/ChangePassword.tsx
@@ -106,11 +106,15 @@ const ChangePassword: FunctionComponent<Props> = ({ onResetPassword }) => {
         </div>
       </Localized>
       {!showForm && (
-        <Localized id="profile-account-changePassword-change">
+        <Localized
+          id="profile-account-changePassword-change"
+          attrs={{ "aria-label": true }}
+        >
           <Button
             variant="flat"
             color="primary"
             paddingSize="none"
+            aria-label="Change password"
             onClick={toggleForm}
             className={cn(
               {

--- a/src/core/client/stream/tabs/Profile/Settings/ChangeUsername/ChangeUsernameContainer.tsx
+++ b/src/core/client/stream/tabs/Profile/Settings/ChangeUsername/ChangeUsernameContainer.tsx
@@ -194,7 +194,10 @@ const ChangeUsernameContainer: FunctionComponent<Props> = ({
               !canChangeUsername || showSuccessMessage,
           })}
         >
-          <Localized id="profile-changeUsername-change">
+          <Localized
+            id="profile-changeUsername-change"
+            attrs={{ "aria-label": true }}
+          >
             <Button
               className={cn(
                 CLASSES.myUsername.editButton,
@@ -205,6 +208,7 @@ const ChangeUsernameContainer: FunctionComponent<Props> = ({
               color="primary"
               onClick={toggleEditForm}
               disabled={!canChangeUsername}
+              aria-label="Change username"
             >
               Change
             </Button>

--- a/src/core/client/stream/test/profile/__snapshots__/account.spec.tsx.snap
+++ b/src/core/client/stream/test/profile/__snapshots__/account.spec.tsx.snap
@@ -30,6 +30,7 @@ exports[`renders the empty settings pane 1`] = `
         class="ChangeUsernameContainer-changeButton"
       >
         <button
+          aria-label="Change username"
           class="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-colorPrimary coral coral-myUsername-editButton coral coral-myUsername-change"
           data-variant="flat"
           type="button"
@@ -132,6 +133,7 @@ to sign in to your account or to receive notifications.
         class="ChangeEmailContainer-changeButton"
       >
         <button
+          aria-label="Change email"
           class="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-colorPrimary coral coral-myEmail-editButton"
           data-variant="flat"
           type="button"
@@ -152,6 +154,7 @@ to sign in to your account or to receive notifications.
         Password
       </div>
       <button
+        aria-label="Change password"
         class="BaseButton-root Button-base Button-flat Button-fontSizeSmall Button-textAlignCenter Button-fontFamilyPrimary Button-fontWeightPrimaryBold Button-colorPrimary ChangePassword-changeButton coral coral-myPassword-editButton"
         data-variant="flat"
         type="button"

--- a/src/core/client/stream/test/profile/changeEmail.spec.tsx
+++ b/src/core/client/stream/test/profile/changeEmail.spec.tsx
@@ -73,7 +73,7 @@ describe("change email form", () => {
   it("ensures email field is required", async () => {
     const changeEmail = await screen.findByTestId("profile-changeEmail");
     const editButton = within(changeEmail).getByRole("button", {
-      name: "Change",
+      name: "Change email",
     });
     userEvent.click(editButton);
     expect(await axe(changeEmail)).toHaveNoViolations();
@@ -87,7 +87,7 @@ describe("change email form", () => {
   it("ensures password field is required", async () => {
     const changeEmail = await screen.findByTestId("profile-changeEmail");
     const editButton = within(changeEmail).getByRole("button", {
-      name: "Change",
+      name: "Change email",
     });
     userEvent.click(editButton);
     const emailInput = within(changeEmail).getByLabelText("New email address", {
@@ -103,7 +103,7 @@ describe("change email form", () => {
   it("updates email if fields are valid", async () => {
     const changeEmail = await screen.findByTestId("profile-changeEmail");
     const editButton = within(changeEmail).getByRole("button", {
-      name: "Change",
+      name: "Change email",
     });
     userEvent.click(editButton);
     const emailInput = within(changeEmail).getByLabelText("New email address", {

--- a/src/core/client/stream/test/profile/changeUsername.spec.tsx
+++ b/src/core/client/stream/test/profile/changeUsername.spec.tsx
@@ -69,7 +69,7 @@ describe("with recently changed username", () => {
     const changeUsername = await screen.findByTestId("profile-changeUsername");
     within(changeUsername).getByText("u_changed");
     const editButton = within(changeUsername).getByRole("button", {
-      name: "Change",
+      name: "Change username",
     });
     userEvent.click(editButton);
     const form = within(changeUsername).queryByTestId(
@@ -104,7 +104,7 @@ describe("with new username", () => {
 
     within(changeUsername).getByText("u_original");
     const editButton = within(changeUsername).getByRole("button", {
-      name: "Change",
+      name: "Change username",
     });
     userEvent.click(editButton);
     expect(await axe(changeUsername)).toHaveNoViolations();
@@ -151,7 +151,7 @@ describe("change username form", () => {
   it("ensures username field is required", async () => {
     const changeUsername = await screen.findByTestId("profile-changeUsername");
     const editButton = within(changeUsername).getByRole("button", {
-      name: "Change",
+      name: "Change username",
     });
     userEvent.click(editButton);
     const saveChanges = within(changeUsername).getByRole("button", {
@@ -163,7 +163,7 @@ describe("change username form", () => {
   it("ensures username confirmation matches", async () => {
     const changeUsername = await screen.findByTestId("profile-changeUsername");
     const editButton = within(changeUsername).getByRole("button", {
-      name: "Change",
+      name: "Change username",
     });
     userEvent.click(editButton);
     const username = within(changeUsername).getByRole("textbox", {
@@ -183,7 +183,7 @@ describe("change username form", () => {
   it("updates username if fields are valid", async () => {
     const changeUsername = await screen.findByTestId("profile-changeUsername");
     const editButton = within(changeUsername).getByRole("button", {
-      name: "Change",
+      name: "Change username",
     });
     userEvent.click(editButton);
     const username = within(changeUsername).getByRole("textbox", {

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -642,6 +642,7 @@ profile-account-deleteAccount-pages-completeWhyDeleteAccount =
   our comment system by emailing { $email }.
 profile-account-changePassword-edit = Edit
 profile-account-changePassword-change = Change
+  .aria-label = Change password
 
 
 ## Notifications
@@ -734,6 +735,7 @@ profile-changeUsername-username = Username
 profile-changeUsername-success = Your username has been successfully updated
 profile-changeUsername-edit = Edit
 profile-changeUsername-change = Change
+  .aria-label = Change username
 profile-changeUsername-heading = Edit your username
 profile-changeUsername-heading-changeYourUsername = Change your username
 profile-changeUsername-desc = Change the username that will appear on all of your past and future comments. <strong>Usernames can be changed once every { framework-timeago-time }.</strong>
@@ -900,6 +902,7 @@ profile-changeEmail-unverified = (Unverified)
 profile-changeEmail-current = (current)
 profile-changeEmail-edit = Edit
 profile-changeEmail-change = Change
+  .aria-label = Change email
 profile-changeEmail-please-verify = Verify your email address
 profile-changeEmail-please-verify-details =
   An email has been sent to { $email } to verify your account.


### PR DESCRIPTION
## What does this PR do?
This PR adds more context to the "Change" buttons for email, username, and password.

## These changes will impact:

- [x] commenters
- [x] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Enable your screenreader of choice
2. In a stream, navigate to My Profile > Account
3. Tab through this pane, and when focusing on the buttons for changing email, username, and password, observe that the screen reader reads "Change email", "Change username", and "Change password", respecitively.

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations needed.
