### PR TITLE
[CORL-2720] optional email pre-mod filter

### DIFF
--- a/src/core/server/graph/schema/schema.graphql
+++ b/src/core/server/graph/schema/schema.graphql
@@ -567,6 +567,12 @@ enum FEATURE_FLAG {
   users, and commentActions more quickly. It is disabled by default.
   """
   DATA_CACHE
+
+  """
+  EMAIL_PREMOD_FILTER enables the feature to premoderate accounts whose emails
+  match patterns that are common with spam accounts.
+  """
+  EMAIL_PREMOD_FILTER
 }
 
 # The moderation mode of the site.

--- a/src/core/server/services/users/emailPremodFilter.ts
+++ b/src/core/server/services/users/emailPremodFilter.ts
@@ -3,7 +3,7 @@ import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
 import { GQLFEATURE_FLAG } from "coral-server/graph/schema/__generated__/types";
 import { User } from "coral-server/models/user";
 
-const EMAIL_PREMOD_FILTER_PERIOD_LIMIT = 3;
+export const EMAIL_PREMOD_FILTER_PERIOD_LIMIT = 3;
 
 const emailHasTooManyPeriods = (email: string | undefined, limit: number) => {
   if (!email) {

--- a/src/core/server/services/users/emailPremodFilter.ts
+++ b/src/core/server/services/users/emailPremodFilter.ts
@@ -11,7 +11,7 @@ const emailHasTooManyPeriods = (email: string | undefined, limit: number) => {
   }
 
   const split = email.split("@");
-  if (split.length !== 2) {
+  if (split.length < 2) {
     return false;
   }
 

--- a/src/core/server/services/users/emailPremodFilter.ts
+++ b/src/core/server/services/users/emailPremodFilter.ts
@@ -1,0 +1,47 @@
+import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
+
+import { GQLFEATURE_FLAG } from "coral-server/graph/schema/__generated__/types";
+import { User } from "coral-server/models/user";
+
+const EMAIL_PREMOD_FILTER_PERIOD_LIMIT = 3;
+
+const emailHasTooManyPeriods = (email: string | undefined, limit: number) => {
+  if (!email) {
+    return false;
+  }
+
+  const split = email.split("@");
+  if (split.length !== 2) {
+    return false;
+  }
+
+  const firstHalf = split[0];
+
+  let periodCount = 0;
+  for (const char of firstHalf) {
+    if (char === ".") {
+      periodCount++;
+    }
+  }
+
+  return periodCount >= limit;
+};
+
+export const shouldPremodDueToLikelySpamEmail = (
+  tenant: Readonly<Tenant>,
+  user: Readonly<User>
+) => {
+  // don't premod check unless the filter is enabled
+  if (!hasFeatureFlag(tenant, GQLFEATURE_FLAG.EMAIL_PREMOD_FILTER)) {
+    return false;
+  }
+
+  // this is an array to allow for adding more rules in the
+  // future as we play whack-a-mole trying to block spammers
+  // and other trouble makers
+  const results = [
+    emailHasTooManyPeriods(user.email, EMAIL_PREMOD_FILTER_PERIOD_LIMIT),
+  ];
+
+  return results.some((v) => v === true);
+};

--- a/src/core/server/services/users/user.emailPremodFilter.spec.ts
+++ b/src/core/server/services/users/user.emailPremodFilter.spec.ts
@@ -1,0 +1,67 @@
+import {
+  createTenantFixture,
+  createUserFixture,
+} from "coral-server/test/fixtures";
+
+import { GQLFEATURE_FLAG } from "coral-server/graph/schema/__generated__/types";
+
+import {
+  EMAIL_PREMOD_FILTER_PERIOD_LIMIT,
+  shouldPremodDueToLikelySpamEmail,
+} from "./emailPremodFilter";
+
+const tooManyPeriodsEmail = "this.has.too.many.periods@test.com";
+const justEnoughPeriodsEmail = "just.enough.periods@test.com";
+const noPeriodsEmail = "noperiodshere@test.com";
+
+it("does not premod filter emails when feature flag is disabled", () => {
+  const tenant = createTenantFixture({
+    featureFlags: [],
+  });
+
+  const user = createUserFixture({
+    email: tooManyPeriodsEmail,
+  });
+
+  const result = shouldPremodDueToLikelySpamEmail(tenant, user);
+  expect(!result);
+});
+
+it(`does not premod filter emails when feature flag enabled and has less than ${EMAIL_PREMOD_FILTER_PERIOD_LIMIT} periods`, () => {
+  const tenant = createTenantFixture({
+    featureFlags: [GQLFEATURE_FLAG.EMAIL_PREMOD_FILTER],
+  });
+
+  const user = createUserFixture({
+    email: justEnoughPeriodsEmail,
+  });
+
+  const result = shouldPremodDueToLikelySpamEmail(tenant, user);
+  expect(result);
+});
+
+it(`does not premod filter emails when feature flag enabled and has no periods`, () => {
+  const tenant = createTenantFixture({
+    featureFlags: [GQLFEATURE_FLAG.EMAIL_PREMOD_FILTER],
+  });
+
+  const user = createUserFixture({
+    email: noPeriodsEmail,
+  });
+
+  const result = shouldPremodDueToLikelySpamEmail(tenant, user);
+  expect(result);
+});
+
+it(`does premod filter emails when feature flag is enabled and has too many (${EMAIL_PREMOD_FILTER_PERIOD_LIMIT} or more) periods`, () => {
+  const tenant = createTenantFixture({
+    featureFlags: [GQLFEATURE_FLAG.EMAIL_PREMOD_FILTER],
+  });
+
+  const user = createUserFixture({
+    email: tooManyPeriodsEmail,
+  });
+
+  const result = shouldPremodDueToLikelySpamEmail(tenant, user);
+  expect(result);
+});

--- a/src/core/server/services/users/users.ts
+++ b/src/core/server/services/users/users.ts
@@ -163,7 +163,6 @@ export interface FindOrCreateUserOptions {
 export async function findOrCreate(
   config: Config,
   mongo: MongoContext,
-  cache: DataCache,
   tenant: Tenant,
   input: FindOrCreateUser,
   options: FindOrCreateUserOptions,
@@ -177,7 +176,7 @@ export async function findOrCreate(
     let { user } = await findOrCreateUser(mongo, tenant.id, input, now);
 
     if (shouldPremodDueToLikelySpamEmail(tenant, user)) {
-      user = await premod(mongo, cache, tenant, null, user.id, now);
+      user = await premodUser(mongo, tenant.id, user.id, undefined, now);
     }
 
     return user;
@@ -191,7 +190,7 @@ export async function findOrCreate(
       let { user } = await findOrCreateUser(mongo, tenant.id, input, now);
 
       if (shouldPremodDueToLikelySpamEmail(tenant, user)) {
-        user = await premod(mongo, cache, tenant, null, user.id, now);
+        user = await premodUser(mongo, tenant.id, user.id, undefined, now);
       }
 
       return user;
@@ -219,7 +218,7 @@ export async function findOrCreate(
       );
 
       if (shouldPremodDueToLikelySpamEmail(tenant, user)) {
-        user = await premod(mongo, cache, tenant, null, user.id, now);
+        user = await premodUser(mongo, tenant.id, user.id, undefined, now);
       }
 
       return user;


### PR DESCRIPTION
## What does this PR do?

Auto-pre-mods emails with 3 or more periods in the email if the `EMAIL_PREMOD_FILTER` feature flag is enabled.

## These changes will impact:

- [X] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds a `EMAIL_PREMOD_FILTER` feature flag.

## Does this PR introduce any new environment variables or feature flags?

Added the `EMAIL_PREMOD_FILTER` feature flag.

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- create a user with too many periods in their email (3 or more)
    - ex: `too.many.periods.here@test.com`
- try and post a comment, see that the user IS NOT pre-modded
- enable the feature flag: `EMAIL_PREMOD_FILTER`
- create a new user with too many periods in their email (3 or more)
- try and post a comment, see that the new user IS pre-modded

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations. Enable the `EMAIL_PREMOD_FILTER` feature flag if you want to use the filter.