### PR TITLE
DSA - fix to send through rejection reason when deleting user and comments

### DIFF
--- a/server/src/core/server/services/users/delete.ts
+++ b/server/src/core/server/services/users/delete.ts
@@ -11,6 +11,7 @@ import { retrieveTenant } from "coral-server/models/tenant";
 import {
   GQLCOMMENT_STATUS,
   GQLDSAReportStatus,
+  GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 
 import { moderate } from "../comments/moderation";
@@ -131,7 +132,8 @@ async function moderateComments(
   filter: FilterQuery<Comment>,
   targetStatus: GQLCOMMENT_STATUS,
   now: Date,
-  isArchived = false
+  isArchived = false,
+  rejectionReason?: GQLREJECTION_REASON_CODE
 ) {
   const tenant = await retrieveTenant(mongo, tenantID);
   if (!tenant) {
@@ -169,6 +171,9 @@ async function moderateComments(
         commentRevisionID: getLatestRevision(comment).id,
         moderatorID: null,
         status: targetStatus,
+        rejectionReason: rejectionReason
+          ? { code: rejectionReason }
+          : undefined,
       },
       now,
       isArchived,
@@ -309,7 +314,8 @@ async function deleteUserComments(
     },
     GQLCOMMENT_STATUS.REJECTED,
     now,
-    isArchived
+    isArchived,
+    GQLREJECTION_REASON_CODE.OTHER
   );
 
   const collection =


### PR DESCRIPTION
## What does this PR do?

This sends through a rejection reason when deleting a user and their comments. This ensures that it will go through and delete the comments without error.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can create a User 1, have them comment. Then have another User 2 report their comment for illegal content. Then have the User 1 request their account be deleted. Go in and update their scheduled deletion date to be now. Run Coral with jobs so that they will be deleted (might want to update to make account deletion run more often in `accountDeletion.ts` so you don't have to wait). See that the user is successfully deleted with no errors. The illegal content report against their comment should now be set to status `Void`.

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
