### PR TITLE
[CORL-2856] Single site ban options

### DIFF
--- a/src/core/client/admin/components/BanModal.tsx
+++ b/src/core/client/admin/components/BanModal.tsx
@@ -322,59 +322,66 @@ const BanModal: FunctionComponent<Props> = ({
                 >
                   {/* BAN FROM/REJECT COMMENTS */}
                   <Flex direction="column">
-                    {/* ban from header */}
-                    <Localized id="community-banModal-banFrom">
-                      <Label className={styles.banFromHeader}>Ban from</Label>
-                    </Localized>
-                    <Flex
-                      direction="row"
-                      className={styles.sitesOptions}
-                      justifyContent="flex-start"
-                      spacing={5}
-                    >
-                      {/* sites options */}
-                      {showAllSitesOption && (
-                        <FormField>
-                          <Localized id="community-banModal-allSites">
-                            <RadioButton
-                              checked={updateType === UpdateType.ALL_SITES}
-                              onChange={() =>
-                                setUpdateType(UpdateType.ALL_SITES)
-                              }
-                              disabled={userBanStatus?.active}
-                            >
-                              All sites
-                            </RadioButton>
-                          </Localized>
-                        </FormField>
-                      )}
-                      <FormField>
-                        <Localized id="community-banModal-specificSites">
-                          <RadioButton
-                            checked={updateType === UpdateType.SPECIFIC_SITES}
-                            onChange={() =>
-                              setUpdateType(UpdateType.SPECIFIC_SITES)
-                            }
-                          >
-                            Specific Sites
-                          </RadioButton>
+                    {isMultisite && (
+                      <>
+                        <Localized id="community-banModal-banFrom">
+                          <Label className={styles.banFromHeader}>
+                            Ban from
+                          </Label>
                         </Localized>
-                      </FormField>
-                      {!viewerIsScoped && userHasAnyBan && (
-                        <FormField>
-                          <Localized id="community-banModal-noSites">
-                            <RadioButton
-                              checked={updateType === UpdateType.NO_SITES}
-                              onChange={() =>
-                                setUpdateType(UpdateType.NO_SITES)
-                              }
-                            >
-                              No Sites
-                            </RadioButton>
-                          </Localized>
-                        </FormField>
-                      )}
-                    </Flex>
+                        <Flex
+                          direction="row"
+                          className={styles.sitesOptions}
+                          justifyContent="flex-start"
+                          spacing={5}
+                        >
+                          {/* sites options */}
+                          {showAllSitesOption && (
+                            <FormField>
+                              <Localized id="community-banModal-allSites">
+                                <RadioButton
+                                  checked={updateType === UpdateType.ALL_SITES}
+                                  onChange={() =>
+                                    setUpdateType(UpdateType.ALL_SITES)
+                                  }
+                                  disabled={userBanStatus?.active}
+                                >
+                                  All sites
+                                </RadioButton>
+                              </Localized>
+                            </FormField>
+                          )}
+                          <FormField>
+                            <Localized id="community-banModal-specificSites">
+                              <RadioButton
+                                checked={
+                                  updateType === UpdateType.SPECIFIC_SITES
+                                }
+                                onChange={() =>
+                                  setUpdateType(UpdateType.SPECIFIC_SITES)
+                                }
+                              >
+                                Specific Sites
+                              </RadioButton>
+                            </Localized>
+                          </FormField>
+                          {!viewerIsScoped && userHasAnyBan && (
+                            <FormField>
+                              <Localized id="community-banModal-noSites">
+                                <RadioButton
+                                  checked={updateType === UpdateType.NO_SITES}
+                                  onChange={() =>
+                                    setUpdateType(UpdateType.NO_SITES)
+                                  }
+                                >
+                                  No Sites
+                                </RadioButton>
+                              </Localized>
+                            </FormField>
+                          )}
+                        </Flex>
+                      </>
+                    )}
                     {/* reject comments option */}
                     {updateType !== UpdateType.NO_SITES && (
                       <Localized

--- a/src/core/client/admin/test/community/banUser.spec.tsx
+++ b/src/core/client/admin/test/community/banUser.spec.tsx
@@ -314,6 +314,39 @@ it("ban user across specific sites", async () => {
   expect(resolvers.Mutation!.updateUserBan!.called).toBe(true);
 });
 
+it.only("displays limited options for single site tenants", async () => {
+  const resolvers = createResolversStub<GQLResolver>({
+    Query: {
+      settings: () => settings, // base settings has multisite: false
+    },
+  });
+
+  const { container } = await createTestRenderer({
+    resolvers,
+  });
+
+  const userRow = within(container).getByRole("row", {
+    name: "Isabelle isabelle@test.com 07/06/18, 06:24 PM Commenter Active",
+  });
+  userEvent.click(
+    within(userRow).getByRole("button", { name: "Change user status" })
+  );
+
+  const dropdown = within(userRow).getByLabelText(
+    "A dropdown to change the user status"
+  );
+  fireEvent.click(within(dropdown).getByRole("button", { name: "Manage Ban" }));
+
+  // MARCUS: why is this passing?
+  const modal = screen.getByLabelText("Are you sure you want to ban Isabelle?");
+  expect(modal).toBeInTheDocument();
+  expect(screen.queryByText("All sites")).not.toBeInTheDocument();
+  expect(screen.queryByText("Specific sites")).not.toBeInTheDocument();
+  expect(
+    screen.queryByText("Are you sure you want to ban Isabelle?")
+  ).not.toBeInTheDocument();
+});
+
 it("site moderators can unban users on their sites but not sites out of their scope", async () => {
   const user = users.siteBannedCommenter;
   const resolvers = createResolversStub<GQLResolver>({

--- a/src/core/client/admin/test/community/banUser.spec.tsx
+++ b/src/core/client/admin/test/community/banUser.spec.tsx
@@ -314,7 +314,7 @@ it("ban user across specific sites", async () => {
   expect(resolvers.Mutation!.updateUserBan!.called).toBe(true);
 });
 
-it.only("displays limited options for single site tenants", async () => {
+it("displays limited options for single site tenants", async () => {
   const resolvers = createResolversStub<GQLResolver>({
     Query: {
       settings: () => settings, // base settings has multisite: false
@@ -337,14 +337,10 @@ it.only("displays limited options for single site tenants", async () => {
   );
   fireEvent.click(within(dropdown).getByRole("button", { name: "Manage Ban" }));
 
-  // MARCUS: why is this passing?
   const modal = screen.getByLabelText("Are you sure you want to ban Isabelle?");
   expect(modal).toBeInTheDocument();
   expect(screen.queryByText("All sites")).not.toBeInTheDocument();
   expect(screen.queryByText("Specific sites")).not.toBeInTheDocument();
-  expect(
-    screen.queryByText("Are you sure you want to ban Isabelle?")
-  ).not.toBeInTheDocument();
 });
 
 it("site moderators can unban users on their sites but not sites out of their scope", async () => {


### PR DESCRIPTION
## What does this PR do?
This PR addresses a bug in which options specific to multi site tenenants were displayed for single site tenants when managing a user's ban status.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a
-->

## How do I test this PR?
On a single site tenant, as a user with ban management privileges, navigate to the community page, and click to manage a user's ban status. Observe that no radio buttons related to "All sites", "Specific sites" or "No sites" are displayed.

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations should be required