### PR TITLE
[CORL-2820]: add refreshStream filter to stream comments mark all connection

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/MarkCommentsAsSeenMutation.tsx
@@ -10,6 +10,8 @@ import { CoralContext } from "coral-framework/lib/bootstrap";
 import {
   commitMutationPromiseNormalized,
   createMutation,
+  LOCAL_ID,
+  lookup,
 } from "coral-framework/lib/relay";
 
 import {
@@ -103,6 +105,7 @@ const enhanced = createMutation(
                 "Stream_comments",
                 {
                   orderBy: input.orderBy,
+                  refreshStream: !!lookup(environment, LOCAL_ID).refreshStream,
                 }
               )!;
               const comments = connection?.getLinkedRecords("edges");


### PR DESCRIPTION
## What does this PR do?

Adds the new `refreshStream` filter to the Stream_comments connection in the mutation to mark comments as seen so that mark all comments as seen works as expected. Without this new filter, the connection was not correctly returning.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Make sure you have the `Z_KEY` and `COMMENT_SEEN` feature flags enabled. Navigate to the stream as a signed-in user. Make sure you have some unseen comments. Press shift + A and mark all as read. Also check on mobile that pressing `Mark all as read` button marks all unseen comments as read and changes them from yellow to white.

## Where any tests migrated to React Testing Library?

## How do we deploy this PR?

