### PR TITLE
DSA - reports tab permissions

### DIFF
--- a/client/src/core/client/admin/App/Main.tsx
+++ b/client/src/core/client/admin/App/Main.tsx
@@ -18,17 +18,18 @@ import styles from "./Main.css";
 interface Props {
   viewer: PropTypesOf<typeof UserMenuContainer>["viewer"] &
     PropTypesOf<typeof NavigationContainer>["viewer"];
+  settings: PropTypesOf<typeof NavigationContainer>["settings"];
   children: React.ReactNode;
 }
 
-const Main: FunctionComponent<Props> = ({ children, viewer }) => (
+const Main: FunctionComponent<Props> = ({ children, viewer, settings }) => (
   <div className={styles.root}>
     <AppBar gutterBegin gutterEnd>
       <Begin itemGutter="double">
         <div className={styles.logoContainer}>
           <LogoHorizontal />
         </div>
-        <NavigationContainer viewer={viewer} />
+        <NavigationContainer viewer={viewer} settings={settings} />
       </Begin>
       <End>
         <DecisionHistoryButton />

--- a/client/src/core/client/admin/App/MainRoute.tsx
+++ b/client/src/core/client/admin/App/MainRoute.tsx
@@ -20,7 +20,12 @@ const MainRoute: React.FunctionComponent<Props> = (props) => {
   return (
     <>
       {ErrorReporterSetUser}
-      <Main viewer={props.data && props.data.viewer}>{props.children}</Main>
+      <Main
+        viewer={props.data && props.data.viewer}
+        settings={props.data && props.data.settings}
+      >
+        {props.children}
+      </Main>
     </>
   );
 };
@@ -32,6 +37,9 @@ const enhanced = withRouteConfig<Props>({
         ...ErrorReporterSetUserContainer_viewer
         ...UserMenuContainer_viewer
         ...NavigationContainer_viewer
+      }
+      settings {
+        ...NavigationContainer_settings
       }
     }
   `,

--- a/client/src/core/client/admin/App/Navigation/Navigation.tsx
+++ b/client/src/core/client/admin/App/Navigation/Navigation.tsx
@@ -32,7 +32,6 @@ const Navigation: FunctionComponent<Props> = (props) => (
         <NavigationLink to="/admin/dashboard">Dashboard</NavigationLink>
       </Localized>
     )}
-    {/* TODO: Any other permissions needed? */}
     {props.showReports && (
       <Localized id="navigation-reports">
         <NavigationLink to="/admin/reports">DSA Reports</NavigationLink>

--- a/client/src/core/client/admin/App/Navigation/NavigationContainer.tsx
+++ b/client/src/core/client/admin/App/Navigation/NavigationContainer.tsx
@@ -2,12 +2,14 @@ import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import { Ability, can } from "coral-admin/permissions/tenant";
+import { GQLUSER_ROLE } from "coral-common/client/src/core/client/framework/schema/__generated__/types";
 import { useLocal, withFragmentContainer } from "coral-framework/lib/relay";
 import {
   SignOutMutation,
   withSignOutMutation,
 } from "coral-framework/mutations";
 
+import { NavigationContainer_settings as SettingsData } from "coral-admin/__generated__/NavigationContainer_settings.graphql";
 import { NavigationContainer_viewer as ViewerData } from "coral-admin/__generated__/NavigationContainer_viewer.graphql";
 import { NavigationContainerLocal } from "coral-admin/__generated__/NavigationContainerLocal.graphql";
 
@@ -16,9 +18,13 @@ import Navigation from "./Navigation";
 interface Props {
   signOut: SignOutMutation;
   viewer: ViewerData | null;
+  settings: SettingsData | null;
 }
 
-const NavigationContainer: FunctionComponent<Props> = ({ viewer }) => {
+const NavigationContainer: FunctionComponent<Props> = ({
+  viewer,
+  settings,
+}) => {
   const [{ dsaFeaturesEnabled }] = useLocal<NavigationContainerLocal>(
     graphql`
       fragment NavigationContainerLocal on Local {
@@ -30,7 +36,19 @@ const NavigationContainer: FunctionComponent<Props> = ({ viewer }) => {
     <Navigation
       showDashboard={!!viewer && can(viewer, Ability.VIEW_STATISTICS)}
       showConfigure={!!viewer && can(viewer, Ability.CHANGE_CONFIGURATION)}
-      showReports={!!dsaFeaturesEnabled}
+      showReports={
+        !!dsaFeaturesEnabled &&
+        !!viewer &&
+        can(viewer, Ability.MODERATE_DSA_REPORTS) &&
+        // Exclude single-site moderators
+        !(
+          settings?.multisite &&
+          viewer.role === GQLUSER_ROLE.MODERATOR &&
+          viewer.moderationScopes &&
+          viewer.moderationScopes.sites &&
+          viewer.moderationScopes.sites.length === 1
+        )
+      }
     />
   );
 };
@@ -40,6 +58,16 @@ const enhanced = withSignOutMutation(
     viewer: graphql`
       fragment NavigationContainer_viewer on User {
         role
+        moderationScopes {
+          sites {
+            id
+          }
+        }
+      }
+    `,
+    settings: graphql`
+      fragment NavigationContainer_settings on Settings {
+        multisite
       }
     `,
   })(NavigationContainer)

--- a/client/src/core/client/admin/permissions/tenant.ts
+++ b/client/src/core/client/admin/permissions/tenant.ts
@@ -5,7 +5,8 @@ import { PermissionMap } from "./types";
 export type AbilityType =
   | "CHANGE_CONFIGURATION"
   | "INVITE_USERS"
-  | "VIEW_STATISTICS";
+  | "VIEW_STATISTICS"
+  | "MODERATE_DSA_REPORTS";
 interface PermissionContext {
   TODO: never;
 }
@@ -18,6 +19,10 @@ const permissionMap: PermissionMap<AbilityType, PermissionContext> = {
     [GQLUSER_ROLE.ADMIN]: () => true,
   },
   VIEW_STATISTICS: {
+    [GQLUSER_ROLE.ADMIN]: () => true,
+    [GQLUSER_ROLE.MODERATOR]: () => true,
+  },
+  MODERATE_DSA_REPORTS: {
     [GQLUSER_ROLE.ADMIN]: () => true,
     [GQLUSER_ROLE.MODERATOR]: () => true,
   },


### PR DESCRIPTION
## What does this PR do?

Update so that all admins/moderators can view DSA Reports tab except single-site moderators on multi-site tenants.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can create some users who are admins, org mods, mods, single site mods, and then test out whether they see the DSA Reports tab in the admin or not when DSA is enabled.

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
