### PR TITLE
DSA - update Reject and moderation reasons modal

### DIFF
--- a/client/src/core/client/admin/components/ModerationReason/DetailedExplanation.css
+++ b/client/src/core/client/admin/components/ModerationReason/DetailedExplanation.css
@@ -4,12 +4,18 @@
 
 .explanationLabel {
   margin-bottom: var(--spacing-2);
+  margin-top: var(--spacing-2);
 }
 
 .changeReason {
   margin-bottom: var(--spacing-3);
+  padding: 0;
 }
 
 .detailedExplanation > textarea {
   resize: none;
+}
+
+.code {
+  font-family: var(--font-family-primary);
 }

--- a/client/src/core/client/admin/components/ModerationReason/DetailedExplanation.tsx
+++ b/client/src/core/client/admin/components/ModerationReason/DetailedExplanation.tsx
@@ -1,9 +1,9 @@
 import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useState } from "react";
 
 import { GQLREJECTION_REASON_CODE } from "coral-framework/schema";
-import { Label, RadioButton } from "coral-ui/components/v2";
+import { Label } from "coral-ui/components/v2";
 import { TextArea } from "coral-ui/components/v3";
 import { Button } from "coral-ui/components/v3/Button/Button";
 
@@ -19,58 +19,73 @@ export interface Props {
   onBack: () => void;
 }
 
+const AddExplanationButton: FunctionComponent<{ onClick: () => void }> = ({
+  onClick,
+}) => (
+  <Localized id="common-moderationReason-addExplanation">
+    <Button
+      onClick={onClick}
+      className={commonStyles.optionAction}
+      variant="none"
+      color="success"
+    >
+      + Add explanation
+    </Button>
+  </Localized>
+);
+
 const DetailedExplanation: FunctionComponent<Props> = ({
   code,
   value,
   onChange,
   onBack,
 }) => {
+  const [showAddExplanation, setShowAddExplanation] = useState(
+    !!(code === GQLREJECTION_REASON_CODE.OTHER)
+  );
+
   return (
     <>
-      <Localized id={`common-moderationReason-rejectionReason-${code}`}>
-        <RadioButton
-          tabIndex={-1}
-          aria-hidden
-          value={code}
-          name={code}
-          key={code}
-          checked
-          readOnly
-        >
-          {unsnake(code)}
-        </RadioButton>
-      </Localized>
-
       <Localized id="common-moderationReason-changeReason">
-        <Button
-          className={cn(commonStyles.optionAction, styles.changeReason)}
-          variant="none"
-          onClick={onBack}
-        >
-          Change Reason
+        <Button className={styles.changeReason} variant="none" onClick={onBack}>
+          &lt; Change Reason
         </Button>
       </Localized>
 
-      <Localized id="common-moderationReason-detailedExplanation">
-        <Label
-          className={cn(commonStyles.sectionLabel, styles.explanationLabel)}
-        >
-          Explanation
-        </Label>
+      <Localized id="common-moderationReason-reasonLabel">
+        <Label>Reason</Label>
       </Localized>
 
-      <Localized
-        id="common-moderationReason-detailedExplanation-placeholder"
-        attrs={{ placeholder: true }}
-      >
-        <TextArea
-          className={styles.detailedExplanation}
-          placeholder="Add your explanation"
-          data-testid="moderation-reason-detailed-explanation"
-          value={value || undefined}
-          onChange={(e) => onChange(e.target.value)}
-        />
+      <Localized id={`common-moderationReason-rejectionReason-${code}`}>
+        <div className={styles.code}>{unsnake(code)}</div>
       </Localized>
+
+      {showAddExplanation ? (
+        <>
+          <Localized id="common-moderationReason-detailedExplanation">
+            <Label
+              className={cn(commonStyles.sectionLabel, styles.explanationLabel)}
+            >
+              Explanation
+            </Label>
+          </Localized>
+
+          <Localized
+            id="common-moderationReason-detailedExplanation-placeholder"
+            attrs={{ placeholder: true }}
+          >
+            <TextArea
+              className={styles.detailedExplanation}
+              placeholder="Add your explanation"
+              data-testid="moderation-reason-detailed-explanation"
+              value={value || undefined}
+              onChange={(e) => onChange(e.target.value)}
+            />
+          </Localized>
+        </>
+      ) : (
+        <AddExplanationButton onClick={() => setShowAddExplanation(true)} />
+      )}
     </>
   );
 };

--- a/client/src/core/client/admin/components/ModerationReason/ModerationReason.css
+++ b/client/src/core/client/admin/components/ModerationReason/ModerationReason.css
@@ -18,16 +18,6 @@
   text-decoration: underline;
 }
 
-.buttons {
-  margin-top: var(--spacing-1);
-}
-
-.cancelButton {
-  width: 109px;
-  align-self: flex-start;
-}
-
 .rejectButton {
-  width: 73px;
-  margin-left: auto;
+  margin-bottom: var(--spacing-2);
 }

--- a/client/src/core/client/admin/components/ModerationReason/ModerationReason.tsx
+++ b/client/src/core/client/admin/components/ModerationReason/ModerationReason.tsx
@@ -56,7 +56,10 @@ const ModerationReason: FunctionComponent<Props> = ({
         />
       ) : (
         <DetailedExplanation
-          onBack={() => setView("REASON")}
+          onBack={() => {
+            setView("REASON");
+            setReasonCode(null);
+          }}
           code={reasonCode!}
           value={detailedExplanation}
           onChange={setDetailedExplanation}

--- a/client/src/core/client/admin/components/ModerationReason/ModerationReason.tsx
+++ b/client/src/core/client/admin/components/ModerationReason/ModerationReason.tsx
@@ -6,7 +6,7 @@ import { Box, Button, Flex } from "coral-ui/components/v2";
 
 import { RejectCommentReasonInput } from "coral-stream/__generated__/RejectCommentMutation.graphql";
 
-import DetailedExplantion from "./DetailedExplanation";
+import DetailedExplanation from "./DetailedExplanation";
 import Reasons from "./Reasons";
 
 import styles from "./ModerationReason.css";
@@ -49,11 +49,13 @@ const ModerationReason: FunctionComponent<Props> = ({
       {view === "REASON" ? (
         <Reasons
           selected={reasonCode}
-          onCode={setReasonCode}
-          onAddExplanation={() => setView("EXPLANATION")}
+          onCode={(code) => {
+            setReasonCode(code);
+            setView("EXPLANATION");
+          }}
         />
       ) : (
-        <DetailedExplantion
+        <DetailedExplanation
           onBack={() => setView("REASON")}
           code={reasonCode!}
           value={detailedExplanation}
@@ -61,32 +63,39 @@ const ModerationReason: FunctionComponent<Props> = ({
         />
       )}
 
-      <Flex className={styles.buttons}>
-        <Localized id="common-moderationReason-cancel">
-          <Button
-            className={styles.cancelButton}
-            variant="outlined"
-            color="mono"
-            onClick={onCancel}
-          >
-            Cancel
-          </Button>
-        </Localized>
+      <Flex marginTop={2} direction="column">
+        {reasonCode && (
+          <Flex>
+            <Localized id="common-moderationReason-reject">
+              <Button
+                className={styles.rejectButton}
+                disabled={
+                  reasonCode === null ||
+                  (reasonCode === GQLREJECTION_REASON_CODE.OTHER &&
+                    !detailedExplanation)
+                }
+                onClick={submitReason}
+                color="alert"
+                fullWidth
+              >
+                Reject
+              </Button>
+            </Localized>
+          </Flex>
+        )}
 
-        <Localized id="common-moderationReason-reject">
-          <Button
-            className={styles.rejectButton}
-            disabled={
-              reasonCode === null ||
-              (reasonCode === GQLREJECTION_REASON_CODE.OTHER &&
-                !detailedExplanation)
-            }
-            onClick={submitReason}
-            color="alert"
-          >
-            Reject
-          </Button>
-        </Localized>
+        <Flex>
+          <Localized id="common-moderationReason-cancel">
+            <Button
+              variant="outlined"
+              color="mono"
+              onClick={onCancel}
+              fullWidth
+            >
+              Cancel
+            </Button>
+          </Localized>
+        </Flex>
       </Flex>
     </Box>
   );

--- a/client/src/core/client/admin/components/ModerationReason/Reasons.tsx
+++ b/client/src/core/client/admin/components/ModerationReason/Reasons.tsx
@@ -2,8 +2,7 @@ import { Localized } from "@fluent/react/compat";
 import React, { FunctionComponent } from "react";
 
 import { GQLREJECTION_REASON_CODE } from "coral-framework/schema";
-import { /* Button, */ RadioButton } from "coral-ui/components/v2";
-import { Button } from "coral-ui/components/v3";
+import { RadioButton } from "coral-ui/components/v2";
 
 import { unsnake } from "./formatting";
 
@@ -12,29 +11,9 @@ import commonStyles from "./ModerationReason.css";
 export interface Props {
   onCode: (code: GQLREJECTION_REASON_CODE) => void;
   selected: GQLREJECTION_REASON_CODE | null;
-  onAddExplanation: () => void;
 }
 
-const AddExplanationButton: FunctionComponent<{ onClick: () => void }> = ({
-  onClick,
-}) => (
-  <Localized id="common-moderationReason-addExplanation">
-    <Button
-      onClick={onClick}
-      className={commonStyles.optionAction}
-      variant="none"
-      color="success"
-    >
-      + Add explanation
-    </Button>
-  </Localized>
-);
-
-const Reasons: FunctionComponent<Props> = ({
-  selected,
-  onCode,
-  onAddExplanation,
-}) => {
+const Reasons: FunctionComponent<Props> = ({ selected, onCode }) => {
   return (
     <>
       <Localized id="common-moderationReason-reason">
@@ -64,37 +43,26 @@ const Reasons: FunctionComponent<Props> = ({
                 {unsnake(code)}
               </RadioButton>
             </Localized>
-
-            {selected === code && (
-              <AddExplanationButton onClick={onAddExplanation} />
-            )}
           </div>
         ))}
 
-      <Localized id="common-moderationReason-reason-moreReasons">
-        <span className={commonStyles.sectionLabel}>+ More reasons</span>
-      </Localized>
-
-      <>
-        <Localized
-          id={`common-moderationReason-rejectionReason-${GQLREJECTION_REASON_CODE.OTHER}`}
+      <Localized
+        id={`common-moderationReason-rejectionReason-${GQLREJECTION_REASON_CODE.OTHER}`}
+      >
+        <RadioButton
+          value={GQLREJECTION_REASON_CODE.OTHER}
+          name={GQLREJECTION_REASON_CODE.OTHER}
+          key={GQLREJECTION_REASON_CODE.OTHER}
+          checked={selected === GQLREJECTION_REASON_CODE.OTHER}
+          onChange={(e) => {
+            if (e.target.checked) {
+              onCode(GQLREJECTION_REASON_CODE.OTHER);
+            }
+          }}
         >
-          <RadioButton
-            value={GQLREJECTION_REASON_CODE.OTHER}
-            name={GQLREJECTION_REASON_CODE.OTHER}
-            key={GQLREJECTION_REASON_CODE.OTHER}
-            checked={selected === GQLREJECTION_REASON_CODE.OTHER}
-            onChange={(e) => {
-              if (e.target.checked) {
-                onCode(GQLREJECTION_REASON_CODE.OTHER);
-                onAddExplanation();
-              }
-            }}
-          >
-            {unsnake(GQLREJECTION_REASON_CODE.OTHER)}
-          </RadioButton>
-        </Localized>
-      </>
+          {unsnake(GQLREJECTION_REASON_CODE.OTHER)}
+        </RadioButton>
+      </Localized>
     </>
   );
 };

--- a/client/src/core/client/admin/test/moderate/regularQueue.spec.tsx
+++ b/client/src/core/client/admin/test/moderate/regularQueue.spec.tsx
@@ -748,6 +748,9 @@ it("rejects comment in reported queue", async () => {
     );
 
   await createTestRenderer({
+    initLocalState(local, source, environment) {
+      local.setValue(false, "dsaFeaturesEnabled");
+    },
     resolvers: createResolversStub<GQLResolver>({
       Query: {
         moderationQueues: () =>
@@ -791,6 +794,7 @@ it("rejects comment in reported queue", async () => {
   const comment = await screen.findByTestId(
     `moderate-comment-card-${reportedComments[0].id}`
   );
+
   const rejectButton = within(comment).getByRole("button", {
     name: "Reject",
   });
@@ -966,19 +970,14 @@ it("requires moderation reason when DSA features enabled", async () => {
 
   const reasonModal = screen.queryByTestId(reasonModalID)!;
 
+  const abusiveRadio = within(reasonModal).getByRole("radio", {
+    name: "Abusive",
+  });
+
+  fireEvent.click(abusiveRadio);
+
   const submitReasonButton = within(reasonModal).getByRole("button", {
     name: "Reject",
-  });
-  expect(submitReasonButton).toBeDisabled();
-
-  const abusiveOption = within(reasonModal).getByLabelText("abusive", {
-    exact: false,
-  });
-
-  expect(abusiveOption).toBeInTheDocument();
-
-  await act(async () => {
-    fireEvent.click(abusiveOption);
   });
 
   expect(submitReasonButton).toBeEnabled();

--- a/client/src/core/client/stream/test/comments/stream/moderation.spec.tsx
+++ b/client/src/core/client/stream/test/comments/stream/moderation.spec.tsx
@@ -694,11 +694,6 @@ it("requires rection reason when dsaFeaturesEnabled", async () => {
 
   expect(reasonModal).toBeInTheDocument();
 
-  const submitReasonButton = within(reasonModal).getByRole("button", {
-    name: "Reject",
-  });
-  expect(submitReasonButton).toBeDisabled();
-
   const otherOption = within(reasonModal).getByLabelText("other", {
     exact: false,
   });
@@ -709,9 +704,15 @@ it("requires rection reason when dsaFeaturesEnabled", async () => {
     fireEvent.click(otherOption);
   });
 
+  const submitReasonButton = within(reasonModal).getByRole("button", {
+    name: "Reject",
+  });
+  expect(submitReasonButton).toBeDisabled();
+
   const additionalInfo = within(reasonModal).getByTestId(
     "moderation-reason-detailed-explanation"
   );
+
   act(() => {
     fireEvent.change(additionalInfo, {
       target: { value: "really weird comment tbh" },

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -50,12 +50,11 @@ common-moderationReason-rejectionReason-HATE_SPEECH =
   Hate speech
 common-moderationReason-rejectionReason-IRRELEVANT_CONTENT = 
   Irrelevant content
-common-moderationReason-reason-moreReasons =
-  + More reasons
 common-moderationReason-rejectionReason-OTHER = 
   Other
 common-moderationReason-changeReason =
-  Change reason
+  &lt; Change reason
+common-moderationReason-reasonLabel = Reason
 common-moderationReason-detailedExplanation =
   Detailed explanation
 common-moderationReason-detailedExplanation-placeholder =


### PR DESCRIPTION
## What does this PR do?

This updates the Reject and moderation reasons modal to match updated designs. Note that it leaves adding the required custom reason for `Other` to a future PR since it needs to be discussed further how to handle.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can try to reject a comment in the stream or in the admin, and you should see the updated rejection reasons modal. Compare with designs. Try out selecting different rejection reasons, adding explanations, rejecting, going back to change reasons, etc. Make sure to test the `Other` option since it requires a detailed explanation to be able to reject.

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
