### PR TITLE
[CORL-2927] Use tenant locale to translate Graphql errors if available

### DIFF
--- a/server/src/core/server/graph/plugins/helpers.ts
+++ b/server/src/core/server/graph/plugins/helpers.ts
@@ -101,7 +101,7 @@ function hoistCoralErrorExtensions(
   }
 
   // Get the translation bundle.
-  const bundle = ctx.i18n.getBundle(ctx.lang);
+  const bundle = ctx.i18n.getBundle(ctx.tenant ? ctx.tenant.locale : ctx.lang);
 
   // Translate the extensions.
   const extensions = originalError.serializeExtensions(bundle, ctx.id);


### PR DESCRIPTION


## What does this PR do?

Use tenant locale to translate Graphql errors if available.

Previously, it was grabbing the locale from the context only which was always set to en-US by default instead of retrieving from the tenant which has the accurate locale.

If the tenant is not available, we simply default back to the context locale to be safe.

This fixes the issue where reposting the same comment twice was not translating the "Are you sure? Your comment looks similar to your previous one" error correctly.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- switch your language to French or Deutsch
  - weirdly, Espanol does not have these error codes translated in their `errors.ftl` yet, wild
- try and post the same comment twice
- see that the nudge prompt for "Are you sure you want to post the same comment twice?" is translated appropriately into French or German properly

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
