### PR TITLE
Fix monorepo docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,20 @@
 # tests are not run in the docker container.
 __tests__
+**/__tests__
+**/coverage
 coverage
 
 # we won't use the .git folder in production.
 .git
+.github
 
 # don't include the dependancies
 node_modules
+**/node_modules
 
 # don't include any logs
 npm-debug.log*
+**/npm-debug.log*
 
 # don't include any yarn files
 yarn-error.log
@@ -17,14 +22,30 @@ yarn.lock
 
 # don't include any OS/editor files
 .env
+**/.env
 .idea/
 .vs
+.vscode
+
 .docz
+**/.docz
+
 *.swp
+**/*.swp
+
 *.DS_STORE
+*.DS_Store
+**/*.DS_STORE
+**/*.DS_Store
 
 # don't include any generated files
 dist
+**/dist
+
 *.css.d.ts
+**/*.css.d.ts
+
 __generated__
-docs/.next
+**/__generated__
+
+**/.next

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,9 @@ RUN cd server && \
   npm prune --production && \
   cd ..
 
+# Set working directory within server folder
+WORKDIR /usr/src/app/server
+
 # Setup the environment
 ENV NODE_ENV production
 ENV PORT 5000

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,4 +72,4 @@ EXPOSE 5000
 
 # Run the node process directly instead of using `npm run start`:
 # SEE: https://github.com/nodejs/docker-node/blob/a2eb9f80b0fd224503ee2678867096c9e19a51c2/docs/BestPractices.md#cmd
-CMD ["node", "server/dist/index.js"]
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## What does this PR do?

Fixes the graphql error on startup for docker monorepo builds.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- perform a docker build
- start it up
  - `docker run --name coral -p 3000:5000 -e FORCE_SSL=false -e SIGNING_SECRET=secret -e "REDIS_URI=redis://host.docker.internal:6379" -e "MONGODB_URI=mongodb://host.docker.internal:27017/coral" -e "MONGODB_ARCHIVE_URI=mongodb://host.docker.internal:27018/archive" <image_tag>`
- see that it is running and working fine by visiting http://localhost:3000

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
