### PR TITLE
[CORL-2836]: Update user cache when user status and data is updated

### DIFF
--- a/src/core/client/admin/components/UserStatus/RemoveUserSuspensionMutation.ts
+++ b/src/core/client/admin/components/UserStatus/RemoveUserSuspensionMutation.ts
@@ -32,8 +32,14 @@ const RemoveUserSuspensionMutation = createMutation(
           "createdBy.username",
         ])
       ) as any;
-      newHistory[newHistory.length - 1].active = false;
-      newHistory[newHistory.length - 1].from.finish = new Date().toISOString();
+      if (
+        newHistory[newHistory.length - 1].active &&
+        newHistory[newHistory.length - 1].from
+      ) {
+        newHistory[newHistory.length - 1].active = false;
+        newHistory[newHistory.length - 1].from.finish =
+          new Date().toISOString();
+      }
     }
 
     return commitMutationPromiseNormalized<MutationTypes>(environment, {

--- a/src/core/server/data/cache/userCache.ts
+++ b/src/core/server/data/cache/userCache.ts
@@ -139,18 +139,7 @@ export class UserCache implements IDataCache {
         modifiedAt?: Date;
         from: { start: Date; finish: Date };
       }) => {
-        if (suspension.modifiedAt) {
-          return {
-            ...suspension,
-            createdAt: new Date(suspension.createdAt),
-            from: {
-              start: new Date(suspension.from.start),
-              finish: new Date(suspension.from.finish),
-            },
-            modifiedAt: new Date(suspension.modifiedAt),
-          };
-        }
-        return {
+        const suspensionUpdated = {
           ...suspension,
           createdAt: new Date(suspension.createdAt),
           from: {
@@ -158,6 +147,13 @@ export class UserCache implements IDataCache {
             finish: new Date(suspension.from.finish),
           },
         };
+        if (suspension.modifiedAt) {
+          return {
+            ...suspensionUpdated,
+            modifiedAt: new Date(suspension.modifiedAt),
+          };
+        }
+        return suspensionUpdated;
       }
     );
 

--- a/src/core/server/data/cache/userCache.ts
+++ b/src/core/server/data/cache/userCache.ts
@@ -126,8 +126,8 @@ export class UserCache implements IDataCache {
     this.usersByKey.set(dataKey, user);
   }
 
-  private serializeObject(comment: Readonly<User>) {
-    const json = JSON.stringify(comment);
+  private serializeObject(user: Readonly<User>) {
+    const json = JSON.stringify(user);
     return json;
   }
 

--- a/src/core/server/data/cache/userCache.ts
+++ b/src/core/server/data/cache/userCache.ts
@@ -136,13 +136,23 @@ export class UserCache implements IDataCache {
     const parsedSuspensionHistory = parsed.status.suspension.history.map(
       (suspension: {
         createdAt: Date;
-        modifiedAt: Date;
+        modifiedAt?: Date;
         from: { start: Date; finish: Date };
       }) => {
+        if (suspension.modifiedAt) {
+          return {
+            ...suspension,
+            createdAt: new Date(suspension.createdAt),
+            from: {
+              start: new Date(suspension.from.start),
+              finish: new Date(suspension.from.finish),
+            },
+            modifiedAt: new Date(suspension.modifiedAt),
+          };
+        }
         return {
           ...suspension,
           createdAt: new Date(suspension.createdAt),
-          modifiedAt: new Date(suspension.modifiedAt),
           from: {
             start: new Date(suspension.from.start),
             finish: new Date(suspension.from.finish),

--- a/src/core/server/data/cache/userCache.ts
+++ b/src/core/server/data/cache/userCache.ts
@@ -133,9 +133,33 @@ export class UserCache implements IDataCache {
 
   private deserializeObject(data: string): Readonly<User> {
     const parsed = JSON.parse(data);
+    const parsedSuspensionHistory = parsed.status.suspension.history.map(
+      (suspension: {
+        createdAt: Date;
+        modifiedAt: Date;
+        from: { start: Date; finish: Date };
+      }) => {
+        return {
+          ...suspension,
+          createdAt: new Date(suspension.createdAt),
+          modifiedAt: new Date(suspension.modifiedAt),
+          from: {
+            start: new Date(suspension.from.start),
+            finish: new Date(suspension.from.finish),
+          },
+        };
+      }
+    );
+
     return {
       ...parsed,
       createdAt: new Date(parsed.createdAt),
+      status: {
+        ...parsed.status,
+        suspension: {
+          history: parsedSuspensionHistory,
+        },
+      },
     };
   }
 }

--- a/src/core/server/data/cache/userCache.ts
+++ b/src/core/server/data/cache/userCache.ts
@@ -117,6 +117,15 @@ export class UserCache implements IDataCache {
     return user;
   }
 
+  public async update(user: Readonly<User>) {
+    const cmd = this.redis.multi();
+    const dataKey = this.computeDataKey(user.tenantID, user.id);
+    cmd.set(dataKey, this.serializeObject(user));
+    cmd.expire(dataKey, this.expirySeconds);
+    await cmd.exec();
+    this.usersByKey.set(dataKey, user);
+  }
+
   private serializeObject(comment: Readonly<User>) {
     const json = JSON.stringify(comment);
     return json;

--- a/src/core/server/graph/mutators/Users.ts
+++ b/src/core/server/graph/mutators/Users.ts
@@ -226,7 +226,7 @@ export const Users = (ctx: GraphContext) => ({
       ctx.user!
     ),
   updateBio: async (input: GQLUpdateBioInput) =>
-    updateBio(ctx.mongo, ctx.tenant, ctx.user!, input.bio),
+    updateBio(ctx.mongo, ctx.cache, ctx.tenant, ctx.user!, input.bio),
   updateUserEmail: async (input: GQLUpdateUserEmailInput) =>
     updateEmailByID(ctx.mongo, ctx.tenant, input.userID, input.email),
   updateEmail: async (input: GQLUpdateEmailInput) =>
@@ -243,12 +243,19 @@ export const Users = (ctx: GraphContext) => ({
     ),
   updateNotificationSettings: async (
     input: WithoutMutationID<GQLUpdateNotificationSettingsInput>
-  ) => updateNotificationSettings(ctx.mongo, ctx.tenant, ctx.user!, input),
+  ) =>
+    updateNotificationSettings(
+      ctx.mongo,
+      ctx.cache,
+      ctx.tenant,
+      ctx.user!,
+      input
+    ),
   updateUserMediaSettings: async (
     input: WithoutMutationID<GQLUpdateUserMediaSettingsInput>
-  ) => updateMediaSettings(ctx.mongo, ctx.tenant, ctx.user!, input),
+  ) => updateMediaSettings(ctx.mongo, ctx.cache, ctx.tenant, ctx.user!, input),
   updateUserAvatar: async (input: GQLUpdateUserAvatarInput) =>
-    updateAvatar(ctx.mongo, ctx.tenant, input.userID, input.avatar),
+    updateAvatar(ctx.mongo, ctx.cache, ctx.tenant, input.userID, input.avatar),
   updateUserRole: async (input: GQLUpdateUserRoleInput) =>
     updateRole(
       ctx.mongo,

--- a/src/core/server/graph/mutators/Users.ts
+++ b/src/core/server/graph/mutators/Users.ts
@@ -210,6 +210,7 @@ export const Users = (ctx: GraphContext) => ({
   updateUsername: async (input: GQLUpdateUsernameInput) =>
     updateUsername(
       ctx.mongo,
+      ctx.cache,
       ctx.mailerQueue,
       ctx.tenant,
       ctx.user!,
@@ -231,6 +232,7 @@ export const Users = (ctx: GraphContext) => ({
   updateEmail: async (input: GQLUpdateEmailInput) =>
     updateEmail(
       ctx.mongo,
+      ctx.cache,
       ctx.tenant,
       ctx.mailerQueue,
       ctx.config,
@@ -349,6 +351,7 @@ export const Users = (ctx: GraphContext) => ({
     async () =>
       updateUserBan(
         ctx.mongo,
+        ctx.cache,
         ctx.mailerQueue,
         ctx.rejectorQueue,
         ctx.tenant,
@@ -363,6 +366,7 @@ export const Users = (ctx: GraphContext) => ({
   warn: async (input: GQLWarnUserInput) =>
     warn(
       ctx.mongo,
+      ctx.cache,
       ctx.tenant,
       ctx.user!,
       input.userID,
@@ -370,7 +374,14 @@ export const Users = (ctx: GraphContext) => ({
       ctx.now
     ),
   removeWarning: async (input: GQLRemoveUserWarningInput) =>
-    removeWarning(ctx.mongo, ctx.tenant, ctx.user!, input.userID, ctx.now),
+    removeWarning(
+      ctx.mongo,
+      ctx.cache,
+      ctx.tenant,
+      ctx.user!,
+      input.userID,
+      ctx.now
+    ),
   acknowledgeWarning: async () =>
     acknowledgeWarning(ctx.mongo, ctx.tenant, ctx.user!.id, ctx.now),
   sendModMessage: async (input: GQLSendModMessageInput) =>
@@ -385,10 +396,11 @@ export const Users = (ctx: GraphContext) => ({
   acknowledgeModMessage: async () =>
     acknowledgeModMessage(ctx.mongo, ctx.tenant, ctx.user!.id, ctx.now),
   premodUser: async (input: GQLPremodUserInput) =>
-    premod(ctx.mongo, ctx.tenant, ctx.user!, input.userID, ctx.now),
+    premod(ctx.mongo, ctx.cache, ctx.tenant, ctx.user!, input.userID, ctx.now),
   suspend: async (input: GQLSuspendUserInput) =>
     suspend(
       ctx.mongo,
+      ctx.cache,
       ctx.mailerQueue,
       ctx.tenant,
       ctx.user!,
@@ -398,11 +410,32 @@ export const Users = (ctx: GraphContext) => ({
       ctx.now
     ),
   removeBan: async (input: GQLRemoveUserBanInput) =>
-    removeBan(ctx.mongo, ctx.tenant, ctx.user!, input.userID, ctx.now),
+    removeBan(
+      ctx.mongo,
+      ctx.cache,
+      ctx.tenant,
+      ctx.user!,
+      input.userID,
+      ctx.now
+    ),
   removeSuspension: async (input: GQLRemoveUserSuspensionInput) =>
-    removeSuspension(ctx.mongo, ctx.tenant, ctx.user!, input.userID, ctx.now),
+    removeSuspension(
+      ctx.mongo,
+      ctx.cache,
+      ctx.tenant,
+      ctx.user!,
+      input.userID,
+      ctx.now
+    ),
   removeUserPremod: async (input: GQLRemovePremodUserInput) =>
-    removePremod(ctx.mongo, ctx.tenant, ctx.user!, input.userID, ctx.now),
+    removePremod(
+      ctx.mongo,
+      ctx.cache,
+      ctx.tenant,
+      ctx.user!,
+      input.userID,
+      ctx.now
+    ),
   ignore: async (input: GQLIgnoreUserInput) =>
     ignore(ctx.mongo, ctx.tenant, ctx.user!, input.userID, ctx.now),
   removeIgnore: async (input: GQLRemoveUserIgnoreInput) =>

--- a/src/core/server/graph/mutators/Users.ts
+++ b/src/core/server/graph/mutators/Users.ts
@@ -327,6 +327,7 @@ export const Users = (ctx: GraphContext) => ({
   }: GQLBanUserInput) =>
     ban(
       ctx.mongo,
+      ctx.cache,
       ctx.mailerQueue,
       ctx.rejectorQueue,
       ctx.tenant,

--- a/src/core/server/services/users/users.spec.ts
+++ b/src/core/server/services/users/users.spec.ts
@@ -8,6 +8,7 @@ import {
   createUserFixture,
 } from "coral-server/test/fixtures";
 import {
+  createMockDataCache,
   createMockMailer,
   createMockMongoContex,
   createMockRejector,
@@ -21,6 +22,7 @@ import { demoteMember, promoteMember } from ".";
 describe("updateUserBan", () => {
   afterEach(jest.clearAllMocks);
 
+  const cache = createMockDataCache();
   const mailer = createMockMailer();
   const rejector = createMockRejector();
   const { ctx: mongo } = createMockMongoContex();
@@ -46,6 +48,7 @@ describe("updateUserBan", () => {
       async () =>
         await updateUserBan(
           mongo,
+          cache,
           mailer,
           rejector,
           tenant,
@@ -66,6 +69,7 @@ describe("updateUserBan", () => {
       async () =>
         await updateUserBan(
           mongo,
+          cache,
           mailer,
           rejector,
           tenant,
@@ -91,6 +95,7 @@ describe("updateUserBan", () => {
       async () =>
         await updateUserBan(
           mongo,
+          cache,
           mailer,
           rejector,
           tenant,
@@ -113,6 +118,7 @@ describe("updateUserBan", () => {
       async () =>
         await updateUserBan(
           mongo,
+          cache,
           mailer,
           rejector,
           tenant,
@@ -137,10 +143,13 @@ describe("updateUserBan", () => {
     });
 
     /* eslint-disable-next-line */
-    require("coral-server/models/user").retrieveUser.mockResolvedValue(bannedOnSiteA);
+    require("coral-server/models/user").retrieveUser.mockResolvedValue(
+      bannedOnSiteA
+    );
 
     const res = await updateUserBan(
       mongo,
+      cache,
       mailer,
       rejector,
       tenant,
@@ -174,6 +183,7 @@ describe("updateUserBan", () => {
 
     const res = await updateUserBan(
       mongo,
+      cache,
       mailer,
       rejector,
       tenant,
@@ -199,6 +209,7 @@ describe("updateUserBan", () => {
 
     const res = await updateUserBan(
       mongo,
+      cache,
       mailer,
       rejector,
       tenant,
@@ -224,6 +235,7 @@ describe("updateUserBan", () => {
 
     const dontRejectRes = await updateUserBan(
       mongo,
+      cache,
       mailer,
       rejector,
       tenant,
@@ -239,6 +251,7 @@ describe("updateUserBan", () => {
 
     const rejectRes = await updateUserBan(
       mongo,
+      cache,
       mailer,
       rejector,
       tenant,

--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -1274,6 +1274,7 @@ export async function updateEmailByID(
  */
 export async function updateBio(
   mongo: MongoContext,
+  cache: DataCache,
   tenant: Tenant,
   user: User,
   bio?: string
@@ -1282,7 +1283,14 @@ export async function updateBio(
     throw new UserBioTooLongError(user.id);
   }
 
-  return updateUserBio(mongo, tenant.id, user.id, bio);
+  const updatedUser = await updateUserBio(mongo, tenant.id, user.id, bio);
+
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.users.update(updatedUser);
+  }
+
+  return updatedUser;
 }
 
 /**
@@ -1295,11 +1303,19 @@ export async function updateBio(
  */
 export async function updateAvatar(
   mongo: MongoContext,
+  cache: DataCache,
   tenant: Tenant,
   userID: string,
   avatar?: string
 ) {
-  return updateUserAvatar(mongo, tenant.id, userID, avatar);
+  const updatedUser = await updateUserAvatar(mongo, tenant.id, userID, avatar);
+
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.users.update(updatedUser);
+  }
+
+  return updatedUser;
 }
 
 /**
@@ -1706,7 +1722,7 @@ export async function premod(
   }
 
   // Premod the user.
-  const premoddedUser = await premodUser(
+  const updatedUser = await premodUser(
     mongo,
     tenant.id,
     userID,
@@ -1716,10 +1732,10 @@ export async function premod(
 
   const cacheAvailable = await cache.available(tenant.id);
   if (cacheAvailable) {
-    await cache.users.update(premoddedUser);
+    await cache.users.update(updatedUser);
   }
 
-  return premoddedUser;
+  return updatedUser;
 }
 
 export async function removePremod(
@@ -1795,7 +1811,7 @@ export async function warn(
   }
 
   // Warn the user.
-  const warnedUser = await warnUser(
+  const updatedUser = await warnUser(
     mongo,
     tenant.id,
     userID,
@@ -1806,10 +1822,10 @@ export async function warn(
 
   const cacheAvailable = await cache.available(tenant.id);
   if (cacheAvailable) {
-    await cache.users.update(warnedUser);
+    await cache.users.update(updatedUser);
   }
 
-  return warnedUser;
+  return updatedUser;
 }
 
 export async function removeWarning(
@@ -2247,20 +2263,46 @@ export async function requestUserCommentsDownload(
 
 export async function updateNotificationSettings(
   mongo: MongoContext,
+  cache: DataCache,
   tenant: Tenant,
   user: User,
   settings: NotificationSettingsInput
 ) {
-  return updateUserNotificationSettings(mongo, tenant.id, user.id, settings);
+  const updatedUser = await updateUserNotificationSettings(
+    mongo,
+    tenant.id,
+    user.id,
+    settings
+  );
+
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.users.update(updatedUser);
+  }
+
+  return updatedUser;
 }
 
 export async function updateMediaSettings(
   mongo: MongoContext,
+  cache: DataCache,
   tenant: Tenant,
   user: User,
   settings: UpdateUserMediaSettingsInput
 ) {
-  return updateUserMediaSettings(mongo, tenant.id, user.id, settings);
+  const updatedUser = await updateUserMediaSettings(
+    mongo,
+    tenant.id,
+    user.id,
+    settings
+  );
+
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.users.update(updatedUser);
+  }
+
+  return updatedUser;
 }
 
 function userLastCommentIDKey(

--- a/src/core/server/test/mocks.ts
+++ b/src/core/server/test/mocks.ts
@@ -1,3 +1,4 @@
+import { DataCache } from "coral-server/data/cache/dataCache";
 import { MongoContext } from "coral-server/data/context";
 import { MailerQueue } from "coral-server/queue/tasks/mailer";
 import { RejectorQueue } from "coral-server/queue/tasks/rejector";
@@ -26,6 +27,11 @@ export const createMockTenantCache = (): TenantCache =>
   ({
     // add methods as nessecary
   } as unknown as TenantCache);
+
+export const createMockDataCache = (): DataCache =>
+  ({
+    available: jest.fn().mockResolvedValue(false),
+  } as unknown as DataCache);
 
 export const createMockMailer = () =>
   ({


### PR DESCRIPTION
## What does this PR do?

This addresses a bug related to the `userCache` being used for the author of comments. The changes in this PR ensure that the user cache is updated when a user's status (banned/suspended/warned) or their email, username, avatar, bio, or settings are changed. 

This fixes the bug where, when the data cache is enabled via feature flag, in the `Community` tab of the admin, users' statuses, names, and emails weren't correctly showing in the user drawer when they had cached comments in the `All comments` or `Rejected` tab of the user drawer.

## These changes will impact:

- [x] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test this PR by ensuring that you have the feature flag `DATA_CACHE` enabled. You'll probably want to make sure that your `REDIS_CACHE_EXPIRY` is set to something long enough that your cache won't expire while you're in the middle of doing testing. I just did `24hr`. Then, build Coral and run with `npm run start:development:withJobs`. Start up multi-site-test. Leave a new comment as a user. Ensure that comment is cached. Navigate to the admin. Find the user who you left a comment as in the `COMMUNITY` tab. Ban them. Click on that user and see that their status says `Banned` as expected. Also check that all-site ban, specific sites bans, suspensions, warnings, and updates to usernames and emails work and show as expected in the user drawer. 

For avatar, bio, and settings, you can check that the correct info is saved in the cache since those can't be checked in the user drawer.

## Where any tests migrated to React Testing Library?

no

## How do we deploy this PR?


