### PR TITLE
[CORL-2872]: Add cors to single comment embed oembed endpoint

### DIFF
--- a/src/core/server/app/router/api/index.ts
+++ b/src/core/server/app/router/api/index.ts
@@ -1,3 +1,4 @@
+import cors from "cors";
 import express from "express";
 import passport from "passport";
 
@@ -95,6 +96,7 @@ export function createAPIRouter(app: AppOptions, options: RouterOptions) {
   router.get("/oembed", cspSiteMiddleware(app), oembedHandler(app));
   router.get(
     "/services/oembed",
+    cors(),
     commentEmbedWhitelisted(app),
     oembedProviderHandler(app)
   );

--- a/src/core/server/app/router/api/index.ts
+++ b/src/core/server/app/router/api/index.ts
@@ -13,6 +13,7 @@ import {
   authenticate,
   commentEmbedWhitelisted,
   corsWhitelisted,
+  createCommentEmbedCorsOptionsDelegate,
   cspSiteMiddleware,
   JSONErrorHandler,
   jsonMiddleware,
@@ -96,8 +97,8 @@ export function createAPIRouter(app: AppOptions, options: RouterOptions) {
   router.get("/oembed", cspSiteMiddleware(app), oembedHandler(app));
   router.get(
     "/services/oembed",
-    cors(),
     commentEmbedWhitelisted(app),
+    cors(createCommentEmbedCorsOptionsDelegate(app.mongo)),
     oembedProviderHandler(app)
   );
   router.get(


### PR DESCRIPTION
## What does this PR do?

Adds cors to the oembed endpoint for single comment embeds. 

(Permissions are still determined via site permitted domains, this just ensures that `Access-Control-Allow-Origin` header for the permitted requesting origin is included if those checks are passed.)

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can uncomment the example of the Oembed API at the bottom of `commentEmbed.html` (you'll need to edit to add a comment id where noted). Inspect in the network tab of dev tools and see that the response still works as expected. 

Also copy over to a test site and embed there (update fetch url and comment ids as needed). See that the comment embed response now includes the `Access-Control-Allow-Origin` header set to the correct origin for the permitted request. Remove your test site from the permitted sites list. See that now you get a 401 Unauthorized error as expected.

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

