### PR TITLE
[HOTFIX v8.2.2] Repair localizations for refresh comments button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/talk",
-      "version": "8.2.1",
+      "version": "8.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/toolbox-cache-url": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.2.1",
+  "version": "8.2.2",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/src/locales/en-US/stream.ftl
+++ b/src/locales/en-US/stream.ftl
@@ -311,13 +311,13 @@ comments-mobileToolbar-closeButton =
 comments-mobileToolbar-unmarkAll = Mark all as read
 comments-mobileToolbar-nextUnread = Next unread
 
-comments-refreshComments-closeButton =
+comments-refreshComments-closeButton = Close
   .aria-label = Close
-comments-refreshComments-refreshButton =
+comments-refreshComments-refreshButton = Refresh comments
   .aria-label = Refresh comments
-comments-refreshQuestions-refreshButton =
+comments-refreshQuestions-refreshButton = Refresh questions
   .aria-label = Refresh questions
-comments-refreshReviews-refreshButton =
+comments-refreshReviews-refreshButton = Refresh reviews
   .aria-label = Refresh reviews
 
 comments-replyChangedWarning-theCommentHasJust =

--- a/src/locales/es/stream.ftl
+++ b/src/locales/es/stream.ftl
@@ -151,13 +151,13 @@ comments-rejectedTombstone =
 
 comments-featuredTag = Resaltado
 
-comments-refreshComments-closeButton =
+comments-refreshComments-closeButton = Cerrar
   .aria-label = Cerrar
-comments-refreshComments-refreshButton =
+comments-refreshComments-refreshButton = Actualizar comentarios
   .aria-label = Actualizar comentarios
-comments-refreshQuestions-refreshButton =
+comments-refreshQuestions-refreshButton = Actualizar preguntas
   .aria-label = Actualizar preguntas
-comments-refreshReviews-refreshButton =
+comments-refreshReviews-refreshButton = Actualizar revisiones
   .aria-label = Actualizar revisiones
 
 ### Q&A

--- a/src/locales/fr-FR/stream.ftl
+++ b/src/locales/fr-FR/stream.ftl
@@ -250,13 +250,13 @@ comments-jumpToComment-GoToReply = Aller à la réponse
 comments-permalink-copyLink = Copier le lien
 comments-permalink-linkCopied = Lien copié
 
-comments-refreshComments-closeButton =
+comments-refreshComments-closeButton = Fermer
   .aria-label = Fermer
-comments-refreshComments-refreshButton =
+comments-refreshComments-refreshButton = Rafraîchir les commentaires
   .aria-label = Rafraîchir les commentaires
-comments-refreshQuestions-refreshButton =
+comments-refreshQuestions-refreshButton = Rafraîchir les questions
   .aria-label = Rafraîchir les questions
-comments-refreshReviews-refreshButton =
+comments-refreshReviews-refreshButton = Rafraîchir les avis
   .aria-label = Rafraîchir les avis
 
 ### Q&A

--- a/src/locales/nl-NL/stream.ftl
+++ b/src/locales/nl-NL/stream.ftl
@@ -312,13 +312,13 @@ comments-mobileToolbar-closeButton =
 comments-mobileToolbar-unmarkAll = Markeer alle als gelezen
 comments-mobileToolbar-nextUnread = Volgende ongelezen
 
-comments-refreshComments-closeButton =
+comments-refreshComments-closeButton = Sluiten
   .aria-label = Sluiten
-comments-refreshComments-refreshButton =
+comments-refreshComments-refreshButton = Herlaad reacties
   .aria-label = Herlaad reacties
-comments-refreshQuestions-refreshButton =
+comments-refreshQuestions-refreshButton = Herlaad vragen
   .aria-label = Herlaad vragen
-comments-refreshReviews-refreshButton =
+comments-refreshReviews-refreshButton = Herlaad reviews
   .aria-label = Herlaad reviews
 
 comments-replyChangedWarning-theCommentHasJust =


### PR DESCRIPTION
## What does this PR do?

Fixes the localization text for the refresh comments button by setting the value for each of the localization keys in the ftl file.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- start up Coral
- change your language in `Admin > Configure > General` to something other than English
     - recommend using `Francais` as it is one of the 3 languages that have been localized
- go to your stream
- change browser tab away from stream
- come back to stream tab
- see the refresh comments button come up
- see that the refresh comments button language is in the language you selected

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

This branch is a hotfix, merge this branch into `main`, tag the release, then merge the changes from `main` back into `develop`.
