### PR TITLE
[CORL-2818] ban shortcut fix

### DIFF
--- a/src/core/client/admin/components/BanModalQuery.tsx
+++ b/src/core/client/admin/components/BanModalQuery.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable */
+import { FunctionComponent } from "react";
+import BanModal from "./BanModal";
+import { withFragmentContainer } from "coral-framework/lib/relay";
+import { QueryRenderer, graphql } from "react-relay";
+
+import { QueryTypes } from "coral-admin/__generated__/BanModalQuery"
+
+export interface Props {
+  user: BanModalContainer_user;
+  viewer: BanModalContainer_viewer;
+  settings: BanModalContainer_settings;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const BanModalContainer: FunctionComponent<Props> = ({
+  viewer,
+  user,
+  settings,
+  onClose,
+  onConfirm
+}) => {
+  return (
+    <QueryRenderer<QueryTypes>
+      query={graphql`
+        query BanModalQuery($userID: ID!) {
+          user(id: $userID) {
+            id
+            username
+            email
+            role
+            status {
+              ban {
+                active
+                sites {
+                  id
+                  name
+                }
+              }
+            }
+          }
+          settings {
+            multisite
+            emailDomainModeration {
+              domain
+              newUserModeration
+            }
+          }
+          viewer {
+            id
+            role
+            moderationScopes {
+              scoped
+              sites {
+                id
+                name
+              }
+              siteIDs
+            }
+          }
+        }
+      `}
+    />
+  );
+  return (
+    <>
+      <BanModal
+        userID={user.id}
+        username={user.username}
+        open={true}
+        onClose={onClose}
+        onConfirm={onConfirm}
+        viewer={viewer as unknown as UserStatusChangeContainer_viewer}
+        emailDomainModeration={settings.emailDomainModeration}
+        userBanStatus={user.status.ban}
+        userEmail={user.email}
+        userRole={user.role}
+        isMultisite={settings.multisite}
+      />
+    </>
+  );
+}

--- a/src/core/client/admin/components/BanModalQuery.tsx
+++ b/src/core/client/admin/components/BanModalQuery.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 import BanModal from "./BanModal";
@@ -62,10 +63,12 @@ const BanModalQuery: FunctionComponent<Props> = ({
         userID,
       }}
       render={({ error, props }) => {
+        console.log("gonna render this", { error, props });
         if (error) {
           return <QueryError error={error} />;
         }
         if (!props || !props.settings || !props.user || !props.viewer) {
+          console.log("missing one of these", { props })
           return null;
         }
         return (

--- a/src/core/client/admin/components/BanModalQuery.tsx
+++ b/src/core/client/admin/components/BanModalQuery.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 import BanModal from "./BanModal";
@@ -63,12 +62,10 @@ const BanModalQuery: FunctionComponent<Props> = ({
         userID,
       }}
       render={({ error, props }) => {
-        console.log("gonna render this", { error, props });
         if (error) {
           return <QueryError error={error} />;
         }
         if (!props || !props.settings || !props.user || !props.viewer) {
-          console.log("missing one of these", { props })
           return null;
         }
         return (

--- a/src/core/client/admin/components/BanModalQuery.tsx
+++ b/src/core/client/admin/components/BanModalQuery.tsx
@@ -1,25 +1,22 @@
-/* eslint-disable */
-import { FunctionComponent } from "react";
+import React, { FunctionComponent } from "react";
+import { graphql } from "react-relay";
 import BanModal from "./BanModal";
-import { withFragmentContainer } from "coral-framework/lib/relay";
-import { QueryRenderer, graphql } from "react-relay";
 
-import { QueryTypes } from "coral-admin/__generated__/BanModalQuery"
+import { BanModalQuery as QueryTypes } from "coral-admin/__generated__/BanModalQuery.graphql";
+import { UserStatusChangeContainer_viewer } from "coral-admin/__generated__/UserStatusChangeContainer_viewer.graphql";
+import { QueryRenderer } from "coral-framework/lib/relay";
+import { QueryError } from "coral-ui/components/v3";
 
 export interface Props {
-  user: BanModalContainer_user;
-  viewer: BanModalContainer_viewer;
-  settings: BanModalContainer_settings;
+  userID: string;
   onClose: () => void;
   onConfirm: () => void;
 }
 
-const BanModalContainer: FunctionComponent<Props> = ({
-  viewer,
-  user,
-  settings,
+const BanModalQuery: FunctionComponent<Props> = ({
+  userID,
   onClose,
-  onConfirm
+  onConfirm,
 }) => {
   return (
     <QueryRenderer<QueryTypes>
@@ -61,23 +58,38 @@ const BanModalContainer: FunctionComponent<Props> = ({
           }
         }
       `}
+      variables={{
+        userID,
+      }}
+      render={({ error, props }) => {
+        if (error) {
+          return <QueryError error={error} />;
+        }
+        if (!props || !props.settings || !props.user || !props.viewer) {
+          return null;
+        }
+        return (
+          <>
+            <BanModal
+              userID={props.user.id}
+              username={props.user.username}
+              open={true}
+              onClose={onClose}
+              onConfirm={onConfirm}
+              viewer={
+                props.viewer as unknown as UserStatusChangeContainer_viewer
+              }
+              emailDomainModeration={props.settings.emailDomainModeration}
+              userBanStatus={props.user.status.ban}
+              userEmail={props.user.email}
+              userRole={props.user.role}
+              isMultisite={props.settings.multisite}
+            />
+          </>
+        );
+      }}
     />
   );
-  return (
-    <>
-      <BanModal
-        userID={user.id}
-        username={user.username}
-        open={true}
-        onClose={onClose}
-        onConfirm={onConfirm}
-        viewer={viewer as unknown as UserStatusChangeContainer_viewer}
-        emailDomainModeration={settings.emailDomainModeration}
-        userBanStatus={user.status.ban}
-        userEmail={user.email}
-        userRole={user.role}
-        isMultisite={settings.multisite}
-      />
-    </>
-  );
-}
+};
+
+export default BanModalQuery;

--- a/src/core/client/admin/components/BanModalQuery.tsx
+++ b/src/core/client/admin/components/BanModalQuery.tsx
@@ -1,11 +1,13 @@
 import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
-import BanModal from "./BanModal";
+
+import { QueryRenderer } from "coral-framework/lib/relay";
+import { QueryError } from "coral-ui/components/v3";
 
 import { BanModalQuery as QueryTypes } from "coral-admin/__generated__/BanModalQuery.graphql";
 import { UserStatusChangeContainer_viewer } from "coral-admin/__generated__/UserStatusChangeContainer_viewer.graphql";
-import { QueryRenderer } from "coral-framework/lib/relay";
-import { QueryError } from "coral-ui/components/v3";
+
+import BanModal from "./BanModal";
 
 export interface Props {
   userID: string;

--- a/src/core/client/admin/components/ModerateCard/ModerateCard.spec.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCard.spec.tsx
@@ -25,7 +25,6 @@ const baseProps: PropTypesOf<typeof ModerateCardN> = {
   onApprove: noop,
   onReject: noop,
   onFeature: noop,
-  onBan: noop,
   onUsernameClick: noop,
   onFocusOrClick: noop,
   onConversationClick: noop,

--- a/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable */
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
+import key from "keymaster";
 import React, {
   FunctionComponent,
   useCallback,
@@ -30,7 +32,9 @@ import FeatureButton from "./FeatureButton";
 import MarkersContainer from "./MarkersContainer";
 import RejectButton from "./RejectButton";
 
+import { HOTKEYS } from "coral-admin/constants";
 import styles from "./ModerateCard.css";
+import { noop } from "lodash";
 
 interface Props {
   id: string;
@@ -121,8 +125,6 @@ const ModerateCard: FunctionComponent<Props> = ({
   deleted = false,
   readOnly = false,
   edited,
-  selectNext,
-  selectPrev,
   isQA,
   bannedWords,
   suspectWords,

--- a/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
@@ -80,7 +80,6 @@ interface Props {
   edited: boolean;
   selectPrev?: () => void;
   selectNext?: () => void;
-  onBan: () => void;
   isQA?: boolean;
   rating?: number | null;
 
@@ -124,7 +123,6 @@ const ModerateCard: FunctionComponent<Props> = ({
   edited,
   selectNext,
   selectPrev,
-  onBan,
   isQA,
   bannedWords,
   suspectWords,

--- a/src/core/client/admin/components/ModerateCard/ModerateCardContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCardContainer.tsx
@@ -3,10 +3,6 @@ import React, { FunctionComponent, useCallback, useMemo } from "react";
 import { graphql } from "react-relay";
 
 import NotAvailable from "coral-admin/components/NotAvailable";
-import {
-  ApproveCommentMutation,
-  RejectCommentMutation,
-} from "coral-admin/mutations";
 import FadeInTransition from "coral-framework/components/FadeInTransition";
 import { getModerationLink } from "coral-framework/helpers";
 import parseModerationOptions from "coral-framework/helpers/parseModerationOptions";
@@ -45,6 +41,8 @@ interface Props {
   selectPrev?: () => void;
   selectNext?: () => void;
   loadNext?: (() => void) | null;
+  handleReject: () => void;
+  handleApprove: () => void;
 }
 
 function getStatus(comment: ModerateCardContainer_comment) {
@@ -77,9 +75,9 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
   onConversationClicked: conversationClicked,
   onSetSelected: setSelected,
   loadNext,
+  handleReject,
+  handleApprove,
 }) => {
-  const approveComment = useMutation(ApproveCommentMutation);
-  const rejectComment = useMutation(RejectCommentMutation);
   const featureComment = useMutation(FeatureCommentMutation);
   const unfeatureComment = useMutation(UnfeatureCommentMutation);
 
@@ -98,70 +96,6 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
     () => scoped && !comment.canModerate,
     [scoped, comment]
   );
-
-  const handleApprove = useCallback(async () => {
-    if (!comment.revision) {
-      return;
-    }
-
-    if (readOnly) {
-      return;
-    }
-
-    const { storyID, siteID, section } = parseModerationOptions(match);
-
-    await approveComment({
-      commentID: comment.id,
-      commentRevisionID: comment.revision.id,
-      storyID,
-      siteID,
-      section,
-      orderBy: moderationQueueSort,
-    });
-    if (loadNext) {
-      loadNext();
-    }
-  }, [
-    approveComment,
-    comment.id,
-    comment.revision,
-    loadNext,
-    match,
-    readOnly,
-    moderationQueueSort,
-  ]);
-
-  const handleReject = useCallback(async () => {
-    if (!comment.revision) {
-      return;
-    }
-
-    if (readOnly) {
-      return;
-    }
-
-    const { storyID, siteID, section } = parseModerationOptions(match);
-
-    await rejectComment({
-      commentID: comment.id,
-      commentRevisionID: comment.revision.id,
-      storyID,
-      siteID,
-      section,
-      orderBy: moderationQueueSort,
-    });
-    if (loadNext) {
-      loadNext();
-    }
-  }, [
-    comment.revision,
-    comment.id,
-    readOnly,
-    match,
-    rejectComment,
-    loadNext,
-    moderationQueueSort,
-  ]);
 
   const handleFeature = useCallback(() => {
     if (!comment.revision) {

--- a/src/core/client/admin/components/ModerateCard/ModerateCardContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCardContainer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { useRouter } from "found";
 import React, {
   FunctionComponent,
@@ -349,25 +350,6 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
           isArchiving={comment.story.isArchiving}
         />
       </FadeInTransition>
-      {comment.author && (
-        <BanModal
-          userID={comment.author.id}
-          username={
-            comment.author && comment.author.username
-              ? comment.author.username
-              : ""
-          }
-          open={showBanModal}
-          onClose={handleBanModalClose}
-          onConfirm={handleBanConfirm}
-          viewer={viewer as unknown as UserStatusChangeContainer_viewer}
-          emailDomainModeration={settings.emailDomainModeration}
-          userBanStatus={comment.author.status.ban}
-          userEmail={comment.author.email}
-          userRole={comment.author.role}
-          isMultisite={settings.multisite}
-        />
-      )}
     </>
   );
 };

--- a/src/core/client/admin/components/ModerateCard/ModerateCardContainer.tsx
+++ b/src/core/client/admin/components/ModerateCard/ModerateCardContainer.tsx
@@ -1,14 +1,7 @@
-/* eslint-disable */
 import { useRouter } from "found";
-import React, {
-  FunctionComponent,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
+import React, { FunctionComponent, useCallback, useMemo } from "react";
 import { graphql } from "react-relay";
 
-import BanModal from "coral-admin/components/BanModal";
 import NotAvailable from "coral-admin/components/NotAvailable";
 import {
   ApproveCommentMutation,
@@ -22,7 +15,7 @@ import {
   useMutation,
   withFragmentContainer,
 } from "coral-framework/lib/relay";
-import { GQLSTORY_MODE, GQLTAG, GQLUSER_STATUS } from "coral-framework/schema";
+import { GQLSTORY_MODE, GQLTAG } from "coral-framework/schema";
 
 import {
   COMMENT_STATUS,
@@ -32,7 +25,6 @@ import { ModerateCardContainer_settings } from "coral-admin/__generated__/Modera
 import { ModerateCardContainer_viewer } from "coral-admin/__generated__/ModerateCardContainer_viewer.graphql";
 import { ModerateCardContainerLocal } from "coral-admin/__generated__/ModerateCardContainerLocal.graphql";
 
-import { UserStatusChangeContainer_viewer } from "coral-admin/__generated__/UserStatusChangeContainer_viewer.graphql";
 import FeatureCommentMutation from "./FeatureCommentMutation";
 import ModerateCard from "./ModerateCard";
 import ModeratedByContainer from "./ModeratedByContainer";
@@ -107,7 +99,6 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
     [scoped, comment]
   );
 
-  const [showBanModal, setShowBanModal] = useState(false);
   const handleApprove = useCallback(async () => {
     if (!comment.revision) {
       return;
@@ -250,23 +241,6 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
     }
   }, [setSelected]);
 
-  const handleBanModalClose = useCallback(() => {
-    setShowBanModal(false);
-  }, [setShowBanModal]);
-
-  const openBanModal = useCallback(() => {
-    if (
-      !comment.author ||
-      comment.author.status.current.includes(GQLUSER_STATUS.BANNED)
-    ) {
-      return;
-    }
-
-    setShowBanModal(true);
-  }, [comment, setShowBanModal]);
-
-  const handleBanConfirm = useCallback(() => setShowBanModal(false), []);
-
   // Only highlight comments that have been flagged for containing a banned or
   // suspect word.
   const highlight = useMemo(() => {
@@ -320,7 +294,6 @@ const ModerateCardContainer: FunctionComponent<Props> = ({
           selectPrev={selectPrev}
           selectNext={selectNext}
           siteName={settings.multisite ? comment.site.name : null}
-          onBan={openBanModal}
           moderatedBy={
             <ModeratedByContainer
               onUsernameClicked={onUsernameClicked}

--- a/src/core/client/admin/routes/Moderate/Queue/ApprovedQueueRoute.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/ApprovedQueueRoute.tsx
@@ -131,6 +131,7 @@ const enhanced = withPaginationContainer<
             node {
               id
               author {
+              revision {
                 id
               }
               ...ModerateCardContainer_comment

--- a/src/core/client/admin/routes/Moderate/Queue/ApprovedQueueRoute.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/ApprovedQueueRoute.tsx
@@ -130,6 +130,9 @@ const enhanced = withPaginationContainer<
           edges {
             node {
               id
+              author {
+                id
+              }
               ...ModerateCardContainer_comment
             }
           }

--- a/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { Localized } from "@fluent/react/compat";
 import key from "keymaster";
 import { noop } from "lodash";
@@ -69,7 +68,6 @@ const Queue: FunctionComponent<Props> = ({
     useState(false);
   const [conversationCommentID, setConversationCommentID] = useState("");
   const memoize = useMemoizer();
-  console.log("Main: selected comment = ", selectedComment);
 
   const toggleView = useCallback(() => {
     if (!singleView) {
@@ -171,8 +169,6 @@ const Queue: FunctionComponent<Props> = ({
     setConversationModalVisible(false);
     setConversationCommentID("");
   }, []);
-
-  console.log(selectedComment, comments[selectedComment!]?.author?.id);
 
   return (
     <HorizontalGutter className={styles.root} size="double">

--- a/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
@@ -109,9 +109,12 @@ const Queue: FunctionComponent<Props> = ({
     }
   }, [window.document]);
 
+  const ban = useCallback(() => {});
+
   useEffect(() => {
     key(HOTKEYS.NEXT, QUEUE_HOTKEY_ID, selectNext);
     key(HOTKEYS.PREV, QUEUE_HOTKEY_ID, selectPrev);
+    key(HOTKEYS.BAN, QUEUE_HOTKEY_ID, ban);
 
     // The the scope such that only events attached to the ${id} scope will
     // be honored.

--- a/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
@@ -26,7 +26,7 @@ import QueueWrapper from "./QueueWrapper";
 
 import styles from "./Queue.css";
 
-type CommentType = { id: string; author: { id: string } } & PropTypesOf<
+type CommentType = { id: string; author: { id: string } | null } & PropTypesOf<
   typeof ModerateCardContainer
 >["comment"];
 
@@ -69,6 +69,7 @@ const Queue: FunctionComponent<Props> = ({
     useState(false);
   const [conversationCommentID, setConversationCommentID] = useState("");
   const memoize = useMemoizer();
+  console.log("Main: selected comment = ", selectedComment);
 
   const toggleView = useCallback(() => {
     if (!singleView) {
@@ -115,9 +116,13 @@ const Queue: FunctionComponent<Props> = ({
   }, [window.document]);
 
   const ban = useCallback(() => {
-    console.log("SHJOW BAND");
-    setShowBanModal(!showBanModal);
-  }, [showBanModal]);
+    if (selectedComment === -1) {
+      console.log("do not show modal", selectedComment)
+      return;
+    }
+    console.log("show modal!");
+    setShowBanModal(true);
+  }, [showBanModal, selectedComment]);
 
   useEffect(() => {
     key(HOTKEYS.NEXT, QUEUE_HOTKEY_ID, selectNext);
@@ -167,7 +172,7 @@ const Queue: FunctionComponent<Props> = ({
     setConversationCommentID("");
   }, []);
 
-  console.log(selectedComment, comments[selectedComment!]);
+  console.log(selectedComment, comments[selectedComment!]?.author?.id);
 
   return (
     <HorizontalGutter className={styles.root} size="double">
@@ -227,10 +232,10 @@ const Queue: FunctionComponent<Props> = ({
         onClose={onHideConversationModal}
         commentID={conversationCommentID}
       />
-      {selectedComment && selectedComment > -1 && showBanModal && (
+      {selectedComment && selectedComment > -1 && showBanModal && !!comments[selectedComment].author?.id && (
         <BanModalQuery
-          userID={comments[selectedComment].author.id}
-          onClose={() => alert("TODO: HOOKU CLODSE")}
+          userID={comments[selectedComment].author!.id}
+          onClose={() => setShowBanModal(false)}
           onConfirm={() => {
             alert("TODO: HOOKUP CONFIRM");
           }}

--- a/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
@@ -117,12 +117,12 @@ const Queue: FunctionComponent<Props> = ({
 
   const ban = useCallback(() => {
     if (selectedComment === -1) {
-      console.log("do not show modal", selectedComment)
       return;
     }
-    console.log("show modal!");
     setShowBanModal(true);
   }, [showBanModal, selectedComment]);
+
+  useEffect(() => setShowBanModal(false), [selectedComment]);
 
   useEffect(() => {
     key(HOTKEYS.NEXT, QUEUE_HOTKEY_ID, selectNext);
@@ -139,7 +139,7 @@ const Queue: FunctionComponent<Props> = ({
     };
 
     return noop;
-  }, [selectNext, selectPrev]);
+  }, [selectNext, selectPrev, ban]);
 
   const onSetUserDrawerUserID = useCallback((userID: string) => {
     setUserDrawerID(userID);
@@ -232,13 +232,11 @@ const Queue: FunctionComponent<Props> = ({
         onClose={onHideConversationModal}
         commentID={conversationCommentID}
       />
-      {selectedComment && selectedComment > -1 && showBanModal && !!comments[selectedComment].author?.id && (
+      {showBanModal && (
         <BanModalQuery
-          userID={comments[selectedComment].author!.id}
+          userID={comments[selectedComment!].author!.id}
           onClose={() => setShowBanModal(false)}
-          onConfirm={() => {
-            alert("TODO: HOOKUP CONFIRM");
-          }}
+          onConfirm={() => setShowBanModal(false)}
         />
       )}
     </HorizontalGutter>

--- a/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/Queue.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import { Localized } from "@fluent/react/compat";
 import key from "keymaster";
 import { noop } from "lodash";
@@ -10,6 +11,7 @@ import React, {
 } from "react";
 
 import AutoLoadMore from "coral-admin/components/AutoLoadMore";
+import BanModalQuery from "coral-admin/components/BanModalQuery";
 import ConversationModal from "coral-admin/components/ConversationModal";
 import ModerateCardContainer from "coral-admin/components/ModerateCard";
 import UserHistoryDrawer from "coral-admin/components/UserHistoryDrawer";
@@ -24,10 +26,12 @@ import QueueWrapper from "./QueueWrapper";
 
 import styles from "./Queue.css";
 
+type CommentType = { id: string; author: { id: string } } & PropTypesOf<
+  typeof ModerateCardContainer
+>["comment"];
+
 interface Props {
-  comments: Array<
-    { id: string } & PropTypesOf<typeof ModerateCardContainer>["comment"]
-  >;
+  comments: CommentType[];
   settings: PropTypesOf<typeof ModerateCardContainer>["settings"];
   viewer: PropTypesOf<typeof ModerateCardContainer>["viewer"];
   onLoadMore: () => void;
@@ -57,6 +61,7 @@ const Queue: FunctionComponent<Props> = ({
 }) => {
   const { window } = useCoralContext();
   const [userDrawerVisible, setUserDrawerVisible] = useState(false);
+  const [showBanModal, setShowBanModal] = useState(false);
   const [userDrawerId, setUserDrawerID] = useState("");
   const [selectedComment, setSelectedComment] = useState<number | null>(-1);
   const [singleView, setSingleView] = useState(false);
@@ -109,7 +114,10 @@ const Queue: FunctionComponent<Props> = ({
     }
   }, [window.document]);
 
-  const ban = useCallback(() => {});
+  const ban = useCallback(() => {
+    console.log("SHJOW BAND");
+    setShowBanModal(!showBanModal);
+  }, [showBanModal]);
 
   useEffect(() => {
     key(HOTKEYS.NEXT, QUEUE_HOTKEY_ID, selectNext);
@@ -158,6 +166,8 @@ const Queue: FunctionComponent<Props> = ({
     setConversationModalVisible(false);
     setConversationCommentID("");
   }, []);
+
+  console.log(selectedComment, comments[selectedComment!]);
 
   return (
     <HorizontalGutter className={styles.root} size="double">
@@ -217,6 +227,15 @@ const Queue: FunctionComponent<Props> = ({
         onClose={onHideConversationModal}
         commentID={conversationCommentID}
       />
+      {selectedComment && selectedComment > -1 && showBanModal && (
+        <BanModalQuery
+          userID={comments[selectedComment].author.id}
+          onClose={() => alert("TODO: HOOKU CLODSE")}
+          onConfirm={() => {
+            alert("TODO: HOOKUP CONFIRM");
+          }}
+        />
+      )}
     </HorizontalGutter>
   );
 };

--- a/src/core/client/admin/routes/Moderate/Queue/QueueRoute.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/QueueRoute.tsx
@@ -290,6 +290,9 @@ const createQueueRoute = (
                   author {
                     id
                   }
+                  revision {
+                    id
+                  }
                   ...ModerateCardContainer_comment
                 }
               }

--- a/src/core/client/admin/routes/Moderate/Queue/QueueRoute.tsx
+++ b/src/core/client/admin/routes/Moderate/Queue/QueueRoute.tsx
@@ -287,6 +287,9 @@ const createQueueRoute = (
               edges {
                 node {
                   id
+                  author {
+                    id
+                  }
                   ...ModerateCardContainer_comment
                 }
               }

--- a/src/core/client/admin/routes/Moderate/SingleModerate/SingleModerateRoute.tsx
+++ b/src/core/client/admin/routes/Moderate/SingleModerate/SingleModerateRoute.tsx
@@ -59,6 +59,9 @@ const enhanced = withRouteConfig<Props, SingleModerateRouteQueryResponse>({
     query SingleModerateRouteQuery($commentID: ID!) {
       comment(id: $commentID) {
         id
+        author {
+          id
+        }
         ...ModerateCardContainer_comment
       }
       settings {

--- a/src/core/client/admin/routes/Moderate/SingleModerate/SingleModerateRoute.tsx
+++ b/src/core/client/admin/routes/Moderate/SingleModerate/SingleModerateRoute.tsx
@@ -62,6 +62,9 @@ const enhanced = withRouteConfig<Props, SingleModerateRouteQueryResponse>({
         author {
           id
         }
+        revision {
+          id
+        }
         ...ModerateCardContainer_comment
       }
       settings {


### PR DESCRIPTION
## What does this PR do?
This PR addresses a regression in which the `b` key shortcut no longer opened the Ban Modal in the moderation queue.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. As an admin or moderator navigate to the moderation queue
2. Either click the first comment, or press the `j` key to focus on the first coment
3. press the `b` key, and observe the the ban modal appears, and is for the user of the currently focused comment

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations needed.
