### PR TITLE
DSA notifications: stop double notifying rejected comment during illegal report decisions

### DIFF
--- a/server/src/core/server/services/dsaReports/reports.ts
+++ b/server/src/core/server/services/dsaReports/reports.ts
@@ -233,7 +233,7 @@ export async function makeDSAReportDecision(
         detailedExplanation,
       },
       req,
-      true,
+      false, // set to false because we're about to notify below
       isArchived
     );
 


### PR DESCRIPTION
## What does this PR do?

Prevents the reject comment flow when determining a comment is illegal from posting a second notification. We already post an illegal comment rejection, so we don't need the `rejectComment` function doing it again for us.

## These changes will impact:

- [X] commenters
- [X] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

- post a comment
- report it as illegal
- use an admin/mod to process the report as illegal
- check the original offending user's notifications
- see they only have one notification, about their comment being rejected for being illegal

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into DSA epic branch
