### PR TITLE
[CORL-3025]: Update banned word rejection messaging

### DIFF
--- a/client/src/core/client/stream/tabs/Comments/Comment/ReplyEditSubmitStatus.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Comment/ReplyEditSubmitStatus.tsx
@@ -33,7 +33,8 @@ function getMessage(
           title={
             <Localized id="comments-submitStatus-submittedAndRejected">
               <span>
-                This comment has been rejected for violating our guidelines
+                This comment has been rejected for language that violates our
+                guidelines
               </span>
             </Localized>
           }

--- a/client/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentRejectedMessage.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/PostCommentForm/PostCommentRejectedMessage.tsx
@@ -20,7 +20,10 @@ const PostCommentRejected: FunctionComponent<PostCommentRejectedProps> = (
       icon={<SvgIcon Icon={AlertCircleIcon} />}
       title={
         <Localized id="comments-submitStatus-submittedAndRejected">
-          <div>This comment has been rejected for violating our guidelines</div>
+          <div>
+            This comment has been rejected for language that violates our
+            guidelines
+          </div>
         </Localized>
       }
       onClose={props.onDismiss}

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -780,7 +780,7 @@ comments-submitStatus-dismiss = Dismiss
 comments-submitStatus-submittedAndWillBeReviewed =
   Your comment has been submitted and will be reviewed by a moderator
 comments-submitStatus-submittedAndRejected =
-  This comment has been rejected for violating our guidelines
+  This comment has been rejected for language that violates our guidelines
 
 # Configure
 configure-configureQuery-errorLoadingProfile = Error loading configure


### PR DESCRIPTION
## What does this PR do?

Update messaging around banned word rejection.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Write a comment/reply with a banned word in it. See that the rejection message now says `This comment has been rejected for language that violates our guidelines`

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
