### PR TITLE
[CORL-2944]: truncate comment body sent to slack to stay under char limits

### DIFF
--- a/server/src/core/server/events/listeners/slack/publishEvent.ts
+++ b/server/src/core/server/events/listeners/slack/publishEvent.ts
@@ -103,9 +103,12 @@ export default class SlackPublishEvent {
     );
     const commentLink = getURLWithCommentID(this.story.url, this.comment.id);
 
-    const body = getHTMLPlainText(getLatestRevision(this.comment).body);
+    // We truncate to less than 3000 characters to stay under Slack limits
+    const truncatedBody = getHTMLPlainText(
+      getLatestRevision(this.comment).body
+    ).slice(0, 2999);
     return {
-      text: body,
+      text: truncatedBody,
       blocks: [
         {
           type: "section",
@@ -121,7 +124,7 @@ export default class SlackPublishEvent {
           block_id: "body-block",
           text: {
             type: "plain_text",
-            text: body,
+            text: truncatedBody,
           },
         },
         {


### PR DESCRIPTION
## What does this PR do?

These changes truncate the comment body that is sent through to Slack via the webhook integration. This ensures that it stays under Slack character limits and doesn't error out.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test this PR by setting up a Slack integration and sending comments to it. Reach out to me and I can share a webhook that I set up that you can use to test as well.

## Where any tests migrated to React Testing Library?



## How do we deploy this PR?


