### PR TITLE
[CORL-2819]: Update comments links to better work with customScrollContainer

### DIFF
--- a/src/core/client/stream/common/scrollToBeginning.ts
+++ b/src/core/client/stream/common/scrollToBeginning.ts
@@ -6,11 +6,12 @@ function scrollToBeginning(
   customScrollContainer?: HTMLElement
 ) {
   const tab = root.getElementById("tab-COMMENTS");
-  const scrollContainer = customScrollContainer ?? window;
   if (tab) {
-    scrollContainer.scrollTo({
-      top: getElementWindowTopOffset(scrollContainer, tab),
-    });
+    if (customScrollContainer) {
+      tab.scrollIntoView();
+    } else {
+      window.scrollTo({ top: getElementWindowTopOffset(window, tab) });
+    }
   }
 }
 

--- a/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
@@ -48,8 +48,11 @@ const CommentsLinks: FunctionComponent<Props> = ({
   const { renderWindow, customScrollContainer } = useCoralContext();
   const root = useShadowRootOrDocument();
   const onGoToArticleTop = useCallback(() => {
+    if (customScrollContainer) {
+      customScrollContainer.scrollTo({ top: 0 });
+    }
     renderWindow.scrollTo({ top: 0 });
-  }, [renderWindow]);
+  }, [renderWindow, customScrollContainer]);
   const onGoToCommentsTop = useCallback(() => {
     scrollToBeginning(root, renderWindow, customScrollContainer);
   }, [root, renderWindow, customScrollContainer]);

--- a/src/core/client/ui/helpers/getElementWindowTopOffset.ts
+++ b/src/core/client/ui/helpers/getElementWindowTopOffset.ts
@@ -1,11 +1,7 @@
 /**
  * Get elements top offset relative to the window.
  */
-function getElementWindowTopOffset(
-  window: Window | React.RefObject<any>["current"],
-  element: Element
-) {
-  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+function getElementWindowTopOffset(window: Window, element: Element) {
   return element.getBoundingClientRect().top + window.scrollY;
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR updates the comments links (`Top of comments` and `Top of article`) to better handle scrolling to the correct place when there is a custom scroll container.

There is one assumption that we're making, which is that a `customScrollContainer` would encompass the article, and that going to the top of it would take someone to the top of the article. This seems like what we would expect.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

n/a

## If any indexes were added, were they added to `INDEXES.md`?

none

## How do I test this PR?

Everything should still work as expected when there is no `customScrollContainer` with these links. Run the app and then click `Top of comments` and `Top of article` on a story and see that they work as expected.

Also reach out to me and I can walk you through verifying that it works with it in a few places where `customScrollContainer` is used.

## Where any tests migrated to React Testing Library?

no

## How do we deploy this PR?

