### PR TITLE
Replace Google Container Registry with Google Artifact Registry

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.REPO_PATCHED_DEPLOY_KEY }}
       -
-        name: Login to GCR
+        name: Login to GAR
         uses: docker/login-action@v2
         with:
           registry: us-east1-docker.pkg.dev

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ on:
   merge_group:
 
 env:
-  IMAGE_REPOSITORY: 'gcr.io/the-coral-project/coral'
+  IMAGE_REPOSITORY: 'us-east1-docker.pkg.dev/the-coral-project/coral/talk'
   IMAGE_CACHE_REPOSITORY: 'coralproject/ci'
   DOCKERHUB_USERNAME: 'coralproject'
 
@@ -30,9 +30,9 @@ jobs:
         name: Login to GCR
         uses: docker/login-action@v2
         with:
-          registry: gcr.io
+          registry: us-east1-docker.pkg.dev
           username: _json_key
-          password: ${{ secrets.GCR_JSON_KEY }}
+          password: ${{ secrets.GAR_JSON_KEY }}
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -34,7 +34,7 @@ jobs:
         id: 'auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          credentials_json: '${{ secrets.GCR_JSON_KEY }}'
+          credentials_json: '${{ secrets.GAR_JSON_KEY }}'
       -
         name: Set up Cloud SDK
         uses: 'google-github-actions/setup-gcloud@v1'


### PR DESCRIPTION
## What does this PR do?

Replaces the image registry location with one using GAR in the coral-project account. This is because GCR is deprecated and will go away in 2024.

More [info](https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation?_ga=2.1459825.-1180216888.1632928171&_gac=1.56016217.1692120383.Cj0KCQiAosmPBhCPARIsAHOen-M6Nm45YuNaSL_MB24ipok1i_vo9-yapQiLakxxfM0pA0G4x_WccuoaAg7TEALw_wcB) about GCR

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

I tested it by pushing the tag `develop-latest` to GAR: 
<img width="1149" alt="Screenshot 2023-08-16 at 11 05 31 AM" src="https://github.com/coralproject/talk/assets/3925948/43effa4c-733f-4d91-8a9c-bf2428e9a59a">


## Where any tests migrated to React Testing Library?

n/a

## How do we deploy this PR?

n/a
