### PR TITLE
[CORL-2862]: Single comment embed get custom css and fonts css from stream embed

### DIFF
--- a/docs/docs/comment-embed.md
+++ b/docs/docs/comment-embed.md
@@ -12,6 +12,20 @@ Add the `commentEmbed.js` script to your `html` tree. On a page that includes th
 ></script>
 ```
 
+If you are manually including the embed script, and you want to set a `customCSSURL` and a `customFontsCSSURL` to use instead or in place of tenant settings for these values, include these as data attributes on the script for the single comment embed to use. If the script is automatically added by the _Stream Embed_, these values will be grabbed and set for you.
+
+Example of how to manually add them:
+
+```html
+<script
+  class="coral-script"
+  src="//{{ CORAL_DOMAIN_NAME }}/assets/js/commentEmbed.js"
+  data-customCSSURL="{{ CUSTOM_CSS_URL }}"
+  data-customFontsCSSURL="{{ CUSTOM_FONTS_CSS_URL }}"
+  defer
+></script>
+```
+
 > **NOTE:** Replace the value of `{{ CORAL_DOMAIN_NAME }}` with the location of your running instance of Coral.
 
 ### Embed code

--- a/src/core/client/embed/StreamEmbed.ts
+++ b/src/core/client/embed/StreamEmbed.ts
@@ -132,7 +132,7 @@ export class StreamEmbed {
     injectCountScriptIfNeeded(config.rootURL, this.ts);
 
     // Detect if comment embed injection is needed and add the comment embed script.
-    injectCommentEmbedScriptIfNeeded(config.rootURL, this.ts);
+    injectCommentEmbedScriptIfNeeded(config, this.ts);
 
     if (config.commentID) {
       // Delay emit of `showPermalink` event to allow user enough time to setup

--- a/src/core/client/embed/injectCommentEmbedScriptIfNeeded.ts
+++ b/src/core/client/embed/injectCommentEmbedScriptIfNeeded.ts
@@ -4,12 +4,14 @@ import {
 } from "coral-framework/constants";
 import { detectCommentEmbedScript } from "coral-framework/helpers";
 
+import { StreamEmbedConfig } from "./StreamEmbed";
+
 /**
  * injectCommentEmbedScriptIfNeeded will detect if comment embed injection is necessary and
  * automatically includes the `commentEmbed.js` script.
  */
 const injectCommentEmbedScriptIfNeeded = (
-  rootURL: string,
+  config: StreamEmbedConfig,
   timestamp: number
 ) => {
   if (detectCommentEmbedScript(window)) {
@@ -17,8 +19,15 @@ const injectCommentEmbedScriptIfNeeded = (
   }
   if (document.querySelector(COMMENT_EMBED_SELECTOR)) {
     const s = document.createElement("script");
-    s.src = `${rootURL}/assets/js/commentEmbed.js?ts=${timestamp}`;
+    s.src = `${config.rootURL}/assets/js/commentEmbed.js?ts=${timestamp}`;
     s.className = ORIGIN_FALLBACK_ID;
+    s.setAttribute("id", "coralSingleCommentEmbedScript");
+    if (config.customCSSURL) {
+      s.setAttribute("data-customCSSURL", config.customCSSURL);
+    }
+    if (config.customFontsCSSURL) {
+      s.setAttribute("data-customFontsCSSURL", config.customFontsCSSURL);
+    }
     s.async = false;
     s.defer = true;
     (document.head || document.body).appendChild(s);

--- a/src/core/client/oembed/index.ts
+++ b/src/core/client/oembed/index.ts
@@ -10,6 +10,8 @@ interface CommentEmbedQueryArgs {
   commentID?: string;
   allowReplies?: string;
   reactionLabel?: string;
+  customFontsCSSURL?: string | null;
+  customCSSURL?: string | null;
 }
 
 /** createCommentEmbedQueryRef creates a unique reference from the query args */
@@ -34,9 +36,22 @@ function detectAndInject(opts: DetectAndInjectArgs = {}) {
     const commentID = element.dataset.commentid;
     const allowReplies = element.dataset.allowreplies;
     const reactionLabel = element.dataset.reactionlabel;
+    const embedScript = document.querySelector(
+      "#coralSingleCommentEmbedScript"
+    );
+    const customCSSURL = embedScript?.getAttribute("data-customCSSURL");
+    const customFontsCSSURL = embedScript?.getAttribute(
+      "data-customFontsCSSURL"
+    );
 
     // Construct the args for generating the ref.
-    const args = { commentID, allowReplies, reactionLabel };
+    const args = {
+      commentID,
+      allowReplies,
+      reactionLabel,
+      customCSSURL,
+      customFontsCSSURL,
+    };
 
     // Get or create a ref.
     let ref = element.dataset.coralRef;
@@ -59,7 +74,13 @@ function detectAndInject(opts: DetectAndInjectArgs = {}) {
 
   // Call server using JSONP.
   Object.keys(queryMap).forEach((ref) => {
-    const { commentID, allowReplies, reactionLabel } = queryMap[ref];
+    const {
+      commentID,
+      allowReplies,
+      reactionLabel,
+      customCSSURL,
+      customFontsCSSURL,
+    } = queryMap[ref];
 
     // Compile the arguments used to generate the
     const args: Record<string, string | undefined> = {
@@ -67,6 +88,8 @@ function detectAndInject(opts: DetectAndInjectArgs = {}) {
       commentID,
       ref,
       reactionLabel,
+      customCSSURL: customCSSURL ?? undefined,
+      customFontsCSSURL: customFontsCSSURL ?? undefined,
     };
 
     // Add the script element with the specified options to the page.

--- a/src/core/server/app/handlers/api/comment/commentEmbed.ts
+++ b/src/core/server/app/handlers/api/comment/commentEmbed.ts
@@ -37,6 +37,8 @@ const CommentEmbedJSONPQuerySchema = Joi.object().keys({
   commentID: Joi.string().required(),
   allowReplies: Joi.string().optional(),
   reactionLabel: Joi.string().optional(),
+  customCSSURL: Joi.string().optional(),
+  customFontsCSSURL: Joi.string().optional(),
   ref: Joi.string().required(),
 });
 
@@ -46,6 +48,8 @@ interface CommentEmbedJSONPQuery {
   ref: string;
   allowReplies?: string;
   reactionLabel?: string;
+  customCSSURL?: string;
+  customFontsCSSURL?: string;
 }
 
 /**
@@ -78,6 +82,8 @@ export const commentEmbedJSONPHandler =
         ref,
         allowReplies,
         reactionLabel,
+        customCSSURL: customCSSURLEmbed,
+        customFontsCSSURL: customFontsCSSURLEmbed,
       }: CommentEmbedJSONPQuery = validate(
         CommentEmbedJSONPQuerySchema,
         req.query
@@ -147,7 +153,7 @@ export const commentEmbedJSONPHandler =
           mediaUrl,
           includeReplies,
           streamCSS,
-          customCSSURL,
+          customCSSURL: customCSSURLEmbed || customCSSURL,
           staticRoot: staticURI || tenantURL,
           giphyMedia,
           tenantURL,
@@ -164,7 +170,7 @@ export const commentEmbedJSONPHandler =
       const data: CommentEmbedJSONPData = {
         ref,
         html,
-        customFontsCSSURL,
+        customFontsCSSURL: customFontsCSSURLEmbed || customFontsCSSURL,
         defaultFontsCSSURL,
         commentID,
         staticRoot: staticURI || tenantURL,


### PR DESCRIPTION
## What does this PR do?

These changes grab the custom CSS URL and custom fonts CSS URL from the stream embed config settings, if present, and set them as data attributes on the single comment embed script. This allows them to be used by the single comment embed so that custom CSS and custom fonts set in stream embed config are applied as expected. First, stream embed config settings will be used, then any tenant settings for custom CSS or custom fonts CSS will be used if they are not specified in stream embed config settings.

The docs are also updated so that it's clear how to add these settings if adding the single comment embed script to a page without a stream embed.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [x] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can update the stream embed config in `src/core/client/embed/index.html` with `customCSSURL` and `customFontsCSSURL` arguments. Try different combinations of setting/not setting these config options here and in the admin. 

Copy the embed code for a comment in the stream with the moderation actions dropdown > copy embed button. Paste it into `src/core/client/embed/index.html`. Inspect elements and see that the correct custom css and custom fonts css urls are included in the single comment embed.

Anything set in the stream embed config should override tenant settings, but tenant settings (set in advanced configuration in the admin) should be applied if these options aren't present in the stream embed config.

## Where any tests migrated to React Testing Library?

no

## How do we deploy this PR?

