### PR TITLE
[CORL-2825] update word lists when tenantCache signals a tenant has changed

### DIFF
--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -124,6 +124,8 @@ class Server {
   private readonly reporter?: ErrorReporter;
 
   private wordList: WordListService;
+  private onTenantDeleteDelegate: () => void;
+  private onTenantUpdateDelegate: () => void;
 
   /**
    * broker stores a reference to all of the listeners that can be used in
@@ -310,9 +312,6 @@ class Server {
       this.onTenantDeleteDelegate
     );
   }
-
-  private onTenantDeleteDelegate: () => void;
-  private onTenantUpdateDelegate: () => void;
 
   private onTenantDelete() {}
 

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -125,7 +125,7 @@ class Server {
 
   private wordList: WordListService;
   private onTenantDeleteDelegate: () => void;
-  private onTenantUpdateDelegate: () => void;
+  private onTenantUpdateDelegate: (tenant: Tenant) => void;
 
   /**
    * broker stores a reference to all of the listeners that can be used in

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -35,6 +35,7 @@ import {
 import { TenantCache } from "coral-server/services/tenant/cache";
 
 import { createMongoContext, MongoContext } from "./data/context";
+import { TenantNotFoundError } from "./errors";
 import {
   AnalyticsCoralEventListener,
   NotifierCoralEventListener,
@@ -45,7 +46,7 @@ import {
   WebhookCoralEventListener,
 } from "./events/listeners";
 import CoralEventListenerBroker from "./events/publisher";
-import { retrieveAllTenants } from "./models/tenant";
+import { retrieveAllTenants, retrieveTenant, Tenant } from "./models/tenant";
 import { WordListCategory } from "./services/comments/pipeline/phases/wordList/message";
 import { WordListService } from "./services/comments/pipeline/phases/wordList/service";
 import { ErrorReporter, SentryErrorReporter } from "./services/errors";
@@ -282,6 +283,8 @@ class Server {
     // Setup the metrics collectors.
     collectDefaultMetrics();
 
+    // word list services
+
     this.wordList = new WordListService(logger);
     const tenants = await retrieveAllTenants(this.mongo);
     for (const tenant of tenants) {
@@ -298,6 +301,41 @@ class Server {
         tenant.wordList.suspect
       );
     }
+
+    this.onTenantDeleteDelegate = this.onTenantDelete.bind(this);
+    this.onTenantUpdateDelegate = this.onTenantUpdate.bind(this);
+
+    this.tenantCache.subscribe(
+      this.onTenantUpdateDelegate,
+      this.onTenantDeleteDelegate
+    );
+  }
+
+  private onTenantDeleteDelegate: () => void;
+  private onTenantUpdateDelegate: () => void;
+
+  private onTenantDelete() {}
+
+  private async onTenantUpdate(tenant: Tenant) {
+    logger.info({ tenantID: tenant.id }, "received remote tenant update");
+
+    const updatedTenant = await retrieveTenant(this.mongo, tenant.id);
+    if (!updatedTenant) {
+      throw new TenantNotFoundError(tenant.domain);
+    }
+
+    await this.wordList.initialize(
+      updatedTenant.id,
+      updatedTenant.locale,
+      WordListCategory.Banned,
+      updatedTenant.wordList.banned
+    );
+    await this.wordList.initialize(
+      updatedTenant.id,
+      updatedTenant.locale,
+      WordListCategory.Suspect,
+      updatedTenant.wordList.suspect
+    );
   }
 
   /**

--- a/src/core/server/services/comments/pipeline/phases/wordList/worker.ts
+++ b/src/core/server/services/comments/pipeline/phases/wordList/worker.ts
@@ -2,6 +2,7 @@ import RE2 from "re2";
 import { isMainThread, parentPort } from "worker_threads";
 
 import { LanguageCode } from "coral-common/helpers";
+import logger from "coral-server/logger";
 import { WordlistMatch } from "coral-server/models/comment";
 
 import createServerWordListRegEx from "../../createServerWordListRegEx";
@@ -32,11 +33,21 @@ const initialize = (
   id: string,
   { tenantID, category, locale, phrases }: InitializationPayload
 ): WordListWorkerResult => {
+  logger.info(
+    { tenantID, category, phrases: phrases.length },
+    "initializing wordlist"
+  );
+
   const key = computeWordListKey(tenantID, category);
   const regex =
     phrases.length > 0 ? createServerWordListRegEx(locale, phrases) : null;
 
   lists.set(key, { tenantID, category, locale, regex });
+
+  logger.info(
+    { tenantID, category, phrases: phrases.length },
+    "successfully initialized wordlist"
+  );
 
   return {
     id,


### PR DESCRIPTION
## What does this PR do?

Propagates word list changes to all pods via the tenantCache.

Adds a listener on the tenantCache for when a tenant has been modified (emits event using Redis) to update the word list for the modified tenant. This ensures that when someone modifies the tenant's wordlist on one pod, it propagates to all the other pods wordlist workers to keep them up to date.

## These changes will impact:

- [X] commenters
- [X] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No new env vars.

## If any indexes were added, were they added to `INDEXES.md`?

No

## How do I test this PR?

It is not possible to properly test this without multiple pods running. Build and deploy a custom image to one of the dev instances with more than 1 pod.

- Change the banned or suspect word lists in Admin > Configure
- Check the pod logs and see that there are multiple of these messages (one per pod plus one for the requested pod that processes the initial request)
    - "received remote tenant update"
    - "initializing wordlist"
    - "successfully initialized wordlist"

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
