### PR TITLE
Add indices for `dsaReports` to `INDEXES.md`

### DIFF
--- a/INDEXES.md
+++ b/INDEXES.md
@@ -6,6 +6,22 @@ The goal of this document is to date-mark the indexes you add to support the cha
 
 If you are releasing, you can use this readme to check all the indexes prior to the release you are deploying and have a good idea of what indexes you might need to deploy to Mongo along with your release of a new Coral Docker image to kubernetes.
 
+## 2023-11-24
+
+```
+db.dsaReports.createIndex({ tenantID: 1, id: 1 }, { unique: true });
+```
+
+- This index creates the uniqueness constraint for the `tenantID` and `id` fields on the `dsaReports`
+
+```
+db.dsaReports.createIndex({ status: 1, createdAt: 1, tenantID: 1 });
+db.dsaReports.createIndex({ referenceID: 1, tenantID: 1 });
+db.dsaReports.createIndex({ submissionID: 1, tenantID: 1 });
+```
+
+- These indices are used to optimize pagination of `dsaReports` and allow them to be retrieved by their `referenceID`, `submissionID` efficiently.
+
 ## 2023-10-18
 
 ```


### PR DESCRIPTION
## What does this PR do?

Add missing indices for `dsaReports` to `INDEXES.md`

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

```
db.dsaReports.createIndex({ tenantID: 1, id: 1 }, { unique: true });
db.dsaReports.createIndex({ status: 1, createdAt: 1, tenantID: 1 });
db.dsaReports.createIndex({ referenceID: 1, tenantID: 1 });
db.dsaReports.createIndex({ submissionID: 1, tenantID: 1 });
```

Added to `INDEXES.md`.

## How do I test this PR?

- Use mongo compass to create indices
- Use DSA functionality, see usage of the indices for their specific purposes

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- When DSA is deployed to an instance, add these indexes to their appropriate collections.
