### PR TITLE
Make `npm run watch` work on M1/2 macs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -203,6 +203,7 @@
         "@typescript-eslint/eslint-plugin": "^3.4.0",
         "@typescript-eslint/eslint-plugin-tslint": "^3.4.0",
         "@typescript-eslint/parser": "^3.4.0",
+        "address": "^1.2.2",
         "autoprefixer": "^9.8.6",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^26.3.0",
@@ -10127,6 +10128,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/address": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
+      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -56959,6 +56969,12 @@
     },
     "acorn-walk": {
       "version": "7.2.0"
+    },
+    "address": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
+      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "@typescript-eslint/eslint-plugin": "^3.4.0",
     "@typescript-eslint/eslint-plugin-tslint": "^3.4.0",
     "@typescript-eslint/parser": "^3.4.0",
+    "address": "^1.2.2",
     "autoprefixer": "^9.8.6",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^26.3.0",


### PR DESCRIPTION
## What does this PR do?

- allow `npm run watch` to work on M1/2 macs that also have the `arm64` build of `watchman` (https://facebook.github.io/watchman/) installed
- be sure to see testing notes for how to set it up and make it work

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- have an M1/2 mac to test with
- install the `arm64` native version of `watchman` using `brew update && brew install watchman`
   - if you already had `watchman` installed, be sure to uninstall it via: `brew uninstall watchman` as it might be an x64 version running with Rosetta and you don't want that
- perform an `npm run build`
   - this is necessary because it generates manifests used by webpack to server the watch tooling
   - you only have to do this once, it should not be required to do this every time before you use `npm run watch`
- run `npm run watch`
- add `http://localhost:8080` to your permitted domain list
- test out the stream at `http://localhost:8080` and the admin at `http://localhost:8080/admin`

NOTE: nothing should change for intel (x64) macs, they just keep running as usual

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
