### PR TITLE
Optimize CommentContainer.spec.tsx test initialization

### DIFF
--- a/src/core/client/stream/test/comments/components/CommentContainer.spec.tsx
+++ b/src/core/client/stream/test/comments/components/CommentContainer.spec.tsx
@@ -1,6 +1,6 @@
-import { screen, within } from "@testing-library/react";
-import { pureMerge } from "coral-common/utils";
+import { screen, waitFor, within } from "@testing-library/react";
 
+import { pureMerge } from "coral-common/utils";
 import { GQLResolver } from "coral-framework/schema";
 import {
   createResolversStub,
@@ -44,7 +44,19 @@ async function createTestRenderer(
 
   customRenderAppWithContext(context);
 
-  const container = await screen.findByTestId("comments-allComments-log");
+  // it is usually best practice to use findByTestId
+  // for async work.
+  //
+  // source: https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-waitfor-to-wait-for-elements-that-can-be-queried-with-find
+  //
+  // however, for some special occasions, the test runner
+  // has a hard time and doing a .getByTestId is more
+  // performant. Since this cuts the `render username and body`
+  // test from 1.32s down to 795ms on my machine, I'm doing
+  // a waitFor + getByTestId here.
+  const container = await waitFor(() =>
+    screen.getByTestId("comments-allComments-log")
+  );
 
   return { container, context };
 }


### PR DESCRIPTION
## What does this PR do?

Use `waitFor` and `getByTestId` for the initialization of the `CommentContainer.spec.tsx` tests.

This cuts a problematic test `render username and body`'s render time down from roughly 1320ms to 795ms. Since we're seeing this test take minutes to run on GitHub Actions CI, this should help it finish without timing out.

I realize replacing a `findBy` with a `waitFor` + `get` is considered less optimal for most occasions, I have documented why this is more optimal in the code. Several folks have found this to be the case for finding objects in particularly large test DOM's on StackOverflow and GitHub issues. For now, this is a nice quick fix to get some speed during a particularly slow test.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- run the tests
- see that they pass
- watch that it passes more reliably in CI

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
