### PR TITLE
DSA notifications: handle not found comment

### DIFF
--- a/server/src/core/server/graph/resolvers/Notification.ts
+++ b/server/src/core/server/graph/resolvers/Notification.ts
@@ -1,4 +1,3 @@
-import { CommentNotFoundError } from "coral-server/errors";
 import { Notification } from "coral-server/models/notifications/notification";
 
 import {
@@ -18,12 +17,7 @@ export const NotificationResolver: Required<
       return null;
     }
 
-    const comment = await ctx.loaders.Comments.comment.load(commentID);
-    if (!comment) {
-      throw new CommentNotFoundError(commentID);
-    }
-
-    return comment;
+    return await ctx.loaders.Comments.comment.load(commentID);
   },
   commentStatus: ({ commentStatus }) => commentStatus,
   dsaReport: async ({ reportID }, input, ctx) => {


### PR DESCRIPTION
## What does this PR do?

Handles the case when a comment no longer exists in the database when resolving notifications in graphql.

## These changes will impact:

- [X] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

- enable DSA in config
- create a new user (you're deleting them soon)
- post a comment
- have a mod/admin reject the comment
- check the user's notifications to see that they have a rejection notification for the comment
- delete the comment using mongo
- go back to the user's notifications
- see that the notification exists, but the referenced comment is not longer there

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into DSA epic branch
