### PR TITLE
[CORL-2864] Left align fallback comment embed

### DIFF
--- a/client/src/core/client/stream/tabs/Comments/Comment/ModerationDropdown/CopyCommentEmbedCodeContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Comment/ModerationDropdown/CopyCommentEmbedCodeContainer.tsx
@@ -104,7 +104,7 @@ const CopyCommentEmbedCodeContainer: FunctionComponent<Props> = ({
 
   const permalinkUrl = getURLWithCommentID(story.url, comment.id);
 
-  const embedCode = `<div class="coral-comment-embed coral-comment-embed-simple" style="background-color: #f4f7f7; padding: 8px; position: relative;" data-commentID=${
+  const embedCode = `<div class="coral-comment-embed coral-comment-embed-simple" style="background-color: #f4f7f7; padding: 8px; position: relative; text-align: left;" data-commentID=${
     comment.id
   } data-reactionLabel="${
     settings.reaction.label


### PR DESCRIPTION
## What does this PR do?
This PR adds a `text alignt: left;` style rule to comment embed code so it will look better when embeded in emails.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Click the 'Embed comment' button on a comment, paste it somehwere and see that there is an additiona inline style rule aligning text to the left.
2. See HTML of before and after attached to Jira ticket to see how it should appear in emails.

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations should be required.
