### PR TITLE
[corl-2844]: Add reject button in view conversation modal in admin

### DIFF
--- a/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.css
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.css
@@ -42,4 +42,8 @@ $conversationModalCommentText: var(--palette-text-500);
 
 .rejectButton {
   height: fit-content;
+  &:disabled {
+    background-color: var(--palette-error-500) !important;
+    opacity: 1 !important;
+  }
 }

--- a/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.css
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.css
@@ -35,3 +35,11 @@ $conversationModalCommentText: var(--palette-text-500);
 .showReplies {
   padding-left: var(--spacing-2);
 }
+
+.commentWrapper {
+  flex: 1;
+}
+
+.rejectButton {
+  height: fit-content;
+}

--- a/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
@@ -1,7 +1,12 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
 import { useRouter } from "found";
-import React, { FunctionComponent, useCallback, useState } from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
 import { graphql } from "react-relay";
 
 import { MediaContainer } from "coral-admin/components/MediaContainer";
@@ -80,6 +85,27 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
       orderBy: moderationQueueSort,
     });
   }, [comment.id, comment.revision, match, moderationQueueSort, rejectComment]);
+  const rejectButtonOptions = useMemo((): {
+    localization: string;
+    variant: "regular" | "outlined";
+    ariaLabel: string;
+    text: string;
+  } => {
+    if (comment.status === "REJECTED") {
+      return {
+        localization: "conversation-modal-rejectButton-rejected",
+        variant: "regular",
+        ariaLabel: "Rejected",
+        text: "Rejected",
+      };
+    }
+    return {
+      localization: "conversation-modal-rejectButton",
+      variant: "outlined",
+      ariaLabel: "Reject",
+      text: "Reject",
+    };
+  }, [comment.status]);
   return (
     <HorizontalGutter>
       <Flex>
@@ -132,17 +158,24 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
               </Flex>
             </Flex>
             <Flex>
-              {/* TODO: Add localized */}
-              <Button
-                className={styles.rejectButton}
-                color="alert"
-                variant={comment.status === "REJECTED" ? "regular" : "outlined"}
-                iconLeft
-                onClick={onRejectComment}
+              <Localized
+                id={rejectButtonOptions.localization}
+                attrs={{ "aria-label": true }}
+                elems={{ icon: <SvgIcon size="xs" Icon={RemoveIcon} /> }}
               >
-                <SvgIcon size="xs" Icon={RemoveIcon} />
-                {comment.status === "REJECTED" ? "Rejected" : "Reject"}
-              </Button>
+                <Button
+                  className={styles.rejectButton}
+                  color="alert"
+                  variant={rejectButtonOptions.variant}
+                  iconLeft
+                  disabled={comment.status === "REJECTED"}
+                  onClick={onRejectComment}
+                  aria-label={rejectButtonOptions.ariaLabel}
+                >
+                  <SvgIcon size="xs" Icon={RemoveIcon} />
+                  {rejectButtonOptions.text}
+                </Button>
+              </Localized>
             </Flex>
           </Flex>
         </HorizontalGutter>

--- a/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
@@ -84,7 +84,16 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
       section,
       orderBy: moderationQueueSort,
     });
-  }, [comment.id, comment.revision, match, moderationQueueSort, rejectComment]);
+  }, [
+    comment.id,
+    comment.revision,
+    match,
+    moderationQueueSort,
+    rejectComment,
+    storyID,
+    siteID,
+    section,
+  ]);
   const rejectButtonOptions = useMemo((): {
     localization: string;
     variant: "regular" | "outlined";

--- a/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
@@ -107,7 +107,7 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
     };
   }, [comment.status]);
   return (
-    <HorizontalGutter>
+    <HorizontalGutter data-testid={`conversation-modal-comment-${comment.id}`}>
       <Flex>
         <Flex
           direction="column"

--- a/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
@@ -99,6 +99,7 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
     variant: "regular" | "outlined";
     ariaLabel: string;
     text: string;
+    disabled: boolean;
   } => {
     if (comment.status === "REJECTED") {
       return {
@@ -106,6 +107,7 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
         variant: "regular",
         ariaLabel: "Rejected",
         text: "Rejected",
+        disabled: true,
       };
     }
     return {
@@ -113,6 +115,7 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
       variant: "outlined",
       ariaLabel: "Reject",
       text: "Reject",
+      disabled: false,
     };
   }, [comment.status]);
   return (
@@ -177,7 +180,7 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
                   color="alert"
                   variant={rejectButtonOptions.variant}
                   iconLeft
-                  disabled={comment.status === "REJECTED"}
+                  disabled={rejectButtonOptions.disabled}
                   onClick={onRejectComment}
                   aria-label={rejectButtonOptions.ariaLabel}
                 >

--- a/src/core/client/admin/components/ConversationModal/ConversationModalContainer.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalContainer.tsx
@@ -14,7 +14,6 @@ import {
 } from "coral-ui/components/v2";
 
 import { ConversationModalContainer_comment } from "coral-admin/__generated__/ConversationModalContainer_comment.graphql";
-import { ConversationModalContainer_settings } from "coral-admin/__generated__/ConversationModalContainer_settings.graphql";
 import { ConversationModalContainerPaginationQueryVariables } from "coral-admin/__generated__/ConversationModalContainerPaginationQuery.graphql";
 
 import { Circle } from "../Timeline";
@@ -25,7 +24,6 @@ import styles from "./ConversationModalContainer.css";
 interface Props {
   relay: RelayPaginationProp;
   comment: ConversationModalContainer_comment;
-  settings: ConversationModalContainer_settings;
   onClose: () => void;
   onUsernameClicked: (id?: string) => void;
 }
@@ -33,7 +31,6 @@ interface Props {
 const ConversationModalContainer: FunctionComponent<Props> = ({
   comment,
   relay,
-  settings,
   onUsernameClicked,
 }) => {
   const [loadMore] = useLoadMore(relay, 5);
@@ -66,13 +63,11 @@ const ConversationModalContainer: FunctionComponent<Props> = ({
           isParent={true}
           comment={parent}
           onUsernameClick={onUsernameClicked}
-          settings={settings}
           isHighlighted={false}
         />
       ))}
       <ConversationModalComment
         comment={comment}
-        settings={settings}
         onUsernameClick={onUsernameClicked}
         isHighlighted={true}
       />
@@ -89,11 +84,6 @@ const enhanced = withPaginationContainer<
   FragmentVariables
 >(
   {
-    settings: graphql`
-      fragment ConversationModalContainer_settings on Settings {
-        ...ConversationModalCommentContainer_settings
-      }
-    `,
     comment: graphql`
       fragment ConversationModalContainer_comment on Comment
       @argumentDefinitions(

--- a/src/core/client/admin/components/ConversationModal/ConversationModalQuery.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalQuery.tsx
@@ -32,10 +32,6 @@ const ConversationModalQuery: FunctionComponent<Props> = ({
     <QueryRenderer<QueryTypes>
       query={graphql`
         query ConversationModalQuery($commentID: ID!) {
-          settings {
-            ...ConversationModalContainer_settings
-            ...ConversationModalRepliesContainer_settings
-          }
           comment(id: $commentID) {
             ...ConversationModalContainer_comment
             ...ConversationModalRepliesContainer_comment
@@ -80,14 +76,12 @@ const ConversationModalQuery: FunctionComponent<Props> = ({
             <div className={styles.body}>
               <ConversationModalContainer
                 onClose={onClose}
-                settings={props.settings}
                 comment={props.comment}
                 onUsernameClicked={onUsernameClicked}
               />
               <ConversationModalRepliesContainer
                 onClose={onClose}
                 comment={props.comment}
-                settings={props.settings}
                 onUsernameClicked={onUsernameClicked}
               />
             </div>

--- a/src/core/client/admin/components/ConversationModal/ConversationModalQuery.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalQuery.tsx
@@ -67,7 +67,7 @@ const ConversationModalQuery: FunctionComponent<Props> = ({
         }
 
         return (
-          <Card className={styles.root}>
+          <Card className={styles.root} data-testid="conversation-modal">
             <ConversationModalHeaderContainer
               onClose={onClose}
               comment={props.comment}

--- a/src/core/client/admin/components/ConversationModal/ConversationModalRepliesContainer.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalRepliesContainer.tsx
@@ -14,7 +14,6 @@ import {
 import { Button, HorizontalGutter } from "coral-ui/components/v2";
 
 import { ConversationModalRepliesContainer_comment } from "coral-admin/__generated__/ConversationModalRepliesContainer_comment.graphql";
-import { ConversationModalRepliesContainer_settings } from "coral-admin/__generated__/ConversationModalRepliesContainer_settings.graphql";
 import { ConversationModalRepliesContainerPaginationQueryVariables } from "coral-admin/__generated__/ConversationModalRepliesContainerPaginationQuery.graphql";
 
 import ConversationModalCommentContainer from "./ConversationModalCommentContainer";
@@ -24,7 +23,6 @@ import styles from "./ConversationModalRepliesContainer.css";
 interface Props {
   relay: RelayPaginationProp;
   comment: ConversationModalRepliesContainer_comment;
-  settings: ConversationModalRepliesContainer_settings;
   onClose: () => void;
   onUsernameClicked: (id?: string) => void;
 }
@@ -32,7 +30,6 @@ interface Props {
 const ConversationModalRepliesContainer: FunctionComponent<Props> = ({
   comment,
   relay,
-  settings,
   onUsernameClicked,
 }) => {
   const [loadMore] = useLoadMore(relay, 5);
@@ -51,7 +48,6 @@ const ConversationModalRepliesContainer: FunctionComponent<Props> = ({
           <div key={reply.id} className={styles.comment}>
             <ConversationModalCommentContainer
               key={reply.id}
-              settings={settings}
               comment={reply}
               isHighlighted={false}
               isReply={true}
@@ -93,11 +89,6 @@ const enhanced = withPaginationContainer<
   FragmentVariables
 >(
   {
-    settings: graphql`
-      fragment ConversationModalRepliesContainer_settings on Settings {
-        ...ConversationModalCommentContainer_settings
-      }
-    `,
     comment: graphql`
       fragment ConversationModalRepliesContainer_comment on Comment
       @argumentDefinitions(

--- a/src/core/client/admin/components/ConversationModal/ConversationModalRepliesQuery.tsx
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalRepliesQuery.tsx
@@ -23,9 +23,6 @@ const ConversationModalRepliesQuery: FunctionComponent<Props> = ({
     <QueryRenderer<QueryTypes>
       query={graphql`
         query ConversationModalRepliesQuery($commentID: ID!) {
-          settings {
-            ...ConversationModalCommentContainer_settings
-          }
           comment(id: $commentID) {
             replies {
               edges {
@@ -72,7 +69,6 @@ const ConversationModalRepliesQuery: FunctionComponent<Props> = ({
                 <ConversationModalCommentContainer
                   key={reply.node.id}
                   comment={reply.node}
-                  settings={props.settings}
                   isHighlighted={false}
                   isReply={true}
                   onUsernameClick={onUsernameClicked}

--- a/src/core/client/admin/test/fixtures.ts
+++ b/src/core/client/admin/test/fixtures.ts
@@ -793,7 +793,7 @@ export const baseComment = createFixture<GQLComment>({
 export const comments = createFixtures<GQLComment>(
   [
     {
-      id: "comment-0",
+      id: "comment-regular-0",
       author: users.commenters[0],
       body: "Joining Too",
       revision: {
@@ -802,7 +802,7 @@ export const comments = createFixtures<GQLComment>(
       permalink: "permalink",
     },
     {
-      id: "comment-1",
+      id: "comment-regular-1",
       author: users.commenters[1],
       body: "What's up?",
       revision: {
@@ -810,7 +810,7 @@ export const comments = createFixtures<GQLComment>(
       },
     },
     {
-      id: "comment-2",
+      id: "comment-regular-2",
       author: users.commenters[2],
       body: "Hey!",
       revision: {

--- a/src/core/client/admin/test/fixtures.ts
+++ b/src/core/client/admin/test/fixtures.ts
@@ -787,7 +787,39 @@ export const baseComment = createFixture<GQLComment>({
   site: sites[0],
   parent: NULL_VALUE,
   deleted: NULL_VALUE,
+  replyCount: 0,
 });
+
+export const comments = createFixtures<GQLComment>(
+  [
+    {
+      id: "comment-0",
+      author: users.commenters[0],
+      body: "Joining Too",
+      revision: {
+        id: "comment-0-revision-0",
+      },
+      permalink: "permalink",
+    },
+    {
+      id: "comment-1",
+      author: users.commenters[1],
+      body: "What's up?",
+      revision: {
+        id: "comment-1-revision-1",
+      },
+    },
+    {
+      id: "comment-2",
+      author: users.commenters[2],
+      body: "Hey!",
+      revision: {
+        id: "comment-2-revision-2",
+      },
+    },
+  ],
+  baseComment
+);
 
 export const unmoderatedComments = createFixtures<GQLComment>(
   [
@@ -864,6 +896,17 @@ export const reportedComments = createFixtures<GQLComment>(
       },
       permalink: "http://localhost/comment/0",
       body: "This is the last random sentence I will be writing and I am going to stop mid-sent",
+      replies: {
+        edges: [
+          { node: comments[0], cursor: comments[0].createdAt },
+          { node: comments[1], cursor: comments[1].createdAt },
+          { node: comments[2], cursor: comments[2].createdAt },
+        ],
+        pageInfo: {
+          hasNextPage: false,
+        },
+      },
+      replyCount: 2,
       flags: {
         edges: [
           {
@@ -916,6 +959,14 @@ export const reportedComments = createFixtures<GQLComment>(
         ],
         pageInfo: { endCursor: "2021-06-01T14:21:21.890Z", hasNextPage: true },
       },
+      parents: {
+        edges: [],
+        pageInfo: {
+          hasPreviousPage: false,
+          startCursor: null,
+        },
+      },
+      parentCount: 0,
     },
     {
       id: "comment-1",

--- a/src/core/client/admin/test/moderate/conversationModal.spec.tsx
+++ b/src/core/client/admin/test/moderate/conversationModal.spec.tsx
@@ -1,0 +1,167 @@
+import { act, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { pureMerge } from "coral-common/utils";
+import {
+  GQLCOMMENT_STATUS,
+  GQLResolver,
+  ModerationQueueToCommentsResolver,
+  MutationToRejectCommentResolver,
+} from "coral-framework/schema";
+import {
+  createMutationResolverStub,
+  createQueryResolverStub,
+  createResolversStub,
+  CreateTestRendererParams,
+  replaceHistoryLocation,
+} from "coral-framework/testHelpers";
+
+import { createContext } from "../create";
+import customRenderAppWithContext from "../customRenderAppWithContext";
+import {
+  comments,
+  emptyModerationQueues,
+  reportedComments,
+  settings,
+  site,
+  siteConnection,
+  users,
+} from "../fixtures";
+
+const viewer = users.admins[0];
+
+beforeEach(async () => {
+  replaceHistoryLocation("http://localhost/admin/moderate");
+});
+
+const rejectCommentStub =
+  createMutationResolverStub<MutationToRejectCommentResolver>(
+    ({ variables }) => {
+      expectAndFail(variables).toMatchObject({
+        commentID: comments[0].id,
+        commentRevisionID: comments[0].revision!.id,
+      });
+      return {
+        comment: {
+          ...comments[0],
+          status: GQLCOMMENT_STATUS.REJECTED,
+          statusHistory: {
+            edges: [
+              {
+                node: {
+                  id: "mod-action",
+                  status: GQLCOMMENT_STATUS.REJECTED,
+                  author: {
+                    id: viewer.id,
+                    username: viewer.username,
+                  },
+                },
+              },
+            ],
+          },
+        },
+        moderationQueues: emptyModerationQueues,
+      };
+    }
+  );
+
+const reportedCommentsEdges = {
+  edges: [
+    {
+      node: reportedComments[0],
+      cursor: reportedComments[0].createdAt,
+    },
+  ],
+  pageInfo: {
+    endCursor: reportedComments[0].createdAt,
+    hasNextPage: false,
+  },
+};
+
+async function createTestRenderer(
+  params: CreateTestRendererParams<GQLResolver> = {}
+) {
+  const { context } = createContext({
+    ...params,
+    resolvers: pureMerge(
+      createResolversStub<GQLResolver>({
+        Query: {
+          settings: () => settings,
+          site: () => site,
+          viewer: () => viewer,
+          moderationQueues: () => emptyModerationQueues,
+          comments: () => {
+            return reportedCommentsEdges;
+          },
+          sites: () => siteConnection,
+          comment: () => reportedComments[0],
+        },
+        Mutation: {
+          rejectComment: rejectCommentStub,
+        },
+      }),
+      params.resolvers
+    ),
+    initLocalState: (localRecord, source, environment) => {
+      if (params.initLocalState) {
+        params.initLocalState(localRecord, source, environment);
+      }
+    },
+  });
+  customRenderAppWithContext(context);
+
+  return { context };
+}
+
+it("renders view conversation thread and allows comments to be rejected there", async () => {
+  await act(async () => {
+    await createTestRenderer({
+      resolvers: createResolversStub<GQLResolver>({
+        Query: {
+          moderationQueues: () =>
+            pureMerge(emptyModerationQueues, {
+              reported: {
+                count: 1,
+                comments:
+                  createQueryResolverStub<ModerationQueueToCommentsResolver>(
+                    ({ variables }) => {
+                      expectAndFail(variables).toEqual({
+                        first: 5,
+                        orderBy: "CREATED_AT_DESC",
+                      });
+                      return reportedCommentsEdges;
+                    }
+                  ) as any,
+              },
+            }),
+        },
+      }),
+    });
+  });
+  const firstComment = screen.getByTestId(
+    `moderate-comment-card-${reportedComments[0].id}`
+  );
+  const viewConversationButton = within(firstComment).getByRole("button", {
+    name: "conversation-chat-text View Conversation",
+  });
+  await act(async () => {
+    userEvent.click(viewConversationButton);
+  });
+  const modal = await screen.findByTestId("conversation-modal");
+
+  // find first reply to comment and its reject button
+  const firstReply = within(modal).getByTestId(
+    `conversation-modal-comment-${comments[0].id}`
+  );
+  const rejectButtonReportedComment0 = within(firstReply).getByRole("button", {
+    name: "Reject",
+  });
+  expect(rejectButtonReportedComment0).toHaveTextContent("Reject");
+
+  // click reject
+  userEvent.click(rejectButtonReportedComment0);
+
+  // check that comment is rejected and the button text updates as expected
+  expect(rejectCommentStub.called).toBe(true);
+  expect(rejectButtonReportedComment0).toHaveTextContent("Rejected");
+});

--- a/src/core/client/admin/test/moderate/conversationModal.spec.tsx
+++ b/src/core/client/admin/test/moderate/conversationModal.spec.tsx
@@ -149,6 +149,11 @@ it("renders view conversation thread and allows comments to be rejected there", 
   });
   const modal = await screen.findByTestId("conversation-modal");
 
+  const showRepliesButton = screen.getByRole("button", {
+    name: "Show replies",
+  });
+  userEvent.click(showRepliesButton);
+
   // find first reply to comment and its reject button
   const firstReply = within(modal).getByTestId(
     `conversation-modal-comment-${comments[0].id}`
@@ -164,4 +169,10 @@ it("renders view conversation thread and allows comments to be rejected there", 
   // check that comment is rejected and the button text updates as expected
   expect(rejectCommentStub.called).toBe(true);
   expect(rejectButtonReportedComment0).toHaveTextContent("Rejected");
+
+  // parent comment should still have button with Reject text
+  const parentComment = within(modal).getByTestId(
+    `conversation-modal-comment-${reportedComments[0].id}`
+  );
+  expect(parentComment).toHaveTextContent("Reject");
 });

--- a/src/locales/en-US/admin.ftl
+++ b/src/locales/en-US/admin.ftl
@@ -1770,6 +1770,10 @@ conversation-modal-commentNotFound = Comment not found.
 conversation-modal-showMoreReplies = Show more replies
 conversation-modal-header-title = Conversation on:
 conversation-modal-header-moderate-link = Moderate story
+conversation-modal-rejectButton = <icon></icon>Reject
+  .aria-label = Reject
+conversation-modal-rejectButton-rejected = <icon></icon>Rejected
+  .aria-label = Rejected
 
 # Control panel
 


### PR DESCRIPTION
## What does this PR do?

These changes make it possible to reject comments using a `Reject` button in the conversation modal view for comments in the moderation queues in the admin. Once a comment is rejected there, the button text updates to `Rejected` and becomes disabled.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test this PR by creating a comment and adding some replies. Find that comment in the admin in the moderation queues. Click its `View conversation` button. See the `Reject` button next to each comment in the modal that opens. Click the `Reject` button. It should say `Rejected` and be disabled after clicking. Close the modal. See that the comment is now rejected.

If you open a comment from the `Rejected` queue, it shows in its conversation modal thread as `Rejected` already upon open, with the option to reject any parent/reply comments to it, as well.

## Where any tests migrated to React Testing Library?


## How do we deploy this PR?


