### PR TITLE
DSA fix: only check for duplicate report if not anonymous user

### DIFF
--- a/server/src/core/server/models/dsaReport/report.ts
+++ b/server/src/core/server/models/dsaReport/report.ts
@@ -274,10 +274,13 @@ export async function createDSAReport(
 
   // check if there's already a dsareport submitted by this user for this comment
   // and return a duplicate error if so
-  const alreadyExistingReport = await mongo.dsaReports().findOne(filter);
+  // only check if there's a userID so we don't throw on anonymous reports
+  if (userID) {
+    const alreadyExistingReport = await mongo.dsaReports().findOne(filter);
 
-  if (alreadyExistingReport) {
-    throw new DuplicateDSAReportError(alreadyExistingReport.id);
+    if (alreadyExistingReport) {
+      throw new DuplicateDSAReportError(alreadyExistingReport.id);
+    }
   }
 
   await mongo.dsaReports().insertOne(report);


### PR DESCRIPTION
## What does this PR do?

Update so that we only check for duplicate DSA reports submitted by a user for a particular comment if the user is signed in and it is **not** an anonymous report.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?
n/a

## How do I test this PR?

Make sure you're signed out. Try to DSA report the same comment twice. See that there are no errors and both show in the `DSA Reports` tab.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
