### PR TITLE
DSA - Archived fixes

### DIFF
--- a/server/src/core/server/graph/mutators/Comments.ts
+++ b/server/src/core/server/graph/mutators/Comments.ts
@@ -146,7 +146,7 @@ export const Comments = (ctx: GraphContext) => ({
         commentRevisionID,
       }
     ),
-  createIllegalContent: ({
+  createIllegalContent: async ({
     commentID,
     commentRevisionID,
   }: GQLCreateIllegalContentInput) =>
@@ -159,6 +159,7 @@ export const Comments = (ctx: GraphContext) => ({
       ctx.broker,
       ctx.tenant,
       ctx.user!,
+      await ctx.loaders.Comments.comment.load(commentID),
       {
         commentID,
         commentRevisionID,

--- a/server/src/core/server/graph/mutators/DSAReports.ts
+++ b/server/src/core/server/graph/mutators/DSAReports.ts
@@ -45,6 +45,7 @@ export const DSAReports = (ctx: GraphContext) => ({
         ctx.broker,
         ctx.tenant,
         ctx.user,
+        await ctx.loaders.Comments.comment.load(commentID),
         { commentID, commentRevisionID },
         ctx.now
       );

--- a/server/src/core/server/models/comment/comment.ts
+++ b/server/src/core/server/models/comment/comment.ts
@@ -927,9 +927,12 @@ export async function updateCommentActionCounts(
   tenantID: string,
   id: string,
   revisionID: string,
-  actionCounts: EncodedCommentActionCounts
+  actionCounts: EncodedCommentActionCounts,
+  isArchived = false
 ) {
-  const result = await mongo.comments().findOneAndUpdate(
+  const collection =
+    isArchived && mongo.archive ? mongo.archivedComments() : mongo.comments();
+  const result = await collection.findOneAndUpdate(
     { id, tenantID },
     // Update all the specific action counts that are associated with each of
     // the counts.

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -86,7 +86,8 @@ const rejectComment = async (
     detailedExplanation?: string | undefined;
   },
   request?: Request | undefined,
-  sendNotification = true
+  sendNotification = true,
+  isArchived = false
 ) => {
   const updateAllCommentCountsArgs = {
     actionCounts: {},
@@ -107,7 +108,7 @@ const rejectComment = async (
       status: GQLCOMMENT_STATUS.REJECTED,
     },
     now,
-    undefined,
+    isArchived,
     updateAllCommentCountsArgs
   );
 
@@ -153,7 +154,7 @@ const rejectComment = async (
 
   // TODO: (wyattjoh) (tessalt) broker cannot easily be passed to stack from tasks,
   // see CORL-935 in jira
-  if (broker && counts) {
+  if (broker && counts && !isArchived) {
     // Publish changes to the event publisher.
     await publishChanges(broker, {
       ...updateStatus,


### PR DESCRIPTION
## What does this PR do?

This makes it so that a DSAReport can be created for an archived comment. An archived comment's DSA Report can also have a decision made on it.

## These changes will impact:

- [x] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

`createAction` and `updateCommentActionCounts` now check for `isArchived` to determine which collection to use

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Archive a story. Report an archived comment for illegal content. See that it submits without error. Look at the report in the Reports table in the admin. Click through to its single report page. Make an illegal decision on the report. See that the comment is rejected and the decision is successfully submitted. (Also can test making a legal decision on the report and seeing it works fine.)

## Where any tests migrated to React Testing Library?


## How do we deploy this PR?


