### PR TITLE
Final copy update for DSA notifications

### DIFF
--- a/client/src/core/client/admin/routes/Configure/sections/General/DSAConfigContainer.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/General/DSAConfigContainer.tsx
@@ -2,14 +2,19 @@ import { Localized } from "@fluent/react/compat";
 import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
+import { FieldSet, FormField, HelperText, Label } from "coral-ui/components/v2";
+
+import ConfigBox from "../../ConfigBox";
 import Header from "../../Header";
-import ConfigBoxWithToggleField from "../Auth/ConfigBoxWithToggleField";
+import OnOffField from "../../OnOffField";
+import DSAMethodOfRedressOptions from "./DSAMethodOfRedressOptions";
 
 // eslint-disable-next-line no-unused-expressions
 graphql`
   fragment DSAConfigContainer_formValues on Settings {
     dsa {
       enabled
+      methodOfRedress
     }
   }
 `;
@@ -20,17 +25,37 @@ interface Props {
 
 export const DSAConfigContainer: FunctionComponent<Props> = ({ disabled }) => {
   return (
-    <ConfigBoxWithToggleField
+    <ConfigBox
       data-testid="configure-general-dsaConfig"
       title={
         <Localized id="configure-general-dsaConfig-title">
-          <Header container="h2">DSA Features (TODO)</Header>
+          <Header container="h2">Digital services act</Header>
         </Localized>
       }
-      name="dsa.enabled"
-      disabled={disabled}
     >
-      {(disabledInside) => <>TODO</>}
-    </ConfigBoxWithToggleField>
+      <FormField container={<FieldSet />}>
+        <Localized id="configure-general-dsaConfig-reportingAndModerationExperience">
+          <Label component="legend">
+            DSA reporting and moderation experience
+          </Label>
+        </Localized>
+        <OnOffField name="dsa.enabled" disabled={disabled} />
+      </FormField>
+
+      <FormField container={<FieldSet />}>
+        <Localized id="configure-general-dsaConfig-methodOfRedress">
+          <Label component="legend">Select your method of redress</Label>
+        </Localized>
+        <Localized id="configure-general-dsaConfig-methodOfRedress-explanation">
+          <HelperText>
+            Let users know if and how they can appeal a moderation decision
+          </HelperText>
+        </Localized>
+        <DSAMethodOfRedressOptions
+          name="dsa.methodOfRedress"
+          disabled={disabled}
+        />
+      </FormField>
+    </ConfigBox>
   );
 };

--- a/client/src/core/client/admin/routes/Configure/sections/General/DSAMethodOfRedressOptions.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/General/DSAMethodOfRedressOptions.tsx
@@ -1,0 +1,100 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent } from "react";
+import { Field } from "react-final-form";
+
+import { Validator } from "coral-framework/lib/validation";
+import { RadioButton } from "coral-ui/components/v2";
+
+interface Props {
+  validate?: Validator;
+  name: string;
+  disabled: boolean;
+  format?: (value: any, name: string) => any;
+  testIDs?: {
+    on: string;
+    off: string;
+  };
+  className?: string;
+}
+
+export enum DSAMethodOfRedress {
+  None = "NONE",
+  Email = "EMAIL",
+  URL = "URL",
+}
+
+export const parseVal = (v: any, name: string) => {
+  if (v === DSAMethodOfRedress.None) {
+    return DSAMethodOfRedress.None;
+  }
+  if (v === DSAMethodOfRedress.Email) {
+    return DSAMethodOfRedress.Email;
+  }
+  if (v === DSAMethodOfRedress.URL) {
+    return DSAMethodOfRedress.URL;
+  }
+
+  return DSAMethodOfRedress.None;
+};
+
+export const format = (v: string, name: string) => {
+  return v;
+};
+
+const DSAMethodOfRedressOptions: FunctionComponent<Props> = ({
+  name,
+  disabled,
+  className,
+}) => (
+  <div className={className}>
+    <Field
+      name={name}
+      type="radio"
+      value={DSAMethodOfRedress.None}
+      parse={parseVal}
+      format={format}
+    >
+      {({ input }) => (
+        <RadioButton {...input} id={`${input.name}-none`} disabled={disabled}>
+          <Localized id="configure-general-dsaConfig-methodOfRedress-none">
+            <span>None</span>
+          </Localized>
+        </RadioButton>
+      )}
+    </Field>
+    <Field
+      name={name}
+      type="radio"
+      value={DSAMethodOfRedress.Email}
+      parse={parseVal}
+      format={format}
+    >
+      {({ input }) => (
+        <RadioButton {...input} id={`${input.name}-email`} disabled={disabled}>
+          <Localized id="configure-general-dsaConfig-methodOfRedress-email">
+            <span>Email</span>
+          </Localized>
+        </RadioButton>
+      )}
+    </Field>
+    <Field
+      name={name}
+      type="radio"
+      parse={parseVal}
+      value={DSAMethodOfRedress.URL}
+      format={format}
+    >
+      {({ input }) => {
+        return (
+          <RadioButton {...input} id={`${input.name}-url`} disabled={disabled}>
+            <Localized id="configure-general-dsaConfig-methodOfRedress-url">
+              <span>URL</span>
+            </Localized>
+          </RadioButton>
+        );
+      }}
+    </Field>
+  </div>
+);
+
+export default DSAMethodOfRedressOptions;

--- a/client/src/core/client/admin/test/fixtures.ts
+++ b/client/src/core/client/admin/test/fixtures.ts
@@ -10,6 +10,7 @@ import {
   GQLCOMMENT_STATUS,
   GQLCommentModerationAction,
   GQLCommentsConnection,
+  GQLDSA_METHOD_OF_REDRESS,
   GQLDSAReport,
   GQLDSAReportDecisionLegality,
   GQLDSAReportStatus,
@@ -235,6 +236,7 @@ export const settings = createFixture<GQLSettings>({
   },
   dsa: {
     enabled: false,
+    methodOfRedress: GQLDSA_METHOD_OF_REDRESS.NONE,
   },
 });
 

--- a/client/src/core/client/stream/tabs/Notifications/DSAReportDecisionMadeNotificationBody.css
+++ b/client/src/core/client/stream/tabs/Notifications/DSAReportDecisionMadeNotificationBody.css
@@ -1,0 +1,14 @@
+.body {
+  margin-left: var(--spacing-5);
+  margin-bottom: var(--spacing-2);
+
+  width: calc(100% - var(--spacing-4));
+
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-regular);
+  font-size: var(--font-size-2);
+}
+
+.body > p {
+  margin-bottom: var(--spacing-3);
+}

--- a/client/src/core/client/stream/tabs/Notifications/DSAReportDecisionMadeNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/DSAReportDecisionMadeNotificationBody.tsx
@@ -1,0 +1,76 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent } from "react";
+import { graphql } from "react-relay";
+
+import { withFragmentContainer } from "coral-framework/lib/relay";
+import { GQLDSAReportDecisionLegality } from "coral-framework/schema";
+
+import { DSAReportDecisionMadeNotificationBody_notification } from "coral-stream/__generated__/DSAReportDecisionMadeNotificationBody_notification.graphql";
+
+import styles from "./DSAReportDecisionMadeNotificationBody.css";
+
+interface Props {
+  notification: DSAReportDecisionMadeNotificationBody_notification;
+}
+
+const DSAReportDecisionMadeNotificationBody: FunctionComponent<Props> = ({
+  notification,
+}) => {
+  const { decisionDetails, dsaReport, comment } = notification;
+
+  const date =
+    dsaReport && dsaReport.createdAt
+      ? new Date(dsaReport.createdAt).toDateString()
+      : new Date(0).toDateString();
+  const username = comment?.author?.username ?? "";
+
+  return (
+    <div className={styles.body}>
+      {decisionDetails &&
+        decisionDetails.legality === GQLDSAReportDecisionLegality.LEGAL && (
+          <Localized
+            id="notifications-reportDecisionMade-legal"
+            vars={{
+              date,
+              author: username,
+            }}
+          >
+            {`On ${date} you reported a comment written by ${username} for containing illegal content. After reviewing your report, our moderation team has decided this comment does not appear to contain illegal content.`}
+          </Localized>
+        )}
+      {decisionDetails &&
+        decisionDetails.legality === GQLDSAReportDecisionLegality.ILLEGAL && (
+          <Localized
+            id="notifications-reportDecisionMade-illegal"
+            vars={{
+              date,
+              author: username,
+            }}
+          >
+            {`On ${date} you reported a comment written by ${username} for containing illegal content. After reviewing your report, our moderation team has decided this comment does contain illegal content.`}
+          </Localized>
+        )}
+    </div>
+  );
+};
+
+const enhanced = withFragmentContainer<Props>({
+  notification: graphql`
+    fragment DSAReportDecisionMadeNotificationBody_notification on Notification {
+      type
+      comment {
+        author {
+          username
+        }
+      }
+      dsaReport {
+        createdAt
+      }
+      decisionDetails {
+        legality
+      }
+    }
+  `,
+})(DSAReportDecisionMadeNotificationBody);
+
+export default enhanced;

--- a/client/src/core/client/stream/tabs/Notifications/NotificationContainer.css
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationContainer.css
@@ -39,17 +39,6 @@
   word-break: break-word;
 }
 
-.body {
-  margin-left: var(--spacing-5);
-  margin-bottom: var(--spacing-2);
-
-  width: calc(100% - var(--spacing-4));
-
-  font-family: var(--font-family-primary);
-  font-weight: var(--font-weight-primary-regular);
-  font-size: var(--font-size-2);
-}
-
 .contextItem {
   margin-left: var(--spacing-5);
   margin-bottom: var(--spacing-2);

--- a/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
@@ -22,6 +22,7 @@ import {
 } from "coral-stream/__generated__/NotificationContainer_notification.graphql";
 import { NotificationContainer_viewer } from "coral-stream/__generated__/NotificationContainer_viewer.graphql";
 
+import DSAReportDecisionMadeNotificationBody from "./DSAReportDecisionMadeNotificationBody";
 import NotificationCommentContainer from "./NotificationCommentContainer";
 import RejectedCommentNotificationBody from "./RejectedCommentNotificationBody";
 
@@ -130,6 +131,9 @@ const NotificationContainer: FunctionComponent<Props> = ({
           type === GQLNOTIFICATION_TYPE.ILLEGAL_REJECTED) && (
           <RejectedCommentNotificationBody notification={notification} />
         )}
+        {type === GQLNOTIFICATION_TYPE.DSA_REPORT_DECISION_MADE && (
+          <DSAReportDecisionMadeNotificationBody notification={notification} />
+        )}
         {comment && (
           <div className={styles.contextItem}>
             <NotificationCommentContainer
@@ -166,6 +170,7 @@ const enhanced = withFragmentContainer<Props>({
       }
       commentStatus
       ...RejectedCommentNotificationBody_notification
+      ...DSAReportDecisionMadeNotificationBody_notification
     }
   `,
 })(NotificationContainer);

--- a/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
@@ -162,8 +162,6 @@ const enhanced = withFragmentContainer<Props>({
       id
       createdAt
       type
-      title
-      body
       comment {
         ...NotificationCommentContainer_comment
         status

--- a/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
@@ -1,13 +1,23 @@
 import cn from "classnames";
-import React, { FunctionComponent, useMemo } from "react";
+import React, { ComponentType, FunctionComponent, useMemo } from "react";
 import { graphql } from "react-relay";
 
 import { withFragmentContainer } from "coral-framework/lib/relay";
+import { GQLNOTIFICATION_TYPE } from "coral-framework/schema";
 import HTMLContent from "coral-stream/common/HTMLContent";
-import { CheckCircleIcon, SvgIcon } from "coral-ui/components/icons";
+import {
+  CheckCircleIcon,
+  LegalHammerIcon,
+  MessagesBubbleSquareIcon,
+  QuestionCircleIcon,
+  SvgIcon,
+} from "coral-ui/components/icons";
 import { Timestamp } from "coral-ui/components/v2";
 
-import { NotificationContainer_notification } from "coral-stream/__generated__/NotificationContainer_notification.graphql";
+import {
+  NOTIFICATION_TYPE,
+  NotificationContainer_notification,
+} from "coral-stream/__generated__/NotificationContainer_notification.graphql";
 import { NotificationContainer_viewer } from "coral-stream/__generated__/NotificationContainer_viewer.graphql";
 
 import NotificationCommentContainer from "./NotificationCommentContainer";
@@ -19,8 +29,28 @@ interface Props {
   notification: NotificationContainer_notification;
 }
 
+const getIcon = (type: NOTIFICATION_TYPE | null): ComponentType => {
+  if (type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED) {
+    return CheckCircleIcon;
+  }
+  if (type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED) {
+    return CheckCircleIcon;
+  }
+  if (type === GQLNOTIFICATION_TYPE.COMMENT_REJECTED) {
+    return MessagesBubbleSquareIcon;
+  }
+  if (type === GQLNOTIFICATION_TYPE.ILLEGAL_REJECTED) {
+    return MessagesBubbleSquareIcon;
+  }
+  if (type === GQLNOTIFICATION_TYPE.DSA_REPORT_DECISION_MADE) {
+    return LegalHammerIcon;
+  }
+
+  return QuestionCircleIcon;
+};
+
 const NotificationContainer: FunctionComponent<Props> = ({
-  notification: { title, body, comment, createdAt, commentStatus },
+  notification: { type, title, body, comment, createdAt, commentStatus },
   viewer,
 }) => {
   const seen = useMemo(() => {
@@ -46,7 +76,7 @@ const NotificationContainer: FunctionComponent<Props> = ({
       >
         {title && (
           <div className={styles.title}>
-            <SvgIcon size="sm" Icon={CheckCircleIcon} />
+            <SvgIcon size="sm" Icon={getIcon(type)} />
             <div className={styles.titleText}>{title}</div>
           </div>
         )}
@@ -82,6 +112,7 @@ const enhanced = withFragmentContainer<Props>({
     fragment NotificationContainer_notification on Notification {
       id
       createdAt
+      type
       title
       body
       comment {

--- a/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.css
+++ b/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.css
@@ -1,0 +1,33 @@
+.body {
+  margin-left: var(--spacing-5);
+  margin-bottom: var(--spacing-2);
+
+  width: calc(100% - var(--spacing-4));
+
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-regular);
+  font-size: var(--font-size-2);
+}
+
+.body > p {
+  margin-bottom: var(--spacing-3);
+}
+
+.details {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-regular);
+  font-size: var(--font-size-2);
+}
+
+.detailLabel {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-semi-bold);
+  font-size: var(--font-size-2);
+  text-transform: uppercase;
+
+  margin-bottom: var(--spacing-1);
+}
+
+.detailItem {
+  margin-bottom: var(--spacing-2);
+}

--- a/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
@@ -1,0 +1,200 @@
+import { FluentBundle } from "@fluent/bundle/compat";
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent } from "react";
+import { graphql } from "react-relay";
+
+import { useCoralContext } from "coral-framework/lib/bootstrap";
+import { getMessage } from "coral-framework/lib/i18n";
+import { withFragmentContainer } from "coral-framework/lib/relay";
+import {
+  GQLDSAReportDecisionLegality,
+  GQLNOTIFICATION_TYPE,
+  GQLREJECTION_REASON_CODE,
+} from "coral-framework/schema";
+
+import {
+  DSAReportDecisionLegality,
+  RejectedCommentNotificationBody_notification,
+  REJECTION_REASON_CODE,
+} from "coral-stream/__generated__/RejectedCommentNotificationBody_notification.graphql";
+
+import styles from "./RejectedCommentNotificationBody.css";
+
+interface Props {
+  notification: RejectedCommentNotificationBody_notification;
+}
+
+const getLegalReason = (
+  bundles: FluentBundle[],
+  legality: DSAReportDecisionLegality | null
+) => {
+  if (legality === GQLDSAReportDecisionLegality.LEGAL) {
+    return getMessage(
+      bundles,
+      "notifications-dsaReportLegality-legal",
+      "Legal content"
+    );
+  }
+  if (legality === GQLDSAReportDecisionLegality.ILLEGAL) {
+    return getMessage(
+      bundles,
+      "notifications-dsaReportLegality-illegal",
+      "Illegal content"
+    );
+  }
+
+  return getMessage(
+    bundles,
+    "notifications-dsaReportLegality-unknown",
+    "Unknown"
+  );
+};
+
+const getGeneralReason = (
+  bundles: FluentBundle[],
+  reason: REJECTION_REASON_CODE | null
+) => {
+  if (reason === GQLREJECTION_REASON_CODE.OFFENSIVE) {
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-offensive",
+      "Offensive"
+    );
+  }
+  if (reason === GQLREJECTION_REASON_CODE.ABUSIVE) {
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-abusive",
+      "Abusive"
+    );
+  }
+  if (reason === GQLREJECTION_REASON_CODE.SPAM) {
+    return getMessage(bundles, "notifications-rejectionReason-spam", "Spam");
+  }
+  if (reason === GQLREJECTION_REASON_CODE.BANNED_WORD) {
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-bannedWord",
+      "Banned word"
+    );
+  }
+  if (reason === GQLREJECTION_REASON_CODE.AD) {
+    return getMessage(bundles, "notifications-rejectionReason-ad", "Ad");
+  }
+  if (reason === GQLREJECTION_REASON_CODE.ILLEGAL_CONTENT) {
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-illegalContent",
+      "Illegal content"
+    );
+  }
+  if (reason === GQLREJECTION_REASON_CODE.OTHER) {
+    return getMessage(bundles, "notifications-rejectionReason-other", "Other");
+  }
+
+  return getMessage(
+    bundles,
+    "notifications-rejectionReason-unknown",
+    "Unknown"
+  );
+};
+
+const stringIsNullOrEmpty = (value: string) => {
+  return value === undefined || value === null || value === "";
+};
+
+const RejectedCommentNotificationBody: FunctionComponent<Props> = ({
+  notification,
+}) => {
+  const { type, decisionDetails, rejectionReason } = notification;
+
+  const { localeBundles } = useCoralContext();
+
+  const hasExplanation = !stringIsNullOrEmpty(
+    (decisionDetails?.explanation ?? "").trim()
+  );
+  const hasLegalGrounds = !stringIsNullOrEmpty(
+    (decisionDetails?.grounds ?? "").trim()
+  );
+
+  return (
+    <div className={styles.body}>
+      <Localized id="notifications-rejectedComment-body">
+        <p>
+          Our moderators have reviewed your comment and determined it contains
+          content that violates our community guidelines or terms of service.
+        </p>
+      </Localized>
+      {type === GQLNOTIFICATION_TYPE.COMMENT_REJECTED &&
+        rejectionReason &&
+        decisionDetails && (
+          <div className={styles.details}>
+            <Localized id="notifications-reasonForRemoval">
+              <div className={styles.detailLabel}>Reason for removal</div>
+            </Localized>
+            <div className={styles.detailItem}>
+              {getGeneralReason(localeBundles, rejectionReason)}
+            </div>
+            {hasExplanation && (
+              <>
+                <Localized id="notifications-additionalExplanation">
+                  <div className={styles.detailLabel}>
+                    Additional explanation
+                  </div>
+                </Localized>
+                <div className={styles.detailItem}>
+                  {decisionDetails.explanation || ""}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      {type === GQLNOTIFICATION_TYPE.ILLEGAL_REJECTED && decisionDetails && (
+        <div className={styles.details}>
+          <Localized id="notifications-reasonForRemoval">
+            <div className={styles.detailLabel}>Reason for removal</div>
+          </Localized>
+          <div className={styles.detailItem}>
+            {getLegalReason(localeBundles, decisionDetails.legality)}
+          </div>
+          {hasLegalGrounds && (
+            <>
+              <Localized id="notifications-legalGrounds">
+                <div className={styles.detailLabel}>Legal grounds</div>
+              </Localized>
+              <div className={styles.detailItem}>
+                {decisionDetails.grounds || ""}
+              </div>
+            </>
+          )}
+          {hasExplanation && (
+            <>
+              <Localized id="notifications-additionalExplanation">
+                <div className={styles.detailLabel}>Additional explanation</div>
+              </Localized>
+              <div className={styles.detailItem}>
+                {decisionDetails.explanation || ""}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const enhanced = withFragmentContainer<Props>({
+  notification: graphql`
+    fragment RejectedCommentNotificationBody_notification on Notification {
+      type
+      rejectionReason
+      decisionDetails {
+        legality
+        grounds
+        explanation
+      }
+    }
+  `,
+})(RejectedCommentNotificationBody);
+
+export default enhanced;

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -1612,7 +1612,16 @@ configure-general-rte-spoilerDesc =
   Words and phrases formatted as Spoiler are hidden behind a
   dark background until the reader chooses to reveal the text.
 
-configure-general-dsaConfig-title = DSA Features (TODO)
+configure-general-dsaConfig-title = Digital services act
+configure-general-dsaConfig-reportingAndModerationExperience =
+  DSA reporting and moderation experience
+configure-general-dsaConfig-methodOfRedress =
+  Select your method of redress
+configure-general-dsaConfig-methodOfRedress-explanation =
+  Let users know if and how they can appeal a moderation decision
+configure-general-dsaConfig-methodOfRedress-none = None
+configure-general-dsaConfig-methodOfRedress-email = Email
+configure-general-dsaConfig-methodOfRedress-url = URL
 
 configure-account-features-title = Commenter account management features
 configure-account-features-explanation =

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1041,3 +1041,32 @@ notification-comment-toggle-rejected-open = Rejected comment
 notification-comment-toggle-rejected-closed = + Rejected comment
 notification-comment-toggle-default-open = Comment
 notification-comment-toggle-default-closed = + Comment
+
+notifications-yourIllegalContentReportHasBeenReviewed =
+  Your illegal content report has been reviewed
+notifications-yourCommentHasBeenRejected =
+  Your comment has been rejected and removed from our site
+notifications-yourCommentHasBeenApproved =
+  Your comment has been approved
+notifications-yourCommentHasBeenFeatured =
+  Your comment has been featured
+notifications-defaultTitle = Notification
+
+notifications-rejectedComment-body =
+  Our moderators have reviewed your comment and determined it contains content that violates our community guidelines or terms of service.
+notifications-reasonForRemoval = Reason for removal
+notifications-legalGrounds = Legal grounds
+notifications-additionalExplanation = Additional explanation
+
+notifications-dsaReportLegality-legal = Legal content
+notifications-dsaReportLegality-illegal = Illegal content
+notifications-dsaReportLegality-unknown = Unknown
+
+notifications-rejectionReason-offensive = Offensive
+notifications-rejectionReason-abusive = Abusive
+notifications-rejectionReason-spam = Spam
+notifications-rejectionReason-bannedWord = Banned word
+notifications-rejectionReason-ad = Ad
+notifications-rejectionReason-illegalContent = Illegal content
+notifications-rejectionReason-other = Other
+notifications-rejectionReason-unknown = Unknown

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1070,3 +1070,8 @@ notifications-rejectionReason-ad = Ad
 notifications-rejectionReason-illegalContent = Illegal content
 notifications-rejectionReason-other = Other
 notifications-rejectionReason-unknown = Unknown
+
+notifications-reportDecisionMade-legal =
+  On { $date } you reported a comment written by { $author } for containing illegal content. After reviewing your report, our moderation team has decided this comment does not appear to contain illegal content.
+notifications-reportDecisionMade-illegal =
+  On { $date } you reported a comment written by { $author } for containing illegal content. After reviewing your report, our moderation team has decided this comment does contain illegal content.

--- a/server/src/core/server/graph/mutators/Comments.ts
+++ b/server/src/core/server/graph/mutators/Comments.ts
@@ -3,7 +3,6 @@ import { ADDITIONAL_DETAILS_MAX_LENGTH } from "coral-common/common/lib/helpers/v
 import GraphContext from "coral-server/graph/context";
 import { mapFieldsetToErrorCodes } from "coral-server/graph/errors";
 import { hasTag } from "coral-server/models/comment";
-import { NotificationType } from "coral-server/models/notifications/notification";
 import { addTag, removeTag } from "coral-server/services/comments";
 import {
   createDontAgree,
@@ -34,6 +33,7 @@ import {
   GQLEditCommentInput,
   GQLFeatureCommentInput,
   GQLMarkCommentsAsSeenInput,
+  GQLNOTIFICATION_TYPE,
   GQLRemoveCommentDontAgreeInput,
   GQLRemoveCommentReactionInput,
   GQLTAG,
@@ -289,7 +289,7 @@ export const Comments = (ctx: GraphContext) => ({
     await ctx.notifications.create(ctx.tenant.id, ctx.tenant.locale, {
       targetUserID: comment.authorID!,
       comment,
-      type: NotificationType.COMMENT_FEATURED,
+      type: GQLNOTIFICATION_TYPE.COMMENT_FEATURED,
     });
 
     // Return it to the next step.

--- a/server/src/core/server/graph/resolvers/DSAConfiguration.ts
+++ b/server/src/core/server/graph/resolvers/DSAConfiguration.ts
@@ -1,9 +1,16 @@
 import * as settings from "coral-server/models/settings";
 
-import { GQLDSAConfigurationTypeResolver } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLDSA_METHOD_OF_REDRESS,
+  GQLDSAConfigurationTypeResolver,
+} from "coral-server/graph/schema/__generated__/types";
 
 export const DSAConfiguration: GQLDSAConfigurationTypeResolver<settings.RTEConfiguration> =
   {
     enabled: (config, args, { tenant }) =>
       tenant.dsa && tenant.dsa.enabled ? tenant.dsa.enabled : false,
+    methodOfRedress: (config, args, { tenant }) =>
+      tenant.dsa && tenant.dsa.methodOfRedress
+        ? tenant.dsa.methodOfRedress
+        : GQLDSA_METHOD_OF_REDRESS.NONE,
   };

--- a/server/src/core/server/graph/resolvers/Notification.ts
+++ b/server/src/core/server/graph/resolvers/Notification.ts
@@ -35,4 +35,6 @@ export const NotificationResolver: Required<
 
     return await ctx.loaders.DSAReports.dsaReport.load({ id: reportID });
   },
+  decisionDetails: ({ decisionDetails }) => decisionDetails,
+  rejectionReason: ({ rejectionReason }) => rejectionReason,
 };

--- a/server/src/core/server/graph/resolvers/Notification.ts
+++ b/server/src/core/server/graph/resolvers/Notification.ts
@@ -1,13 +1,17 @@
 import { CommentNotFoundError } from "coral-server/errors";
 import { Notification } from "coral-server/models/notifications/notification";
 
-import { GQLNotificationTypeResolver } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLNOTIFICATION_TYPE,
+  GQLNotificationTypeResolver,
+} from "coral-server/graph/schema/__generated__/types";
 
 export const NotificationResolver: Required<
   GQLNotificationTypeResolver<Notification>
 > = {
   id: ({ id }) => id,
   ownerID: ({ ownerID }) => ownerID,
+  type: ({ type }) => (type ? type : GQLNOTIFICATION_TYPE.UNKNOWN),
   createdAt: ({ createdAt }) => createdAt,
   title: ({ title }) => title,
   body: ({ body }) => body,

--- a/server/src/core/server/graph/resolvers/Notification.ts
+++ b/server/src/core/server/graph/resolvers/Notification.ts
@@ -13,8 +13,6 @@ export const NotificationResolver: Required<
   ownerID: ({ ownerID }) => ownerID,
   type: ({ type }) => (type ? type : GQLNOTIFICATION_TYPE.UNKNOWN),
   createdAt: ({ createdAt }) => createdAt,
-  title: ({ title }) => title,
-  body: ({ body }) => body,
   comment: async ({ commentID }, input, ctx) => {
     if (!commentID) {
       return null;

--- a/server/src/core/server/graph/resolvers/NotificationDSAReportDetails.ts
+++ b/server/src/core/server/graph/resolvers/NotificationDSAReportDetails.ts
@@ -6,6 +6,7 @@ export const NotificationDSAReportDetailsResolver: Required<
   GQLNotificationDSAReportDetailsTypeResolver<DSAReport>
 > = {
   id: ({ id }) => id,
+  createdAt: ({ createdAt }) => createdAt,
   referenceID: ({ referenceID }) => referenceID,
   comment: async ({ commentID }, input, ctx) => {
     if (!commentID) {

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -4693,6 +4693,15 @@ type Queues {
 ## Notifications
 ################################################################################
 
+enum NOTIFICATION_TYPE {
+  UNKNOWN
+  COMMENT_FEATURED
+  COMMENT_APPROVED
+  COMMENT_REJECTED
+  ILLEGAL_REJECTED
+  DSA_REPORT_DECISION_MADE
+}
+
 type Notification {
   """
   id is the uuid identifier for the notification.
@@ -4703,6 +4712,12 @@ type Notification {
   ownerID is the string identifier for who this notification is directed to.
   """
   ownerID: ID!
+
+  """
+  type defines the template type for this notification used to generate
+  it. Useful for sorting and filtering categorized notifications.
+  """
+  type: NOTIFICATION_TYPE
 
   """
   createdAt is when this notification was created, used for sorting.

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -4725,16 +4725,6 @@ type Notification {
   createdAt: Time!
 
   """
-  title is the title text of this notification.
-  """
-  title: String
-
-  """
-  body is the text content of this notification.
-  """
-  body: String
-
-  """
   comment is the optional comment that is linked to this notification.
   """
   comment: Comment

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -4748,6 +4748,17 @@ type Notification {
   commentStatus: COMMENT_STATUS
 
   """
+  rejectionReason is an optional field that defines why a comment was rejected.
+  """
+  rejectionReason: REJECTION_REASON_CODE
+
+  """
+  decisionDetails is an optional field that contains further details pertaining
+  to DSA or moderation decisions.
+  """
+  decisionDetails: NotificationDecisionDetails
+
+  """
   dsaReport is the details of the DSA Report related to the notification.
   This is usually in reference to the comment that is also related to
   the notification.
@@ -4824,6 +4835,23 @@ type NotificationDSAReportDetails {
   a collection of co-related DSA reports.
   """
   submissionID: ID @auth(roles: [ADMIN, MODERATOR])
+}
+
+type NotificationDecisionDetails {
+  """
+  legality defines whether the rejection reason is of legal or illegal state.
+  """
+  legality: DSAReportDecisionLegality
+
+  """
+  grounds is the legal grounds for which the rejection may have been made.
+  """
+  grounds: String
+
+  """
+  explanation gives further context to the reasons for rejection.
+  """
+  explanation: String
 }
 
 ################################################################################

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -4802,6 +4802,11 @@ type NotificationDSAReportDetails {
   id: ID!
 
   """
+  createdAt is the date when this report was created
+  """
+  createdAt: Time!
+
+  """
   referenceID is the friendly identifier that is human readable
   for the DSA report.
   """

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -1948,12 +1948,24 @@ type RTEConfiguration {
   sarcasm: Boolean!
 }
 
+enum DSA_METHOD_OF_REDRESS {
+  NONE
+  EMAIL
+  URL
+}
+
 type DSAConfiguration {
   """
   enabled when true turns on the European Union DSA compliance
   features for commenting, reporting, and moderation flows.
   """
   enabled: Boolean!
+
+  """
+  methodOfRedress lets users know if and how they can appeal a
+  moderation decision
+  """
+  methodOfRedress: DSA_METHOD_OF_REDRESS!
 }
 
 """
@@ -6053,7 +6065,17 @@ DSAConfigurationInput specifies the configuration for DSA European Union
 moderation and reporting features.
 """
 input DSAConfigurationInput {
+  """
+  enabled when true turns on the European Union DSA compliance
+  features for commenting, reporting, and moderation flows.
+  """
   enabled: Boolean
+
+  """
+  methodOfRedress lets users know if and how they can appeal a
+  moderation decision
+  """
+  methodOfRedress: DSA_METHOD_OF_REDRESS
 }
 
 """

--- a/server/src/core/server/locales/en-US/common.ftl
+++ b/server/src/core/server/locales/en-US/common.ftl
@@ -54,6 +54,33 @@ notifications-illegalContentReportReviewed-description =
   containing illegal content. After reviewing your report, our moderation
   team has decided this comment { $decision }.
 
+notifications-commentRejected-title =
+  Your comment has been rejected and removed from our site
+notifications-commentRejected-description =
+  Our moderators have reviewed your comment and determined your comment contains content that violates our community guidelines or terms of service.
+  <br/>
+  <br/>
+  { $details }
+
+notifications-commentRejected-details-general =
+  <b>REASON FOR REMOVAL</b><br/>
+  { $reason }<br/>
+  <b>ADDITIONAL EXPLANATION</b><br/>
+  { $explanation }
+
+notifications-commentRejected-details-illegalContent =
+  <b>REASON FOR REMOVAL</b><br/>
+  <descriptItem>{ $reason }</descriptItem><br/>
+  <b>LEGAL GROUNDS</b><br/>
+  { $grounds }<br/>
+  <b>ADDITIONAL EXPLANATION</b><br/>
+  { $explanation }
+
+notification-reasonForRemoval-illegal = Illegal content
+
+notifications-commentRejected-details-notFound =
+  Details for this rejection cannot be found.
+
 # Notifications (old)
 
 notifications-commentWasFeatured-title = Comment was featured

--- a/server/src/core/server/locales/en-US/common.ftl
+++ b/server/src/core/server/locales/en-US/common.ftl
@@ -59,14 +59,7 @@ notifications-commentRejected-title =
 notifications-commentRejected-description =
   Our moderators have reviewed your comment and determined your comment contains content that violates our community guidelines or terms of service.
   <br/>
-  <br/>
   { $details }
-
-notifications-commentRejected-details-general =
-  <b>REASON FOR REMOVAL</b><br/>
-  { $reason }<br/>
-  <b>ADDITIONAL EXPLANATION</b><br/>
-  { $explanation }
 
 notifications-commentRejected-details-illegalContent =
   <b>REASON FOR REMOVAL</b><br/>
@@ -76,7 +69,20 @@ notifications-commentRejected-details-illegalContent =
   <b>ADDITIONAL EXPLANATION</b><br/>
   { $explanation }
 
+notifications-commentRejected-details-general =
+  <b>REASON FOR REMOVAL</b><br/>
+  { $reason }<br/>
+  <b>ADDITIONAL EXPLANATION</b><br/>
+  { $explanation }
+
+notification-reasonForRemoval-offensive = Offensive
+notification-reasonForRemoval-abusive = Abusive
+notification-reasonForRemoval-spam = Spam
+notification-reasonForRemoval-bannedWord = Banned word
+notification-reasonForRemoval-ad = Ad
+notification-reasonForRemoval-other = Other
 notification-reasonForRemoval-illegal = Illegal content
+notification-reasonForRemoval-unknown = Unknown
 
 notifications-commentRejected-details-notFound =
   Details for this rejection cannot be found.

--- a/server/src/core/server/locales/en-US/common.ftl
+++ b/server/src/core/server/locales/en-US/common.ftl
@@ -39,6 +39,22 @@ dsaReportCSV-legality-legal = Legality: Legal
 dsaReportCSV-legalGrounds = Legal grounds
 dsaReportCSV-explanation = Explanation
 
+# Notifications
+
+notifications-illegalContentReportReviewed-title =
+  Your illegal content report has been reviewed
+
+notifications-illegalContentReportReviewed-decision-legal =
+  does not appear to contain illegal content
+notifications-illegalContentReportReviewed-decision-illegal =
+  does contain illegal content
+
+notifications-illegalContentReportReviewed-description =
+  On { $date } you reported a comment written by { $author } for
+  containing illegal content. After reviewing your report, our moderation
+  team has decided this comment { $decision }.
+
+# Notifications (old)
 
 notifications-commentWasFeatured-title = Comment was featured
 notifications-commentWasFeatured-body = The comment { $commentID } was featured.

--- a/server/src/core/server/models/notifications/notification.ts
+++ b/server/src/core/server/models/notifications/notification.ts
@@ -27,9 +27,6 @@ export interface Notification extends TenantResource {
 
   rejectionReason?: GQLREJECTION_REASON_CODE;
   decisionDetails?: GQLNotificationDecisionDetails;
-
-  title?: string;
-  body?: string;
 }
 
 type BaseConnectionInput = ConnectionInput<Notification>;

--- a/server/src/core/server/models/notifications/notification.ts
+++ b/server/src/core/server/models/notifications/notification.ts
@@ -3,6 +3,8 @@ import { MongoContext } from "coral-server/data/context";
 import {
   GQLCOMMENT_STATUS,
   GQLNOTIFICATION_TYPE,
+  GQLNotificationDecisionDetails,
+  GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 
 import { ConnectionInput, Query, resolveConnection } from "../helpers";
@@ -22,6 +24,9 @@ export interface Notification extends TenantResource {
 
   commentID?: string;
   commentStatus?: GQLCOMMENT_STATUS;
+
+  rejectionReason?: GQLREJECTION_REASON_CODE;
+  decisionDetails?: GQLNotificationDecisionDetails;
 
   title?: string;
   body?: string;

--- a/server/src/core/server/models/notifications/notification.ts
+++ b/server/src/core/server/models/notifications/notification.ts
@@ -1,22 +1,17 @@
 import { MongoContext } from "coral-server/data/context";
 
-import { GQLCOMMENT_STATUS } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLCOMMENT_STATUS,
+  GQLNOTIFICATION_TYPE,
+} from "coral-server/graph/schema/__generated__/types";
 
 import { ConnectionInput, Query, resolveConnection } from "../helpers";
 import { TenantResource } from "../tenant";
 import { User } from "../user";
 
-export enum NotificationType {
-  COMMENT_FEATURED = "COMMENT_FEATURED",
-  COMMENT_APPROVED = "COMMENT_APPROVED",
-  COMMENT_REJECTED = "COMMENT_REJECTED",
-  ILLEGAL_REJECTED = "ILLEGAL_REJECTED",
-  DSA_REPORT_DECISION_MADE = "DSA_REPORT_DECISION_MADE",
-}
-
 export interface Notification extends TenantResource {
   readonly id: string;
-  readonly type: NotificationType;
+  readonly type: GQLNOTIFICATION_TYPE;
   readonly tenantID: string;
 
   createdAt: Date;

--- a/server/src/core/server/models/tenant/tenant.ts
+++ b/server/src/core/server/models/tenant/tenant.ts
@@ -23,6 +23,7 @@ import { dotize } from "coral-server/utils/dotize";
 
 import {
   GQLAnnouncement,
+  GQLDSA_METHOD_OF_REDRESS,
   GQLFEATURE_FLAG,
   GQLMODERATION_MODE,
   GQLSettings,
@@ -301,6 +302,7 @@ export async function createTenant(
     },
     dsa: {
       enabled: false,
+      methodOfRedress: GQLDSA_METHOD_OF_REDRESS.NONE,
     },
   };
 

--- a/server/src/core/server/services/dsaReports/reports.ts
+++ b/server/src/core/server/services/dsaReports/reports.ts
@@ -12,7 +12,6 @@ import {
   makeDSAReportDecision as makeReportDecision,
   retrieveDSAReport,
 } from "coral-server/models/dsaReport/report";
-import { NotificationType } from "coral-server/models/notifications/notification";
 import { Tenant } from "coral-server/models/tenant";
 import { rejectComment } from "coral-server/stacks";
 import { Request } from "coral-server/types/express";
@@ -20,6 +19,7 @@ import { Request } from "coral-server/types/express";
 import {
   GQLDSAReportDecisionLegality,
   GQLDSAReportStatus,
+  GQLNOTIFICATION_TYPE,
   GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 
@@ -225,7 +225,7 @@ export async function makeDSAReportDecision(
     if (rejectedComment.authorID) {
       await notifications.create(tenant.id, tenant.locale, {
         targetUserID: rejectedComment.authorID,
-        type: NotificationType.ILLEGAL_REJECTED,
+        type: GQLNOTIFICATION_TYPE.ILLEGAL_REJECTED,
         comment: rejectedComment,
         legal: {
           legality: input.legality,
@@ -240,7 +240,7 @@ export async function makeDSAReportDecision(
   if (report) {
     await notifications.create(tenant.id, tenant.locale, {
       targetUserID: report.userID,
-      type: NotificationType.DSA_REPORT_DECISION_MADE,
+      type: GQLNOTIFICATION_TYPE.DSA_REPORT_DECISION_MADE,
       comment,
       report,
       legal: {

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -310,34 +310,49 @@ export class InternalNotificationContext {
     legal: DSALegality | undefined,
     now: Date
   ) {
-    const reason = legal
+    const title = this.translatePhrase(
+      lang,
+      "notifications-commentRejected-title",
+      "Your comment has been rejected and removed from our site"
+    );
+
+    const reasonForRemoval = this.translatePhrase(
+      lang,
+      "notification-reasonForRemoval-illegal",
+      "Illegal content"
+    );
+
+    const details = legal
       ? this.translatePhrase(
           lang,
-          "notifications-dsaIllegalRejectedReason-information",
-          `Grounds:
-          ${legal?.grounds}
-          Explanation:
-          ${legal?.explanation}`,
+          "notifications-commentRejected-details-illegalContent",
+          `<b>REASON FOR REMOVAL</b><br/>
+        ${reasonForRemoval}<br/>
+        <b>LEGAL GROUNDS</b><br/>
+        ${legal.grounds}<br/>
+        <b>ADDITIONAL EXPLANATION</b><br/>
+        ${legal.explanation}`,
           {
-            grounds: legal.grounds,
-            explanation: legal.explanation,
+            reason: reasonForRemoval,
+            grounds: legal.grounds ?? "",
+            explanation: legal.explanation ?? "",
           }
         )
       : this.translatePhrase(
           lang,
-          "notifications-dsaIllegalRejectedReason-informationNotFound",
-          "The reasoning for this decision cannot be found."
+          "notifications-commentRejected-details-notFound",
+          "Details for this rejection cannot be found."
         );
 
-    const body = this.translatePhrase(
+    const description = this.translatePhrase(
       lang,
-      "notifications-commentWasRejectedAndIllegal-body",
-      `The comment ${comment.id} was rejected for containing illegal content.
-      The reason of which was: ${reason}
-      `,
+      "notifications-commentRejected-description",
+      `Our moderators have reviewed your comment determined your comment contains
+      violates our community guidelines or terms of service.<br/>
+      <br/>
+      ${details}`,
       {
-        commentID: comment.id,
-        reason,
+        details,
       }
     ).replace("\n", "<br/>");
 
@@ -347,12 +362,8 @@ export class InternalNotificationContext {
       type,
       createdAt: now,
       ownerID: targetUserID,
-      title: this.translatePhrase(
-        lang,
-        "notifications-commentWasRejectedAndIllegal-title",
-        "Comment was deemed to contain illegal content and was rejected"
-      ),
-      body,
+      title,
+      body: description,
       commentID: comment.id,
       commentStatus: comment.status,
     });

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -205,6 +205,10 @@ export class InternalNotificationContext {
       body,
       commentID: comment.id,
       commentStatus: comment.status,
+      rejectionReason: rejectionReason?.code ?? undefined,
+      decisionDetails: {
+        explanation: rejectionReason?.detailedExplanation ?? undefined,
+      },
     });
 
     return notification;

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -10,7 +10,7 @@ import {
   Notification,
 } from "coral-server/models/notifications/notification";
 import { retrieveUser } from "coral-server/models/user";
-import { I18n, translate } from "coral-server/services/i18n";
+import { I18n } from "coral-server/services/i18n";
 
 import {
   GQLDSAReportDecisionLegality,
@@ -50,11 +50,11 @@ interface CreationResult {
 export class InternalNotificationContext {
   private mongo: MongoContext;
   private log: Logger;
-  private i18n: I18n;
+  // private i18n: I18n;
 
   constructor(mongo: MongoContext, i18n: I18n, log: Logger) {
     this.mongo = mongo;
-    this.i18n = i18n;
+    // this.i18n = i18n;
     this.log = log;
   }
 
@@ -172,45 +172,45 @@ export class InternalNotificationContext {
     return notification;
   }
 
-  private async createFeatureCommentNotification(
-    tenantID: string,
-    type: GQLNOTIFICATION_TYPE,
-    targetUserID: string,
-    comment: Readonly<Comment>,
-    now: Date
-  ) {
-    const notification = await createNotification(this.mongo, {
-      id: uuid(),
-      tenantID,
-      type,
-      createdAt: now,
-      ownerID: targetUserID,
-      commentID: comment.id,
-      commentStatus: comment.status,
-    });
+  // private async createFeatureCommentNotification(
+  //   tenantID: string,
+  //   type: GQLNOTIFICATION_TYPE,
+  //   targetUserID: string,
+  //   comment: Readonly<Comment>,
+  //   now: Date
+  // ) {
+  //   const notification = await createNotification(this.mongo, {
+  //     id: uuid(),
+  //     tenantID,
+  //     type,
+  //     createdAt: now,
+  //     ownerID: targetUserID,
+  //     commentID: comment.id,
+  //     commentStatus: comment.status,
+  //   });
 
-    return notification;
-  }
+  //   return notification;
+  // }
 
-  private async createApproveCommentNotification(
-    tenantID: string,
-    type: GQLNOTIFICATION_TYPE,
-    targetUserID: string,
-    comment: Readonly<Comment>,
-    now: Date
-  ) {
-    const notification = await createNotification(this.mongo, {
-      id: uuid(),
-      tenantID,
-      type,
-      createdAt: now,
-      ownerID: targetUserID,
-      commentID: comment.id,
-      commentStatus: comment.status,
-    });
+  // private async createApproveCommentNotification(
+  //   tenantID: string,
+  //   type: GQLNOTIFICATION_TYPE,
+  //   targetUserID: string,
+  //   comment: Readonly<Comment>,
+  //   now: Date
+  // ) {
+  //   const notification = await createNotification(this.mongo, {
+  //     id: uuid(),
+  //     tenantID,
+  //     type,
+  //     createdAt: now,
+  //     ownerID: targetUserID,
+  //     commentID: comment.id,
+  //     commentStatus: comment.status,
+  //   });
 
-    return notification;
-  }
+  //   return notification;
+  // }
 
   private async createIllegalRejectionNotification(
     tenantID: string,
@@ -275,17 +275,17 @@ export class InternalNotificationContext {
     return notification;
   }
 
-  private translatePhrase(
-    lang: LanguageCode,
-    key: string,
-    text: string,
-    args?: object | undefined
-  ) {
-    const bundle = this.i18n.getBundle(lang);
-    const result = translate(bundle, text, key, args);
+  // private translatePhrase(
+  //   lang: LanguageCode,
+  //   key: string,
+  //   text: string,
+  //   args?: object | undefined
+  // ) {
+  //   const bundle = this.i18n.getBundle(lang);
+  //   const result = translate(bundle, text, key, args);
 
-    return result;
-  }
+  //   return result;
+  // }
 
   private logCreateNotificationError(
     tenantID: string,

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -8,13 +8,13 @@ import { DSAReport } from "coral-server/models/dsaReport/report";
 import {
   createNotification,
   Notification,
-  NotificationType,
 } from "coral-server/models/notifications/notification";
 import { retrieveUser } from "coral-server/models/user";
 import { I18n, translate } from "coral-server/services/i18n";
 
 import {
   GQLDSAReportDecisionLegality,
+  GQLNOTIFICATION_TYPE,
   GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 
@@ -32,7 +32,7 @@ export interface RejectionReasonInput {
 
 export interface CreateNotificationInput {
   targetUserID: string;
-  type: NotificationType;
+  type: GQLNOTIFICATION_TYPE;
 
   comment?: Readonly<Comment> | null;
   rejectionReason?: RejectionReasonInput | null;
@@ -82,7 +82,7 @@ export class InternalNotificationContext {
       attempted: false,
     };
 
-    if (type === NotificationType.COMMENT_FEATURED && comment) {
+    if (type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED && comment) {
       result.notification = await this.createFeatureCommentNotification(
         lang,
         tenantID,
@@ -92,7 +92,7 @@ export class InternalNotificationContext {
         now
       );
       result.attempted = true;
-    } else if (type === NotificationType.COMMENT_APPROVED && comment) {
+    } else if (type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED && comment) {
       result.notification = await this.createApproveCommentNotification(
         lang,
         tenantID,
@@ -102,7 +102,7 @@ export class InternalNotificationContext {
         now
       );
       result.attempted = true;
-    } else if (type === NotificationType.COMMENT_REJECTED && comment) {
+    } else if (type === GQLNOTIFICATION_TYPE.COMMENT_REJECTED && comment) {
       result.notification = await this.createRejectCommentNotification(
         lang,
         tenantID,
@@ -113,7 +113,7 @@ export class InternalNotificationContext {
         now
       );
       result.attempted = true;
-    } else if (type === NotificationType.ILLEGAL_REJECTED && comment) {
+    } else if (type === GQLNOTIFICATION_TYPE.ILLEGAL_REJECTED && comment) {
       result.notification = await this.createIllegalRejectionNotification(
         lang,
         tenantID,
@@ -125,7 +125,7 @@ export class InternalNotificationContext {
       );
       result.attempted = true;
     } else if (
-      type === NotificationType.DSA_REPORT_DECISION_MADE &&
+      type === GQLNOTIFICATION_TYPE.DSA_REPORT_DECISION_MADE &&
       comment &&
       report
     ) {
@@ -150,7 +150,7 @@ export class InternalNotificationContext {
   private async createRejectCommentNotification(
     lang: LanguageCode,
     tenantID: string,
-    type: NotificationType,
+    type: GQLNOTIFICATION_TYPE,
     targetUserID: string,
     comment: Readonly<Comment>,
     rejectionReason?: RejectionReasonInput | null,
@@ -236,7 +236,7 @@ export class InternalNotificationContext {
   private async createFeatureCommentNotification(
     lang: LanguageCode,
     tenantID: string,
-    type: NotificationType,
+    type: GQLNOTIFICATION_TYPE,
     targetUserID: string,
     comment: Readonly<Comment>,
     now: Date
@@ -270,7 +270,7 @@ export class InternalNotificationContext {
   private async createApproveCommentNotification(
     lang: LanguageCode,
     tenantID: string,
-    type: NotificationType,
+    type: GQLNOTIFICATION_TYPE,
     targetUserID: string,
     comment: Readonly<Comment>,
     now: Date
@@ -304,7 +304,7 @@ export class InternalNotificationContext {
   private async createIllegalRejectionNotification(
     lang: LanguageCode,
     tenantID: string,
-    type: NotificationType,
+    type: GQLNOTIFICATION_TYPE,
     targetUserID: string,
     comment: Readonly<Comment>,
     legal: DSALegality | undefined,
@@ -363,7 +363,7 @@ export class InternalNotificationContext {
   private async createDSAReportDecisionMadeNotification(
     lang: LanguageCode,
     tenantID: string,
-    type: NotificationType,
+    type: GQLNOTIFICATION_TYPE,
     targetUserID: string,
     comment: Readonly<Comment>,
     report: Readonly<DSAReport>,

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -342,6 +342,12 @@ export class InternalNotificationContext {
       body: description,
       commentID: comment.id,
       commentStatus: comment.status,
+      rejectionReason: GQLREJECTION_REASON_CODE.ILLEGAL_CONTENT,
+      decisionDetails: {
+        legality: legal ? legal.legality : undefined,
+        grounds: legal ? legal.grounds : undefined,
+        explanation: legal ? legal.explanation : undefined,
+      },
     });
 
     return notification;
@@ -414,6 +420,11 @@ export class InternalNotificationContext {
       commentID: comment.id,
       commentStatus: comment.status,
       reportID: report.id,
+      decisionDetails: {
+        legality: legal.legality,
+        grounds: legal.grounds,
+        explanation: legal.explanation,
+      },
     });
 
     return notification;

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -82,25 +82,30 @@ export class InternalNotificationContext {
       attempted: false,
     };
 
-    if (type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED && comment) {
-      result.notification = await this.createFeatureCommentNotification(
-        tenantID,
-        type,
-        targetUserID,
-        comment,
-        now
-      );
-      result.attempted = true;
-    } else if (type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED && comment) {
-      result.notification = await this.createApproveCommentNotification(
-        tenantID,
-        type,
-        targetUserID,
-        comment,
-        now
-      );
-      result.attempted = true;
-    } else if (type === GQLNOTIFICATION_TYPE.COMMENT_REJECTED && comment) {
+    /*
+      For the time being, we are not doing approved and featured
+      comment notifications.
+    */
+    // if (type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED && comment) {
+    //   result.notification = await this.createFeatureCommentNotification(
+    //     tenantID,
+    //     type,
+    //     targetUserID,
+    //     comment,
+    //     now
+    //   );
+    //   result.attempted = true;
+    // } else if (type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED && comment) {
+    //   result.notification = await this.createApproveCommentNotification(
+    //     tenantID,
+    //     type,
+    //     targetUserID,
+    //     comment,
+    //     now
+    //   );
+    //   result.attempted = true;
+    // }
+    if (type === GQLNOTIFICATION_TYPE.COMMENT_REJECTED && comment) {
       result.notification = await this.createRejectCommentNotification(
         tenantID,
         type,

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -3,7 +3,6 @@ import { DataCache } from "coral-server/data/cache/dataCache";
 import { MongoContext } from "coral-server/data/context";
 import { CoralEventPublisherBroker } from "coral-server/events/publisher";
 import { getLatestRevision } from "coral-server/models/comment";
-import { NotificationType } from "coral-server/models/notifications/notification";
 import { Tenant } from "coral-server/models/tenant";
 import { moderate } from "coral-server/services/comments/moderation";
 import { I18n } from "coral-server/services/i18n";
@@ -12,7 +11,10 @@ import { AugmentedRedis } from "coral-server/services/redis";
 import { submitCommentAsNotSpam } from "coral-server/services/spam";
 import { Request } from "coral-server/types/express";
 
-import { GQLCOMMENT_STATUS } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLCOMMENT_STATUS,
+  GQLNOTIFICATION_TYPE,
+} from "coral-server/graph/schema/__generated__/types";
 
 import { publishChanges } from "./helpers";
 
@@ -87,7 +89,7 @@ const approveComment = async (
   await notifications.create(tenant.id, tenant.locale, {
     targetUserID: result.after.authorID!,
     comment: result.after,
-    type: NotificationType.COMMENT_APPROVED,
+    type: GQLNOTIFICATION_TYPE.COMMENT_APPROVED,
   });
 
   // Return the resulting comment.

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -8,7 +8,6 @@ import {
   hasTag,
   UpdateCommentStatus,
 } from "coral-server/models/comment";
-import { NotificationType } from "coral-server/models/notifications/notification";
 import { Tenant } from "coral-server/models/tenant";
 import { removeTag } from "coral-server/services/comments";
 import { moderate } from "coral-server/services/comments/moderation";
@@ -20,6 +19,7 @@ import { Request } from "coral-server/types/express";
 
 import {
   GQLCOMMENT_STATUS,
+  GQLNOTIFICATION_TYPE,
   GQLREJECTION_REASON_CODE,
   GQLTAG,
 } from "coral-server/graph/schema/__generated__/types";
@@ -168,7 +168,7 @@ const rejectComment = async (
       targetUserID: result.after.authorID!,
       comment: result.after,
       rejectionReason: reason,
-      type: NotificationType.COMMENT_REJECTED,
+      type: GQLNOTIFICATION_TYPE.COMMENT_REJECTED,
     });
   }
 

--- a/server/src/core/server/test/fixtures.ts
+++ b/server/src/core/server/test/fixtures.ts
@@ -11,6 +11,7 @@ import { Token, User } from "coral-server/models/user";
 import {
   GQLCOMMENT_STATUS,
   GQLDIGEST_FREQUENCY,
+  GQLDSA_METHOD_OF_REDRESS,
   GQLMODERATION_MODE,
   GQLUSER_ROLE,
 } from "coral-server/graph/schema/__generated__/types";
@@ -186,6 +187,7 @@ export const createTenantFixture = (
     emailDomainModeration: [],
     dsa: {
       enabled: false,
+      methodOfRedress: GQLDSA_METHOD_OF_REDRESS.NONE,
     },
     embeddedComments: {
       allowReplies: true,


### PR DESCRIPTION
## What does this PR do?



## These changes will impact:

- [X] commenters
- [X] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices

## How do I test this PR?

- enable DSA reporting flow via Admin > Config > General > DSA
- create a comment with a commenter
- report it with an illegal report (DSA report) as the same commenter
- use an admin/mod to process the DSA report as illegal
- check the commenter's stream side notifications
    - should have a notification about the comment being rejected
    - should have a notification about their DSA report being decided/reviewed
- create another comment as commenter
- have an admin/mod reject it normally via mod queue while selecting a reason
- check the notifications for the commenter
    - should have a notification about the comment being rejected

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into DSA epic branch and release with rest of DSA features.
