### PR TITLE
Fix translations not working on `commentModerationActions` when user accounts are deleted

### DIFF
--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -62,5 +62,3 @@ common-moderationReason-detailedExplanation-placeholder =
 
 common-userBanned =
   User was banned.
-common-accountDeleted =
-  User account was deleted.

--- a/server/src/core/server/locales/en-US/common.ftl
+++ b/server/src/core/server/locales/en-US/common.ftl
@@ -149,3 +149,6 @@ notifications-dsaReportDecisionMade-body-withInfo =
   { $decision }
   <br/>
   { $information }
+
+common-accountDeleted =
+  User account was deleted.


### PR DESCRIPTION
## What does this PR do?

There are two `common.ftl` files, one is server side, the other is in the shared library between the `server` and the `client`.

This moves the `common-accountDeleted` into the server side `ftl` so that it can be pulled by the `i18n` bundles duirng the user deletion task.

## These changes will impact:

- [X] commenters
- [X] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices.

## How do I test this PR?

- Modify the value of `common-accountDeleted` in `server/src/core/server/locales/en-US/common.ftl` to something obvious like `THIS IS TRANSLATED`
- Leave the default in the code under `server/src/core/server/services/users/delete.ts` at the value of `User account deleted` so you can see that the text is translated
- Modify the `cronTime` to `"0,30 * * * * *"` (five `*`'s, not 4) in `server/src/core/server/cron/accountDeletion.ts` so that it runs twice a minute
- Start up the code base using `multi-site-test` and `npm run development:withJobs`
- Enable DSA under `Admin > Config > General > DSA` with an admin/mod user
- Enable user deletion under `Admin > Config > Authentication > Commenter account management features` with an admin/mod user
- Create a new user (will delete them soon)
- Post some comments with the new user
- Schedule the user you created for deletion
- Using Mongo, modify the `scheduledForDeletionDate` on that user to some time months ago 
- Wait 30-ish seconds for the account to be deleted
- Check the users comments for `commentModerationActions` where the `detailedExplanation` is `THIS IS TRANSLATED` to prove that the translation happened properly for the rejected/deleted comments

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
