### PR TITLE
DSA no notifications placeholder text

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/NotificationsContainer.css
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsContainer.css
@@ -11,19 +11,3 @@
 
   margin-bottom: var(--spacing-2);
 }
-
-.methodOfRedress {
-  padding-left: var(--spacing-4);
-  padding-right: var(--spacing-4);
-  padding-top: var(--spacing-2);
-  padding-bottom: var(--spacing-2);
-
-  background-color: var(--palette-primary-100);
-
-  font-family: var(--font-family-primary);
-  color: var(--palette-text-200);
-  font-weight: var(--font-weight-primary-regular);
-  font-size: var(--font-size-3);
-
-  margin-bottom: var(--spacing-2);
-}

--- a/client/src/core/client/stream/tabs/Notifications/NotificationsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsContainer.tsx
@@ -3,7 +3,6 @@ import React, { FunctionComponent, useCallback, useEffect } from "react";
 import { graphql } from "react-relay";
 
 import { useLocal, withFragmentContainer } from "coral-framework/lib/relay";
-import { GQLDSA_METHOD_OF_REDRESS } from "coral-framework/schema";
 import { UserBoxContainer } from "coral-stream/common/UserBox";
 
 import { NotificationsContainer_settings } from "coral-stream/__generated__/NotificationsContainer_settings.graphql";
@@ -45,36 +44,6 @@ const NotificationsContainer: FunctionComponent<Props> = ({
       <div className={styles.title}>
         <Localized id="notifications-title">Notifications</Localized>
       </div>
-      <div className={styles.methodOfRedress}>
-        {settings.dsa.methodOfRedress.method ===
-          GQLDSA_METHOD_OF_REDRESS.NONE && (
-          <Localized id="notifications-methodOfRedress-none">
-            All moderation decisions are final and cannot be appealed
-          </Localized>
-        )}
-        {settings.dsa.methodOfRedress.method ===
-          GQLDSA_METHOD_OF_REDRESS.EMAIL && (
-          <Localized
-            id="notifications-methodOfRedress-email"
-            vars={{
-              email: settings.dsa.methodOfRedress.email,
-            }}
-          >
-            {`To appeal a decision that appears here please contact ${settings.dsa.methodOfRedress.email}`}
-          </Localized>
-        )}
-        {settings.dsa.methodOfRedress.method ===
-          GQLDSA_METHOD_OF_REDRESS.URL && (
-          <Localized
-            id="notifications-methodOfRedress-url"
-            vars={{
-              url: settings.dsa.methodOfRedress.url,
-            }}
-          >
-            {`To appeal a decision that appears here please visit ${settings.dsa.methodOfRedress.url}`}
-          </Localized>
-        )}
-      </div>
       <NotificationsListQuery viewerID={viewer.id} />
     </>
   );
@@ -90,13 +59,6 @@ const enhanced = withFragmentContainer<Props>({
   settings: graphql`
     fragment NotificationsContainer_settings on Settings {
       ...UserBoxContainer_settings
-      dsa {
-        methodOfRedress {
-          method
-          email
-          url
-        }
-      }
     }
   `,
 })(NotificationsContainer);

--- a/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.css
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.css
@@ -1,0 +1,25 @@
+.none {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-semi-bold);
+  font-size: var(--font-size-3);
+
+  color: var(--palette-text-100);
+
+  margin: var(--spacing-2);
+}
+
+.methodOfRedress {
+  padding-left: var(--spacing-4);
+  padding-right: var(--spacing-4);
+  padding-top: var(--spacing-2);
+  padding-bottom: var(--spacing-2);
+
+  background-color: var(--palette-primary-100);
+
+  font-family: var(--font-family-primary);
+  color: var(--palette-text-200);
+  font-weight: var(--font-weight-primary-regular);
+  font-size: var(--font-size-3);
+
+  margin-bottom: var(--spacing-2);
+}

--- a/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
@@ -85,6 +85,8 @@ const NotificationsPaginator: FunctionComponent<Props> = (props) => {
               a: (
                 <a
                   href={`mailto: ${props.query.settings.dsa.methodOfRedress.email}`}
+                  target="_blank"
+                  rel="noreferrer"
                 >
                   {props.query.settings.dsa.methodOfRedress.email}
                 </a>
@@ -103,7 +105,11 @@ const NotificationsPaginator: FunctionComponent<Props> = (props) => {
             }}
             elems={{
               a: (
-                <a href={`${props.query.settings.dsa.methodOfRedress.url}`}>
+                <a
+                  href={`${props.query.settings.dsa.methodOfRedress.url}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
                   {props.query.settings.dsa.methodOfRedress.url}
                 </a>
               ),

--- a/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
@@ -81,8 +81,17 @@ const NotificationsPaginator: FunctionComponent<Props> = (props) => {
             vars={{
               email: props.query.settings.dsa.methodOfRedress.email,
             }}
+            elems={{
+              a: (
+                <a
+                  href={`mailto: ${props.query.settings.dsa.methodOfRedress.email}`}
+                >
+                  {props.query.settings.dsa.methodOfRedress.email}
+                </a>
+              ),
+            }}
           >
-            {`To appeal a decision that appears here please contact ${props.query.settings.dsa.methodOfRedress.email}`}
+            <span>{`To appeal a decision that appears here please contact ${props.query.settings.dsa.methodOfRedress.email}`}</span>
           </Localized>
         )}
         {props.query.settings.dsa.methodOfRedress.method ===
@@ -92,8 +101,15 @@ const NotificationsPaginator: FunctionComponent<Props> = (props) => {
             vars={{
               url: props.query.settings.dsa.methodOfRedress.url,
             }}
+            elems={{
+              a: (
+                <a href={`${props.query.settings.dsa.methodOfRedress.url}`}>
+                  {props.query.settings.dsa.methodOfRedress.url}
+                </a>
+              ),
+            }}
           >
-            {`To appeal a decision that appears here please visit ${props.query.settings.dsa.methodOfRedress.url}`}
+            <span>{`To appeal a decision that appears here please visit ${props.query.settings.dsa.methodOfRedress.url}`}</span>
           </Localized>
         )}
       </div>

--- a/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
@@ -7,10 +7,13 @@ import CLASSES from "coral-stream/classes";
 import Spinner from "coral-stream/common/Spinner";
 import { Button } from "coral-ui/components/v3";
 
+import { GQLDSA_METHOD_OF_REDRESS } from "coral-common/client/src/core/client/framework/schema/__generated__/types";
 import { NotificationsPaginator_query } from "coral-stream/__generated__/NotificationsPaginator_query.graphql";
 import { NotificationsPaginatorPaginationQueryVariables } from "coral-stream/__generated__/NotificationsPaginatorPaginationQuery.graphql";
 
 import NotificationContainer from "./NotificationContainer";
+
+import styles from "./NotificationsPaginator.css";
 
 interface Props {
   query: NotificationsPaginator_query;
@@ -52,35 +55,77 @@ const NotificationsPaginator: FunctionComponent<Props> = (props) => {
     return null;
   }
 
-  return (
-    <div>
-      {props.query.notifications.edges.map(({ node }) => {
-        return (
-          <NotificationContainer
-            key={node.id}
-            notification={node}
-            viewer={props.query.viewer}
-          />
-        );
-      })}
-      {isRefetching && <Spinner />}
-      {!isRefetching && !disableLoadMore && props.relay.hasMore() && (
-        <Localized id="notifications-loadMore">
-          <Button
-            key={props.query.notifications.edges.length}
-            onClick={loadMore}
-            variant="outlined"
-            color="secondary"
-            fullWidth
-            disabled={disableLoadMore}
-            aria-controls="notifications-loadMore"
-            className={CLASSES.tabBarNotifications.loadMore}
-          >
-            Load More
-          </Button>
+  if (props.query.notifications.edges.length === 0) {
+    return (
+      <div className={styles.none}>
+        <Localized id="notifications-youDoNotCurrentlyHaveAny">
+          You do not currently have any notifications
         </Localized>
-      )}
-    </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className={styles.methodOfRedress}>
+        {props.query.settings.dsa.methodOfRedress.method ===
+          GQLDSA_METHOD_OF_REDRESS.NONE && (
+          <Localized id="notifications-methodOfRedress-none">
+            All moderation decisions are final and cannot be appealed
+          </Localized>
+        )}
+        {props.query.settings.dsa.methodOfRedress.method ===
+          GQLDSA_METHOD_OF_REDRESS.EMAIL && (
+          <Localized
+            id="notifications-methodOfRedress-email"
+            vars={{
+              email: props.query.settings.dsa.methodOfRedress.email,
+            }}
+          >
+            {`To appeal a decision that appears here please contact ${props.query.settings.dsa.methodOfRedress.email}`}
+          </Localized>
+        )}
+        {props.query.settings.dsa.methodOfRedress.method ===
+          GQLDSA_METHOD_OF_REDRESS.URL && (
+          <Localized
+            id="notifications-methodOfRedress-url"
+            vars={{
+              url: props.query.settings.dsa.methodOfRedress.url,
+            }}
+          >
+            {`To appeal a decision that appears here please visit ${props.query.settings.dsa.methodOfRedress.url}`}
+          </Localized>
+        )}
+      </div>
+      <div>
+        {props.query.notifications.edges.map(({ node }) => {
+          return (
+            <NotificationContainer
+              key={node.id}
+              notification={node}
+              viewer={props.query.viewer}
+            />
+          );
+        })}
+        {isRefetching && <Spinner />}
+        {!isRefetching && !disableLoadMore && props.relay.hasMore() && (
+          <Localized id="notifications-loadMore">
+            <Button
+              key={props.query.notifications.edges.length}
+              onClick={loadMore}
+              variant="outlined"
+              color="secondary"
+              fullWidth
+              disabled={disableLoadMore}
+              aria-controls="notifications-loadMore"
+              className={CLASSES.tabBarNotifications.loadMore}
+            >
+              Load More
+            </Button>
+          </Localized>
+        )}
+      </div>
+    </>
   );
 };
 
@@ -101,6 +146,15 @@ const enhanced = withPaginationContainer<
       ) {
         viewer {
           ...NotificationContainer_viewer
+        }
+        settings {
+          dsa {
+            methodOfRedress {
+              method
+              email
+              url
+            }
+          }
         }
         notifications(ownerID: $viewerID, after: $cursor, first: $count)
           @connection(key: "NotificationsPaginator_notifications") {

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1085,3 +1085,5 @@ notifications-methodOfRedress-email =
   To appeal a decision that appears here please contact { $email }
 notifications-methodOfRedress-url =
   To appeal a decision that appears here please visit { $url }
+
+notifications-youDoNotCurrentlyHaveAny = You do not currently have any notifications

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1082,8 +1082,8 @@ notifications-reportDecisionMade-illegal =
 notifications-methodOfRedress-none =
   All moderation decisions are final and cannot be appealed
 notifications-methodOfRedress-email =
-  To appeal a decision that appears here please contact { $email }
+  To appeal a decision that appears here please contact <a>{ $email }</a>
 notifications-methodOfRedress-url =
-  To appeal a decision that appears here please visit { $url }
+  To appeal a decision that appears here please visit <a>{ $url }</a>
 
 notifications-youDoNotCurrentlyHaveAny = You do not currently have any notifications


### PR DESCRIPTION
## What does this PR do?

- Show placeholder text when user has no notifications
- Make method of redress email/url a link

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices

## How do I test this PR?

- Turn on DSA mode in Admin > Configure > General > DSA
- Select the Email or URL option for method of redress and provide a value
- Make a new user
- Check their notifications
- See that they have a placeholder when they have no notifications
- Create a comment
- Reject it
- Check notifications
- See that the notification appeared for the rejection
- See that the method of redress shows with a link to the email/url option you filled out in the config earlier

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge to DSA epic branch
