### PR TITLE
create docker-compose + README for wordpress dev environment

### DIFF
--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -1,0 +1,33 @@
+## Wordpress Dev Environment
+
+This is a dev environment for testing out the [talk-wp-plugin](https://github.com/coralproject/talk-wp-plugin) with Coral.
+
+### Usage
+
+- Spin up the mysql and wordpress containers:
+
+    ```
+    cd wordpress
+    docker-compose up
+    ```
+
+- Spin up Coral and add `http://localhost:8081` to a new or existing site so the new Wordpress URL is allowed.
+
+- Then navigate to `http://localhost:8081`.
+
+- Follow the steps to create a new admin user for the wordpress deployment.
+
+- Install the plugin from [talk-wp-plugin](https://github.com/coralproject/talk-wp-plugin) by downloading the source code and zipping it up into a `.zip` archive.
+
+- Navigate to http://localhost:8081/wp-admin/plugins.php and click `Add New Plugin`.
+
+- From there, click `Upload Plugin`.
+
+- Point it to the `talk-wp-plugin` archive you created from its source code.
+
+- Enable the Coral plugin in the `Installed Plugins` list if it is not already enabled.
+
+- Go to `Settings > Coral Settings` and set the `Server Base URL` to http://localhost:3000 or http://localhost:8080 based on whether you're running Coral standalone or in watch mode.
+
+- Head to `Appearance > Themes` and select the oldest theme you can find (Twenty Twenty-Two as of this writing) as the Coral plugin can't override the PHP for comments in newer themes yet.
+    - If you need to set this manually, check the [README](https://github.com/coralproject/talk-wp-plugin?tab=readme-ov-file#theme-usage) on the `talk-wp-plugin` repo for how to [edit the theme to show Coral comments](https://github.com/coralproject/talk-wp-plugin?tab=readme-ov-file#theme-usage).

--- a/wordpress/README.md
+++ b/wordpress/README.md
@@ -11,9 +11,11 @@ This is a dev environment for testing out the [talk-wp-plugin](https://github.co
     docker-compose up
     ```
 
+- Close the terminal after docker-compose runs
+
 - Spin up Coral and add `http://localhost:8081` to a new or existing site so the new Wordpress URL is allowed.
 
-- Then navigate to `http://localhost:8081`.
+- Navigate to `http://localhost:8081`.
 
 - Follow the steps to create a new admin user for the wordpress deployment.
 
@@ -28,6 +30,8 @@ This is a dev environment for testing out the [talk-wp-plugin](https://github.co
 - Enable the Coral plugin in the `Installed Plugins` list if it is not already enabled.
 
 - Go to `Settings > Coral Settings` and set the `Server Base URL` to http://localhost:3000 or http://localhost:8080 based on whether you're running Coral standalone or in watch mode.
+
+- Set the Coral stream version to `v5+`.
 
 - Head to `Appearance > Themes` and select the oldest theme you can find (Twenty Twenty-Two as of this writing) as the Coral plugin can't override the PHP for comments in newer themes yet.
     - If you need to set this manually, check the [README](https://github.com/coralproject/talk-wp-plugin?tab=readme-ov-file#theme-usage) on the `talk-wp-plugin` repo for how to [edit the theme to show Coral comments](https://github.com/coralproject/talk-wp-plugin?tab=readme-ov-file#theme-usage).

--- a/wordpress/docker-compose.yml
+++ b/wordpress/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  wp-mysql:
+    image: mysql:8.2.0
+    restart: always
+    ports: 
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=wp-mysql-secret
+      - MYSQL_DATABASE=wp
+      - MYSQL_USER=wp
+      - MYSQL_PASSWORD=wp-user-secret
+  wp:
+    image: wordpress:6.4.2-php8.1-apache
+    restart: always
+    ports:
+      - "8081:80"
+    environment:
+      - WORDPRESS_DB_HOST=wp-mysql
+      - WORDPRESS_DB_NAME=wp
+      - WORDPRESS_DB_USER=wp
+      - WORDPRESS_DB_PASSWORD=wp-user-secret


### PR DESCRIPTION
## What does this PR do?

Adds a docker-compose and readme file for setting up a wordpress environment to work with Coral development as a site host.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

Check the readme under `wordpress/`, follow its directions, and make sure it works with Coral.

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
