### PR TITLE
Revert "Merge pull request #4312 from coralproject/wyattjoh/promise-worker-threads

### DIFF
--- a/src/core/server/services/comments/pipeline/phases/wordList/service.ts
+++ b/src/core/server/services/comments/pipeline/phases/wordList/service.ts
@@ -24,25 +24,18 @@ import {
 const WORKER_SCRIPT =
   "./dist/core/server/services/comments/pipeline/phases/wordList/worker.js";
 
-interface PromiseCallbacks<R> {
-  resolve: (result: R) => void;
-  reject: (err: Error) => void;
-}
-
 export class WordListService {
   private worker: Worker;
 
   private onMessageDelegate: (event: MessageEvent) => void;
-  private readonly callbacks: Map<
-    string,
-    PromiseCallbacks<WordListWorkerResult>
-  > = new Map();
+  private results: Map<string, WordListWorkerResult>;
   private logger: Logger;
   private sanitizer: Sanitize;
 
-  constructor(logger: Logger) {
+  constructor(logger: Logger, numWorkers = 3) {
     this.logger = logger;
 
+    this.results = new Map<string, WordListWorkerResult>();
     this.onMessageDelegate = this.onMessage.bind(this);
 
     this.worker = new Worker(WORKER_SCRIPT);
@@ -59,37 +52,20 @@ export class WordListService {
     });
   }
 
+  private sleep(ms: number) {
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, ms);
+    });
+  }
+
   private onMessage(result: WordListWorkerResult) {
     if (!result) {
       return;
     }
 
-    // Get the callbacks for this result.
-    const callbacks = this.callbacks.get(result.id);
-    if (!callbacks) {
-      throw new Error(`Invalid result id: ${result.id}`);
-    }
-
-    // Delete the callbacks for this result.
-    this.callbacks.delete(result.id);
-
-    // Resolve the promise.
-    if (result.ok) {
-      callbacks.resolve(result);
-    } else {
-      callbacks.reject(result.err!);
-    }
-  }
-
-  private send(message: WordListWorkerMessage) {
-    // Create a new promise to wait for the worker to finish.
-    const promise = new Promise<WordListWorkerResult>((resolve, reject) => {
-      this.callbacks.set(message.id, { resolve, reject });
-    });
-
-    this.worker.postMessage(message);
-
-    return promise;
+    this.results.set(result.id, result);
   }
 
   public async initialize(
@@ -111,7 +87,31 @@ export class WordListService {
       data,
     };
 
-    const result = await this.send(message);
+    const builder = async () => {
+      let hasResult = this.results.has(message.id);
+      while (!hasResult) {
+        await this.sleep(1);
+        hasResult = this.results.has(message.id);
+      }
+
+      const result = this.results.get(message.id);
+      if (!result) {
+        this.results.delete(message.id);
+        return {
+          id: message.id,
+          tenantID,
+          ok: false,
+          err: new Error("result was undefined"),
+        };
+      }
+
+      this.results.delete(message.id);
+      return result;
+    };
+
+    this.worker.postMessage(message);
+    const result = await builder();
+
     if (!result.ok || result.err) {
       this.logger.error(
         { tenantID: result.tenantID, id: result.id },
@@ -143,8 +143,32 @@ export class WordListService {
       data,
     };
 
-    // Send the message to the worker.
-    const result = await this.send(message);
+    this.worker.postMessage(message);
+
+    const builder = async () => {
+      let hasResult = this.results.has(message.id);
+      while (!hasResult) {
+        await this.sleep(1);
+        hasResult = this.results.has(message.id);
+      }
+
+      const result = this.results.get(message.id);
+      if (!result) {
+        this.results.delete(message.id);
+        return {
+          id: message.id,
+          tenantID,
+          ok: false,
+          err: new Error("result was undefined"),
+        };
+      }
+
+      this.results.delete(message.id);
+      return result;
+    };
+
+    const result = await builder();
+
     if (!result.ok || result.err) {
       return {
         isMatched: false,


### PR DESCRIPTION
## What does this PR do?

This reverts commit 9e31852cadf5292d0841fc95b61b5dc79c81d00f, reversing changes made to b177389e275dbf59295dd24643f13ab040a04f23.

There is a bug in this that doesn't handle the flow of an empty wordlist and returning the correct result. Until I have time to figure this out and fix it up, reverting for now.

The issue is that if there are no wordlist items and a user tries to post a comment, they will get `InternalError: no wordlist found for tenant.` Even if there are no wordlist items, a user should be allowed to comment.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- empty your wordlists (banned and suspect)
- post a comment
- no error should show up

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
