### PR TITLE
[CORL-2875]: update Redis cache key name for comment embed jsonp

### DIFF
--- a/src/core/server/app/middleware/cache.ts
+++ b/src/core/server/app/middleware/cache.ts
@@ -37,13 +37,23 @@ async function get(
 }
 
 const cacheMiddleware =
-  (redis: Redis, ttl: number): RequestHandler =>
+  (
+    redis: Redis,
+    ttl: number,
+    jsonpType: "count" | "commentEmbed"
+  ): RequestHandler =>
   async (req, res, next) => {
     // Compute the cache key.
     const url = new URL(`${req.hostname}:${req.originalUrl}`);
     const params = new URLSearchParams(url.search);
 
-    const key = `rmc:CoralCount&url=${params.get("url")}`;
+    let key = "";
+    if (jsonpType === "count") {
+      key = `rmc:CoralCount&url=${params.get("url")}`;
+    }
+    if (jsonpType === "commentEmbed") {
+      key = `rmc:CoralCommentEmbed&commentID=${params.get("commentID")}`;
+    }
     const log = logger.child({ key }, true);
 
     // Try to lookup the entry in the cache.

--- a/src/core/server/app/router/api/comment.ts
+++ b/src/core/server/app/router/api/comment.ts
@@ -15,7 +15,7 @@ export function createCommentRouter(app: AppOptions) {
   const router = createAPIRouter({ cacheDuration, immutable });
 
   if (app.config.get("jsonp_response_cache")) {
-    router.use(cacheMiddleware(app.redis, cacheDuration));
+    router.use(cacheMiddleware(app.redis, cacheDuration, "commentEmbed"));
   }
 
   router.get("/featured.js", featuredHander(app));

--- a/src/core/server/app/router/api/story.ts
+++ b/src/core/server/app/router/api/story.ts
@@ -16,7 +16,7 @@ export function createStoryRouter(app: AppOptions) {
   const router = createAPIRouter({ cacheDuration, immutable });
 
   if (app.config.get("jsonp_response_cache")) {
-    router.use(cacheMiddleware(app.redis, cacheDuration));
+    router.use(cacheMiddleware(app.redis, cacheDuration, "count"));
   }
 
   router.get("/count", countHandler(app));


### PR DESCRIPTION
## What does this PR do?

This fix ensures that when the comment embed jsonp is set in the Redis cache, each comment has its own consistent key specific to comment embeds. The comment count jsonp should still have a consistent Redis cache key specific to comment counts, as well.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can go to `/commentEmbed.html` and add a comment embed. Load the page. Go into Redis (`docker exec -it redis redis-cli`). Check its keys (`KEYS *`). See that there is a key that corresponds to the comment embed you loaded (something like `rmc:CoralCommentEmbed&commentID=COMMENT_ID`).

Also load comment counts somewhere (you can add `<span class="coral-count" data-coral-url="STORY_URL"></span>` to your embed index.html` or use multi-site test). Check the keys again and see that there's a key that corresponds to the count as well.

## Where any tests migrated to React Testing Library?

no

## How do we deploy this PR?

