### PR TITLE
Fix/localize rejection reason

### DIFF
--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -60,3 +60,6 @@ common-moderationReason-detailedExplanation =
   Detailed explanation
 common-moderationReason-detailedExplanation-placeholder =
    .placeholder = Add your explanation
+
+common-accountDeleted =
+  User account was deleted.

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -60,6 +60,3 @@ common-moderationReason-detailedExplanation =
   Detailed explanation
 common-moderationReason-detailedExplanation-placeholder =
    .placeholder = Add your explanation
-
-common-accountDeleted =
-  User account was deleted.

--- a/server/src/core/server/services/users/delete.ts
+++ b/server/src/core/server/services/users/delete.ts
@@ -6,7 +6,7 @@ import { ACTION_TYPE } from "coral-server/models/action/comment";
 import { Comment, getLatestRevision } from "coral-server/models/comment";
 import { DSAReport } from "coral-server/models/dsaReport";
 import { Story } from "coral-server/models/story";
-import { retrieveTenant } from "coral-server/models/tenant";
+import { retrieveTenant, Tenant } from "coral-server/models/tenant";
 
 import {
   GQLCOMMENT_STATUS,
@@ -16,7 +16,7 @@ import {
 } from "coral-server/graph/schema/__generated__/types";
 
 import { moderate } from "../comments/moderation";
-import { I18n } from "../i18n";
+import { I18n, translate } from "../i18n";
 import { AugmentedRedis } from "../redis";
 
 const BATCH_SIZE = 500;
@@ -129,18 +129,13 @@ async function moderateComments(
   redis: AugmentedRedis,
   config: Config,
   i18n: I18n,
-  tenantID: string,
+  tenant: Tenant,
   filter: FilterQuery<Comment>,
   targetStatus: GQLCOMMENT_STATUS,
   now: Date,
   isArchived = false,
   rejectionReason?: GQLRejectionReason
 ) {
-  const tenant = await retrieveTenant(mongo, tenantID);
-  if (!tenant) {
-    throw new Error("unable to retrieve tenant");
-  }
-
   const coll =
     isArchived && mongo.archive ? mongo.archivedComments() : mongo.comments();
   const comments = coll.find(filter);
@@ -270,6 +265,10 @@ async function deleteUserComments(
   now: Date,
   isArchived?: boolean
 ) {
+  const tenant = await retrieveTenant(mongo, tenantID);
+  if (!tenant) {
+    throw new Error("unable to retrieve tenant");
+  }
   // Approve any comments that have children.
   // This allows the children to be visible after
   // the comment is deleted.
@@ -278,7 +277,7 @@ async function deleteUserComments(
     redis,
     config,
     i18n,
-    tenantID,
+    tenant,
     {
       tenantID,
       authorID,
@@ -290,6 +289,13 @@ async function deleteUserComments(
     isArchived
   );
 
+  const bundle = i18n.getBundle(tenant.locale);
+  const translatedExplanation = translate(
+    bundle,
+    "User account deleted",
+    "common-accountDeleted"
+  );
+
   // reject any comments that don't have children
   // This gets rid of any empty/childless deleted comments.
   await moderateComments(
@@ -297,7 +303,7 @@ async function deleteUserComments(
     redis,
     config,
     i18n,
-    tenantID,
+    tenant,
     {
       tenantID,
       authorID,
@@ -316,7 +322,7 @@ async function deleteUserComments(
     isArchived,
     {
       code: GQLREJECTION_REASON_CODE.OTHER,
-      detailedExplanation: "User account deleted",
+      detailedExplanation: translatedExplanation,
     }
   );
 


### PR DESCRIPTION
## What does this PR do?
This PR localizes the string passes as the explanation of the rejection reason when rejecting a users comments as part of the account deletion flow.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No.

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
Change your tenants locale to something other than english.
In the FTL file for that locale, add a translation for `common-accountDeleted`.
Delete a user's account, observe that the moderation actions for the resulting rejected comments have a `detailedExplanation` field matching your FTL entry.

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations should be needed
