### PR TITLE
[CORL-2934]: DSA - Send rejection reason through when illegal content decision made

### DIFF
--- a/server/src/core/server/services/dsaReports/reports.ts
+++ b/server/src/core/server/services/dsaReports/reports.ts
@@ -16,6 +16,7 @@ import { rejectComment } from "coral-server/stacks";
 import {
   GQLDSAReportDecisionLegality,
   GQLDSAReportStatus,
+  GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 
 import { I18n } from "../i18n";
@@ -182,13 +183,12 @@ export async function makeDSAReportDecision(
   input: MakeDSAReportDecisionInput,
   now = new Date()
 ) {
-  // TODO: Send through rejection legalGrounds and detailedExplanation once backend support is available
   const {
     commentID,
     commentRevisionID,
     userID,
-    // legalGrounds,
-    // detailedExplanation,
+    legalGrounds,
+    detailedExplanation,
   } = input;
 
   // REJECT if ILLEGAL
@@ -205,7 +205,12 @@ export async function makeDSAReportDecision(
       commentID,
       commentRevisionID,
       userID,
-      now
+      now,
+      {
+        code: GQLREJECTION_REASON_CODE.ILLEGAL_CONTENT,
+        legalGrounds,
+        detailedExplanation,
+      }
     );
   }
 

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -151,9 +151,6 @@ export class InternalNotificationContext {
 
     const result = translate(bundle, text, key, args);
 
-    // eslint-disable-next-line no-console
-    console.log(result, args);
-
     return result;
   }
 


### PR DESCRIPTION
## What does this PR do?

These changes update to send through the rejection reason when an illegal content report decision is made and the reported comment is therefore rejected.

## These changes will impact:

- [x] commenters
- [x] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can create a DSA report. Then go into the admin and make an illegal content decision with legal grounds and detailed explanation. Find the comment moderation action for this rejection and see that it includes the correct code for illegal content, as well as the legal grounds and detailed explanation.

## Where any tests migrated to React Testing Library?



## How do we deploy this PR?


