### PR TITLE
Fix reported states for archived, Q&A, and R&R stories when data cache is enabled

### DIFF
--- a/client/src/core/client/admin/permissions/story.ts
+++ b/client/src/core/client/admin/permissions/story.ts
@@ -17,7 +17,7 @@ const permissionMap: PermissionMap<AbilityType, PermissionContext> = {
     [GQLUSER_ROLE.MODERATOR]: () => true,
   },
   ARCHIVE_STORY: {
-    [GQLUSER_ROLE.ADMIN]: () => false,
+    [GQLUSER_ROLE.ADMIN]: () => true,
   },
 };
 

--- a/server/src/core/server/graph/loaders/Comments.ts
+++ b/server/src/core/server/graph/loaders/Comments.ts
@@ -58,7 +58,7 @@ const tagFilter = (tag?: GQLTAG): CommentConnectionInput["filter"] => {
   return {};
 };
 
-const isRatingsAndReviews = (
+export const isRatingsAndReviews = (
   tenant: Pick<Tenant, "featureFlags">,
   story: Story
 ) => {
@@ -68,7 +68,7 @@ const isRatingsAndReviews = (
   );
 };
 
-const isQA = (tenant: Pick<Tenant, "featureFlags">, story: Story) => {
+export const isQA = (tenant: Pick<Tenant, "featureFlags">, story: Story) => {
   return (
     hasFeatureFlag(tenant, GQLFEATURE_FLAG.ENABLE_QA) &&
     story.settings.mode === GQLSTORY_MODE.QA
@@ -173,6 +173,8 @@ const mapVisibleComment = (user?: Pick<User, "role">) => {
 interface ActionPresenceArgs {
   commentID: string;
   isArchived: boolean;
+  isQA: boolean;
+  isRR: boolean;
 }
 
 /**
@@ -268,6 +270,7 @@ export default (ctx: GraphContext) => ({
 
     const commentIDs = args.map((rd) => rd.commentID);
     const hasArchivedData = args.some((rd) => rd.isArchived);
+    const hasRROrQA = args.some((rd) => rd.isQA || rd.isRR);
 
     const result = await retrieveManyUserActionPresence(
       ctx.mongo,
@@ -275,6 +278,7 @@ export default (ctx: GraphContext) => ({
       ctx.tenant.id,
       ctx.user.id,
       commentIDs,
+      !(hasRROrQA || hasArchivedData),
       hasArchivedData
     );
 

--- a/server/src/core/server/graph/resolvers/Comment.ts
+++ b/server/src/core/server/graph/resolvers/Comment.ts
@@ -32,6 +32,7 @@ import {
 } from "coral-server/graph/schema/__generated__/types";
 
 import GraphContext from "../context";
+import { isQA, isRatingsAndReviews } from "../loaders/Comments";
 import { setCacheHint } from "../setCacheHint";
 
 export const maybeLoadOnlyID = async (
@@ -213,6 +214,8 @@ export const Comment: GQLCommentTypeResolver<comment.Comment> = {
     return ctx.loaders.Comments.retrieveMyActionPresence.load({
       commentID: c.id,
       isArchived: !!story.isArchived,
+      isRR: isRatingsAndReviews(ctx.tenant, story),
+      isQA: isQA(ctx.tenant, story),
     });
   },
 

--- a/server/src/core/server/models/action/comment.ts
+++ b/server/src/core/server/models/action/comment.ts
@@ -377,11 +377,13 @@ export async function retrieveManyUserActionPresence(
   tenantID: string,
   userID: string | null,
   commentIDs: string[],
+  useCache = true,
   isArchived = false
 ): Promise<GQLActionPresence[]> {
   let actions: Readonly<CommentAction>[] = [];
 
-  const cacheAvailable = await commentActionsCache.available(tenantID);
+  const cacheAvailable =
+    useCache && (await commentActionsCache.available(tenantID));
   if (cacheAvailable) {
     const actionsFromCache = await commentActionsCache.findMany(
       tenantID,


### PR DESCRIPTION
## What does this PR do?

Causes R&R, Q&A, and Archived stories to use mongo instead of data cache for retrieving the user's action presence as these story states are not supported in the data cache yet.

## These changes will impact:

- [X] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

- Enable data cache feature flag
- Report comments on Q&A, R&R, and archived stories
    - Use both regular reporting, and also illegal reporting
- See that the reported state appears properly on these comments and persists on refresh

- Check a regular comment stream
- Report comments on Q&A, R&R, and archived stories
    - Use both regular reporting, and also illegal reporting
- See that the reported state appears properly on these comments and persists on refresh

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
