### PR TITLE
[CORL-2970]: DSA - Display related reports on single report screen

### DIFF
--- a/client/src/core/client/admin/routes/Reports/RelatedReports.css
+++ b/client/src/core/client/admin/routes/Reports/RelatedReports.css
@@ -1,0 +1,23 @@
+.label {
+  font-size: var(--font-size-1);
+  text-transform: uppercase;
+}
+
+.button {
+  background-color: var(--palette-grey-200);
+  color: var(--palette-grey-500);
+  text-align: left;
+}
+
+.reportIDLabel {
+  text-transform: uppercase;
+}
+
+.referenceID {
+  margin-left: var(--spacing-2);
+  text-decoration: underline;
+}
+
+.arrowIcon {
+  margin-left: auto;
+}

--- a/client/src/core/client/admin/routes/Reports/RelatedReports.tsx
+++ b/client/src/core/client/admin/routes/Reports/RelatedReports.tsx
@@ -1,0 +1,85 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent } from "react";
+import { graphql } from "react-relay";
+
+import { withFragmentContainer } from "coral-framework/lib/relay";
+import { ArrowRightIcon, SvgIcon } from "coral-ui/components/icons";
+import { Flex } from "coral-ui/components/v2";
+import { Button } from "coral-ui/components/v3";
+
+import { RelatedReports_dsaReport } from "coral-admin/__generated__/RelatedReports_dsaReport.graphql";
+
+import styles from "./RelatedReports.css";
+
+interface Props {
+  dsaReport: RelatedReports_dsaReport;
+}
+
+const RelatedReports: FunctionComponent<Props> = ({ dsaReport }) => {
+  const relatedReports = dsaReport.relatedReports.edges.map(
+    (edge) => edge.node
+  );
+
+  if (relatedReports.length === 0) {
+    return null;
+  }
+
+  return (
+    <Flex direction="column">
+      <Localized id="reports-relatedReports-label">
+        <div className={styles.label}>Related Reports</div>
+      </Localized>
+      {relatedReports.map((report) => {
+        return (
+          <Flex marginTop={2} key={report.id}>
+            <Button
+              className={styles.button}
+              fullWidth
+              color="none"
+              variant="flat"
+              href={`/admin/reports/report/${report.id}`}
+            >
+              <Flex>
+                <Flex>
+                  <Localized id="reports-relatedReports-reportIDLabel">
+                    <span className={styles.reportIDLabel}>Report ID</span>
+                  </Localized>
+                  <span className={styles.referenceID}>
+                    {report.referenceID}
+                  </span>
+                </Flex>
+                <Flex className={styles.arrowIcon}>
+                  <SvgIcon Icon={ArrowRightIcon} />
+                </Flex>
+              </Flex>
+            </Button>
+          </Flex>
+        );
+      })}
+    </Flex>
+  );
+};
+
+const enhanced = withFragmentContainer<Props>({
+  dsaReport: graphql`
+    fragment RelatedReports_dsaReport on DSAReport
+    @argumentDefinitions(
+      count: { type: "Int", defaultValue: 20 }
+      cursor: { type: "Cursor" }
+      orderBy: { type: "REPORT_SORT", defaultValue: CREATED_AT_DESC }
+    ) {
+      id
+      relatedReports(first: $count, after: $cursor, orderBy: $orderBy)
+        @connection(key: "RelatedReports_relatedReports") {
+        edges {
+          node {
+            id
+            referenceID
+          }
+        }
+      }
+    }
+  `,
+})(RelatedReports);
+
+export default enhanced;

--- a/client/src/core/client/admin/routes/Reports/RelatedReports.tsx
+++ b/client/src/core/client/admin/routes/Reports/RelatedReports.tsx
@@ -64,7 +64,7 @@ const enhanced = withFragmentContainer<Props>({
   dsaReport: graphql`
     fragment RelatedReports_dsaReport on DSAReport
     @argumentDefinitions(
-      count: { type: "Int", defaultValue: 20 }
+      count: { type: "Int", defaultValue: 10 }
       cursor: { type: "Cursor" }
       orderBy: { type: "REPORT_SORT", defaultValue: CREATED_AT_DESC }
     ) {

--- a/client/src/core/client/admin/routes/Reports/SingleReportRoute.tsx
+++ b/client/src/core/client/admin/routes/Reports/SingleReportRoute.tsx
@@ -36,6 +36,7 @@ import styles from "./SingleReportRoute.css";
 
 import NotFound from "../NotFound";
 import ChangeStatusModal from "./ChangeStatusModal";
+import RelatedReports from "./RelatedReports";
 import ReportedComment from "./ReportedComment";
 import ReportHistory from "./ReportHistory";
 import ReportMakeDecisionModal from "./ReportMakeDecisionModal";
@@ -235,6 +236,7 @@ const SingleReportRoute: FunctionComponent<Props> & {
                 dsaReport={dsaReport}
                 onShowUserDrawer={onShowUserDrawer}
               />
+              <RelatedReports dsaReport={dsaReport} />
               {dsaReport.decision && (
                 <>
                   <Divider />
@@ -381,6 +383,7 @@ SingleReportRoute.routeConfig = createRouteConfig<
         ...ReportShareButton_dsaReport
         ...ReportMakeDecisionModal_dsaReport
         ...ReportedComment_dsaReport
+        ...RelatedReports_dsaReport
       }
     }
   `,

--- a/client/src/core/client/admin/test/fixtures.ts
+++ b/client/src/core/client/admin/test/fixtures.ts
@@ -851,6 +851,7 @@ export const dsaReports = createFixtures<GQLDSAReport>([
     additionalInformation:
       "The additional information supporting why that law is alleged to have been broken",
     history: [],
+    relatedReports: { edges: [], pageInfo: { hasNextPage: false } },
   },
   {
     id: "dsa-report-2",
@@ -869,6 +870,7 @@ export const dsaReports = createFixtures<GQLDSAReport>([
         "A detailed explanation of why it is a violation of Law number 2",
     },
     history: [],
+    relatedReports: { edges: [], pageInfo: { hasNextPage: false } },
   },
 ]);
 

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -1909,6 +1909,9 @@ reports-decisionModal-detailedExplanationLabel = Detailed explanation
 reports-decisionModal-detailedExplanationTextarea =
   .placeholder = Add explanation...
 
+reports-relatedReports-label = Related reports
+reports-relatedReports-reportIDLabel = Report ID
+
 # Control panel
 
 controlPanel-redis-redis = Redis

--- a/server/src/core/server/graph/loaders/DSAReports.ts
+++ b/server/src/core/server/graph/loaders/DSAReports.ts
@@ -58,7 +58,7 @@ export default (ctx: GraphContext) => ({
   relatedReports: (
     submissionID: string,
     id: string,
-    { first, orderBy }: DSAReportToRelatedReportsArgs
+    { first, orderBy, after }: DSAReportToRelatedReportsArgs
   ) =>
     retrieveDSAReportRelatedReportsConnection(
       ctx.mongo,
@@ -68,6 +68,7 @@ export default (ctx: GraphContext) => ({
       {
         first: defaultTo(first, 10),
         orderBy: defaultTo(orderBy, GQLREPORT_SORT.CREATED_AT_DESC),
+        after,
       }
     ),
 });

--- a/server/src/core/server/graph/loaders/DSAReports.ts
+++ b/server/src/core/server/graph/loaders/DSAReports.ts
@@ -5,12 +5,14 @@ import {
   DSAReportConnectionInput,
   find,
   retrieveDSAReportConnection,
+  retrieveDSAReportRelatedReportsConnection,
 } from "coral-server/models/dsaReport";
 
 import GraphContext from "../context";
 import { createManyBatchLoadFn } from "./util";
 
 import {
+  DSAReportToRelatedReportsArgs,
   GQLDSAREPORT_STATUS_FILTER,
   GQLREPORT_SORT,
   QueryToDsaReportsArgs,
@@ -53,4 +55,19 @@ export default (ctx: GraphContext) => ({
       cache: !ctx.disableCaching,
     }
   ),
+  relatedReports: (
+    submissionID: string,
+    id: string,
+    { first, orderBy }: DSAReportToRelatedReportsArgs
+  ) =>
+    retrieveDSAReportRelatedReportsConnection(
+      ctx.mongo,
+      ctx.tenant.id,
+      submissionID,
+      id,
+      {
+        first: defaultTo(first, 10),
+        orderBy: defaultTo(orderBy, GQLREPORT_SORT.CREATED_AT_DESC),
+      }
+    ),
 });

--- a/server/src/core/server/graph/resolvers/DSAReport.ts
+++ b/server/src/core/server/graph/resolvers/DSAReport.ts
@@ -1,6 +1,11 @@
+import { defaultTo } from "lodash";
+
 import * as dsaReport from "coral-server/models/dsaReport";
 
-import { GQLDSAReportTypeResolver } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLDSAReportTypeResolver,
+  GQLREPORT_SORT,
+} from "coral-server/graph/schema/__generated__/types";
 
 export const DSAReport: GQLDSAReportTypeResolver<dsaReport.DSAReport> = {
   reporter: (report, args, ctx) => {
@@ -32,5 +37,12 @@ export const DSAReport: GQLDSAReportTypeResolver<dsaReport.DSAReport> = {
     } else {
       return null;
     }
+  },
+  relatedReports: ({ submissionID, id }, { first, after, orderBy }, ctx) => {
+    return ctx.loaders.DSAReports.relatedReports(submissionID, id, {
+      first: defaultTo(first, 10),
+      after,
+      orderBy: defaultTo(orderBy, GQLREPORT_SORT.CREATED_AT_DESC),
+    });
   },
 };

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -3662,6 +3662,10 @@ type DSAReport {
   """
   lastUpdated: Time
 
+  """
+  relatedReports are DSAReports that share a submissionID and were submitted at the same time
+  in one illegal content report
+  """
   relatedReports(
     first: Int = 10 @constraint(max: 50)
     orderBy: REPORT_SORT = CREATED_AT_DESC

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -3661,6 +3661,12 @@ type DSAReport {
   such as a note added, status changed, or decision made
   """
   lastUpdated: Time
+
+  relatedReports(
+    first: Int = 10 @constraint(max: 50)
+    orderBy: REPORT_SORT = CREATED_AT_DESC
+    after: Cursor
+  ): DSAReportsConnection!
 }
 
 type CommentRevisionPerspectiveMetadata {

--- a/server/src/core/server/models/dsaReport/report.ts
+++ b/server/src/core/server/models/dsaReport/report.ts
@@ -167,6 +167,23 @@ export async function retrieveDSAReportConnection(
   return retrieveConnection(input, query);
 }
 
+export async function retrieveDSAReportRelatedReportsConnection(
+  mongo: MongoContext,
+  tenantID: string,
+  submissionID: string,
+  id: string,
+  input: DSAReportConnectionInput
+): Promise<Readonly<Connection<Readonly<DSAReport>>>> {
+  // Create the query.
+  const query = new Query(mongo.dsaReports()).where({
+    tenantID,
+    submissionID,
+    id: { $ne: id },
+  });
+
+  return retrieveConnection(input, query);
+}
+
 export async function retrieveDSAReport(
   mongo: MongoContext,
   tenantID: string,


### PR DESCRIPTION
## What does this PR do?

These changes add the display of related reports to the DSA single report screen in the admin. Related reports are reports that were submitted at the same time as containing illegal content, and they share the same `submissionID`.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds a `relatedReports` connection to DSA Reports. Returns reports where the `submissionID` is the same but `id` is not (so that the report itself is not returned as a related report).

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test this by submitting multiple comments at a time in one illegal content report. Then go into the admin and go to the DSA Reports tab and click through to the reports you created. At the bottom of each report's page, you should see a `Related Reports` section with all related reports that were submitted together. If you click on one, you should then be taken to that report's single report screen.

Check that any reports submitted by themselves without additional related reports **do not** include a `Related Reports` section on their single report screen.

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
