### PR TITLE
[CORL-2856] Single site ban options

### DIFF
--- a/src/core/client/admin/test/community/banUser.spec.tsx
+++ b/src/core/client/admin/test/community/banUser.spec.tsx
@@ -340,7 +340,6 @@ it.only("displays limited options for single site tenants", async () => {
   // MARCUS: why is this passing?
   const modal = screen.getByLabelText("Are you sure you want to ban Isabelle?");
   expect(modal).toBeInTheDocument();
-  // userEvent.click(within(modal).getByLabelText("All sites"));
   expect(screen.queryByText("All sites")).not.toBeInTheDocument();
   expect(screen.queryByText("Specific sites")).not.toBeInTheDocument();
   expect(


### PR DESCRIPTION
## What does this PR do?
This PR addresses a bug in which options specific to multi site tenenants were displayed for single site tenants when managing a user's ban status.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a
-->

## How do I test this PR?
On a single site tenant, as a user with ban management privileges, navigate to the community page, and click to manage a user's ban status. Observe that no radio buttons related to "All sites", "Specific sites" or "No sites" are displayed.

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations should be required