### PR TITLE
[CORL-2825] handle tenant not found more gracefully in wordlist tenant subscriber

### DIFF
--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -320,7 +320,11 @@ class Server {
 
     const updatedTenant = await retrieveTenant(this.mongo, tenant.id);
     if (!updatedTenant) {
-      throw new TenantNotFoundError(tenant.domain);
+      logger.warn(
+        { tenantID: tenant.id },
+        "tenant not found during tenantCache wordlist update"
+      );
+      return;
     }
 
     await this.wordList.initialize(

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -35,7 +35,6 @@ import {
 import { TenantCache } from "coral-server/services/tenant/cache";
 
 import { createMongoContext, MongoContext } from "./data/context";
-import { TenantNotFoundError } from "./errors";
 import {
   AnalyticsCoralEventListener,
   NotifierCoralEventListener,


### PR DESCRIPTION
## What does this PR do?

Log a warning and ignore update request instead of throwing an error at the server level when we can't find the tenant during a remote tenant update. This prevents the pods from screaming they can't find a tenant during pod start up if other pods signal tenant updates.

However, it will still be logged as a warning in logs that we can debug if it becomes an issue or we need to dig into it!

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No

## How do I test this PR?

N/A

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
