### PR TITLE
[CORL-2825] ensure settings are propagated to word list workers

### DIFF
--- a/src/core/server/graph/mutators/Settings.ts
+++ b/src/core/server/graph/mutators/Settings.ts
@@ -65,10 +65,10 @@ export const Settings = ({
   mailerQueue,
   user,
 }: GraphContext) => ({
-  update: (
+  update: async (
     input: WithoutMutationID<GQLUpdateSettingsInput>
-  ): Promise<Tenant | null> =>
-    update(
+  ): Promise<Tenant | null> => {
+    return await update(
       mongo,
       redis,
       tenantCache,
@@ -77,7 +77,8 @@ export const Settings = ({
       tenant,
       user!,
       input.settings
-    ),
+    );
+  },
   rotateSSOSigningSecret: ({ inactiveIn }: GQLRotateSSOSigningSecretInput) =>
     rotateSSOSigningSecret(mongo, redis, tenantCache, tenant, inactiveIn, now),
   deleteSSOSigningSecret: ({ kid }: GQLDeleteSSOSigningSecretInput) =>

--- a/src/core/server/services/comments/pipeline/phases/wordList/service.ts
+++ b/src/core/server/services/comments/pipeline/phases/wordList/service.ts
@@ -25,8 +25,7 @@ const WORKER_SCRIPT =
   "./dist/core/server/services/comments/pipeline/phases/wordList/worker.js";
 
 export class WordListService {
-  private pool: Worker[];
-  private selectedWorkerIndex: number;
+  private worker: Worker;
 
   private onMessageDelegate: (event: MessageEvent) => void;
   private results: Map<string, WordListWorkerResult>;
@@ -39,15 +38,8 @@ export class WordListService {
     this.results = new Map<string, WordListWorkerResult>();
     this.onMessageDelegate = this.onMessage.bind(this);
 
-    this.pool = [];
-    for (let i = 0; i < numWorkers; i++) {
-      const worker = new Worker(WORKER_SCRIPT);
-      worker.on("message", this.onMessageDelegate);
-
-      this.pool.push(worker);
-    }
-
-    this.selectedWorkerIndex = 0;
+    this.worker = new Worker(WORKER_SCRIPT);
+    this.worker.on("message", this.onMessageDelegate);
 
     this.sanitizer = createSanitize(new JSDOM("", {}).window as any, {
       // We need normalized text nodes to mark nodes for suspect/banned words.
@@ -82,63 +74,54 @@ export class WordListService {
     category: WordListCategory,
     phrases: string[]
   ) {
-    const operations: Promise<WordListWorkerResult>[] = [];
-    for (const worker of this.pool) {
-      const data: InitializationPayload = {
-        tenantID,
-        locale,
-        category,
-        phrases,
-      };
+    const data: InitializationPayload = {
+      tenantID,
+      locale,
+      category,
+      phrases,
+    };
 
-      const message: WordListWorkerMessage = {
-        id: uuid(),
-        type: MessageType.Initialize,
-        data,
-      };
+    const message: WordListWorkerMessage = {
+      id: uuid(),
+      type: MessageType.Initialize,
+      data,
+    };
 
-      worker.postMessage(message);
-
-      const builder = async () => {
-        let hasResult = this.results.has(message.id);
-        while (!hasResult) {
-          await this.sleep(1);
-          hasResult = this.results.has(message.id);
-        }
-
-        const result = this.results.get(message.id);
-        if (!result) {
-          this.results.delete(message.id);
-          return {
-            id: message.id,
-            tenantID,
-            ok: false,
-            err: new Error("result was undefined"),
-          };
-        }
-
-        this.results.delete(message.id);
-        return result;
-      };
-
-      operations.push(builder());
-    }
-
-    let errors = 0;
-
-    const results = await Promise.all(operations);
-    for (const result of results) {
-      if (!result.ok || result.err) {
-        this.logger.error(
-          { tenantID: result.tenantID, id: result.id },
-          "unable to initialize"
-        );
-
-        errors++;
+    const builder = async () => {
+      let hasResult = this.results.has(message.id);
+      while (!hasResult) {
+        await this.sleep(1);
+        hasResult = this.results.has(message.id);
       }
+
+      const result = this.results.get(message.id);
+      if (!result) {
+        this.results.delete(message.id);
+        return {
+          id: message.id,
+          tenantID,
+          ok: false,
+          err: new Error("result was undefined"),
+        };
+      }
+
+      this.results.delete(message.id);
+      return result;
+    };
+
+    this.worker.postMessage(message);
+    const result = await builder();
+
+    if (!result.ok || result.err) {
+      this.logger.error(
+        { tenantID: result.tenantID, id: result.id },
+        "unable to initialize"
+      );
+
+      return false;
     }
 
-    return errors === 0;
+    return true;
   }
 
   public async process(
@@ -146,13 +129,6 @@ export class WordListService {
     category: WordListCategory,
     testString: string
   ): Promise<WordListMatchResult> {
-    const worker = this.pool[this.selectedWorkerIndex];
-
-    this.selectedWorkerIndex++;
-    if (this.selectedWorkerIndex >= this.pool.length) {
-      this.selectedWorkerIndex = 0;
-    }
-
     const sanitizedTestString = this.sanitizer(testString).innerHTML;
 
     const data: ProcessPayload = {
@@ -167,7 +143,7 @@ export class WordListService {
       data,
     };
 
-    worker.postMessage(message);
+    this.worker.postMessage(message);
 
     const builder = async () => {
       let hasResult = this.results.has(message.id);

--- a/src/core/server/services/comments/pipeline/phases/wordList/worker.ts
+++ b/src/core/server/services/comments/pipeline/phases/wordList/worker.ts
@@ -62,23 +62,12 @@ const process = (
   const listKey = computeWordListKey(tenantID, category);
   const list = lists.get(listKey);
 
-  if (!list) {
-    return {
-      id,
-      tenantID,
-      ok: false,
-    };
-  }
-
   if (!list || list.regex === null) {
     return {
       id,
       tenantID,
-      ok: true,
-      data: {
-        isMatched: false,
-        matches: [],
-      },
+      ok: false,
+      err: new Error("word list for tenant not found"),
     };
   }
 


### PR DESCRIPTION
## What does this PR do?

- fixes a free-floating promise resolution inside the mutators when modifying tenant settings
- remove the word list worker pool in favour of a single worker per pod
    - simplifies the worker architecture and makes it easier to debug if issues arise
    - better matches the limited CPU resources of most pod setups for Coral
- add additional logging around word list initialization and processing

## These changes will impact:

- [ ] commenters
- [X] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- set some banned and suspect words in Admin > Configure > Banned and Suspect Words
- go to stream as a commenter and post comments using these words, ensure they are blocked and/or end up highlighted in the mod queues
    - be sure to test both banned and suspect words
- add a new word to both banned and suspect word lists
- immediately test these words and see they are caught by the wordlist pipeline phases

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
