### PR TITLE
Fix translation for comment rejection reason when user is banned

### DIFF
--- a/server/src/core/server/locales/en-US/common.ftl
+++ b/server/src/core/server/locales/en-US/common.ftl
@@ -153,3 +153,6 @@ notifications-dsaReportDecisionMade-body-withInfo =
 
 common-accountDeleted =
   User account was deleted.
+
+common-userBanned =
+  User was banned.

--- a/server/src/core/server/services/users/users.ts
+++ b/server/src/core/server/services/users/users.ts
@@ -1471,8 +1471,8 @@ export async function ban(
   const bundle = i18n.getBundle(tenant.locale);
   const tranlsatedExplanation = translate(
     bundle,
-    "common-userBanned",
-    "User banned."
+    "User was banned.",
+    "common-userBanned"
   );
   const rejectionReason = {
     code: GQLREJECTION_REASON_CODE.OTHER,
@@ -1706,8 +1706,8 @@ export async function updateUserBan(
         const bundle = i18n.getBundle(tenant.locale);
         const detailedExplanation = translate(
           bundle,
-          "common-userBanned",
-          "User was banned."
+          "User was banned.",
+          "common-userBanned"
         );
         await rejector.add({
           tenantID: tenant.id,


### PR DESCRIPTION
## What does this PR do?

The translation string used in the case of comments being rejected when a user is banned is now sent through in the correct order and found in the correct translation file, as well.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can ban a user. Then check the moderate card for the comment(s) rejected when they were banned in the admin and see that it says "User was banned." under detailed explanation and not "common-userBanned".

## Where any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
