### PR TITLE
[CORL-2384] upgrade node to v18.16+ and set compatibility flags

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,10 +43,10 @@ jobs:
         name: Define SHORT_SHA with commit short sha
         run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
       -
-        name: Setup Node14.x
+        name: Setup Node18.x
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.16.x'
       -
         name: Install npm 8
         run: npm i -g npm@8.0.0 --registry=https://registry.npmjs.org

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -51,10 +51,10 @@ jobs:
         name: Define RC_TAG
         run: echo "RC_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       -
-        name: Setup Node14.x
+        name: Setup Node18.x
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.16.x'
       -
         name: Install npm 8
         run: npm i -g npm@8.0.0 --registry=https://registry.npmjs.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:18-alpine
 
 ENV NODE_OPTIONS=--max-old-space-size=8192
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:18-alpine
 ENV NODE_OPTIONS=--max-old-space-size=8192
 
 # Install build dependancies.
-RUN apk --no-cache add git python3
+RUN apk --no-cache --update add g++ make git python3 \
+  && rm -rf /var/cache/apk/*
 
 RUN npm install -g npm@8.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
         "@babel/preset-typescript": "^7.10.1",
         "@babel/runtime-corejs3": "^7.10.3",
         "@coralproject/npm-run-all": "^4.1.5",
-        "@coralproject/rte": "^2.2.2",
+        "@coralproject/rte": "^2.2.4",
         "@fluent/react": "^0.12.0",
         "@giphy/js-fetch-api": "^4.1.2",
         "@giphy/react-components": "^5.4.0",
@@ -348,8 +348,8 @@
         "whatwg-fetch": "^3.4.0"
       },
       "engines": {
-        "node": "^14.18",
-        "npm": "^8.0.0"
+        "node": "^18.16.0",
+        "npm": "8.0.0"
       }
     },
     "node_modules/@ampproject/toolbox-cache-url": {
@@ -2627,16 +2627,21 @@
       }
     },
     "node_modules/@coralproject/rte": {
-      "version": "2.2.2",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@coralproject/rte/-/rte-2.2.4.tgz",
+      "integrity": "sha512-neIIoH6BarMZPzLGqVW4CkzD1t+CZrhvcQWjwMIW/Jv9txwSL7jCL/dMRysvXX+yXB7IJ5Pot57VI0SVQxFUEg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.6",
         "squire-rte": "1.11.0"
       },
+      "engines": {
+        "node": "^18.16.0",
+        "npm": "^8.0.0"
+      },
       "peerDependencies": {
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@csstools/convert-colors": {
@@ -51400,7 +51405,9 @@
       }
     },
     "@coralproject/rte": {
-      "version": "2.2.2",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@coralproject/rte/-/rte-2.2.4.tgz",
+      "integrity": "sha512-neIIoH6BarMZPzLGqVW4CkzD1t+CZrhvcQWjwMIW/Jv9txwSL7jCL/dMRysvXX+yXB7IJ5Pot57VI0SVQxFUEg==",
       "dev": true,
       "requires": {
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "url": "git://github.com/coralproject/talk.git"
   },
   "engines": {
-    "node": "^14.18",
-    "npm": "^8.0.0"
+    "node": "^18.16.0",
+    "npm": "8.0.0"
   },
   "bugs": "https://github.com/coralproject/talk/issues",
   "contributors": [
@@ -22,10 +22,10 @@
   "description": "A better commenting experience from Vox Media.",
   "scripts": {
     "build:client": "ts-node --transpile-only ./scripts/build.ts",
-    "build:development": "NODE_ENV=development npm-run-all generate --parallel build:client build:server",
+    "build:development": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" NODE_ENV=development npm-run-all generate --parallel build:client build:server",
     "build:server": "gulp server",
     "build:withProfiler": "NODE_ENV=production REACT_PROFILER=true npm-run-all generate --parallel build:client build:server",
-    "build": "NODE_ENV=production npm-run-all generate-persist --parallel build:client build:server",
+    "build": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" NODE_ENV=production npm-run-all generate-persist --parallel build:client build:server",
     "clean": "gulp clean",
     "docs:css-variables": "ts-node ./scripts/generateCSSVariablesDocs.ts ./src/core/client/ui/theme/streamVariables.ts ./CSS_VARIABLES.md",
     "docs:events": "ts-node ./scripts/generateEventDocs.ts ./src/core/client/stream/events.ts ./CLIENT_EVENTS.md",
@@ -68,7 +68,7 @@
     "tscheck:scripts": "tsc --project ./tsconfig.json --noEmit",
     "tscheck:server": "tsc --project ./src/tsconfig.json --noEmit",
     "tscheck": "npm-run-all --parallel tscheck:*",
-    "watch": "NODE_ENV=development ts-node --transpile-only ./scripts/watcher/bin/watcher.ts --config ./config/watcher.ts"
+    "watch": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" NODE_ENV=development ts-node --transpile-only ./scripts/watcher/bin/watcher.ts --config ./config/watcher.ts"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -173,7 +173,7 @@
     "@babel/preset-typescript": "^7.10.1",
     "@babel/runtime-corejs3": "^7.10.3",
     "@coralproject/npm-run-all": "^4.1.5",
-    "@coralproject/rte": "^2.2.2",
+    "@coralproject/rte": "^2.2.4",
     "@fluent/react": "^0.12.0",
     "@giphy/js-fetch-api": "^4.1.2",
     "@giphy/react-components": "^5.4.0",


### PR DESCRIPTION
## What does this PR do?

Update the target engine (node version) to `v18.16.0+` and set required compatibility flags so that the runtime doesn't complain about our older libraries living in a modern node environment.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- install node 18 LTS
   - can do this via nvm as well via: `nvm install 18.16.0`
   - recommend setting an alias like: `nvm alias coral-new 18.16.0`
       - can then switch to that alias via `nvm use coral-new`
       - can check you're on the right version via `node --version`
- install npm 8.0.0 globally
   - `npm install -g npm@8.0.0`
   - if you do this when nvm is using the right version, will replace the `npm` version for that `nvm` mode for you, which is handy so you don't need to check with `npm` you have installed for `v18.16+`
- perform and `npm run build:development` build
- start up Coral via `npm run start:development`
- see that it runs and works correctly in stream + admin
- perform and `npm run build` build
- start up Coral via `npm run start`
- see that it runs and works correctly in stream + admin

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Standard deploy procedure.
