### PR TITLE
[CORL-2994]: Add Top commenter badge config to admin

### DIFF
--- a/client/src/core/client/admin/routes/Configure/sections/General/GeneralConfigContainer.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/General/GeneralConfigContainer.tsx
@@ -27,6 +27,7 @@ import MemberBioConfig from "./MemberBioConfig";
 import ReactionConfigContainer from "./ReactionConfigContainer";
 import RTEConfig from "./RTEConfig";
 import SitewideCommentingConfig from "./SitewideCommentingConfig";
+import TopCommenterConfig from "./TopCommenterConfig";
 
 import styles from "./GeneralConfigContainer.css";
 
@@ -61,6 +62,7 @@ const GeneralConfigContainer: React.FunctionComponent<Props> = ({
       <ReactionConfigContainer disabled={submitting} settings={settings} />
       <FeaturedByConfig disabled={submitting} />
       <BadgeConfig disabled={submitting} />
+      <TopCommenterConfig disabled={submitting} />
       <FlairBadgeConfigContainer disabled={submitting} settings={settings} />
       <MemberBioConfig disabled={submitting} />
       <MediaLinksConfig disabled={submitting} />
@@ -85,6 +87,7 @@ const enhanced = withFragmentContainer<Props>({
       ...FeaturedByConfig_formValues @relay(mask: false)
       ...ReactionConfig_formValues @relay(mask: false)
       ...BadgeConfig_formValues @relay(mask: false)
+      ...TopCommenterConfig_formValues @relay(mask: false)
       ...FlairBadgeConfigContainer_formValues @relay(mask: false)
       ...FlairBadgeConfigContainer_settings
       ...RTEConfig_formValues @relay(mask: false)

--- a/client/src/core/client/admin/routes/Configure/sections/General/TopCommenterConfig.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/General/TopCommenterConfig.tsx
@@ -1,0 +1,52 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent } from "react";
+import { graphql } from "react-relay";
+
+import {
+  FieldSet,
+  FormField,
+  FormFieldDescription,
+  Label,
+} from "coral-ui/components/v2";
+
+import ConfigBox from "../../ConfigBox";
+import Header from "../../Header";
+import OnOffField from "../../OnOffField";
+
+// eslint-disable-next-line no-unused-expressions
+graphql`
+  fragment TopCommenterConfig_formValues on Settings {
+    topCommenter {
+      enabled
+    }
+  }
+`;
+
+interface Props {
+  disabled: boolean;
+}
+
+const TopCommenterConfig: FunctionComponent<Props> = ({ disabled }) => (
+  <ConfigBox
+    title={
+      <Localized id="configure-general-topCommenter-title">
+        <Header container="h2">Top commenter</Header>
+      </Localized>
+    }
+  >
+    <Localized id="configure-general-topCommenter-explanation">
+      <FormFieldDescription>
+        Add top commenter badge to commenters with featured comments in the last
+        10 days
+      </FormFieldDescription>
+    </Localized>
+    <FormField container={<FieldSet />}>
+      <Localized id="configure-general-topCommenter-enabled">
+        <Label component="legend">Top commenter</Label>
+      </Localized>
+      <OnOffField name="topCommenter.enabled" disabled={disabled} />
+    </FormField>
+  </ConfigBox>
+);
+
+export default TopCommenterConfig;

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -510,6 +510,10 @@ configure-general-featuredBy-title = Featured by
 configure-general-featuredBy-enabled = Featured by enabled
 configure-general-featuredBy-explanation = Add moderator name to featured comment display
 
+configure-general-topCommenter-title = Top commenter
+configure-general-topCommenter-explanation = Add top commenter badge to commenters with featured comments in the last 10 days
+configure-general-topCommenter-enabled = Top commenter
+
 configure-general-flairBadge-header = Custom flair badges
 configure-general-flairBadge-description = Encourage user engagement and participation by adding custom flair
   badges for your site. Badges can be allocated as part of your <externalLink>JWT claim</externalLink>.

--- a/server/src/core/server/graph/resolvers/Settings.ts
+++ b/server/src/core/server/graph/resolvers/Settings.ts
@@ -45,6 +45,7 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
     Boolean(disableDefaultFonts),
   emailDomainModeration: ({ emailDomainModeration = [] }) =>
     emailDomainModeration,
+  topCommenter: ({ topCommenter = { enabled: false } }) => topCommenter,
   badges: ({ badges, staff }, args, ctx) => {
     const badgeConfig = badges || staff;
 

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -1734,6 +1734,17 @@ type BadgeConfiguration {
 }
 
 """
+topCommenter specifies whether or not the feature is enabled to show that commenters
+with comments featured within the last 10 days are top commenters
+"""
+type TopCommenterConfiguration {
+  """
+  enabled is whether the Top commenter feature is enabled
+  """
+  enabled: Boolean
+}
+
+"""
 FlairBadgeConfiguration specifies the configuration for flair badges, including
 whether they are enabled and any configured image urls.
 """
@@ -2200,6 +2211,12 @@ type Settings @cacheControl(maxAge: 30) {
   featuredBy specifies whether or not to display 'Featured by' for featured comments
   """
   featuredBy: Boolean
+
+  """
+  topCommenter specifies whether or not the feature is enabled to show that commenters
+  with comments featured within the last 10 days are top commenters
+  """
+  topCommenter: TopCommenterConfiguration
 
   """
   staff specifies the configuration for the user badges assigned to users with
@@ -5989,6 +6006,17 @@ input ReactionConfigurationInput {
 }
 
 """
+topCommenter specifies whether or not the feature is enabled to show that commenters
+with comments featured within the last 10 days are top commenters
+"""
+input TopCommenterConfigurationInput {
+  """
+  enabled is whether the Top commenter feature is enabled
+  """
+  enabled: Boolean
+}
+
+"""
 BadgeConfigurationInput specifies the configuration for the staff badges
 assigned to users with any role above COMMENTER.
 """
@@ -6375,6 +6403,12 @@ input SettingsInput {
   featuredBy: Boolean
 
   """
+  topCommenter specifies whether or not the feature is enabled to show that commenters
+  with comments featured within the last 10 days are top commenters
+  """
+  topCommenter: TopCommenterConfigurationInput
+
+  """
   badges specifies the configuration for user badges assigned to users with
   any role above COMMENTER.
   """
@@ -6463,7 +6497,6 @@ input SettingsInput {
   they are enabled and any configured image urls
   """
   flairBadges: FlairBadgeConfigurationInput
-
 
   """
   dsa specifies the configuration for DSA European Union moderation and

--- a/server/src/core/server/models/settings/settings.ts
+++ b/server/src/core/server/models/settings/settings.ts
@@ -309,6 +309,10 @@ export interface FlairBadgeConfig {
   badges?: FlairBadge[];
 }
 
+export interface TopCommenterConfig {
+  enabled?: boolean;
+}
+
 export interface PremoderateEmailAddressConfig {
   tooManyPeriods?: {
     enabled?: boolean;
@@ -425,6 +429,12 @@ export type Settings = GlobalModerationSettings &
     flairBadges?: FlairBadgeConfig;
 
     premoderateEmailAddress?: PremoderateEmailAddressConfig;
+
+    /**
+     * topCommenter specifies whether or not the feature is enabled to show that commenters
+     * with comments featured within the last 10 days are top commenters
+     */
+    topCommenter?: TopCommenterConfig;
   };
 
 export const defaultRTEConfiguration: RTEConfiguration = {

--- a/server/src/core/server/models/tenant/tenant.ts
+++ b/server/src/core/server/models/tenant/tenant.ts
@@ -306,6 +306,9 @@ export async function createTenant(
         method: GQLDSA_METHOD_OF_REDRESS.NONE,
       },
     },
+    topCommenter: {
+      enabled: false,
+    },
   };
 
   // Create the new Tenant by merging it together with the defaults.


### PR DESCRIPTION
## What does this PR do?

These changes add the Top commenter badge configuration to the admin.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

This adds `topCommenter` and whether it's `enabled` or not to `Settings`.

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Go into admin Config -> General, and right below Member badges you should see Top commenter. See that you can enable/disable it.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
