### PR TITLE
[CORL-2976]: Notifications for comment rejection updates

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
@@ -60,18 +60,22 @@ const getGeneralReason = (
     return getMessage(
       bundles,
       "notifications-rejectionReason-offensive",
-      "Offensive"
+      "This comment contains offensive language"
     );
   }
   if (reason === GQLREJECTION_REASON_CODE.ABUSIVE) {
     return getMessage(
       bundles,
       "notifications-rejectionReason-abusive",
-      "Abusive"
+      "This comment contains abusive language"
     );
   }
   if (reason === GQLREJECTION_REASON_CODE.SPAM) {
-    return getMessage(bundles, "notifications-rejectionReason-spam", "Spam");
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-spam",
+      "This comment is spam"
+    );
   }
   if (reason === GQLREJECTION_REASON_CODE.BANNED_WORD) {
     return getMessage(
@@ -81,13 +85,17 @@ const getGeneralReason = (
     );
   }
   if (reason === GQLREJECTION_REASON_CODE.AD) {
-    return getMessage(bundles, "notifications-rejectionReason-ad", "Ad");
+    return getMessage(
+      bundles,
+      "notifications-rejectionReason-ad",
+      "This comment is an advertisement"
+    );
   }
   if (reason === GQLREJECTION_REASON_CODE.ILLEGAL_CONTENT) {
     return getMessage(
       bundles,
       "notifications-rejectionReason-illegalContent",
-      "Illegal content"
+      "This comment contains illegal content"
     );
   }
 
@@ -95,28 +103,28 @@ const getGeneralReason = (
     return getMessage(
       bundles,
       "notifications-rejectionReason-harassmentBullying",
-      "Harassment or bullying"
+      "This comment contains harassing or bullying language"
     );
   }
   if (reason === GQLREJECTION_REASON_CODE.MISINFORMATION) {
     return getMessage(
       bundles,
       "notifications-rejectionReason-misinformation",
-      "Misinformation"
+      "This comment contains misinformation"
     );
   }
   if (reason === GQLREJECTION_REASON_CODE.HATE_SPEECH) {
     return getMessage(
       bundles,
       "notifications-rejectionReason-hateSpeech",
-      "Hate speech"
+      "This comment contains hate speech"
     );
   }
   if (reason === GQLREJECTION_REASON_CODE.IRRELEVANT_CONTENT) {
     return getMessage(
       bundles,
       "notifications-rejectionReason-irrelevant",
-      "Irrelevant content"
+      "This comment is irrelevant to the discussion"
     );
   }
 

--- a/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
@@ -54,7 +54,8 @@ const getLegalReason = (
 
 const getGeneralReason = (
   bundles: FluentBundle[],
-  reason: REJECTION_REASON_CODE | null
+  reason: REJECTION_REASON_CODE | null,
+  customReason: string | null
 ) => {
   if (reason === GQLREJECTION_REASON_CODE.OFFENSIVE) {
     return getMessage(
@@ -129,7 +130,20 @@ const getGeneralReason = (
   }
 
   if (reason === GQLREJECTION_REASON_CODE.OTHER) {
-    return getMessage(bundles, "notifications-rejectionReason-other", "Other");
+    if (customReason) {
+      return getMessage(
+        bundles,
+        "notifications-rejectionReason-other-customReason",
+        `Other - ${customReason}`,
+        { vars: { customReason } }
+      );
+    } else {
+      return getMessage(
+        bundles,
+        "notifications-rejectionReason-other",
+        "Other"
+      );
+    }
   }
 
   return getMessage(
@@ -146,7 +160,8 @@ const stringIsNullOrEmpty = (value: string) => {
 const RejectedCommentNotificationBody: FunctionComponent<Props> = ({
   notification,
 }) => {
-  const { type, decisionDetails, rejectionReason, comment } = notification;
+  const { type, decisionDetails, rejectionReason, customReason, comment } =
+    notification;
 
   const { localeBundles } = useCoralContext();
 
@@ -173,7 +188,7 @@ const RejectedCommentNotificationBody: FunctionComponent<Props> = ({
               <div className={styles.detailLabel}>Reason for removal</div>
             </Localized>
             <div className={styles.detailItem}>
-              {getGeneralReason(localeBundles, rejectionReason)}
+              {getGeneralReason(localeBundles, rejectionReason, customReason)}
             </div>
             {hasExplanation && (
               <>
@@ -245,6 +260,7 @@ const enhanced = withFragmentContainer<Props>({
     fragment RejectedCommentNotificationBody_notification on Notification {
       type
       rejectionReason
+      customReason
       decisionDetails {
         legality
         grounds

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1074,6 +1074,7 @@ notifications-rejectionReason-misinformation = This comment contains misinformat
 notifications-rejectionReason-hateSpeech = This comment contains hate speech
 notifications-rejectionReason-irrelevant = This comment is irrelevant to the discussion
 notifications-rejectionReason-other = Other
+notifications-rejectionReason-other-customReason = Other - { $customReason }
 notifications-rejectionReason-unknown = Unknown
 
 notifications-reportDecisionMade-legal =

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1063,16 +1063,16 @@ notifications-dsaReportLegality-legal = Legal content
 notifications-dsaReportLegality-illegal = Illegal content
 notifications-dsaReportLegality-unknown = Unknown
 
-notifications-rejectionReason-offensive = Offensive
-notifications-rejectionReason-abusive = Abusive
-notifications-rejectionReason-spam = Spam
+notifications-rejectionReason-offensive = This comment contains offensive language
+notifications-rejectionReason-abusive = This comment contains abusive language
+notifications-rejectionReason-spam = This comment is spam
 notifications-rejectionReason-bannedWord = Banned word
-notifications-rejectionReason-ad = Ad
-notifications-rejectionReason-illegalContent = Illegal content
-notifications-rejectionReason-harassmentBullying = Harassment or bullying
-notifications-rejectionReason-misinformation = Misinformation
-notifications-rejectionReason-hateSpeech = Hate speech
-notifications-rejectionReason-irrelevant = Irrelevant content
+notifications-rejectionReason-ad = This comment is an advertisement
+notifications-rejectionReason-illegalContent = This comment contains illegal content
+notifications-rejectionReason-harassmentBullying = This comment contains harassing or bullying language
+notifications-rejectionReason-misinformation = This comment contains misinformation
+notifications-rejectionReason-hateSpeech = This comment contains hate speech
+notifications-rejectionReason-irrelevant = This comment is irrelevant to the discussion
 notifications-rejectionReason-other = Other
 notifications-rejectionReason-unknown = Unknown
 

--- a/server/src/core/server/graph/resolvers/Notification.ts
+++ b/server/src/core/server/graph/resolvers/Notification.ts
@@ -29,4 +29,5 @@ export const NotificationResolver: Required<
   },
   decisionDetails: ({ decisionDetails }) => decisionDetails,
   rejectionReason: ({ rejectionReason }) => rejectionReason,
+  customReason: ({ customReason }) => customReason,
 };

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -3459,6 +3459,11 @@ type RejectionReason {
   detailedExplanation is any additional information the user wishes to provide.
   """
   detailedExplanation: String
+
+  """
+  customReason is a reason provided for rejection when the Other rejection code is selected.
+  """
+  customReason: String
 }
 
 type CommentModerationAction {
@@ -3494,6 +3499,11 @@ type CommentModerationAction {
   createdAt is the time that the CommentModerationAction was created.
   """
   createdAt: Time!
+
+  """
+  customReason is a reason provided for rejection when the Other rejection code is selected.
+  """
+  customReason: String
 }
 
 type CommentModerationActionEdge {
@@ -4785,6 +4795,11 @@ type Notification {
   to DSA or moderation decisions.
   """
   decisionDetails: NotificationDecisionDetails
+
+  """
+  customReason is a reason provided for rejection when the Other rejection code is selected.
+  """
+  customReason: String
 
   """
   dsaReport is the details of the DSA Report related to the notification.

--- a/server/src/core/server/models/notifications/notification.ts
+++ b/server/src/core/server/models/notifications/notification.ts
@@ -27,6 +27,7 @@ export interface Notification extends TenantResource {
 
   rejectionReason?: GQLREJECTION_REASON_CODE;
   decisionDetails?: GQLNotificationDecisionDetails;
+  customReason?: string;
 }
 
 type BaseConnectionInput = ConnectionInput<Notification>;

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -28,6 +28,7 @@ export interface RejectionReasonInput {
   code: GQLREJECTION_REASON_CODE;
   legalGrounds?: string | undefined;
   detailedExplanation?: string | undefined;
+  customReason?: string | undefined;
 }
 
 export interface CreateNotificationInput {
@@ -164,6 +165,7 @@ export class InternalNotificationContext {
       commentID: comment.id,
       commentStatus: comment.status,
       rejectionReason: rejectionReason?.code ?? undefined,
+      customReason: rejectionReason?.customReason ?? undefined,
       decisionDetails: {
         explanation: rejectionReason?.detailedExplanation ?? undefined,
       },

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -164,7 +164,10 @@ const rejectComment = async (
     });
   }
 
-  if (sendNotification) {
+  if (
+    sendNotification &&
+    !(reason?.code === GQLREJECTION_REASON_CODE.BANNED_WORD)
+  ) {
     await notifications.create(tenant.id, tenant.locale, {
       targetUserID: result.after.authorID!,
       comment: result.after,


### PR DESCRIPTION
## What does this PR do?

These changes update the copy sent out for notifications when comments are rejected to be more friendly and descriptive. It also displays the custom reason entered for the `Other` rejection reason now. And comments rejected for banned words do **not** send out a notification.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds in the `customReason` introduced in another PR so that it can be displayed here if available.

## Does this PR introduce any new environment variables or feature flags?
no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test this by making a bunch of comments and rejecting one comment for each rejection reason. Check in the notifications for the user who created those comments that you rejected. See the updated text displayed. 

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
