### PR TITLE
[8.7.1] bump version to 8.7.1

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/talk",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/toolbox-cache-url": "^2.9.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "common",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "license": "ISC",
       "dependencies": {
         "coral-config": "../config/dist",

--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/config/package-lock.json
+++ b/config/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "common",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "common",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "license": "ISC",
       "dependencies": {
         "typescript": "^3.9.5"

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/talk",
-      "version": "8.7.0",
+      "version": "8.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/toolbox-cache-url": "^2.9.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "8.7.0",
+  "version": "8.7.1",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [


### PR DESCRIPTION
## What does this PR do?

Bumps the version number to v8.7.1 so we can prep a release candidate.

Note: One PR left to merge in before this can go into `develop`. That PR is: https://github.com/coralproject/talk/pull/4452. Thank you to @kabeaty for taking the time to fix what I believe were 4 conflicted PR's 🙌 .

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

- let CI build
- deploy to dev1-4 and QA

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge it
