### PR TITLE
[CORL-2831] upgrade @giphy/react-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
   "dependencies": {
     "@ampproject/toolbox-cache-url": "^2.9.0",
     "@coralproject/bunyan-prettystream": "^0.1.4",
+    "@emotion/cache": "^10.0.29",
+    "@emotion/core": "^10.1.1",
     "@fluent/bundle": "^0.15.1",
     "@fluent/dom": "^0.7.0",
     "@google-cloud/profiler": "^5.0.3",
@@ -176,7 +178,7 @@
     "@coralproject/rte": "^2.2.2",
     "@fluent/react": "^0.12.0",
     "@giphy/js-fetch-api": "^4.1.2",
-    "@giphy/react-components": "^5.4.0",
+    "@giphy/react-components": "^8.1.0",
     "@graphql-codegen/cli": "^1.20.0",
     "@graphql-codegen/introspection": "^1.18.1",
     "@intervolga/optimize-cssnano-plugin": "^1.0.6",


### PR DESCRIPTION
## What does this PR do?
This PR upgrades @giphy/react-components to the latest version. It also explicitly installs @emotion/core and @emotion/cache, which we had used directly without adding to our dependencies (as they used to be transitive deps through @giphy, but no longer are)

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
Create a comment with and attached gif, and observe that it functions as it did before.

## Where any tests migrated to React Testing Library?
No. 

## How do we deploy this PR?
No special considerations should be required.
