### PR TITLE
fix typo in german localization

### DIFF
--- a/src/locales/de/stream.ftl
+++ b/src/locales/de/stream.ftl
@@ -788,7 +788,7 @@ suspendInfo-heading-yourAccountHasBeen =
   Ihr Benutzerkonto wurde vorübergehend für Kommentare gesperrt.
 ## suspendInfo-info =
 suspendInfo-description-inAccordanceWith =
-  In Übereinstimmung mit den Community-Richtlinien von { $organisation } wurde Ihr Benutzerkonto vorübergehend gesperrt. Während der Sperrung können Sie keine Kommentare verfassen, Reaktionen verwenden oder Kommentare melden.
+  In Übereinstimmung mit den Community-Richtlinien von { $organization } wurde Ihr Benutzerkonto vorübergehend gesperrt. Während der Sperrung können Sie keine Kommentare verfassen, Reaktionen verwenden oder Kommentare melden.
 suspendInfo-until-pleaseRejoinThe =
   Bitte nehmen Sie bis { $until } wieder an der Unterhaltung teil.
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes a type in the .ftl file for DE which caused the organization name to not render correctly for users who had been suspended.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. As an admin, configure your tenant to use Deutsch
2. Pick a commenter, and suspend them
3. Log into a stream as that commenter. 
4. Observe the the suspension message contains the name of your organization, rather than `{orginisation}`

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations needed.
