### PR TITLE
[CORL-2859]: add defaults for flair badge config

### DIFF
--- a/src/core/server/graph/resolvers/Settings.ts
+++ b/src/core/server/graph/resolvers/Settings.ts
@@ -58,4 +58,15 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
     args,
     ctx
   ) => embeddedComments,
+  flairBadges: ({
+    flairBadges = { flairBadgesEnabled: false, badges: [] },
+  }) => {
+    if (!flairBadges.badges) {
+      return {
+        flairBadgesEnabled: flairBadges.flairBadgesEnabled ?? false,
+        badges: [],
+      };
+    }
+    return flairBadges;
+  },
 };


### PR DESCRIPTION
## What does this PR do?

Adds a default if flair badges aren't configured, since `badges` is non-nullable.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [x] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test that when flair badges aren't configured on a tenant, the default of false for flairBadgesEnabled and empty badges array is there. There should be no error when loading the stream.

If flair badges are enabled but no badges configured, flairBadgesEnabled should be true and an empty badges array returned.

If flair badges are enabled and badges are configured, then both those values should be correctly returned.

## Where any tests migrated to React Testing Library?

no

## How do we deploy this PR?


