### PR TITLE
Enable/disable data cache with feature flag

### DIFF
--- a/src/core/common/errors.ts
+++ b/src/core/common/errors.ts
@@ -425,4 +425,10 @@ export enum ERROR_CODES {
    * their username and the provided username has already been taken.
    */
   USERNAME_ALREADY_EXISTS = "USERNAME_ALREADY_EXISTS",
+
+  /**
+   * DATA_CACHING_NOT_AVAILABLE is thrown when someone tries to enact a data
+   * caching action when it is not available for that tenant.
+   */
+  DATA_CACHING_NOT_AVAILABLE = "DATA_CACHING_NOT_AVAILABLE",
 }

--- a/src/core/server/data/cache/commentCache.spec.ts
+++ b/src/core/server/data/cache/commentCache.spec.ts
@@ -44,6 +44,7 @@ const createFixtures = async (
   const commentCache = new CommentCache(
     mongo,
     redis,
+    null,
     logger,
     false,
     options?.expirySeconds ? options.expirySeconds : 5 * 60

--- a/src/core/server/data/cache/dataCache.ts
+++ b/src/core/server/data/cache/dataCache.ts
@@ -1,16 +1,41 @@
 import { MongoContext } from "coral-server/data/context";
 import { Logger } from "coral-server/logger";
+import { hasFeatureFlag } from "coral-server/models/tenant";
 import { AugmentedRedis } from "coral-server/services/redis";
-import { CommentActionsCache } from "./commentActionsCache";
+import { TenantCache } from "coral-server/services/tenant/cache";
 
+import { GQLFEATURE_FLAG } from "core/client/framework/schema/__generated__/types";
+
+import { CommentActionsCache } from "./commentActionsCache";
 import { CommentCache } from "./commentCache";
 import { UserCache } from "./userCache";
 
 export const DEFAULT_DATA_EXPIRY_SECONDS = 24 * 60 * 60;
 
-export class DataCache {
+export const dataCacheAvailable = async (
+  tenantCache: TenantCache | null,
+  tenantID: string
+): Promise<boolean> => {
+  if (!tenantCache) {
+    return false;
+  }
+
+  const tenant = await tenantCache.retrieveByID(tenantID);
+  if (!tenant) {
+    return false;
+  }
+
+  return hasFeatureFlag(tenant, GQLFEATURE_FLAG.DATA_CACHE);
+};
+
+export interface IDataCache {
+  available(tenantID: string): Promise<boolean>;
+}
+
+export class DataCache implements IDataCache {
   private mongo: MongoContext;
   private redis: AugmentedRedis;
+  private tenantCache: TenantCache;
   private logger: Logger;
 
   private expirySeconds: number;
@@ -24,18 +49,21 @@ export class DataCache {
   constructor(
     mongo: MongoContext,
     redis: AugmentedRedis,
+    tenantCache: TenantCache,
     logger: Logger,
     disableCaching?: boolean,
     expirySeconds: number = DEFAULT_DATA_EXPIRY_SECONDS
   ) {
     this.mongo = mongo;
     this.redis = redis;
+    this.tenantCache = tenantCache;
     this.logger = logger.child({ traceID: this.traceID });
     this.expirySeconds = expirySeconds;
 
     this.comments = new CommentCache(
       this.mongo,
       this.redis,
+      this.tenantCache,
       this.logger,
       Boolean(disableCaching),
       this.expirySeconds
@@ -43,14 +71,20 @@ export class DataCache {
     this.commentActions = new CommentActionsCache(
       this.mongo,
       this.redis,
+      this.tenantCache,
       this.logger,
       this.expirySeconds
     );
     this.users = new UserCache(
       this.mongo,
       this.redis,
+      this.tenantCache,
       this.logger,
       this.expirySeconds
     );
+  }
+
+  public async available(tenantID: string): Promise<boolean> {
+    return dataCacheAvailable(this.tenantCache, tenantID);
   }
 }

--- a/src/core/server/errors/index.ts
+++ b/src/core/server/errors/index.ts
@@ -999,3 +999,12 @@ export class UsernameAlreadyExists extends CoralError {
     });
   }
 }
+
+export class DataCachingNotAvailableError extends CoralError {
+  constructor(tenantID: string) {
+    super({
+      code: ERROR_CODES.DATA_CACHING_NOT_AVAILABLE,
+      context: { pub: { tenantID } },
+    });
+  }
+}

--- a/src/core/server/errors/translations.ts
+++ b/src/core/server/errors/translations.ts
@@ -77,4 +77,5 @@ export const ERROR_TRANSLATIONS: Record<ERROR_CODES, string> = {
   CANNOT_OPEN_AN_ARCHIVED_STORY: "error-cannotOpenAnArchivedStory",
   CANNOT_MERGE_AN_ARCHIVED_STORY: "error-cannotMergeAnArchivedStory",
   USERNAME_ALREADY_EXISTS: "error-usernameAlreadyExists",
+  DATA_CACHING_NOT_AVAILABLE: "error-dataCachingNotAvailable",
 };

--- a/src/core/server/graph/context.ts
+++ b/src/core/server/graph/context.ts
@@ -140,6 +140,7 @@ export default class GraphContext {
     this.cache = new DataCache(
       this.mongo,
       this.redis,
+      this.tenantCache,
       this.logger,
       this.disableCaching,
       this.config.get("redis_cache_expiry") / 1000

--- a/src/core/server/graph/loaders/Comments.ts
+++ b/src/core/server/graph/loaders/Comments.ts
@@ -19,6 +19,7 @@ import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
 import { User } from "coral-server/models/user";
 import {
   retrieveAllCommentsUserConnection,
+  retrieveChildrenForParentConnection,
   retrieveCommentConnection,
   retrieveCommentParentsConnection,
   retrieveCommentRepliesConnection,
@@ -325,8 +326,10 @@ export default (ctx: GraphContext) => ({
     }
 
     const isArchived = !!(story.isArchived || story.isArchiving);
+    const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
 
     if (
+      !cacheAvailable ||
       isRatingsAndReviews(ctx.tenant, story) ||
       isQA(ctx.tenant, story) ||
       isArchived
@@ -386,8 +389,10 @@ export default (ctx: GraphContext) => ({
     }
 
     const isArchived = !!(story.isArchived || story.isArchiving);
+    const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
 
     if (
+      !cacheAvailable ||
       isRatingsAndReviews(ctx.tenant, story) ||
       isQA(ctx.tenant, story) ||
       isArchived
@@ -454,6 +459,20 @@ export default (ctx: GraphContext) => ({
     const story = await ctx.loaders.Stories.story.load(comment.storyID);
     if (!story) {
       throw new StoryNotFoundError(comment.storyID);
+    }
+
+    const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
+    if (!cacheAvailable) {
+      return retrieveChildrenForParentConnection(
+        ctx.mongo,
+        ctx.tenant.id,
+        comment,
+        {
+          first: 9999,
+          orderBy: defaultTo(orderBy, GQLCOMMENT_SORT.CREATED_AT_ASC),
+        },
+        story.isArchived
+      ).then(primeCommentsFromConnection(ctx));
     }
 
     const conn = await ctx.cache.comments.allChildComments(

--- a/src/core/server/graph/mutators/Stories.ts
+++ b/src/core/server/graph/mutators/Stories.ts
@@ -1,7 +1,10 @@
 import { isNull, omitBy } from "lodash";
 
 import { ERROR_CODES } from "coral-common/errors";
-import { StoryNotFoundError } from "coral-server/errors";
+import {
+  DataCachingNotAvailableError,
+  StoryNotFoundError,
+} from "coral-server/errors";
 import GraphContext from "coral-server/graph/context";
 import { mapFieldsetToErrorCodes } from "coral-server/graph/errors";
 import { initializeCommentTagCountsForStory } from "coral-server/models/comment";
@@ -195,6 +198,11 @@ export const Stories = (ctx: GraphContext) => ({
     }
   },
   cacheStory: async (input: GQLCacheStoryInput) => {
+    const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
+    if (!cacheAvailable) {
+      throw new DataCachingNotAvailableError(ctx.tenant.id);
+    }
+
     const story = await ctx.loaders.Stories.find.load({ id: input.id });
     if (!story) {
       throw new StoryNotFoundError(input.id);
@@ -208,6 +216,11 @@ export const Stories = (ctx: GraphContext) => ({
     return story;
   },
   invalidateCachedStory: async (input: GQLCacheStoryInput) => {
+    const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
+    if (!cacheAvailable) {
+      throw new DataCachingNotAvailableError(ctx.tenant.id);
+    }
+
     const story = await ctx.loaders.Stories.find.load({ id: input.id });
     if (!story) {
       throw new StoryNotFoundError(input.id);

--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -561,6 +561,12 @@ enum FEATURE_FLAG {
   an external profile for a user.
   """
   CONFIGURE_PUBLIC_PROFILE_URL
+
+  """
+  DATA_CACHE will allow the use of the data cache to store and load comments,
+  users, and commentActions more quickly. It is disabled by default.
+  """
+  DATA_CACHE
 }
 
 # The moderation mode of the site.

--- a/src/core/server/locales/en-US/errors.ftl
+++ b/src/core/server/locales/en-US/errors.ftl
@@ -77,3 +77,4 @@ error-cannotCreateCommentOnArchivedStory = Cannot create a comment on an archive
 error-cannotOpenAnArchivedStory = Cannot open an archived story. The story must be unarchived first.
 error-cannotMergeAnArchivedStory = Cannot merge an archived story. The story must be unarchived first.
 error-usernameAlreadyExists = This username already exists. Please choose another.
+error-dataCachingNotAvailable = Data caching is not available at this time.

--- a/src/core/server/queue/tasks/loadCache.ts
+++ b/src/core/server/queue/tasks/loadCache.ts
@@ -46,6 +46,7 @@ const createJobProcessor =
     const { comments, commentActions, users } = new DataCache(
       mongo,
       redis,
+      tenantCache,
       log,
       false,
       config.get("redis_cache_expiry") / 1000

--- a/src/core/server/queue/tasks/loadCache.ts
+++ b/src/core/server/queue/tasks/loadCache.ts
@@ -1,7 +1,10 @@
 import { QueueOptions } from "bull";
 
 import { Config } from "coral-server/config";
-import { DataCache } from "coral-server/data/cache/dataCache";
+import {
+  DataCache,
+  dataCacheAvailable,
+} from "coral-server/data/cache/dataCache";
 import { MongoContext } from "coral-server/data/context";
 import { createTimer } from "coral-server/helpers";
 import logger from "coral-server/logger";
@@ -41,6 +44,15 @@ const createJobProcessor =
       },
       true
     );
+
+    const cacheAvailable = await dataCacheAvailable(tenantCache, tenantID);
+    if (!cacheAvailable) {
+      log.info(
+        { tenantID },
+        "skipping load cache as caching is not enabled on tenant"
+      );
+      return;
+    }
 
     const timer = createTimer();
     const { comments, commentActions, users } = new DataCache(

--- a/src/core/server/queue/tasks/rejector.ts
+++ b/src/core/server/queue/tasks/rejector.ts
@@ -223,6 +223,7 @@ const createJobProcessor =
     const cache = new DataCache(
       mongo,
       redis,
+      tenantCache,
       log,
       false,
       config.get("redis_cache_expiry") / 1000

--- a/src/core/server/services/comments/actions.ts
+++ b/src/core/server/services/comments/actions.ts
@@ -240,8 +240,11 @@ export async function removeCommentAction(
       throw new Error("could not update comment action counts");
     }
 
-    await cache.commentActions.remove(action);
-    await cache.comments.update(updatedComment);
+    const cacheAvailable = await cache.available(tenant.id);
+    if (cacheAvailable) {
+      await cache.commentActions.remove(action);
+      await cache.comments.update(updatedComment);
+    }
 
     // Update the comment counts onto other documents.
     const counts = await updateAllCommentCounts(mongo, redis, {
@@ -294,8 +297,11 @@ export async function createReaction(
     now
   );
   if (action) {
-    await cache.commentActions.add(action);
-    await cache.comments.update(comment);
+    const cacheAvailable = await cache.available(tenant.id);
+    if (cacheAvailable) {
+      await cache.commentActions.add(action);
+      await cache.comments.update(comment);
+    }
 
     // A comment reaction was created! Publish it.
     publishCommentReactionCreated(
@@ -363,7 +369,8 @@ export async function createDontAgree(
     now
   );
 
-  if (action) {
+  const cacheAvailable = await commentActionsCache.available(tenant.id);
+  if (action && cacheAvailable) {
     await commentActionsCache.add(action);
   }
 
@@ -426,7 +433,8 @@ export async function createFlag(
     now
   );
   if (action) {
-    if (action) {
+    const cacheAvailable = await commentActionsCache.available(tenant.id);
+    if (cacheAvailable) {
       await commentActionsCache.add(action);
     }
 

--- a/src/core/server/services/stories/index.ts
+++ b/src/core/server/services/stories/index.ts
@@ -147,10 +147,12 @@ export async function findOrCreate(
     });
   }
 
-  const storyIsCached = await cache.isCached(tenant.id, story.id);
-
-  if (!storyIsCached && !story.isArchived && !story.isArchiving) {
-    await queue.add({ tenantID: tenant.id, storyID: story.id });
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    const storyIsCached = await cache.isCached(tenant.id, story.id);
+    if (!storyIsCached && !story.isArchived && !story.isArchiving) {
+      await queue.add({ tenantID: tenant.id, storyID: story.id });
+    }
   }
 
   if (tenant.stories.scraping.enabled && !story.metadata && !story.scrapedAt) {

--- a/src/core/server/stacks/approveComment.ts
+++ b/src/core/server/stacks/approveComment.ts
@@ -67,9 +67,12 @@ const approveComment = async (
     });
   }
 
-  await cache.comments.update(result.after);
-  if (result.after.authorID) {
-    await cache.users.populateUsers(tenant.id, [result.after.authorID]);
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.comments.update(result.after);
+    if (result.after.authorID) {
+      await cache.users.populateUsers(tenant.id, [result.after.authorID]);
+    }
   }
 
   // Return the resulting comment.

--- a/src/core/server/stacks/createComment.ts
+++ b/src/core/server/stacks/createComment.ts
@@ -443,16 +443,19 @@ export default async function create(
     after: comment,
   });
 
-  await cache.comments.update(comment);
-  if (comment.authorID) {
-    await cache.users.populateUsers(tenant.id, [comment.authorID]);
-  }
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.comments.update(comment);
+    if (comment.authorID) {
+      await cache.users.populateUsers(tenant.id, [comment.authorID]);
+    }
 
-  if (parent) {
-    await cache.comments.update(parent);
+    if (parent) {
+      await cache.comments.update(parent);
 
-    if (parent.authorID) {
-      await cache.users.populateUsers(tenant.id, [parent.authorID]);
+      if (parent.authorID) {
+        await cache.users.populateUsers(tenant.id, [parent.authorID]);
+      }
     }
   }
 

--- a/src/core/server/stacks/editComment.ts
+++ b/src/core/server/stacks/editComment.ts
@@ -273,9 +273,12 @@ export default async function edit(
     ...result,
   });
 
-  await cache.comments.update(result.after);
-  if (result.after.authorID) {
-    await cache.users.populateUsers(tenant.id, [result.after.authorID]);
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.comments.update(result.after);
+    if (result.after.authorID) {
+      await cache.users.populateUsers(tenant.id, [result.after.authorID]);
+    }
   }
 
   // Publish changes to the event publisher.

--- a/src/core/server/stacks/rejectComment.ts
+++ b/src/core/server/stacks/rejectComment.ts
@@ -101,7 +101,10 @@ const rejectComment = async (
     return tagResult;
   }
 
-  await cache.comments.remove(result.after);
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.comments.remove(result.after);
+  }
 
   // Return the resulting comment.
   return result.after;


### PR DESCRIPTION
## What does this PR do?

Allows the enabling and disabling of the redis data cache via the feature flag `DATA_CACHE`. It is **OFF** by default.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds the `DATA_CACHE` feature flag to the `FEATURE_FLAGS` type.

## Does this PR introduce any new environment variables or feature flags?

Adds the `DATA_CACHE` feature flag.

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- connect to your redis and flush keys via:
    - `docker exec -it redis redis-cli`
    - `FLUSHALL`
- start up Coral with `npm run start:development:withJobs`
- navigate to a stream with comments
- in your redis-cli execute `KEYS *`
    - see that there are no redis data cache keys like:
        - `<tenantID>:<storyID>:lock`
        - `<tenantID>:<storyID>:<commentID>:data`
        -  etc
- enable the data cache  via the `enableFeatureFlag` mutation

```
mutation EnableFeatureFlagMutation($featureFlag: FEATURE_FLAG!) {
	enableFeatureFlag(input: { flag: $featureFlag, clientMutationId: "1" }) {
		flags
	}
}
```
Query variables:
```
{
	"featureFlag": "DATA_CACHE"
}
```

- you may want to restart Coral, but it should be fine
- navigate to a stream with comments
- in your redis-cli execute `KEYS *`
    - see that there are now lots of redis data cache keys like:
        - `<tenantID>:<storyID>:lock`
        - `<tenantID>:<storyID>:<commentID>:data`
        -  etc
- disable the data cache  via the `disableFeatureFlag` mutation

```
mutation DisableFeatureFlagMutation($featureFlag: FEATURE_FLAG!) {
	disableFeatureFlag(input: { flag: $featureFlag, clientMutationId: "1" }) {
		flags
	}
}
```
Query variables:
```
{
	"featureFlag": "DATA_CACHE"
}
```

- clear redis with a `FLUSHALL`
- navigate to a stream with comments
- in your redis-cli execute `KEYS *`
    - see that there are no redis data cache keys like:
        - `<tenantID>:<storyID>:lock`
        - `<tenantID>:<storyID>:<commentID>:data`
        -  etc

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
