### PR TITLE
[HOTFIX] Resolve possible null and undefined tenant DSA configurations (8.6.1)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/talk",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/toolbox-cache-url": "^2.9.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "common",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "license": "ISC",
       "dependencies": {
         "coral-config": "../config/dist",

--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/config/package-lock.json
+++ b/config/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "common",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "license": "ISC",
       "dependencies": {
         "typescript": "^3.9.5"

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/talk",
-      "version": "8.6.0",
+      "version": "8.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/toolbox-cache-url": "^2.9.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/server/src/core/server/cron/accountDeletion.ts
+++ b/server/src/core/server/cron/accountDeletion.ts
@@ -75,7 +75,7 @@ const deleteScheduledAccounts: ScheduledJobCommand<Options> = async ({
         user.id,
         tenant.id,
         now,
-        tenant.dsa.enabled
+        tenant.dsa?.enabled
       );
 
       // If the user has an email, then send them a confirmation that their account

--- a/server/src/core/server/graph/mutators/Users.ts
+++ b/server/src/core/server/graph/mutators/Users.ts
@@ -189,7 +189,7 @@ export const Users = (ctx: GraphContext) => ({
       input.userID,
       ctx.tenant.id,
       ctx.now,
-      ctx.tenant.dsa.enabled
+      ctx.tenant.dsa?.enabled
     );
   },
   cancelAccountDeletion: async (

--- a/server/src/core/server/models/settings/settings.ts
+++ b/server/src/core/server/models/settings/settings.ts
@@ -2,6 +2,7 @@ import {
   GQLAuth,
   GQLAuthenticationTargetFilter,
   GQLCOMMENT_BODY_FORMAT,
+  GQLDSA_METHOD_OF_REDRESS,
   GQLEmailConfiguration,
   GQLFacebookAuthIntegration,
   GQLGoogleAuthIntegration,
@@ -421,8 +422,14 @@ export const defaultRTEConfiguration: RTEConfiguration = {
 
 export interface DSAConfiguration {
   enabled: boolean;
+  methodOfRedress: {
+    method: GQLDSA_METHOD_OF_REDRESS;
+  };
 }
 
 export const defaultDSAConfiguration: DSAConfiguration = {
   enabled: false,
+  methodOfRedress: {
+    method: GQLDSA_METHOD_OF_REDRESS.NONE,
+  },
 };

--- a/server/src/core/server/services/comments/moderation/moderate.spec.ts
+++ b/server/src/core/server/services/comments/moderation/moderate.spec.ts
@@ -13,6 +13,7 @@ import moderate, { Moderate } from "./moderate";
 
 import {
   GQLCOMMENT_STATUS,
+  GQLDSA_METHOD_OF_REDRESS,
   GQLUSER_ROLE,
 } from "coral-server/graph/schema/__generated__/types";
 import { I18n } from "coral-server/services/i18n";
@@ -23,7 +24,10 @@ jest.mock("coral-server/models/action/moderation/comment");
 
 it("requires a valid rejection reason if dsaFeatures are enabled", async () => {
   const tenant = createTenantFixture({
-    dsa: { enabled: true },
+    dsa: {
+      enabled: true,
+      methodOfRedress: { method: GQLDSA_METHOD_OF_REDRESS.NONE },
+    },
   });
   const config = {} as Config;
   const story = createStoryFixture({ tenantID: tenant.id });

--- a/server/src/core/server/services/comments/moderation/moderate.ts
+++ b/server/src/core/server/services/comments/moderation/moderate.ts
@@ -45,7 +45,7 @@ export default async function moderate(
   }
 ) {
   if (
-    tenant.dsa.enabled &&
+    tenant.dsa?.enabled &&
     input.status === GQLCOMMENT_STATUS.REJECTED &&
     !input.rejectionReason
   ) {

--- a/server/src/core/server/services/comments/pipeline/phases/external.ts
+++ b/server/src/core/server/services/comments/pipeline/phases/external.ts
@@ -287,7 +287,7 @@ export const external: IntermediateModerationPhase = async (ctx) => {
     !ctx.tenant.integrations.external ||
     ctx.tenant.integrations.external.phases.length === 0 ||
     // (marcushaddon) DSA and external moderation are mutually exclusive for the time being
-    ctx.tenant.dsa.enabled
+    ctx.tenant.dsa?.enabled
   ) {
     return;
   }


### PR DESCRIPTION
## What does this PR do?

- Handles the default possibly null/undefined value coming from Mongo for DSA configuration on the tenant/settings.
- Sets the defaults in the default initialization and handles the optional state in resolvers

## These changes will impact:

- [X] commenters
- [X] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No new variables

## If any indexes were added, were they added to `INDEXES.md`?

No new indices

## How do I test this PR?

- Wipe Coral mongo db and install a brand new tenant
- Delete any DSA config fields from the tenant using mongo (search for `dsa` on the document and remove)
- Ensure that DSA config is disabled (should be by default)
- Post a comment
- Moderate the comment (approve/reject)
- See that this works
- Enable DSA
- Repeat posting comment and moderating

## Where any tests migrated to React Testing Library?

No

## How do we deploy this PR?

This is merged to main as a hotfix.
