### PR TITLE
fix: spam ban mod reason

### DIFF
--- a/client/src/core/client/stream/tabs/Comments/Comment/UserBanPopover/UserBanPopoverContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Comment/UserBanPopover/UserBanPopoverContainer.tsx
@@ -16,6 +16,7 @@ import {
   useMutation,
   withFragmentContainer,
 } from "coral-framework/lib/relay";
+import { GQLREJECTION_REASON_CODE } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
 import {
   AlertCircleIcon,
@@ -136,12 +137,21 @@ const UserBanPopoverContainer: FunctionComponent<Props> = ({
         ),
         siteIDs: siteBan || viewerScoped ? [story.site.id] : [],
       });
+
       if (!rejected && comment.revision) {
         await reject({
           commentID: comment.id,
           commentRevisionID: comment.revision.id,
           storyID: story.id,
           noEmit: true,
+          reason: {
+            code: GQLREJECTION_REASON_CODE.OTHER,
+            detailedExplanation: getMessage(
+              localeBundles,
+              "common-userBanned",
+              "User was banned."
+            ),
+          },
         });
       }
     } catch (e) {

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -62,4 +62,4 @@ common-moderationReason-detailedExplanation-placeholder =
    .placeholder = Add your explanation
 
 common-userBanned =
-  User banned.
+  User was banned.

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -60,3 +60,6 @@ common-moderationReason-detailedExplanation =
   Detailed explanation
 common-moderationReason-detailedExplanation-placeholder =
    .placeholder = Add your explanation
+
+common-userBanned =
+  User banned.

--- a/server/src/core/server/graph/mutators/Users.ts
+++ b/server/src/core/server/graph/mutators/Users.ts
@@ -346,6 +346,7 @@ export const Users = (ctx: GraphContext) => ({
       ctx.user!,
       userID,
       message,
+      ctx.i18n,
       rejectExistingComments,
       siteIDs,
       ctx.now
@@ -365,6 +366,7 @@ export const Users = (ctx: GraphContext) => ({
         ctx.mailerQueue,
         ctx.rejectorQueue,
         ctx.tenant,
+        ctx.i18n,
         ctx.user!,
         userID,
         message,

--- a/server/src/core/server/services/users/users.spec.ts
+++ b/server/src/core/server/services/users/users.spec.ts
@@ -18,6 +18,7 @@ import { updateRole, updateUserBan } from "./users";
 
 import { GQLUSER_ROLE } from "coral-server/graph/schema/__generated__/types";
 import { demoteMember, promoteMember } from ".";
+import { I18n } from "../i18n";
 
 describe("updateUserBan", () => {
   afterEach(jest.clearAllMocks);
@@ -52,6 +53,7 @@ describe("updateUserBan", () => {
           mailer,
           rejector,
           tenant,
+          new I18n("en-US"),
           commenter,
           badUser.id,
           "Test message",
@@ -73,6 +75,7 @@ describe("updateUserBan", () => {
           mailer,
           rejector,
           tenant,
+          new I18n("en-US"),
           staff,
           badUser.id,
           "Test message",
@@ -99,6 +102,7 @@ describe("updateUserBan", () => {
           mailer,
           rejector,
           tenant,
+          new I18n("en-US"),
           siteAMod,
           badUser.id,
           "Test message",
@@ -122,6 +126,7 @@ describe("updateUserBan", () => {
           mailer,
           rejector,
           tenant,
+          new I18n("en-US"),
           orgMod,
           badUser.id,
           "Test message",
@@ -153,6 +158,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
+      new I18n("en-US"),
       admin,
       bannedOnSiteA.id,
       "Test message",
@@ -187,6 +193,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
+      new I18n("en-US"),
       admin,
       bannedOnSiteB.id,
       "TEST MESSAGE",
@@ -213,6 +220,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
+      new I18n("en-US"),
       admin,
       notBannedUser.id,
       "TEST MESSAGE",
@@ -239,6 +247,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
+      new I18n("en-US"),
       admin,
       unbannedUser.id,
       "Test Message",
@@ -255,6 +264,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
+      new I18n("en-US"),
       admin,
       unbannedUser.id,
       "Test Message",

--- a/server/src/core/server/services/users/users.spec.ts
+++ b/server/src/core/server/services/users/users.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "coral-server/test/fixtures";
 import {
   createMockDataCache,
+  createMockI18n,
   createMockMailer,
   createMockMongoContex,
   createMockRejector,
@@ -36,6 +37,7 @@ describe("updateUserBan", () => {
     tenantID,
     role: GQLUSER_ROLE.ADMIN,
   });
+  const i18n = createMockI18n("User was banned.");
 
   /* eslint-disable-next-line */
   const userService = require("coral-server/models/user");
@@ -53,7 +55,7 @@ describe("updateUserBan", () => {
           mailer,
           rejector,
           tenant,
-          new I18n("en-US"),
+          i18n,
           commenter,
           badUser.id,
           "Test message",
@@ -102,7 +104,7 @@ describe("updateUserBan", () => {
           mailer,
           rejector,
           tenant,
-          new I18n("en-US"),
+          i18n,
           siteAMod,
           badUser.id,
           "Test message",
@@ -126,7 +128,7 @@ describe("updateUserBan", () => {
           mailer,
           rejector,
           tenant,
-          new I18n("en-US"),
+          i18n,
           orgMod,
           badUser.id,
           "Test message",
@@ -158,7 +160,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
-      new I18n("en-US"),
+      i18n,
       admin,
       bannedOnSiteA.id,
       "Test message",
@@ -193,7 +195,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
-      new I18n("en-US"),
+      i18n,
       admin,
       bannedOnSiteB.id,
       "TEST MESSAGE",
@@ -220,7 +222,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
-      new I18n("en-US"),
+      i18n,
       admin,
       notBannedUser.id,
       "TEST MESSAGE",
@@ -247,7 +249,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
-      new I18n("en-US"),
+      i18n,
       admin,
       unbannedUser.id,
       "Test Message",
@@ -264,7 +266,7 @@ describe("updateUserBan", () => {
       mailer,
       rejector,
       tenant,
-      new I18n("en-US"),
+      i18n,
       admin,
       unbannedUser.id,
       "Test Message",

--- a/server/src/core/server/services/users/users.ts
+++ b/server/src/core/server/services/users/users.ts
@@ -1472,7 +1472,7 @@ export async function ban(
   const tranlsatedExplanation = translate(
     bundle,
     "common-userBanned",
-    "User banned"
+    "User banned."
   );
   const rejectionReason = {
     code: GQLREJECTION_REASON_CODE.OTHER,

--- a/server/src/core/server/services/users/users.ts
+++ b/server/src/core/server/services/users/users.ts
@@ -1471,8 +1471,8 @@ export async function ban(
   const bundle = i18n.getBundle(tenant.locale);
   const tranlsatedExplanation = translate(
     bundle,
-    "User banned",
-    "common-userBanned"
+    "common-userBanned",
+    "User banned"
   );
   const rejectionReason = {
     code: GQLREJECTION_REASON_CODE.OTHER,

--- a/server/src/core/server/test/mocks.ts
+++ b/server/src/core/server/test/mocks.ts
@@ -2,6 +2,7 @@ import { DataCache } from "coral-server/data/cache/dataCache";
 import { MongoContext } from "coral-server/data/context";
 import { MailerQueue } from "coral-server/queue/tasks/mailer";
 import { RejectorQueue } from "coral-server/queue/tasks/rejector";
+import { I18n } from "coral-server/services/i18n";
 import { AugmentedRedis } from "coral-server/services/redis";
 import { TenantCache } from "coral-server/services/tenant/cache";
 
@@ -45,3 +46,15 @@ export const createMockRejector = () =>
   ({
     add: jest.fn().mockResolvedValue({}),
   } as unknown as RejectorQueue);
+
+export const createMockI18n = (value: string) =>
+  ({
+    getBundle: () => {
+      return {
+        getMessage: () => {
+          return { value };
+        },
+        formatPattern: () => {},
+      };
+    },
+  } as unknown as I18n);


### PR DESCRIPTION
## What does this PR do?
This PR includes a rejectionReason when rejecting a user's comments as part of a ban with `rejectExistingComments = true`. This addresses the issue with both spam banning and managing a users ban via the community view.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
None.

## Does this PR introduce any new environment variables or feature flags?
No. 

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?
1. Start the server with cron jobs running
2. As a user with mod priveledges, navigate to the stream and spam ban a user.
3. Observe that the ban goes through, and that the users comments are rejected. Additionally, the resulting commentModerationActions should have a reason attached stating that the user was banned.
4. As a user with mod priveledges, ban a user across all sites via the community view
5. Observe that the ban goes through, and that the users comments are rejected. Additionally, the resulting commentModerationActions should have a reason attached stating that the user was banned.
6. As a user with mod priveledges, ban a user across selected sites via the community view
7. Observe that the ban goes through, and that the users comments on the selected sites are rejected. Additionally, the resulting commentModerationActions should have a reason attached stating that the user was banned.

## Where any tests migrated to React Testing Library?
No.

## How do we deploy this PR?
No special considerations should be needed.
