### PR TITLE
Show reported state on archived stories

### DIFF
--- a/server/src/core/server/graph/resolvers/Comment.ts
+++ b/server/src/core/server/graph/resolvers/Comment.ts
@@ -198,14 +198,21 @@ export const Comment: GQLCommentTypeResolver<comment.Comment> = {
         commentID: id,
       },
     }),
-  viewerActionPresence: (c, input, ctx, info) => {
+  viewerActionPresence: async (c, input, ctx, info) => {
     if (!ctx.user) {
       return null;
     }
 
     setCacheHint(info, { scope: CacheScope.Private });
 
-    return ctx.loaders.Comments.retrieveMyActionPresence.load(c.id);
+    const story = await ctx.loaders.Stories.find.load({ id: c.storyID });
+    if (!story) {
+      throw new StoryNotFoundError(c.storyID);
+    }
+
+    return ctx.loaders.Comments.retrieveMyActionPresence.load(
+      `${c.id}:${!!story.isArchived}`
+    );
   },
 
   parentCount: (c) => getDepth(c),

--- a/server/src/core/server/graph/resolvers/Comment.ts
+++ b/server/src/core/server/graph/resolvers/Comment.ts
@@ -210,9 +210,10 @@ export const Comment: GQLCommentTypeResolver<comment.Comment> = {
       throw new StoryNotFoundError(c.storyID);
     }
 
-    return ctx.loaders.Comments.retrieveMyActionPresence.load(
-      `${c.id}:${!!story.isArchived}`
-    );
+    return ctx.loaders.Comments.retrieveMyActionPresence.load({
+      commentID: c.id,
+      isArchived: !!story.isArchived,
+    });
   },
 
   parentCount: (c) => getDepth(c),


### PR DESCRIPTION
## What does this PR do?

Show reported state on archived stories.

If there is nothing in the live comment actions for a user from a set of comment id's and the archive is available, use the archived comment actions to try and find their reported status for a comment.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- Make some comments on a stream
- Report those comments however you wish
- See that it shows the red `Reported` button on the reported comments
- Archive the story
- Reload the stream
- See it still shows the red `Reported` button on the reported comments

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into DSA epic branch, then that will go out with the rest of the DSA release.
