### PR TITLE
[CORL-2824]: Add refresh reviews text for refresh button for R&R mode

### DIFF
--- a/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -221,14 +221,19 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
   }, [refreshStream]);
 
   const refreshCommentsLocalization =
-    story.settings.mode === GQLSTORY_MODE.COMMENTS
+    story.settings.mode === GQLSTORY_MODE.QA
       ? {
-          id: "comments-refreshComments-refreshButton",
-          text: "Refresh comments",
-        }
-      : {
           id: "comments-refreshQuestions-refreshButton",
           text: "Refresh questions",
+        }
+      : story.settings.mode === GQLSTORY_MODE.RATINGS_AND_REVIEWS
+      ? {
+          id: "comments-refreshReviews-refreshButton",
+          text: "Refresh reviews",
+        }
+      : {
+          id: "comments-refreshComments-refreshButton",
+          text: "Refresh comments",
         };
 
   const onChangeRating = useCallback(

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -316,6 +316,8 @@ comments-refreshComments-refreshButton =
   .aria-label = Refresh comments
 comments-refreshQuestions-refreshButton =
   .aria-label = Refresh questions
+  comments-refreshReviews-refreshButton =
+  .aria-label = Refresh reviews
 
 comments-replyChangedWarning-theCommentHasJust =
   This comment has just been edited. The latest version is displayed above.


### PR DESCRIPTION
## What does this PR do?

Adds the text `Refresh reviews` for Ratings & Reviews stories for the `Refresh` button.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Change a story's mode to `RATINGS_AND_REVIEWS`. Navigate to the stream. Change to another tab and then back to the stream. See that the refresh button that shows up says `Refresh reviews`. See that comments and Q&A stories still have the correct text, as well.

## Where any tests migrated to React Testing Library?



## How do we deploy this PR?


