### PR TITLE
DSA notifications: more rejection reasons

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
@@ -90,6 +90,36 @@ const getGeneralReason = (
       "Illegal content"
     );
   }
+
+  if (reason === GQLREJECTION_REASON_CODE.HARASSMENT_BULLYING) {
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-harassmentBullying",
+      "Harassment or bullying"
+    );
+  }
+  if (reason === GQLREJECTION_REASON_CODE.MISINFORMATION) {
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-misinformation",
+      "Misinformation"
+    );
+  }
+  if (reason === GQLREJECTION_REASON_CODE.HATE_SPEECH) {
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-hateSpeech",
+      "Hate speech"
+    );
+  }
+  if (reason === GQLREJECTION_REASON_CODE.IRRELEVANT_CONTENT) {
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-irrelevant",
+      "Irrelevant content"
+    );
+  }
+
   if (reason === GQLREJECTION_REASON_CODE.OTHER) {
     return getMessage(bundles, "notifications-rejectionReason-other", "Other");
   }

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1069,6 +1069,10 @@ notifications-rejectionReason-spam = Spam
 notifications-rejectionReason-bannedWord = Banned word
 notifications-rejectionReason-ad = Ad
 notifications-rejectionReason-illegalContent = Illegal content
+notifications-rejectionReason-harassmentBullying = Harassment or bullying
+notifications-rejectionReason-misinformation = Misinformation
+notifications-rejectionReason-hateSpeech = Hate speech
+notifications-rejectionReason-irrelevant = Irrelevant content
 notifications-rejectionReason-other = Other
 notifications-rejectionReason-unknown = Unknown
 


### PR DESCRIPTION
## What does this PR do?

- Adds more translations to the DSA notifications for the new rejection reasons.

## These changes will impact:

- [X] commenters
- [X] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

None

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

- enable DSA in config
- post a comment
- reject it with the various rejection reasons
- check user notifications and see that it has proper translations for the reason instead of `Unknown`

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into epic branch