### PR TITLE
Fix: DSA copy and style update for report form

### DIFF
--- a/client/src/core/client/stream/tabs/Comments/Comment/ArchivedReportFlow/ArchivedReportFlowContainer.css
+++ b/client/src/core/client/stream/tabs/Comments/Comment/ArchivedReportFlow/ArchivedReportFlowContainer.css
@@ -43,6 +43,7 @@
 
 .illegalContentReportButton {
   margin-bottom: var(--spacing-2);
+  white-space: initial;
 }
 
 .linkIcon {

--- a/client/src/core/client/stream/tabs/Comments/Comment/ArchivedReportFlow/ArchivedReportFlowContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Comment/ArchivedReportFlow/ArchivedReportFlowContainer.tsx
@@ -106,11 +106,12 @@ const ArchivedReportFlowContainer: FunctionComponent<Props> = ({
           paddingSize="none"
           target="_blank"
           anchor
+          textAlign="left"
           underline
           href={reportLink}
         >
           <Localized id="comments-reportForm-reportIllegalContent-button">
-            <span>Does this comment potentially contain illegal content?</span>
+            <span>This comment contains illegal content</span>
           </Localized>
           <ButtonSvgIcon
             className={styles.linkIcon}

--- a/client/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.css
+++ b/client/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.css
@@ -90,6 +90,7 @@
 
 .reportIllegalLink {
   margin-bottom: var(--spacing-3);
+  white-space: initial;
 }
 
 .linkIcon {

--- a/client/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Comment/ReportFlow/ReportCommentForm.tsx
@@ -185,12 +185,11 @@ const ReportCommentForm: FunctionComponent<Props> = ({
                   target="_blank"
                   anchor
                   underline
+                  textAlign="left"
                   href={reportLink}
                 >
                   <Localized id="comments-reportForm-reportIllegalContent-button">
-                    <span>
-                      Does this comment potentially contain illegal content?
-                    </span>
+                    <span>This comment contains illegal content</span>
                   </Localized>
                   <ButtonSvgIcon
                     className={styles.linkIcon}

--- a/client/src/core/client/stream/test/comments/stream/reportComment.spec.tsx
+++ b/client/src/core/client/stream/test/comments/stream/reportComment.spec.tsx
@@ -205,7 +205,7 @@ it("report comment includes link to report illegal content", async () => {
   userEvent.click(reportButton);
   const form = within(comment).getByTestId("report-comment-form");
   const reportIllegalContentButton = within(form).getByRole("link", {
-    name: "Does this comment potentially contain illegal content? share-external-link-1",
+    name: "This comment contains illegal content share-external-link-1",
   });
   expect(reportIllegalContentButton).toHaveAttribute(
     "href",

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -748,7 +748,7 @@ comments-reportPopover-receivedMessage =
 
 comments-reportPopover-dismiss = Dismiss
 
-comments-reportForm-reportIllegalContent-button = Does this comment potentially contain illegal content?
+comments-reportForm-reportIllegalContent-button = This comment contains illegal content
 
 ## Archived Report Comment Popover
 


### PR DESCRIPTION
## What does this PR do?

Updates the copy for the report illegal content link in report forms for both archived and non-archived comments. Also updates styles so that on mobile the link text doesn't overflow.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?
no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Click `Report` for a comment in the stream. See the updated `This comment contains illegal content` text and icon for the report link. Check on mobile. Text should wrap instead of overflowing out of the report form (note that with the copy update, you may need to make text longer while testing to make it wrap).

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
