### PR TITLE
DSA Notifications: fix the tab sizing

### DIFF
--- a/client/src/core/client/stream/App/TabBar.css
+++ b/client/src/core/client/stream/App/TabBar.css
@@ -2,8 +2,32 @@
   padding: var(--spacing-3);
 }
 
-.condensedTab {
-  padding: var(--spacing-2);
+.notificationsTab {
+  padding-top: var(--spacing-3);
+  padding-bottom: var(--spacing-2);
+  padding-left: var(--spacing-4);
+  padding-right: var(--spacing-4);
+}
+
+.notificationsIcon {
+  height: var(--spacing-5);
+  overflow: hidden;
+}
+
+.notificationsIconSmall {
+  /* unlike the configure cog icon, the bell is taller than
+     it is wide, so it pushes up the tab, we constrain it
+     using this, allowing all the other padding styles to
+     remain consistent */
+  height: 22.5px;
+  overflow: hidden;
+}
+
+.notificationsTabSmall {
+  padding-top: var(--spacing-3);
+  padding-bottom: var(--spacing-3);
+  padding-left: var(--spacing-4);
+  padding-right: var(--spacing-4);
 }
 
 .configureTab {

--- a/client/src/core/client/stream/App/TabBar.tsx
+++ b/client/src/core/client/stream/App/TabBar.tsx
@@ -167,15 +167,24 @@ const AppTabBar: FunctionComponent<Props> = (props) => {
 
           {props.showNotificationsTab && (
             <Tab
-              className={cn(CLASSES.tabBar.notifications, {
-                [CLASSES.tabBar.activeTab]: props.activeTab === "NOTIFICATIONS",
-                [styles.condensedTab]: matches,
-                [styles.smallTab]: !matches,
-              })}
+              className={cn(
+                CLASSES.tabBar.notifications,
+                styles.notificationsTab,
+                {
+                  [CLASSES.tabBar.activeTab]:
+                    props.activeTab === "NOTIFICATIONS",
+                  [styles.notificationsTabSmall]: !matches,
+                }
+              )}
               tabID="NOTIFICATIONS"
               variant="streamPrimary"
             >
-              <div>
+              <div
+                className={cn({
+                  [styles.notificationsIcon]: matches,
+                  [styles.notificationsIconSmall]: !matches,
+                })}
+              >
                 <SvgIcon
                   size="md"
                   Icon={


### PR DESCRIPTION
## What does this PR do?

Fixes the tab sizing of the notifications tab to be consistent with the other tabs.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

- Enable DSA
- Go to stream tab
- See notifications tab looks normal compared to the other tabs
- Check mobiles (or reduced screen size) and see that the tab also looks appropriate when responsively squeezed down small

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into DSA epic branch
