### PR TITLE
[CORL-296]7 view conversation rejection reasons

### DIFF
--- a/client/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
+++ b/client/src/core/client/admin/components/ConversationModal/ConversationModalCommentContainer.tsx
@@ -182,6 +182,10 @@ const ConversationModalCommentContainer: FunctionComponent<Props> = ({
             <Flex>
               <Popover
                 id={`reject-reason-${comment.id}`}
+                modifiers={{
+                  arrow: { enabled: false },
+                  offset: { offset: "0, 4" },
+                }}
                 placement="bottom-start"
                 body={({ toggleVisibility, visible }) => (
                   <ClickOutside onClickOutside={toggleVisibility}>

--- a/client/src/core/client/admin/components/ModerateCard/ModerateCard.css
+++ b/client/src/core/client/admin/components/ModerateCard/ModerateCard.css
@@ -111,10 +111,6 @@ $moderateCardLinkTextColor: $colors-teal-700;
   padding-bottom: var(--spacing-1);
 }
 
-.moderationReasonDropdown {
-  opacity: 1;
-}
-
 .moderationReasonCard {
  padding: 0;
  margin: 0;

--- a/client/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
+++ b/client/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
@@ -360,7 +360,7 @@ const ModerateCard: FunctionComponent<Props> = ({
               body={({ toggleVisibility, visible }) => {
                 return (
                   <ClickOutside onClickOutside={toggleVisibility}>
-                    <Dropdown className={styles.moderationReasonDropdown}>
+                    <Dropdown>
                       <ModerationReason
                         onReason={onReason}
                         onCancel={toggleVisibility}

--- a/client/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
+++ b/client/src/core/client/admin/components/ModerateCard/ModerateCard.tsx
@@ -362,7 +362,10 @@ const ModerateCard: FunctionComponent<Props> = ({
                   <ClickOutside onClickOutside={toggleVisibility}>
                     <Dropdown>
                       <ModerationReason
-                        onReason={onReason}
+                        onReason={(reason) => {
+                          onReason(reason);
+                          toggleVisibility();
+                        }}
                         onCancel={toggleVisibility}
                         id={id}
                       />

--- a/client/src/core/client/admin/components/ModerationReason/DetailedExplanation.tsx
+++ b/client/src/core/client/admin/components/ModerationReason/DetailedExplanation.tsx
@@ -35,6 +35,7 @@ const DetailedExplanation: FunctionComponent<Props> = ({
           name={code}
           key={code}
           checked
+          readOnly
         >
           {unsnake(code)}
         </RadioButton>

--- a/server/src/core/server/services/users/delete.ts
+++ b/server/src/core/server/services/users/delete.ts
@@ -12,10 +12,10 @@ import {
   GQLCOMMENT_STATUS,
   GQLDSAReportStatus,
   GQLREJECTION_REASON_CODE,
+  GQLRejectionReason,
 } from "coral-server/graph/schema/__generated__/types";
 
 import { moderate } from "../comments/moderation";
-import { Moderate } from "../comments/moderation/moderate";
 import { I18n } from "../i18n";
 import { AugmentedRedis } from "../redis";
 
@@ -134,7 +134,7 @@ async function moderateComments(
   targetStatus: GQLCOMMENT_STATUS,
   now: Date,
   isArchived = false,
-  rejectionReason?: Moderate["rejectionReason"]
+  rejectionReason?: GQLRejectionReason
 ) {
   const tenant = await retrieveTenant(mongo, tenantID);
   if (!tenant) {

--- a/server/src/core/server/services/users/delete.ts
+++ b/server/src/core/server/services/users/delete.ts
@@ -11,9 +11,11 @@ import { retrieveTenant } from "coral-server/models/tenant";
 import {
   GQLCOMMENT_STATUS,
   GQLDSAReportStatus,
+  GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 
 import { moderate } from "../comments/moderation";
+import { Moderate } from "../comments/moderation/moderate";
 import { I18n } from "../i18n";
 import { AugmentedRedis } from "../redis";
 
@@ -131,7 +133,8 @@ async function moderateComments(
   filter: FilterQuery<Comment>,
   targetStatus: GQLCOMMENT_STATUS,
   now: Date,
-  isArchived = false
+  isArchived = false,
+  rejectionReason?: Moderate["rejectionReason"]
 ) {
   const tenant = await retrieveTenant(mongo, tenantID);
   if (!tenant) {
@@ -169,6 +172,7 @@ async function moderateComments(
         commentRevisionID: getLatestRevision(comment).id,
         moderatorID: null,
         status: targetStatus,
+        rejectionReason,
       },
       now,
       isArchived,
@@ -309,7 +313,11 @@ async function deleteUserComments(
     },
     GQLCOMMENT_STATUS.REJECTED,
     now,
-    isArchived
+    isArchived,
+    {
+      code: GQLREJECTION_REASON_CODE.OTHER,
+      detailedExplanation: "User account deleted",
+    }
   );
 
   const collection =


### PR DESCRIPTION


## What does this PR do?
This PR fixes a bug in which the moderation reasons modal doesn't close after seelcting a reason when in the user drawer. It also updates the user deletion flow to include comment rejection reasons when rejecting the deleted users comments.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
Navigate to a user drawer for any usera as an user with mod privileges, with DSA enabled. Reject a comment from the drawer. Observe that a reason is requried, and when one is supplied, the Moderation Reason modal closes.

Find a user with comments with no replies. As that user, request that your account be deleted. In the database, set the scheduled deletion time to something soon. Observe that the account is successfully deteleted, and the comments with no replies are rejected, and the resulting CommentModerationActions specify a reason.

## Where any tests migrated to React Testing Library?
No

