### PR TITLE
[CORL-3009]: Site search fixes to add margin and handle enter

### DIFF
--- a/client/src/core/client/admin/components/PaginatedSelect/PaginatedSelect.css
+++ b/client/src/core/client/admin/components/PaginatedSelect/PaginatedSelect.css
@@ -34,6 +34,8 @@
   height: 100%;
   width: auto;
   overflow: hidden;
+  margin-left: var(--spacing-1);
+  margin-right: var(--spacing-1);
 }
 
 .filterInput > textarea {

--- a/client/src/core/client/admin/components/PaginatedSelect/PaginatedSelect.tsx
+++ b/client/src/core/client/admin/components/PaginatedSelect/PaginatedSelect.tsx
@@ -117,6 +117,12 @@ const PaginatedSelect: FunctionComponent<Props> = ({
               >
                 <TextArea
                   className={styles.filterInput}
+                  onKeyDown={(e) => {
+                    // We don't want blank lines to be added in input
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                    }
+                  }}
                   onChange={(e) => onFilter(e.target.value)}
                   ref={filterRef}
                   aria-label="Filter results"


### PR DESCRIPTION
## What does this PR do?

These changes add some margin on the right and left to the site search text area. They also ensure that hitting return doesn't add multiple blank lines when searching.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Go to Moderate in admin. Search for some sites and see that there is some margin on the right and left of the focused site search text area now. Hit return key. See that no blank lines are added now.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
