### PR TITLE
[CORL-3008] when auth token is invalid, clear it and reload the stream

### DIFF
--- a/client/src/core/client/framework/lib/auth/auth.ts
+++ b/client/src/core/client/framework/lib/auth/auth.ts
@@ -9,7 +9,7 @@ import { Claims, computeExpiresIn, parseAccessTokenClaims } from "./helpers";
 /**
  * ACCESS_TOKEN_KEY is the key in storage where the accessToken is stored.
  */
-const ACCESS_TOKEN_KEY = "v2:accessToken";
+export const ACCESS_TOKEN_KEY = "v2:accessToken";
 
 export interface AuthState {
   /**

--- a/client/src/core/client/framework/lib/bootstrap/createManaged.tsx
+++ b/client/src/core/client/framework/lib/bootstrap/createManaged.tsx
@@ -112,6 +112,11 @@ interface CreateContextArguments {
    */
   customScrollContainer?: HTMLElement;
 
+  /**
+   * called when a token is invalid and we are unable to login so we can
+   * clear the local auth token allowing a user to login again instead of
+   * throwing a network error that is impassable.
+   */
   onAuthError?: () => void;
 }
 

--- a/client/src/core/client/framework/lib/bootstrap/createManaged.tsx
+++ b/client/src/core/client/framework/lib/bootstrap/createManaged.tsx
@@ -111,6 +111,8 @@ interface CreateContextArguments {
    * of the render window
    */
   customScrollContainer?: HTMLElement;
+
+  onAuthError?: () => void;
 }
 
 /**
@@ -142,6 +144,7 @@ function createRelayEnvironment(
   clientID: string,
   localeBundles: FluentBundle[],
   tokenRefreshProvider: TokenRefreshProvider,
+  onAuthError?: () => void,
   clearCacheBefore?: Date
 ) {
   const source = new RecordSource();
@@ -160,6 +163,7 @@ function createRelayEnvironment(
       clientID,
       accessTokenProvider,
       localeBundles,
+      onAuthError,
       tokenRefreshProvider.refreshToken,
       clearCacheBefore
     ),
@@ -203,6 +207,8 @@ function createManagedCoralContextProvider(
   clientID: string,
   initLocalState: InitLocalState,
   localesData: LocalesData,
+  localStorage: PromisifiedStorage<string>,
+  onAuthError?: () => void,
   ErrorBoundary?: React.ComponentType<{ children?: React.ReactNode }>,
   refreshAccessTokenPromise?: RefreshAccessTokenPromise,
   staticConfig?: StaticConfig | null
@@ -270,6 +276,7 @@ function createManagedCoralContextProvider(
         clientID,
         this.state.context.localeBundles,
         this.state.context.tokenRefreshProvider,
+        onAuthError,
         // Disable the cache on requests for the next 30 seconds.
         new Date(Date.now() + 30 * 1000)
       );
@@ -339,7 +346,7 @@ function createManagedCoralContextProvider(
 /*
  * resolveStorage decides which storage to use in the context
  */
-function resolveStorage(
+export function resolveStorage(
   type: "localStorage" | "sessionStorage" | "indexedDB"
 ): PromisifiedStorage {
   switch (type) {
@@ -397,6 +404,7 @@ export default async function createManaged({
   refreshAccessTokenPromise,
   staticConfig = getStaticConfig(window),
   customScrollContainer,
+  onAuthError,
 }: CreateContextArguments): Promise<
   ComponentType<{ children?: React.ReactNode }>
 > {
@@ -468,7 +476,8 @@ export default async function createManaged({
     subscriptionClient,
     clientID,
     localeBundles,
-    tokenRefreshProvider
+    tokenRefreshProvider,
+    onAuthError
   );
 
   // Assemble context.
@@ -522,6 +531,8 @@ export default async function createManaged({
     clientID,
     initLocalState,
     localesData,
+    localStorage,
+    onAuthError,
     reporter?.ErrorBoundary,
     refreshAccessTokenPromise,
     staticConfig

--- a/client/src/core/client/framework/lib/network/createNetwork.ts
+++ b/client/src/core/client/framework/lib/network/createNetwork.ts
@@ -55,6 +55,7 @@ export default function createNetwork(
   clientID: string,
   accessTokenProvider: AccessTokenProvider,
   localeBundles: FluentBundle[],
+  onAuthError?: () => void,
   tokenRefresh?: TokenRefresh,
   clearCacheBefore?: Date
 ) {
@@ -78,7 +79,11 @@ export default function createNetwork(
         retryDelays: (attempt: number) => Math.pow(2, attempt + 4) * 100,
         // or simple array [3200, 6400, 12800, 25600, 51200, 102400, 204800, 409600],
         statusCodes: [500, 503, 504],
-        beforeRetry: ({ abort, attempt, lastError }) => {
+        beforeRetry: async ({ abort, attempt, lastError }) => {
+          if (lastError?.name === "Missing Auth Error" && onAuthError) {
+            onAuthError();
+          }
+
           if (attempt > 2) {
             let message = lastError?.message;
             if (message && lastError?.name !== "RRNLRetryMiddlewareError") {

--- a/client/src/core/client/stream/App/RefreshTokenHandler/RefreshTokenHandler.tsx
+++ b/client/src/core/client/stream/App/RefreshTokenHandler/RefreshTokenHandler.tsx
@@ -19,6 +19,7 @@ import {
   ShowAuthPopupMutation,
   waitTillAuthPopupIsClosed,
 } from "../../common/AuthPopup";
+import { MissingAuthError } from "./missingAuthError";
 
 const authControlQuery = graphql`
   query RefreshTokenHandlerAuthControlQuery {
@@ -59,7 +60,7 @@ const RefreshTokenHandler: FunctionComponent = () => {
       );
 
       if (!data?.settings?.auth) {
-        throw new Error(
+        throw new MissingAuthError(
           "Missing auth data. Make sure <UserBoxContainer /> has been rendered."
         );
       }

--- a/client/src/core/client/stream/App/RefreshTokenHandler/missingAuthError.ts
+++ b/client/src/core/client/stream/App/RefreshTokenHandler/missingAuthError.ts
@@ -1,0 +1,9 @@
+export class MissingAuthError extends Error {
+  public readonly name: string;
+
+  constructor(message: string | undefined) {
+    super(message);
+
+    this.name = "Missing Auth Error";
+  }
+}

--- a/client/src/core/client/stream/stream.tsx
+++ b/client/src/core/client/stream/stream.tsx
@@ -31,6 +31,7 @@ import localesData from "./locales";
 import { EmotionShadowRoot } from "./shadow";
 
 // Import css variables.
+import { ACCESS_TOKEN_KEY } from "coral-framework/lib/auth";
 import "coral-ui/theme/streamEmbed.css";
 import "coral-ui/theme/typography.css";
 
@@ -104,7 +105,7 @@ export async function attach(options: AttachOptions) {
 
   const onContextAuthError = async () => {
     const localStorage = resolveStorage("localStorage");
-    await localStorage.removeItem("v2:accessToken");
+    await localStorage.removeItem(ACCESS_TOKEN_KEY);
     await remove(options.element);
     await attach(options);
   };


### PR DESCRIPTION
## What does this PR do?

Makes it so that the stream clears the user's auth token when it is invalid or expired and reloads the stream so they can view comments, log in again, and continue using Coral.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No new indices

## How do I test this PR?

- Start up `npm run watch` on both server and client
- Login to the stream at `http://localhost:8080` with a user account
- Stop the Coral server watch task (shut down the server)
- Delete your `coral` database in Mongo
- Start up the server with `npm run start:development`
- Install a new tenant at `http://localhost:3000/install`
- Stop the server again
- Resume `npm run watch` for the server
- Navigate to `http://localhost:8080`
- See that the stream obliterates the `coral:v2:accessToken` storage key and the stream shows up in the signed out state

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
