### PR TITLE
[CORL-3029]: update to always show notifications

### DIFF
--- a/client/src/core/client/stream/App/App.tsx
+++ b/client/src/core/client/stream/App/App.tsx
@@ -19,7 +19,6 @@ type TabValue = "COMMENTS" | "PROFILE" | "DISCUSSIONS" | "%future added value";
 
 export interface AppProps {
   activeTab: TabValue;
-  dsaFeaturesEnabled: boolean;
 }
 
 const App: FunctionComponent<AppProps> = (props) => {
@@ -71,15 +70,13 @@ const App: FunctionComponent<AppProps> = (props) => {
             >
               <Configure />
             </TabPane>
-            {props.dsaFeaturesEnabled && (
-              <TabPane
-                className={CLASSES.notificationsTabPane.$root}
-                tabID="NOTIFICATIONS"
-                data-testid="current-tab-pane"
-              >
-                <NotificationsQuery />
-              </TabPane>
-            )}
+            <TabPane
+              className={CLASSES.notificationsTabPane.$root}
+              tabID="NOTIFICATIONS"
+              data-testid="current-tab-pane"
+            >
+              <NotificationsQuery />
+            </TabPane>
           </TabContent>
         </div>
       </HorizontalGutter>

--- a/client/src/core/client/stream/App/AppContainer.tsx
+++ b/client/src/core/client/stream/App/AppContainer.tsx
@@ -30,18 +30,16 @@ interface Props {
 }
 
 const AppContainer: FunctionComponent<Props> = ({ disableListeners }) => {
-  const [{ activeTab, dsaFeaturesEnabled }] =
-    useLocal<AppContainerLocal>(graphql`
-      fragment AppContainerLocal on Local {
-        activeTab
-        dsaFeaturesEnabled
-      }
-    `);
+  const [{ activeTab }] = useLocal<AppContainerLocal>(graphql`
+    fragment AppContainerLocal on Local {
+      activeTab
+    }
+  `);
   return (
     <>
       {disableListeners ? null : listeners}
       <RefreshTokenHandler />
-      <App activeTab={activeTab} dsaFeaturesEnabled={!!dsaFeaturesEnabled} />
+      <App activeTab={activeTab} />
     </>
   );
 };

--- a/client/src/core/client/stream/App/TabBarContainer.tsx
+++ b/client/src/core/client/stream/App/TabBarContainer.tsx
@@ -38,11 +38,10 @@ export const TabBarContainer: FunctionComponent<Props> = ({
 }) => {
   const setCommentID = useMutation(SetCommentIDMutation);
   const { window } = useCoralContext();
-  const [{ activeTab, dsaFeaturesEnabled, hasNewNotifications }] =
+  const [{ activeTab, hasNewNotifications }] =
     useLocal<TabBarContainerLocal>(graphql`
       fragment TabBarContainerLocal on Local {
         activeTab
-        dsaFeaturesEnabled
         hasNewNotifications
       }
     `);
@@ -75,11 +74,6 @@ export const TabBarContainer: FunctionComponent<Props> = ({
     [viewer, story]
   );
 
-  const showNotificationsTab = useMemo(
-    () => !!viewer && !!dsaFeaturesEnabled,
-    [viewer, dsaFeaturesEnabled]
-  );
-
   return (
     <TabBar
       mode={story ? story.settings.mode : GQLSTORY_MODE.COMMENTS}
@@ -87,7 +81,7 @@ export const TabBarContainer: FunctionComponent<Props> = ({
       showProfileTab={!!viewer}
       showDiscussionsTab={showDiscussionsTab}
       showConfigureTab={showConfigureTab}
-      showNotificationsTab={showNotificationsTab}
+      showNotificationsTab={!!viewer}
       hasNewNotifications={!!hasNewNotifications}
       onTabClick={handleSetActiveTab}
     />

--- a/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
@@ -67,58 +67,60 @@ const NotificationsPaginator: FunctionComponent<Props> = (props) => {
 
   return (
     <>
-      <div className={styles.methodOfRedress}>
-        {props.query.settings.dsa.methodOfRedress.method ===
-          GQLDSA_METHOD_OF_REDRESS.NONE && (
-          <Localized id="notifications-methodOfRedress-none">
-            All moderation decisions are final and cannot be appealed
-          </Localized>
-        )}
-        {props.query.settings.dsa.methodOfRedress.method ===
-          GQLDSA_METHOD_OF_REDRESS.EMAIL && (
-          <Localized
-            id="notifications-methodOfRedress-email"
-            vars={{
-              email: props.query.settings.dsa.methodOfRedress.email,
-            }}
-            elems={{
-              a: (
-                <a
-                  href={`mailto: ${props.query.settings.dsa.methodOfRedress.email}`}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {props.query.settings.dsa.methodOfRedress.email}
-                </a>
-              ),
-            }}
-          >
-            <span>{`To appeal a decision that appears here please contact ${props.query.settings.dsa.methodOfRedress.email}`}</span>
-          </Localized>
-        )}
-        {props.query.settings.dsa.methodOfRedress.method ===
-          GQLDSA_METHOD_OF_REDRESS.URL && (
-          <Localized
-            id="notifications-methodOfRedress-url"
-            vars={{
-              url: props.query.settings.dsa.methodOfRedress.url,
-            }}
-            elems={{
-              a: (
-                <a
-                  href={`${props.query.settings.dsa.methodOfRedress.url}`}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {props.query.settings.dsa.methodOfRedress.url}
-                </a>
-              ),
-            }}
-          >
-            <span>{`To appeal a decision that appears here please visit ${props.query.settings.dsa.methodOfRedress.url}`}</span>
-          </Localized>
-        )}
-      </div>
+      {props.query.settings.dsa.enabled && (
+        <div className={styles.methodOfRedress}>
+          {props.query.settings.dsa.methodOfRedress.method ===
+            GQLDSA_METHOD_OF_REDRESS.NONE && (
+            <Localized id="notifications-methodOfRedress-none">
+              All moderation decisions are final and cannot be appealed
+            </Localized>
+          )}
+          {props.query.settings.dsa.methodOfRedress.method ===
+            GQLDSA_METHOD_OF_REDRESS.EMAIL && (
+            <Localized
+              id="notifications-methodOfRedress-email"
+              vars={{
+                email: props.query.settings.dsa.methodOfRedress.email,
+              }}
+              elems={{
+                a: (
+                  <a
+                    href={`mailto: ${props.query.settings.dsa.methodOfRedress.email}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {props.query.settings.dsa.methodOfRedress.email}
+                  </a>
+                ),
+              }}
+            >
+              <span>{`To appeal a decision that appears here please contact ${props.query.settings.dsa.methodOfRedress.email}`}</span>
+            </Localized>
+          )}
+          {props.query.settings.dsa.methodOfRedress.method ===
+            GQLDSA_METHOD_OF_REDRESS.URL && (
+            <Localized
+              id="notifications-methodOfRedress-url"
+              vars={{
+                url: props.query.settings.dsa.methodOfRedress.url,
+              }}
+              elems={{
+                a: (
+                  <a
+                    href={`${props.query.settings.dsa.methodOfRedress.url}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {props.query.settings.dsa.methodOfRedress.url}
+                  </a>
+                ),
+              }}
+            >
+              <span>{`To appeal a decision that appears here please visit ${props.query.settings.dsa.methodOfRedress.url}`}</span>
+            </Localized>
+          )}
+        </div>
+      )}
       <div>
         {props.query.notifications.edges.map(({ node }) => {
           return (
@@ -171,6 +173,7 @@ const enhanced = withPaginationContainer<
         }
         settings {
           dsa {
+            enabled
             methodOfRedress {
               method
               email


### PR DESCRIPTION
## What does this PR do?

These changes update to always show notifications, whether DSA is enabled or not.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test this by making sure that DSA is turned off. Log in as a commenter and see that notifications tab is visible. See that you either have a message about not yet having any notifications or there are notifications. 

Turn DSA back on and see notifications are still showing. See that if there is a DSA method of redress, this only shows at the top of notifications if DSA is enabled.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
