### PR TITLE
HOTFIX (8.0.4): resolve bad import in dataCache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/talk",
-      "version": "8.0.3",
+      "version": "8.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/toolbox-cache-url": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/src/core/server/data/cache/dataCache.ts
+++ b/src/core/server/data/cache/dataCache.ts
@@ -4,7 +4,7 @@ import { hasFeatureFlag } from "coral-server/models/tenant";
 import { AugmentedRedis } from "coral-server/services/redis";
 import { TenantCache } from "coral-server/services/tenant/cache";
 
-import { GQLFEATURE_FLAG } from "core/client/framework/schema/__generated__/types";
+import { GQLFEATURE_FLAG } from "coral-server/graph/schema/__generated__/types";
 
 import { CommentActionsCache } from "./commentActionsCache";
 import { CommentCache } from "./commentCache";


### PR DESCRIPTION
## What does this PR do?

Fixes a single bad import pulling client code into the server files. Caused by TS auto-importing from whichever path is alphabetically first (`coral-client` comes before `coral-server`).

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- perform a prod build `npm run build`
- start Coral up `npm run start`
- see that it doesn't fail to start

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `main`
- cut a release for `v8.0.4` and tag it
- create PR to merge main back into `develop`
    - updates develop with fix and keeps `package.json` consistent