### PR TITLE
[CORL-2911]: update all comment-count translations to remove $numberClass

### DIFF
--- a/server/src/core/server/locales/de-CH/common.ftl
+++ b/server/src/core/server/locales/de-CH/common.ftl
@@ -6,7 +6,6 @@ reaction-labelActiveRespected = Respektiert
 reaction-sortLabelMostRespected = Am meisten Respektiert
 
 comment-count =
-  <span class="{ $numberClass }">{ $number }</span>
   <span class="{ $textClass }">{ $number  ->
     [one] Kommentar
     *[other] Kommentare

--- a/server/src/core/server/locales/de/common.ftl
+++ b/server/src/core/server/locales/de/common.ftl
@@ -6,7 +6,6 @@ reaction-labelActiveRespected = Respektiert
 reaction-sortLabelMostRespected = Am meisten Respektiert
 
 comment-count =
-  <span class="{ $numberClass }">{ $number }</span>
   <span class="{ $textClass }">{ $number  ->
     [one] Kommentar
     *[other] Kommentare

--- a/server/src/core/server/locales/fi-FI/common.ftl
+++ b/server/src/core/server/locales/fi-FI/common.ftl
@@ -6,7 +6,6 @@ reaction-labelActiveRespected = Hyvä kommentti
 reaction-sortLabelMostRespected = Parhaat kommentit
 
 comment-count =
-  <span class="{ $numberClass }">{ $number }</span>
   <span class="{ $textClass }">{ $number  ->
     [one] kommentti
     *[other] kommenttia

--- a/server/src/core/server/locales/fr-FR/common.ftl
+++ b/server/src/core/server/locales/fr-FR/common.ftl
@@ -6,7 +6,6 @@ reaction-labelActiveRespected = Aimé
 reaction-sortLabelMostRespected = Le plus aimé
 
 comment-count =
-  <span class="{ $numberClass }">{ $number }</span>
   <span class="{ $textClass }">{ $number  ->
     [one] Commentaire
     *[other] Commentaires

--- a/server/src/core/server/locales/pl/common.ftl
+++ b/server/src/core/server/locales/pl/common.ftl
@@ -6,7 +6,6 @@ reaction-labelActiveRespected = Polecany
 reaction-sortLabelMostRespected = Najbardziej polecane
 
 comment-count =
-  <span class="{ $numberClass }">{ $number }</span>
   <span class="{ $textClass }">{ $number  ->
     [one] Komentarz
     [few] Komentarze

--- a/server/src/core/server/locales/pt-BR/common.ftl
+++ b/server/src/core/server/locales/pt-BR/common.ftl
@@ -6,7 +6,6 @@ reaction-labelActiveRespected = Respeitado
 reaction-sortLabelMostRespected = Mais Respeitados
 
 comment-count =
-  <span class="{ $numberClass }">{ $number }</span>
   <span class="{ $textClass }">{ $number  ->
     [one] Comentário
     *[other] Comentários

--- a/server/src/core/server/locales/sv/common.ftl
+++ b/server/src/core/server/locales/sv/common.ftl
@@ -6,7 +6,6 @@ reaction-labelActiveRespected = Respekterad
 reaction-sortLabelMostRespected = Mest respekterade
 
 comment-count =
-  <span class="{ $numberClass }">{ $number }</span>
   <span class="{ $textClass }">{ $number  ->
     [one] kommentar
     *[other] kommentarer


### PR DESCRIPTION
## What does this PR do?

Some translation files for `comment-count` still included `$numberClass` and count, although the inclusion of this has been moved to the front end count injection. Translation files have been updated so there is no longer an error.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You'll need to do a fresh build: `npm run build:development`

Then you can see that comment counts work as expected in the affected languages such as de, fr, etc. Change the language and see that the coral count at the top of the example stream is working as expected. Can also test in multi site test.

## Where any tests migrated to React Testing Library?



## How do we deploy this PR?


