### PR TITLE
[CORL-2905]: add optional count param to active stories script

### DIFF
--- a/server/src/core/server/app/handlers/api/story/active.ts
+++ b/server/src/core/server/app/handlers/api/story/active.ts
@@ -14,7 +14,7 @@ export type Options = Pick<AppOptions, "mongo">;
 const ActiveStoriesQuerySchema = Joi.object().keys({
   callback: Joi.string().allow("").optional(),
   siteID: Joi.string().required(),
-  count: Joi.number().optional(),
+  count: Joi.number().optional().max(999),
 });
 
 interface ActiveStoriesQuery {

--- a/server/src/core/server/app/handlers/api/story/active.ts
+++ b/server/src/core/server/app/handlers/api/story/active.ts
@@ -14,11 +14,13 @@ export type Options = Pick<AppOptions, "mongo">;
 const ActiveStoriesQuerySchema = Joi.object().keys({
   callback: Joi.string().allow("").optional(),
   siteID: Joi.string().required(),
+  count: Joi.number().optional(),
 });
 
 interface ActiveStoriesQuery {
   callback: string;
   siteID: string;
+  count: number;
 }
 
 /**
@@ -44,7 +46,7 @@ export const activeJSONPHandler =
       const { tenant, now } = req.coral;
 
       // Ensure we have a siteID on the query.
-      const { siteID }: ActiveStoriesQuery = validate(
+      const { siteID, count }: ActiveStoriesQuery = validate(
         ActiveStoriesQuerySchema,
         req.query
       );
@@ -61,7 +63,7 @@ export const activeJSONPHandler =
         mongo,
         tenant.id,
         siteID,
-        5,
+        count ?? 5,
         start,
         now
       );


### PR DESCRIPTION
## What does this PR do?

These changes add an optional `count` param to the active stories jsonp script. If the `count` param is passed in, then that is the number of stories that will be returned. If no `count` param is passed, the count defaults to 5.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can either visit in your browser or run curl against these urls to see that you get the expected response:
`http://localhost:8080/api/story/active.js?siteID=SITE_ID` (should get the default of 5 stories)
`http://localhost:8080/api/story/active.js?siteID=SITE_ID&count=10` (should get 10 stories)
`http://localhost:8080/api/story/active.js?siteID=SITE_ID&count=2` (should get 2 stories)

Note that if your site has fewer than the requested number of stories, all stories will be returned.

## Where any tests migrated to React Testing Library?



## How do we deploy this PR?

