### PR TITLE
[CORL-2882] Fix flaky and slow CommentContainer tests

### DIFF
--- a/src/core/client/stream/test/comments/components/CommentContainer.spec.tsx
+++ b/src/core/client/stream/test/comments/components/CommentContainer.spec.tsx
@@ -9,6 +9,7 @@ import {
 import {
   commenters,
   settings,
+  singleCommentStory,
   stories,
   storyWithDeletedComments,
   storyWithReplies,
@@ -51,7 +52,14 @@ async function createTestRenderer(
 afterEach(jest.clearAllMocks);
 
 it("renders username and body", async () => {
-  const { container } = await createTestRenderer();
+  const { container } = await createTestRenderer({
+    resolvers: {
+      Query: {
+        story: () => singleCommentStory,
+        stream: () => singleCommentStory,
+      },
+    },
+  });
 
   const firstComment = stories[0].comments.edges[0].node;
   const commentElement = await within(container).findByTestId(

--- a/src/core/client/stream/test/comments/components/CommentContainer.spec.tsx
+++ b/src/core/client/stream/test/comments/components/CommentContainer.spec.tsx
@@ -61,7 +61,7 @@ it("renders username and body", async () => {
     },
   });
 
-  const firstComment = stories[0].comments.edges[0].node;
+  const firstComment = singleCommentStory.comments.edges[0].node;
   const commentElement = await within(container).findByTestId(
     `comment-${firstComment.id}`
   );

--- a/src/core/client/stream/test/fixtures.ts
+++ b/src/core/client/stream/test/fixtures.ts
@@ -797,6 +797,19 @@ export const commentsFromStaff = denormalizeComments(
   )
 );
 
+export const singleCommentStory = denormalizeStory(
+  createFixture<GQLStory>(
+    {
+      id: "story-1",
+      url: "http://localhost/stories/story-1",
+      comments: {
+        edges: [{ node: comments[0], cursor: comments[0].createdAt }],
+      },
+    },
+    baseStory
+  )
+);
+
 export const stories = denormalizeStories(
   createFixtures<GQLStory>(
     [


### PR DESCRIPTION
## What does this PR do?

Simplifies the stream structure for the `render username and body` test in `CommentContainer.spec.tsx` that was timing out and acting flaky.

Because the default story fixture provided to the `createTestRenderer` was quite large, it was taking a long time to render the DOM inside Jest (more than 1 minute locally).

Since we have large stream logic tests elsewhere already, I made a simple story that only has one comment for this specific test which now renders in **less than 5 seconds locally**.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

Check CI or run `npm run test` and see that it passes.

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
