### PR TITLE
[8.6.4] Release branch (into `develop`)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/talk",
-      "version": "8.6.3",
+      "version": "8.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/toolbox-cache-url": "^2.9.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/client/src/core/client/admin/routes/Configure/sections/Moderation/ModerationConfigContainer.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/Moderation/ModerationConfigContainer.tsx
@@ -50,8 +50,8 @@ export const ModerationConfigContainer: React.FunctionComponent<Props> = ({
       <NewCommentersConfigContainer disabled={submitting} settings={settings} />
       <RecentCommentHistoryConfig disabled={submitting} />
       <ExternalLinksConfigContainer disabled={submitting} settings={settings} />
-      <EmailDomainConfigContainer settings={settings} />
       <PremoderateEmailAddressConfig disabled={submitting} />
+      <EmailDomainConfigContainer settings={settings} />
     </HorizontalGutter>
   );
 };

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "common",
-      "version": "8.6.3",
+      "version": "8.6.4",
       "license": "ISC",
       "dependencies": {
         "coral-config": "../config/dist",

--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/config/package-lock.json
+++ b/config/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "common",
-      "version": "8.6.3",
+      "version": "8.6.4",
       "license": "ISC",
       "dependencies": {
         "typescript": "^3.9.5"

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/talk",
-      "version": "8.6.3",
+      "version": "8.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/toolbox-cache-url": "^2.9.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.6.3",
+  "version": "8.6.4",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [


### PR DESCRIPTION
## What does this PR do?

Bump version number to `8.6.4`.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- See the package json's are bumped

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into develop, then develop into main
