### PR TITLE
Fix: DSA - download void report csv

### DIFF
--- a/server/src/core/server/services/dsaReports/download.ts
+++ b/server/src/core/server/services/dsaReports/download.ts
@@ -95,7 +95,7 @@ export async function sendReportDownload(
     translate(bundle, "Action", "dsaReportCSV-action"),
     translate(bundle, "Details", "dsaReportCSV-details"),
   ]);
-  if (reportedComment) {
+  if (reportedComment && report.status !== GQLDSAReportStatus.VOID) {
     csv.write([
       formatter.format(report.createdAt),
       reporter?.username,

--- a/server/src/core/server/services/users/delete.ts
+++ b/server/src/core/server/services/users/delete.ts
@@ -1,4 +1,5 @@
 import { Collection, FilterQuery } from "mongodb";
+import { v4 as uuid } from "uuid";
 
 import { Config } from "coral-server/config";
 import { MongoContext } from "coral-server/data/context";
@@ -10,6 +11,7 @@ import { retrieveTenant } from "coral-server/models/tenant";
 
 import {
   GQLCOMMENT_STATUS,
+  GQLDSAReportHistoryType,
   GQLDSAReportStatus,
   GQLREJECTION_REASON_CODE,
   GQLRejectionReason,
@@ -230,6 +232,16 @@ async function updateUserDSAReports(
       continue;
     }
 
+    const id = uuid();
+
+    const statusChangeHistoryItem = {
+      id,
+      createdBy: null,
+      createdAt: new Date(),
+      status: GQLDSAReportStatus.VOID,
+      type: GQLDSAReportHistoryType.STATUS_CHANGED,
+    };
+
     batch.dsaReports.push({
       updateMany: {
         filter: {
@@ -245,6 +257,9 @@ async function updateUserDSAReports(
         update: {
           $set: {
             status: "VOID",
+          },
+          $push: {
+            history: statusChangeHistoryItem,
           },
         },
       },


### PR DESCRIPTION
## What does this PR do?

These changes make it so that downloading a `VOID` status CSV no longer causes an error. If status is void, we don't try to add the deleted comment info. Also, it updates to add the void status change to the report's history. This shows up in the report timeline on the single report page now.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can create a User 1, have them comment. Then have another User 2 report their comment for illegal content. Then have the User 1 request their account be deleted. Go in and update their scheduled deletion date to be now. Run Coral with jobs so that they will be deleted (might want to update to make account deletion run more often in accountDeletion.ts so you don't have to wait). See that the user is successfully deleted with no errors. The illegal content report against their comment should now be set to status Void. Try to download the CSV for the report and see that there are no errors. Also see that the status update is shown in the report timeline (that the user deleted their account and the report is void).

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
