### PR TITLE
Fix: DSA add additional comments validation update

### DIFF
--- a/client/src/core/client/stream/tabs/Comments/IllegalContentReportView/AddAdditionalComments.tsx
+++ b/client/src/core/client/stream/tabs/Comments/IllegalContentReportView/AddAdditionalComments.tsx
@@ -203,7 +203,7 @@ const AddAdditionalComments: FunctionComponent<Props> = ({
                         paddingSize="small"
                         upperCase
                         onClick={onAddCommentURL}
-                        disabled={!input.value || !!addAdditionalCommentError}
+                        disabled={!input.value}
                       >
                         <ButtonSvgIcon
                           Icon={AddIcon}


### PR DESCRIPTION
## What does this PR do?

Don't check for errors when disabling add additional comments button. You will still get errors if you try to submit an invalid comment URL, and it will be disabled if there is no input.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Add additional comments to a DSA report. Add some that error. See that you can still add new URLs and the `Add` button isn't disabled after you get an error. You should still see correct errors upon clicking `Add`.

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
