### PR TITLE
trigger build and test on add to merge queue

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,6 +3,7 @@ name: Build and Test
 on:
   workflow_dispatch:
   push:
+  merge_group:
 
 env:
   IMAGE_REPOSITORY: 'gcr.io/the-coral-project/coral'


### PR DESCRIPTION
## What does this PR do?

Triggers a build and test job when a PR is added to a [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions) this will allow us to test out this feature to see if it can speed up the process of assembling a release. 

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
none

## Does this PR introduce any new environment variables or feature flags?
none

## If any indexes were added, were they added to `INDEXES.md`?
none
## How do I test this PR?
N/A
