### PR TITLE
[CPSRE-1342] Refactored Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:14-alpine
+FROM node:14-alpine AS builder
 
 ENV NODE_OPTIONS=--max-old-space-size=8192
 
 # Install build dependancies.
-RUN apk --no-cache add git python3
+RUN apk --no-cache add git python3 build-base
 
 RUN npm install -g npm@8.0.0
 
@@ -61,6 +61,10 @@ RUN cd server && \
   npm run build && \
   npm prune --production && \
   cd ..
+
+# Copy previously built assets to a stock alpine image to reduce final size
+FROM node:14-alpine AS runner
+COPY --from=builder . .
 
 # Set working directory within server folder
 WORKDIR /usr/src/app/server


### PR DESCRIPTION
## What does this PR do?

By leveraging a multi-stage build within the Dockerfile, we can add additional build tools (to support a future arm64 or multiarch build) while still achieving a smaller final image size:

| Arch | Dockerfile | Build time | Compressed size | Size on disk |
| --- | --- | --- | --- | --- |
| x86_64 | Single-stage | ~20 minutes | 659 MB | 2.39 GB |
| x86_64 | Multi-stage | ~20 minutes | 450 MB | 1.44 GB |

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

N/A

## Does this PR introduce any new environment variables or feature flags?

Nope

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

Pull the changes and build from source as normal. Compare the final image size to the current develop default.

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No additional considerations are necessary.
