### PR TITLE
[CORL-2844]: update reject button and comment spacing in admin conversation modal

### DIFF
--- a/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.css
+++ b/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.css
@@ -2,6 +2,7 @@ $conversationModalHighlightBackground: $colors-teal-100;
 $conversationModalCommentText: var(--palette-text-500);
 .root {
   flex: 1;
+  padding: 0 var(--spacing-2);
 }
 
 .line {
@@ -42,6 +43,7 @@ $conversationModalCommentText: var(--palette-text-500);
 
 .rejectButton {
   height: fit-content;
+  margin-top: var(--spacing-1);
   &:disabled {
     background-color: var(--palette-error-500) !important;
     opacity: 1 !important;


### PR DESCRIPTION
## What does this PR do?

This updates the spacing in the conversation thread modal in the admin for moderation cards. It ensures all new reject buttons are aligned and there is the same amount of spacing around all comments.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can create a few comments and replies in the stream. Go to the moderation admin view and find them in moderation cards. Click `View Conversation`. See that the `Reject` buttons are aligned, whether they are in highlighted or regular comments. See that the left side of the comments are all aligned too. Compare with screenshots of expected alignment in bugs doc.

## Where any tests migrated to React Testing Library?



## How do we deploy this PR?

