### PR TITLE
[CORL-2801]: Fix add announcement

### DIFF
--- a/src/core/client/admin/routes/Configure/sections/General/AnnouncementFormModal.tsx
+++ b/src/core/client/admin/routes/Configure/sections/General/AnnouncementFormModal.tsx
@@ -28,6 +28,7 @@ import {
   ModalProps,
   Textarea,
 } from "coral-ui/components/v2";
+import Portal from "coral-ui/components/v2/Modal/Portal";
 
 import ValidationMessage from "../../ValidationMessage";
 
@@ -44,99 +45,105 @@ const AnnouncementForm: FunctionComponent<Props> = ({
   ...rest
 }) => {
   return (
-    <Modal {...rest}>
-      {({ firstFocusableRef }) => (
-        <Card className={styles.root}>
-          <Flex justifyContent="flex-end">
-            <CardCloseButton onClick={onClose} ref={firstFocusableRef} />
-          </Flex>
-          <Form
-            onSubmit={onSubmit}
-            initialValues={{ content: "", duration: 86400 }}
-          >
-            {({ handleSubmit, submitting, submitError }) => (
-              <form
-                autoComplete="off"
-                onSubmit={handleSubmit}
-                id="announcements-form"
-              >
-                <HorizontalGutter spacing={4}>
-                  <HorizontalGutter spacing={3}>
-                    <FormField>
-                      <FormFieldHeader>
-                        <Localized id="configure-general-announcements-title">
-                          <Label htmlFor="configure-general-announcements-content">
-                            Announcement text
+    <Portal>
+      <Modal {...rest}>
+        {({ firstFocusableRef }) => (
+          <Card className={styles.root}>
+            <Flex justifyContent="flex-end">
+              <CardCloseButton onClick={onClose} ref={firstFocusableRef} />
+            </Flex>
+            <Form
+              onSubmit={onSubmit}
+              initialValues={{ content: "", duration: 86400 }}
+            >
+              {({ handleSubmit, submitting, submitError }) => (
+                <form
+                  autoComplete="off"
+                  onSubmit={handleSubmit}
+                  id="announcements-form"
+                >
+                  <HorizontalGutter spacing={4}>
+                    <HorizontalGutter spacing={3}>
+                      <FormField>
+                        <FormFieldHeader>
+                          <Localized id="configure-general-announcements-title">
+                            <Label htmlFor="configure-general-announcements-content">
+                              Announcement text
+                            </Label>
+                          </Localized>
+                        </FormFieldHeader>
+
+                        <Field
+                          name="content"
+                          parse={parseEmptyAsNull}
+                          validate={required}
+                        >
+                          {({ input, meta }) => (
+                            <>
+                              <Textarea
+                                {...input}
+                                fullwidth
+                                id="configure-general-announcements-content"
+                              />
+                              <ValidationMessage meta={meta} fullWidth />
+                            </>
+                          )}
+                        </Field>
+                      </FormField>
+                      <FormField container={<FieldSet />}>
+                        <Localized id="configure-general-announcements-duration">
+                          <Label component="legend">
+                            Show this announcement for
                           </Label>
                         </Localized>
-                      </FormFieldHeader>
 
-                      <Field
-                        name="content"
-                        parse={parseEmptyAsNull}
-                        validate={required}
-                      >
-                        {({ input, meta }) => (
-                          <>
-                            <Textarea
-                              {...input}
-                              fullwidth
-                              id="configure-general-announcements-content"
-                            />
-                            <ValidationMessage meta={meta} fullWidth />
-                          </>
-                        )}
-                      </Field>
-                    </FormField>
-                    <FormField container={<FieldSet />}>
-                      <Localized id="configure-general-announcements-duration">
-                        <Label component="legend">
-                          Show this announcement for
-                        </Label>
+                        <Field
+                          name="duration"
+                          validate={composeValidators(
+                            required,
+                            validateWholeNumberGreaterThan(0)
+                          )}
+                          parse={parseInteger}
+                        >
+                          {({ input, meta }) => (
+                            <>
+                              <DurationField
+                                {...input}
+                                units={[
+                                  DURATION_UNIT.HOUR,
+                                  DURATION_UNIT.DAY,
+                                  DURATION_UNIT.WEEK,
+                                ]}
+                                color={colorFromMeta(meta)}
+                              />
+                              <ValidationMessage meta={meta} fullWidth />
+                            </>
+                          )}
+                        </Field>
+                      </FormField>
+                    </HorizontalGutter>
+                    <Flex itemGutter justifyContent="flex-end">
+                      <Localized id="configure-general-announcements-cancel">
+                        <Button
+                          color="mono"
+                          variant="outlined"
+                          onClick={onClose}
+                        >
+                          Cancel
+                        </Button>
                       </Localized>
-
-                      <Field
-                        name="duration"
-                        validate={composeValidators(
-                          required,
-                          validateWholeNumberGreaterThan(0)
-                        )}
-                        parse={parseInteger}
-                      >
-                        {({ input, meta }) => (
-                          <>
-                            <DurationField
-                              {...input}
-                              units={[
-                                DURATION_UNIT.HOUR,
-                                DURATION_UNIT.DAY,
-                                DURATION_UNIT.WEEK,
-                              ]}
-                              color={colorFromMeta(meta)}
-                            />
-                            <ValidationMessage meta={meta} fullWidth />
-                          </>
-                        )}
-                      </Field>
-                    </FormField>
+                      <Localized id="configure-general-announcements-start">
+                        <Button type="submit">Start announcement</Button>
+                      </Localized>
+                    </Flex>
                   </HorizontalGutter>
-                  <Flex itemGutter justifyContent="flex-end">
-                    <Localized id="configure-general-announcements-cancel">
-                      <Button color="mono" variant="outlined" onClick={onClose}>
-                        Cancel
-                      </Button>
-                    </Localized>
-                    <Localized id="configure-general-announcements-start">
-                      <Button type="submit">Start announcement</Button>
-                    </Localized>
-                  </Flex>
-                </HorizontalGutter>
-              </form>
-            )}
-          </Form>
-        </Card>
-      )}
-    </Modal>
+                </form>
+              )}
+            </Form>
+          </Card>
+        )}
+      </Modal>
+    </Portal>
   );
 };
 

--- a/src/core/client/admin/test/configure/general.spec.tsx
+++ b/src/core/client/admin/test/configure/general.spec.tsx
@@ -598,3 +598,40 @@ it("change rte config", async () => {
   });
   expect(resolvers.Mutation!.updateSettings!.called).toBe(true);
 });
+
+it("add announcement", async () => {
+  const resolvers = createResolversStub<GQLResolver>({
+    Mutation: {
+      createAnnouncement: ({ variables }) => {
+        expectAndFail(variables.content).toEqual("hello");
+        expectAndFail(variables.duration).toEqual(86400);
+        return {
+          settings: pureMerge(settings, {
+            announcement: {
+              id: "123456",
+              createdAt: "2020-01-01T01:00:00.000Z",
+              ...variables,
+            },
+          }),
+        };
+      },
+    },
+  });
+  await createTestRenderer({
+    resolvers,
+  });
+  const addAnnouncementButton = screen.getByRole("button", {
+    name: "Add announcement",
+  });
+  userEvent.click(addAnnouncementButton);
+  const announcementContent = screen.getByRole("textbox", {
+    name: "Community announcement",
+  });
+  userEvent.type(announcementContent, "hello");
+  const startAnnouncementButton = screen.getByRole("button", {
+    name: "Start announcement",
+  });
+  userEvent.click(startAnnouncementButton);
+
+  expect(resolvers.Mutation!.createAnnouncement!.called).toBe(true);
+});


### PR DESCRIPTION
## What does this PR do?

This fixes a bug that was preventing announcements from being added in the admin. The modal for adding announcements is now rendered inside of a React portal, as the modal was encountering an issue with nested forms and therefore not correctly submitting.

Also, a test was added for adding announcements.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can go to `Configure` --> `General` in the admin and click `Add announcement`. Type in an announcement. Click `Start announcement`. Go to the stream. See the announcement you added. Go back and remove the announcement. See that it's correctly removed as well.

## Where any tests migrated to React Testing Library?

no

## How do we deploy this PR?


