### PR TITLE
remove auth directive from tag.createdBy

### DIFF
--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -3587,7 +3587,7 @@ type Tag {
   createdBy is the User that assigned the Tag. This is null when the Tag is
   assigned by the System.
   """
-  createdBy: User @auth(roles: [MODERATOR, ADMIN])
+  createdBy: User
 
   """
   createdAt is the time that the Tag was assigned on.


### PR DESCRIPTION
## What does this PR do?

Removes the auth directive from the `tag.createdBy` field, which will allow this field to be retrieved by any users, required for the "featured by" feature.

Note this means that any API user can query this field as well, regardless of whether the feature is enabled. I believe this should not be a problem, as who a comment has been featured by is not secret or private information. 

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Auth directive that previously restricted `tags.createdBy` to moderators and admins is removed, the field is no longer restricted. 

## How do I test this PR?

- enable the "featured by" feature and feature a comment as a staff member
- log in as a commenter and attempt to view the "featured" tab
- you should be able to view the comment and the name of the staff member that featured it

