### PR TITLE
Fix: DSA - reviewed report notifications copy update

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/DSAReportDecisionMadeNotificationBody.css
+++ b/client/src/core/client/stream/tabs/Notifications/DSAReportDecisionMadeNotificationBody.css
@@ -12,3 +12,9 @@
 .body > p {
   margin-bottom: var(--spacing-3);
 }
+
+.body > span > strong {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-semi-bold);
+  font-size: var(--font-size-2);
+}

--- a/client/src/core/client/stream/tabs/Notifications/DSAReportDecisionMadeNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/DSAReportDecisionMadeNotificationBody.tsx
@@ -34,8 +34,15 @@ const DSAReportDecisionMadeNotificationBody: FunctionComponent<Props> = ({
               date,
               author: username,
             }}
+            elems={{ strong: <strong /> }}
           >
-            {`On ${date} you reported a comment written by ${username} for containing illegal content. After reviewing your report, our moderation team has decided this comment does not appear to contain illegal content.`}
+            <span>
+              On <strong>{date}</strong> you reported a comment written by{" "}
+              <strong>{username}</strong> for containing illegal content. After
+              reviewing your report, our moderation team has decide this comment{" "}
+              <strong>does not appear to contain illegal content.</strong> Thank
+              you for helping to keep our community safe.
+            </span>
           </Localized>
         )}
       {decisionDetails &&
@@ -46,8 +53,17 @@ const DSAReportDecisionMadeNotificationBody: FunctionComponent<Props> = ({
               date,
               author: username,
             }}
+            elems={{ strong: <strong /> }}
           >
-            {`On ${date} you reported a comment written by ${username} for containing illegal content. After reviewing your report, our moderation team has decided this comment does contain illegal content.`}
+            <span>
+              On <strong>{date}</strong> you reported a comment written by{" "}
+              <strong>{username}</strong> for containing illegal content. After
+              reviewing your report, our moderation team has decided this
+              comment <strong>does contain illegal content</strong> and has been
+              removed. Further action may be taken against the commenter,
+              however you will not be notified of any additional steps. Thank
+              you for helping to keep our community safe.
+            </span>
           </Localized>
         )}
     </div>

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1073,9 +1073,9 @@ notifications-rejectionReason-other = Other
 notifications-rejectionReason-unknown = Unknown
 
 notifications-reportDecisionMade-legal =
-  On { $date } you reported a comment written by { $author } for containing illegal content. After reviewing your report, our moderation team has decided this comment does not appear to contain illegal content.
+  On <strong>{ $date }</strong> you reported a comment written by <strong>{ $author }</strong> for containing illegal content. After reviewing your report, our moderation team has decided this comment <strong>does not appear to contain illegal content.</strong> Thank you for helping to keep our community safe.
 notifications-reportDecisionMade-illegal =
-  On { $date } you reported a comment written by { $author } for containing illegal content. After reviewing your report, our moderation team has decided this comment does contain illegal content.
+  On <strong>{ $date }</strong> you reported a comment written by <strong>{ $author }</strong> for containing illegal content. After reviewing your report, our moderation team has decided this comment <strong>does contain illegal content</strong> and has been removed. Further action may be taken against the commenter, however you will not be notified of any additional steps. Thank you for helping to keep our community safe.
 
 notifications-methodOfRedress-none =
   All moderation decisions are final and cannot be appealed


### PR DESCRIPTION
## What does this PR do?

Updates the copy and bolding for notifications for reviewed DSA reports.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Make an illegal content decision on a report. Check the notification in the reporter's notifications tab and see that it has the correct updated copy and bolded text.

Make a legal content decision on a report. Check the notification in the reporter's notifications tab and see that it has the correct updated copy and bolded text.

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
