### PR TITLE
feat/rejection-reason-models

### DIFF
--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -3339,9 +3339,9 @@ type RejectionReason {
   legalGrounds: String
 
   """
-  detailedExplaination is any additional information the user wishes to provide.
+  detailedExplanation is any additional information the user wishes to provide.
   """
-  detailedExplaination: String
+  detailedExplanation: String
 }
 
 type CommentModerationAction {
@@ -6731,9 +6731,9 @@ input RejectCommentReasonInput {
   legalGrounds: String
 
   """
-  detailedExplaination is any additional information the user wishes to provide.
+  detailedExplanation is any additional information the user wishes to provide.
   """
-  detailedExplaination: String
+  detailedExplanation: String
 }
 
 input RejectCommentInput {

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -3290,6 +3290,43 @@ enum COMMENT_STATUS {
   SYSTEM_WITHHELD
 }
 
+enum REJECTION_REASON {
+  """
+  OFFENSIVE represents a rejection of a comment for being offensive.
+  """
+  OFFENSIVE
+
+  """
+  ABUSIVE represents a rejection of a comment for being abusive.
+  """
+  ABUSIVE
+
+  """
+  SPAM represents a rejection of a comment for being spam.
+  """
+  SPAM
+
+  """
+  BANNED_WORD represents a rejection of a comment for containing a banned word.
+  """
+  BANNED_WORD
+
+  """
+  AD represents a rejection of a comment for being and ad.
+  """
+  AD
+
+  """
+  ILLEGAL_CONTENT represents a rejection of a comment for containing illegal content.
+  """
+  ILLEGAL_CONTENT
+
+  """
+  OTHER is reserved for reasons that arent adequately described by the other options.
+  """
+  OTHER
+}
+
 type CommentModerationAction {
   id: ID!
 
@@ -3313,6 +3350,11 @@ type CommentModerationAction {
   that the system has assigned the moderation status.
   """
   moderator: User
+
+  """
+  reason is the reason the comment was rejected, if it was rejected
+  """
+  reason: REJECTION_REASON
 
   """
   createdAt is the time that the CommentModerationAction was created.

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -3290,7 +3290,7 @@ enum COMMENT_STATUS {
   SYSTEM_WITHHELD
 }
 
-enum REJECTION_REASON {
+enum REJECTION_REASON_CODE {
   """
   OFFENSIVE represents a rejection of a comment for being offensive.
   """
@@ -3327,6 +3327,23 @@ enum REJECTION_REASON {
   OTHER
 }
 
+type RejectionReason {
+  """
+  code is the reason that the comment was rejected
+  """
+  code: REJECTION_REASON_CODE!
+
+  """
+  legalGrounds is the specific laws broken as described by the reporter
+  """
+  legalGrounds: String
+
+  """
+  detailedExplaination is any additional information the user wishes to provide.
+  """
+  detailedExplaination: String
+}
+
 type CommentModerationAction {
   id: ID!
 
@@ -3354,7 +3371,7 @@ type CommentModerationAction {
   """
   reason is the reason the comment was rejected, if it was rejected
   """
-  reason: REJECTION_REASON
+  reason: RejectionReason
 
   """
   createdAt is the time that the CommentModerationAction was created.
@@ -6702,6 +6719,23 @@ type ApproveCommentPayload {
 # rejectComment
 ##################
 
+input RejectCommentReasonInput {
+  """
+  code is the enumerated code for the reason the comment is being rejected.
+  """
+  code: REJECTION_REASON_CODE!
+
+  """
+  legalGrounds is the specific laws broken as described by the reporter.
+  """
+  legalGrounds: String
+
+  """
+  detailedExplaination is any additional information the user wishes to provide.
+  """
+  detailedExplaination: String
+}
+
 input RejectCommentInput {
   """
   commentID is the ID of the Comment that was rejected.
@@ -6717,6 +6751,11 @@ input RejectCommentInput {
   clientMutationId is required for Relay support.
   """
   clientMutationId: String!
+
+  """
+  reason is the reason the comment is being rejected if DSA features are enabled.
+  """
+  reason: RejectCommentReasonInput
 }
 
 type RejectCommentPayload {

--- a/server/src/core/server/models/action/moderation/comment.ts
+++ b/server/src/core/server/models/action/moderation/comment.ts
@@ -10,7 +10,10 @@ import {
 } from "coral-server/models/helpers";
 import { TenantResource } from "coral-server/models/tenant";
 
-import { GQLCOMMENT_STATUS } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLCOMMENT_STATUS,
+  GQLREJECTION_REASON,
+} from "coral-server/graph/schema/__generated__/types";
 
 /**
  * CommentModerationAction stores information around a moderation action that
@@ -40,6 +43,15 @@ export interface CommentModerationAction extends TenantResource {
    * moderation action.
    */
   status: GQLCOMMENT_STATUS;
+
+  /**
+   * reason is the GQLMODERATION_REASON_REASON for the decision, if it is
+   * a rejection
+   */
+  rejectionReason?: {
+    reason: GQLREJECTION_REASON;
+    metaData?: string;
+  };
 
   /**
    * moderatorID is the ID of the User that created the moderation action. If

--- a/server/src/core/server/models/action/moderation/comment.ts
+++ b/server/src/core/server/models/action/moderation/comment.ts
@@ -12,7 +12,7 @@ import { TenantResource } from "coral-server/models/tenant";
 
 import {
   GQLCOMMENT_STATUS,
-  GQLREJECTION_REASON,
+  GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 
 /**
@@ -49,8 +49,9 @@ export interface CommentModerationAction extends TenantResource {
    * a rejection
    */
   rejectionReason?: {
-    reason: GQLREJECTION_REASON;
-    metaData?: string;
+    reason: GQLREJECTION_REASON_CODE;
+    legalGrounds?: string;
+    detailedExplaination?: string;
   };
 
   /**

--- a/server/src/core/server/models/action/moderation/comment.ts
+++ b/server/src/core/server/models/action/moderation/comment.ts
@@ -51,7 +51,7 @@ export interface CommentModerationAction extends TenantResource {
   rejectionReason?: {
     reason: GQLREJECTION_REASON_CODE;
     legalGrounds?: string;
-    detailedExplaination?: string;
+    detailedExplanation?: string;
   };
 
   /**


### PR DESCRIPTION
## What does this PR do?
This PR brings in the backend models related to rejection reasons, so that any other work that needs to reference them may do so.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
New types `RejectionReason`, `REJECTION_REASON_CODE`, `CommentRejectionReasonInput` were created. The model for `CommentModerationAction` was updated to include an optional field for `reason`.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
`npm test` and `npm run watch`.

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations needed.
