### PR TITLE
[CORL-2826]: Update Q&A to use refreshStream

### DIFF
--- a/src/core/client/stream/tabs/Comments/Comment/RemoveAnswered.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/RemoveAnswered.tsx
@@ -19,15 +19,22 @@ interface Props {
 const RemoveAnswered: FunctionComponent<Props> = ({ commentID, storyID }) => {
   const removeAnswered = useMutation(RemoveAnsweredMutation);
 
-  const [{ commentsOrderBy }] = useLocal<RemoveAnsweredLocal>(graphql`
-    fragment RemoveAnsweredLocal on Local {
-      commentsOrderBy
-    }
-  `);
+  const [{ commentsOrderBy, refreshStream }] =
+    useLocal<RemoveAnsweredLocal>(graphql`
+      fragment RemoveAnsweredLocal on Local {
+        commentsOrderBy
+        refreshStream
+      }
+    `);
 
   const onRemove = useCallback(async () => {
-    await removeAnswered({ commentID, storyID, orderBy: commentsOrderBy });
-  }, [commentID, commentsOrderBy, removeAnswered, storyID]);
+    await removeAnswered({
+      commentID,
+      storyID,
+      orderBy: commentsOrderBy,
+      refreshStream,
+    });
+  }, [commentID, commentsOrderBy, removeAnswered, storyID, refreshStream]);
 
   return (
     <>

--- a/src/core/client/stream/tabs/Comments/Comment/RemoveAnsweredMutation.tsx
+++ b/src/core/client/stream/tabs/Comments/Comment/RemoveAnsweredMutation.tsx
@@ -13,6 +13,7 @@ export interface RemoveAnsweredMutationInput {
   commentID: string;
   storyID: string;
   orderBy: COMMENT_SORT;
+  refreshStream: boolean | null;
 }
 
 export async function commit(
@@ -37,6 +38,7 @@ export async function commit(
       {
         orderBy: input.orderBy,
         tag: "UNANSWERED",
+        refreshStream: input.refreshStream,
       }
     );
 

--- a/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabCommentContainer.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabCommentContainer.tsx
@@ -96,10 +96,13 @@ const enhanced = withFragmentContainer<Props>({
     }
   `,
   comment: graphql`
-    fragment UnansweredCommentsTabCommentContainer_comment on Comment {
+    fragment UnansweredCommentsTabCommentContainer_comment on Comment
+    @argumentDefinitions(
+      refreshStream: { type: "Boolean", defaultValue: false }
+    ) {
       enteredLive
       ...CommentContainer_comment
-      ...ReplyListContainer1_comment
+      ...ReplyListContainer1_comment @arguments(refreshStream: $refreshStream)
       ...IgnoredTombstoneOrHideContainer_comment
     }
   `,

--- a/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabQuery.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabQuery.tsx
@@ -19,7 +19,8 @@ import UnansweredCommentsTabContainer from "./UnansweredCommentsTabContainer";
 
 export const render = (
   data: QueryRenderData<QueryTypes>,
-  flattenReplies: boolean
+  flattenReplies: boolean,
+  refreshStream: boolean | null
 ) => {
   if (!data) {
     return null;
@@ -43,6 +44,7 @@ export const render = (
           viewer={data.props.viewer}
           story={data.props.story}
           flattenReplies={flattenReplies}
+          refreshStream={refreshStream}
         />
       </SpinnerWhileRendering>
     );
@@ -56,12 +58,13 @@ export const render = (
 
 const UnansweredCommentsTabQuery: FunctionComponent = () => {
   const flattenReplies = useStaticFlattenReplies();
-  const [{ storyID, storyURL, commentsOrderBy }] =
+  const [{ storyID, storyURL, commentsOrderBy, refreshStream }] =
     useLocal<UnansweredCommentsTabQueryLocal>(graphql`
       fragment UnansweredCommentsTabQueryLocal on Local {
         storyID
         storyURL
         commentsOrderBy
+        refreshStream
       }
     `);
   return (
@@ -72,13 +75,18 @@ const UnansweredCommentsTabQuery: FunctionComponent = () => {
           $storyURL: String
           $commentsOrderBy: COMMENT_SORT
           $flattenReplies: Boolean!
+          $refreshStream: Boolean
         ) {
           viewer {
             ...UnansweredCommentsTabContainer_viewer
           }
           story: stream(id: $storyID, url: $storyURL) {
             ...UnansweredCommentsTabContainer_story
-              @arguments(orderBy: $commentsOrderBy, tag: UNANSWERED)
+              @arguments(
+                orderBy: $commentsOrderBy
+                tag: UNANSWERED
+                refreshStream: $refreshStream
+              )
           }
           settings {
             ...UnansweredCommentsTabContainer_settings
@@ -90,8 +98,9 @@ const UnansweredCommentsTabQuery: FunctionComponent = () => {
         storyURL,
         commentsOrderBy,
         flattenReplies,
+        refreshStream,
       }}
-      render={(data) => render(data, flattenReplies)}
+      render={(data) => render(data, flattenReplies, refreshStream)}
     />
   );
 };

--- a/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabViewNewMutation.tsx
+++ b/src/core/client/stream/tabs/Comments/Stream/UnansweredCommentsTab/UnansweredCommentsTabViewNewMutation.tsx
@@ -4,6 +4,8 @@ import { CoralContext } from "coral-framework/lib/bootstrap";
 import {
   commitLocalUpdatePromisified,
   createMutation,
+  LOCAL_ID,
+  lookup,
 } from "coral-framework/lib/relay";
 import { GQLCOMMENT_SORT, GQLTAG } from "coral-framework/schema";
 import { ViewNewCommentsEvent } from "coral-stream/events";
@@ -22,12 +24,14 @@ const UnansweredCommentsTabViewNewMutation = createMutation(
   ) => {
     await commitLocalUpdatePromisified(environment, async (store) => {
       const story = store.get(input.storyID)!;
+      const refreshStream = !!lookup(environment, LOCAL_ID).refreshStream;
       const connection = ConnectionHandler.getConnection(
         story,
         "UnansweredStream_comments",
         {
           orderBy: GQLCOMMENT_SORT.CREATED_AT_DESC,
           tag: GQLTAG.UNANSWERED,
+          refreshStream,
         }
       )!;
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue with Q&A stories where replying to unanswered questions, marking them as done, and viewing new questions that came in via subscription weren't working. Now, the new `refreshStream` filter has been added to the relevant places so that these work as expected.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Change a story to Q&A in the `Configure` tab --> `Switch to Q&A Format`. Add one user as an expert. Navigate to the stream. Add some unanswered questions as a non-expert user. As an expert user, answer an unanswered question. See that the answer goes through as expected. When the button to mark the question as `DONE` shows up, click it and see that the question is moved to the answered tab. In another tab/window, add a new question. See that it shows up via subscription and when you click `View new question`, it's added to the stream as expected.

## Where any tests migrated to React Testing Library?



## How do we deploy this PR?


