### PR TITLE
[CORL-2820] make mark all as seen load newly marked comments

### DIFF
--- a/src/core/server/graph/mutators/Comments.ts
+++ b/src/core/server/graph/mutators/Comments.ts
@@ -291,7 +291,7 @@ export const Comments = (ctx: GraphContext) => ({
     markAllAsSeen,
   }: WithoutMutationID<GQLMarkCommentsAsSeenInput>) => {
     if (ctx.user) {
-      await markSeen(
+      const result = await markSeen(
         ctx.mongo,
         ctx.cache,
         ctx.tenant.id,
@@ -301,10 +301,22 @@ export const Comments = (ctx: GraphContext) => ({
         ctx.now,
         markAllAsSeen
       );
-    }
 
-    const comments =
-      (await ctx.loaders.Comments.comment.loadMany(commentIDs)) ?? [];
-    return comments;
+      if (result) {
+        const ids: string[] = [];
+        Object.entries(result.comments).forEach(([id]) => ids.push(id));
+        const comments =
+          (await ctx.loaders.Comments.comment.loadMany(ids)) ?? [];
+        return comments;
+      } else {
+        const comments =
+          (await ctx.loaders.Comments.comment.loadMany(commentIDs)) ?? [];
+        return comments;
+      }
+    } else {
+      const comments =
+        (await ctx.loaders.Comments.comment.loadMany(commentIDs)) ?? [];
+      return comments;
+    }
   },
 });

--- a/src/core/server/services/seenComments/index.ts
+++ b/src/core/server/services/seenComments/index.ts
@@ -25,7 +25,7 @@ export async function markSeen(
   now: Date,
   markAllAsSeen?: boolean
 ) {
-  await markSeenComments(
+  return await markSeenComments(
     mongo,
     cache,
     tenantID,


### PR DESCRIPTION
## What does this PR do?

Returns the marked comments during mark seen mutations and then uses those id's to load the newly modified comments so that the seen flag can come through.

This appears to have been broken for some time now (prior to 8.0), I don't  know how mark all as seen worked prior to this as the code has never been returning and loading the marked comments all the way down the stack through the service calls. Maybe at one point we assumed all were marked and didn't use the reloaded comments client side?

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- enable `Z_KEY` and `COMMENT_SEEN` feature flags
- visit stream
- sign in as user
- ensure you have some yellow unseen comments
- press Shift + A to mark all as read
- see that stream changes all comments from yellow to white

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
