### PR TITLE
[CORL-2933] Add rr.com to the protected email domains

### DIFF
--- a/common/lib/constants.ts
+++ b/common/lib/constants.ts
@@ -152,6 +152,7 @@ export const PROTECTED_EMAIL_DOMAINS = new Set<string>([
   "live.no",
   "yahoo.no",
   "hotmail.no",
+  "rr.com"
 ]);
 
 export const FLAIR_BADGE_NAME_REGEX = "^[\\w.-]+$";


### PR DESCRIPTION
## What does this PR do?

Add rr.com to the protected email domains

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- rebuild `common` (because the list is shared in the common library)
- rebuild `server` and `client` and spin up Coral
- attempt to spam ban a domain using `rr.com` in it
- see that it is blocked like all the other protected domains

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
