### PR TITLE
fix true/false mixup in permission map

### DIFF
--- a/client/src/core/client/admin/permissions/story.ts
+++ b/client/src/core/client/admin/permissions/story.ts
@@ -17,7 +17,7 @@ const permissionMap: PermissionMap<AbilityType, PermissionContext> = {
     [GQLUSER_ROLE.MODERATOR]: () => true,
   },
   ARCHIVE_STORY: {
-    [GQLUSER_ROLE.ADMIN]: () => false,
+    [GQLUSER_ROLE.ADMIN]: () => true,
   },
 };
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes a mistake that disallows admins from archiving stories.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
As an admin, archive a story

## Where any tests migrated to React Testing Library?
No

## How do we deploy this PR?
No special considerations should be needed
