### PR TITLE
[CORL-2886]: add web view troubleshooting info to docs

### DIFF
--- a/docs/docs/migrating-6-to-7.md
+++ b/docs/docs/migrating-6-to-7.md
@@ -57,6 +57,14 @@ html {
 
 4. If your site has a Content Security Policy that prohibits websocket (`wss://`) requests, you will need to update it to whitelist `wss://[your coral URL]/api/graphql/live` in order for live updates to function.
 
+## Native mobile applications
+
+- If the Coral embed is not loading in web view after this update, you may need to add in this call:
+
+```js
+webView.getSettings.setDomStorageEnabled(true);
+```
+
 ## After Coral has been updated to v7
 
 Once the update is complete and you are running v7, you may wish to undo some of the previous steps for better maintainability:

--- a/docs/docs/mobile.md
+++ b/docs/docs/mobile.md
@@ -29,3 +29,11 @@ Integration with native mobile applications is done through web view, you will n
 This will initialize the Coral stream with a logged-in user.
 
 5. You will need to use the same method to pass a Story ID or Story URL to the embed code using the `storyID` or `storyURL` options passed to `createStreamEmbed`. See [CMS Integration](/cms) for more details.
+
+### Troubleshooting
+
+If the Coral embed is not loading in web view, and you are using Coral >= v7.0.0, you may need to add in this call:
+
+```js
+webView.getSettings.setDomStorageEnabled(true);
+```


### PR DESCRIPTION
## What does this PR do?

Adds web view troubleshooting info to docs if Coral is not loading after upgrade to v7.0.0 in web view.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?



## Where any tests migrated to React Testing Library?



## How do we deploy this PR?


