### PR TITLE
[CORL-2953] replace dead link to docs from moderation phases config

### DIFF
--- a/client/src/core/client/admin/routes/Configure/sections/ModerationPhases/ModerationPhasesConfigContainer.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/ModerationPhases/ModerationPhasesConfigContainer.tsx
@@ -49,7 +49,7 @@ const ModerationPhasesConfigContainer: FunctionComponent<Props> = ({
           id="configure-moderationPhases-description"
           elems={{
             externalLink: (
-              <ExternalLink href="https://github.com/coralproject/talk/blob/main/EXTERNAL_MODERATION_PHASES.md#request-signing" />
+              <ExternalLink href="https://docs.coralproject.net/external-moderation-phases" />
             ),
           }}
         >
@@ -57,7 +57,7 @@ const ModerationPhasesConfigContainer: FunctionComponent<Props> = ({
             Configure a external moderation phase to automate some moderation
             actions. Moderation requests will be JSON encoded and signed. To
             learn more about moderation requests, visit our{" "}
-            <ExternalLink href="https://github.com/coralproject/talk/blob/main/EXTERNAL_MODERATION_PHASES.md#request-signing">
+            <ExternalLink href="https://docs.coralproject.net/external-moderation-phases">
               docs
             </ExternalLink>
             .


### PR DESCRIPTION
## What does this PR do?
This PR replaces a dead link to our docs from the external moderation phases config in the admin.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Navigate to Admin > Confgure > Moderation Phases.
2. Click on the link that says "Docs".
3. Observe that you are directed to a working page related to external moderation phases.

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations should be needed
