### PR TITLE
[CORL-3031]: User preferences for in-page notifications

### DIFF
--- a/client/CLIENT_EVENTS.md
+++ b/client/CLIENT_EVENTS.md
@@ -621,7 +621,7 @@ createComment.error
       onFeatured?: boolean | null | undefined;
       onStaffReplies?: boolean | null | undefined;
       onModeration?: boolean | null | undefined;
-      digestFrequency?: any;
+      digestFrequency?: "NONE" | "DAILY" | "HOURLY" | null | undefined;
       success: {};
       error: {
           message: string;

--- a/client/CLIENT_EVENTS.md
+++ b/client/CLIENT_EVENTS.md
@@ -621,7 +621,7 @@ createComment.error
       onFeatured?: boolean | null | undefined;
       onStaffReplies?: boolean | null | undefined;
       onModeration?: boolean | null | undefined;
-      digestFrequency?: "NONE" | "DAILY" | "HOURLY" | null | undefined;
+      digestFrequency?: any;
       success: {};
       error: {
           message: string;

--- a/client/CLIENT_EVENTS.md
+++ b/client/CLIENT_EVENTS.md
@@ -141,7 +141,8 @@ createComment.error
 - <a href="#signedIn">signedIn</a>
 - <a href="#unfeatureComment">unfeatureComment</a>
 - <a href="#unmarkAll">unmarkAll</a>
-- <a href="#updateNotificationSettings">updateNotificationSettings</a>
+- <a href="#updateEmailNotificationSettings">updateEmailNotificationSettings</a>
+- <a href="#updateInPageNotificationSettings">updateInPageNotificationSettings</a>
 - <a href="#updateStorySettings">updateStorySettings</a>
 - <a href="#updateUserMediaSettings">updateUserMediaSettings</a>
 - <a href="#viewConversation">viewConversation</a>
@@ -614,7 +615,7 @@ createComment.error
       source: "keyboard" | "mobileToolbar";
   }
   ```
-- <a id="updateNotificationSettings">**updateNotificationSettings.success**, **updateNotificationSettings.error**</a>: This event is emitted when the viewer updates its notification settings.
+- <a id="updateEmailNotificationSettings">**updateEmailNotificationSettings.success**, **updateEmailNotificationSettings.error**</a>: This event is emitted when the viewer updates their email notification settings.
   ```ts
   {
       onReply?: boolean | null | undefined;
@@ -622,6 +623,22 @@ createComment.error
       onStaffReplies?: boolean | null | undefined;
       onModeration?: boolean | null | undefined;
       digestFrequency?: "NONE" | "DAILY" | "HOURLY" | null | undefined;
+      success: {};
+      error: {
+          message: string;
+          code?: string | undefined;
+      };
+  }
+  ```
+- <a id="updateInPageNotificationSettings">**updateInPageNotificationSettings.success**, **updateInPageNotificationSettings.error**</a>: This event is emitted when the viewer updates their in-page notification settings.
+  ```ts
+  {
+      onReply?: boolean | null | undefined;
+      onFeatured?: boolean | null | undefined;
+      onStaffReplies?: boolean | null | undefined;
+      onModeration?: boolean | null | undefined;
+      includeCountInBadge?: boolean | null | undefined;
+      bellRemainsVisible?: boolean | null | undefined;
       success: {};
       error: {
           message: string;

--- a/client/src/core/client/stream/classes.ts
+++ b/client/src/core/client/stream/classes.ts
@@ -5,7 +5,7 @@ const CLASSES = {
   app: "coral coral-stream",
 
   /**
-   * guidlines represents the box containing the guidlines.
+   * guidelines represents the box containing the guidelines.
    */
   guidelines: {
     container: "coral coral-guidelines",
@@ -13,7 +13,7 @@ const CLASSES = {
   },
 
   /**
-   * guidlines represents the box containing the guidlines.
+   * announcement represents the box containing the announcement.
    */
   announcement: "coral coral-announcement",
 
@@ -1059,11 +1059,13 @@ const CLASSES = {
     openButton: "coral coral-openCommentStream-openButton",
   },
 
-  emailNotifications: {
-    $root: "coral coral-emailNotifications",
-    heading: "coral coral-emailNotifications-heading",
-    label: "coral coral-emailNotifications-label",
-    updateButton: "coral coral-emailNotifications-updateButton",
+  notifications: {
+    $root: "coral coral-emailNotifications coral-notifications",
+    heading:
+      "coral coral-emailNotifications-heading coral-notifications-heading",
+    label: "coral coral-emailNotifications-label coral-notifications-label",
+    updateButton:
+      "coral coral-emailNotifications-updateButton coral-notifications-updateButton",
   },
 
   mediaPreferences: {

--- a/client/src/core/client/stream/events.ts
+++ b/client/src/core/client/stream/events.ts
@@ -201,10 +201,10 @@ export const SignOutEvent = createViewerNetworkEvent<{
 export const SignedInEvent = createViewerEvent("signedIn");
 
 /**
- * This event is emitted when the viewer updates its
- * notification settings.
+ * This event is emitted when the viewer updates their
+ * email notification settings.
  */
-export const UpdateNotificationSettingsEvent = createViewerNetworkEvent<{
+export const UpdateEmailNotificationSettingsEvent = createViewerNetworkEvent<{
   onReply?: boolean | null;
   onFeatured?: boolean | null;
   onStaffReplies?: boolean | null;
@@ -215,7 +215,25 @@ export const UpdateNotificationSettingsEvent = createViewerNetworkEvent<{
     message: string;
     code?: string;
   };
-}>("updateNotificationSettings");
+}>("updateEmailNotificationSettings");
+
+/**
+ * This event is emitted when the viewer updates their
+ * in-page notification settings.
+ */
+export const UpdateInPageNotificationSettingsEvent = createViewerNetworkEvent<{
+  onReply?: boolean | null;
+  onFeatured?: boolean | null;
+  onStaffReplies?: boolean | null;
+  onModeration?: boolean | null;
+  includeCountInBadge?: boolean | null;
+  bellRemainsVisible?: boolean | null;
+  success: {};
+  error: {
+    message: string;
+    code?: string;
+  };
+}>("updateInPageNotificationSettings");
 
 export const UpdateUserMediaSettingsEvent = createViewerNetworkEvent<{
   unfurlEmbeds?: boolean | null;

--- a/client/src/core/client/stream/events.ts
+++ b/client/src/core/client/stream/events.ts
@@ -23,7 +23,7 @@ import {
 } from "coral-framework/lib/events";
 
 import { COMMENT_STATUS } from "./__generated__/CreateCommentMutation.graphql";
-import { DIGEST_FREQUENCY } from "./__generated__/NotificationSettingsContainer_viewer.graphql";
+import { DIGEST_FREQUENCY } from "./__generated__/EmailNotificationSettingsContainer_viewer.graphql";
 import { MODERATION_MODE } from "./__generated__/UpdateStorySettingsMutation.graphql";
 
 /**

--- a/client/src/core/client/stream/tabs/Profile/Preferences/EmailNotificationSettingsContainer.css
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/EmailNotificationSettingsContainer.css
@@ -3,6 +3,7 @@
   font-weight: var(--font-weight-primary-semi-bold);
   font-size: var(--font-size-4);
   line-height: 1.11;
+  margin: 0;
 
   color: var(--palette-text-900);
 

--- a/client/src/core/client/stream/tabs/Profile/Preferences/EmailNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/EmailNotificationSettingsContainer.tsx
@@ -29,7 +29,7 @@ import { EmailNotificationSettingsContainer_viewer } from "coral-stream/__genera
 
 import UpdateEmailNotificationSettingsMutation from "./UpdateEmailNotificationSettingsMutation";
 
-import styles from "./NotificationSettingsContainer.css";
+import styles from "./EmailNotificationSettingsContainer.css";
 
 interface Props {
   viewer: EmailNotificationSettingsContainer_viewer;

--- a/client/src/core/client/stream/tabs/Profile/Preferences/EmailNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/EmailNotificationSettingsContainer.tsx
@@ -1,0 +1,303 @@
+import { Localized } from "@fluent/react/compat";
+import cn from "classnames";
+import { FORM_ERROR } from "final-form";
+import React, { FunctionComponent, useCallback, useState } from "react";
+import { Field, Form, FormSpy } from "react-final-form";
+import { graphql } from "react-relay";
+
+import { InvalidRequestError } from "coral-framework/lib/errors";
+import { useMutation, withFragmentContainer } from "coral-framework/lib/relay";
+import { GQLDIGEST_FREQUENCY } from "coral-framework/schema";
+import CLASSES from "coral-stream/classes";
+import {
+  AlertTriangleIcon,
+  CheckCircleIcon,
+  SvgIcon,
+} from "coral-ui/components/icons";
+import {
+  CheckBox,
+  FieldSet,
+  FormField,
+  HorizontalGutter,
+  HorizontalRule,
+  Option,
+  SelectField,
+} from "coral-ui/components/v2";
+import { Button, CallOut } from "coral-ui/components/v3";
+
+import { EmailNotificationSettingsContainer_viewer } from "coral-stream/__generated__/EmailNotificationSettingsContainer_viewer.graphql";
+
+import UpdateEmailNotificationSettingsMutation from "./UpdateEmailNotificationSettingsMutation";
+
+import styles from "./NotificationSettingsContainer.css";
+
+interface Props {
+  viewer: EmailNotificationSettingsContainer_viewer;
+}
+
+type FormProps = EmailNotificationSettingsContainer_viewer["notifications"];
+
+const EmailNotificationSettingsContainer: FunctionComponent<Props> = ({
+  viewer: { notifications },
+}) => {
+  const mutation = useMutation(UpdateEmailNotificationSettingsMutation);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [showError, setShowError] = useState(false);
+  const closeSuccess = useCallback(() => {
+    setShowSuccess(false);
+  }, [setShowSuccess]);
+  const closeError = useCallback(() => {
+    setShowError(false);
+  }, [setShowError]);
+  const onSubmit = useCallback(
+    async (values: FormProps) => {
+      try {
+        await mutation(values);
+        setShowSuccess(true);
+      } catch (err) {
+        if (err instanceof InvalidRequestError) {
+          return err.invalidArgs;
+        }
+
+        setShowError(true);
+        return {
+          [FORM_ERROR]: err.message,
+        };
+      }
+
+      return;
+    },
+    [mutation, setShowSuccess, setShowError]
+  );
+
+  return (
+    <HorizontalGutter
+      data-testid="profile-account-notifications"
+      className={CLASSES.emailNotifications.$root}
+      container="section"
+      aria-labelledby="profile-account-notifications-emailNotifications-title"
+    >
+      <Form initialValues={{ ...notifications }} onSubmit={onSubmit}>
+        {({
+          handleSubmit,
+          submitting,
+          submitError,
+          pristine,
+          submitSucceeded,
+        }) => (
+          <form onSubmit={handleSubmit}>
+            <HorizontalGutter>
+              <HorizontalGutter>
+                <Localized id="profile-account-notifications-emailNotifications">
+                  <h2
+                    className={cn(
+                      styles.title,
+                      CLASSES.emailNotifications.heading
+                    )}
+                    id="profile-account-notifications-emailNotifications-title"
+                  >
+                    Email Notifications
+                  </h2>
+                </Localized>
+              </HorizontalGutter>
+              <HorizontalGutter>
+                <Localized id="profile-account-notifications-receiveWhen">
+                  <div
+                    className={cn(
+                      styles.header,
+                      CLASSES.emailNotifications.label
+                    )}
+                    id="profile-account-notifications-receiveWhen"
+                  >
+                    Receive notifications when:
+                  </div>
+                </Localized>
+                <FieldSet aria-labelledby="profile-account-notifications-receiveWhen">
+                  <FormField>
+                    <Field name="onReply" type="checkbox">
+                      {({ input }) => (
+                        <Localized id="profile-account-notifications-onReply">
+                          <CheckBox
+                            {...input}
+                            id={input.name}
+                            className={styles.checkBox}
+                            variant="streamBlue"
+                          >
+                            My comment receives a reply
+                          </CheckBox>
+                        </Localized>
+                      )}
+                    </Field>
+                  </FormField>
+                  <FormField>
+                    <Field name="onFeatured" type="checkbox">
+                      {({ input }) => (
+                        <Localized id="profile-account-notifications-onFeatured">
+                          <CheckBox
+                            {...input}
+                            id={input.name}
+                            className={styles.checkBox}
+                            variant="streamBlue"
+                          >
+                            My comment is featured
+                          </CheckBox>
+                        </Localized>
+                      )}
+                    </Field>
+                  </FormField>
+                  <FormField>
+                    <Field name="onStaffReplies" type="checkbox">
+                      {({ input }) => (
+                        <Localized id="profile-account-notifications-onStaffReplies">
+                          <CheckBox
+                            {...input}
+                            id={input.name}
+                            className={styles.checkBox}
+                            variant="streamBlue"
+                          >
+                            A staff member replies to my comment
+                          </CheckBox>
+                        </Localized>
+                      )}
+                    </Field>
+                  </FormField>
+                  <FormField>
+                    <Field name="onModeration" type="checkbox">
+                      {({ input }) => (
+                        <Localized id="profile-account-notifications-onModeration">
+                          <CheckBox
+                            {...input}
+                            id={input.name}
+                            className={styles.checkBox}
+                            variant="streamBlue"
+                          >
+                            My pending comment has been reviewed
+                          </CheckBox>
+                        </Localized>
+                      )}
+                    </Field>
+                  </FormField>
+                  <FormField>
+                    <Localized id="profile-account-notifications-sendNotifications">
+                      <label
+                        className={cn(
+                          styles.header,
+                          styles.sendNotifications,
+                          CLASSES.emailNotifications.label
+                        )}
+                        htmlFor="digestFrequency"
+                      >
+                        Send Notifications:
+                      </label>
+                    </Localized>
+                    <FormSpy subscription={{ values: true }}>
+                      {({ values }) => (
+                        <Field name="digestFrequency">
+                          {({ input }) => (
+                            <div>
+                              <SelectField
+                                {...input}
+                                id={input.name}
+                                disabled={
+                                  !values.onReply &&
+                                  !values.onStaffReplies &&
+                                  !values.onFeatured &&
+                                  !values.onModeration
+                                }
+                              >
+                                <Localized id="profile-account-notifications-sendNotifications-immediately">
+                                  <Option value={GQLDIGEST_FREQUENCY.NONE}>
+                                    Immediately
+                                  </Option>
+                                </Localized>
+                                <Localized id="profile-account-notifications-sendNotifications-daily">
+                                  <Option value={GQLDIGEST_FREQUENCY.DAILY}>
+                                    Daily
+                                  </Option>
+                                </Localized>
+                                <Localized id="profile-account-notifications-sendNotifications-hourly">
+                                  <Option value={GQLDIGEST_FREQUENCY.HOURLY}>
+                                    Hourly
+                                  </Option>
+                                </Localized>
+                              </SelectField>
+                            </div>
+                          )}
+                        </Field>
+                      )}
+                    </FormSpy>
+                  </FormField>
+                </FieldSet>
+              </HorizontalGutter>
+              <div
+                className={cn(styles.updateButton, {
+                  [styles.updateButtonNotification]: showSuccess || showError,
+                })}
+              >
+                <Localized id="profile-account-notifications-button-update">
+                  <Button
+                    type="submit"
+                    disabled={submitting || pristine}
+                    className={CLASSES.emailNotifications.updateButton}
+                    upperCase
+                  >
+                    Update
+                  </Button>
+                </Localized>
+              </div>
+              {((submitError && showError) ||
+                (submitSucceeded && showSuccess)) && (
+                <div className={styles.callOut}>
+                  {submitError && showError && (
+                    <CallOut
+                      color="error"
+                      onClose={closeError}
+                      icon={<SvgIcon Icon={AlertTriangleIcon} />}
+                      titleWeight="semiBold"
+                      title={<span>{submitError}</span>}
+                      role="alert"
+                    />
+                  )}
+                  {submitSucceeded && showSuccess && (
+                    <CallOut
+                      color="success"
+                      onClose={closeSuccess}
+                      icon={<SvgIcon Icon={CheckCircleIcon} />}
+                      titleWeight="semiBold"
+                      title={
+                        <Localized id="profile-account-notifications-updated">
+                          <span>
+                            Your notification settings have been updated
+                          </span>
+                        </Localized>
+                      }
+                      role="dialog"
+                      aria-live="polite"
+                    />
+                  )}
+                </div>
+              )}
+            </HorizontalGutter>
+          </form>
+        )}
+      </Form>
+      <HorizontalRule></HorizontalRule>
+    </HorizontalGutter>
+  );
+};
+
+const enhanced = withFragmentContainer<Props>({
+  viewer: graphql`
+    fragment EmailNotificationSettingsContainer_viewer on User {
+      notifications {
+        onReply
+        onFeatured
+        onStaffReplies
+        onModeration
+        digestFrequency
+      }
+    }
+  `,
+})(EmailNotificationSettingsContainer);
+
+export default enhanced;

--- a/client/src/core/client/stream/tabs/Profile/Preferences/EmailNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/EmailNotificationSettingsContainer.tsx
@@ -73,7 +73,7 @@ const EmailNotificationSettingsContainer: FunctionComponent<Props> = ({
   return (
     <HorizontalGutter
       data-testid="profile-account-notifications"
-      className={CLASSES.emailNotifications.$root}
+      className={CLASSES.notifications.$root}
       container="section"
       aria-labelledby="profile-account-notifications-emailNotifications-title"
     >
@@ -90,10 +90,7 @@ const EmailNotificationSettingsContainer: FunctionComponent<Props> = ({
               <HorizontalGutter>
                 <Localized id="profile-account-notifications-emailNotifications">
                   <h2
-                    className={cn(
-                      styles.title,
-                      CLASSES.emailNotifications.heading
-                    )}
+                    className={cn(styles.title, CLASSES.notifications.heading)}
                     id="profile-account-notifications-emailNotifications-title"
                   >
                     Email Notifications
@@ -103,10 +100,7 @@ const EmailNotificationSettingsContainer: FunctionComponent<Props> = ({
               <HorizontalGutter>
                 <Localized id="profile-account-notifications-receiveWhen">
                   <div
-                    className={cn(
-                      styles.header,
-                      CLASSES.emailNotifications.label
-                    )}
+                    className={cn(styles.header, CLASSES.notifications.label)}
                     id="profile-account-notifications-receiveWhen"
                   >
                     Receive notifications when:
@@ -183,7 +177,7 @@ const EmailNotificationSettingsContainer: FunctionComponent<Props> = ({
                         className={cn(
                           styles.header,
                           styles.sendNotifications,
-                          CLASSES.emailNotifications.label
+                          CLASSES.notifications.label
                         )}
                         htmlFor="digestFrequency"
                       >
@@ -238,7 +232,7 @@ const EmailNotificationSettingsContainer: FunctionComponent<Props> = ({
                   <Button
                     type="submit"
                     disabled={submitting || pristine}
-                    className={CLASSES.emailNotifications.updateButton}
+                    className={CLASSES.notifications.updateButton}
                     upperCase
                   >
                     Update

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.css
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.css
@@ -1,0 +1,57 @@
+.bellIcon {
+  margin-right: var(--spacing-1);
+}
+
+.title {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-semi-bold);
+  font-size: var(--font-size-4);
+  line-height: 1.11;
+  margin: 0;
+
+  color: var(--palette-text-900);
+
+  padding-bottom: var(--spacing-1);
+}
+
+.header {
+  display: inline-block;
+
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-bold);
+  font-size: var(--font-size-2);
+  line-height: 1.14;
+
+  color: var(--palette-text-500);
+
+  padding-bottom: var(--spacing-1);
+}
+
+.sendNotifications {
+  padding-top: var(--spacing-1);
+}
+
+.checkBox {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-primary-regular);
+  font-size: var(--font-size-3);
+  line-height: 1.125;
+
+  color: var(--palette-text-500);
+
+  padding-bottom: var(--spacing-2);
+}
+
+.updateButton {
+  padding-top: var(--spacing-2);
+  padding-bottom: var(--spacing-3);
+}
+
+.updateButtonNotification {
+  padding-top: var(--spacing-2);
+  padding-bottom: var(--spacing-1);
+}
+
+.callOut {
+  padding-bottom: var(--spacing-2);
+}

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -70,10 +70,9 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
 
   return (
     <HorizontalGutter
-      // data-testid="profile-account-notifications"
-      className={CLASSES.emailNotifications.$root}
+      className={CLASSES.notifications.$root}
       container="section"
-      // aria-labelledby="profile-account-notifications-emailNotifications-title"
+      aria-labelledby="profile-account-notifications-inPageNotifications-title"
     >
       <Form initialValues={{ ...inPageNotifications }} onSubmit={onSubmit}>
         {({
@@ -86,31 +85,25 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
           <form onSubmit={handleSubmit}>
             <HorizontalGutter>
               <HorizontalGutter>
-                <Localized id="">
+                <Localized id="profile-account-notifications-inPageNotifications">
                   <h2
-                    className={cn(
-                      styles.title,
-                      CLASSES.emailNotifications.heading
-                    )}
-                    id=""
+                    className={cn(styles.title, CLASSES.notifications.heading)}
+                    id="profile-account-notifications-inPageNotifications-title"
                   >
                     In-page Notifications
                   </h2>
                 </Localized>
               </HorizontalGutter>
               <HorizontalGutter>
-                <Localized id="">
+                <Localized id="profile-account-notifications-includeInPageWhen">
                   <div
-                    className={cn(
-                      styles.header,
-                      CLASSES.emailNotifications.label
-                    )}
-                    id="profile-account-notifications-includeWhen"
+                    className={cn(styles.header, CLASSES.notifications.label)}
+                    id="profile-account-notifications-includeInPageWhen"
                   >
                     Include notifications when
                   </div>
                 </Localized>
-                <FieldSet aria-labelledby="profile-account-notifications-includeWhen">
+                <FieldSet aria-labelledby="profile-account-notifications-includeInPageWhen">
                   <FormField>
                     <Field name="onReply" type="checkbox">
                       {({ input }) => (
@@ -178,22 +171,19 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                 </FieldSet>
               </HorizontalGutter>
               <HorizontalGutter>
-                <Localized id="profile-account-notifications-interface">
+                <Localized id="profile-account-notifications-interfacePreferences">
                   <div
-                    className={cn(
-                      styles.header,
-                      CLASSES.emailNotifications.label
-                    )}
-                    id="profile-account-notifications-interface"
+                    className={cn(styles.header, CLASSES.notifications.label)}
+                    id="profile-account-notifications-interfacePreferences"
                   >
                     Interface preferences
                   </div>
                 </Localized>
-                <FieldSet aria-labelledby="profile-account-notifications-interface">
+                <FieldSet aria-labelledby="profile-account-notifications-interfacePreferences">
                   <FormField>
                     <Field name="includeCountInBadge" type="checkbox">
                       {({ input }) => (
-                        <Localized id="">
+                        <Localized id="profile-account-notifications-includeCountInBadge">
                           <CheckBox
                             {...input}
                             id={input.name}
@@ -209,7 +199,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                   <FormField>
                     <Field name="bellRemainsVisible" type="checkbox">
                       {({ input }) => (
-                        <Localized id="">
+                        <Localized id="profile-account-notifications-bellRemainsVisible">
                           <CheckBox
                             {...input}
                             id={input.name}
@@ -233,7 +223,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                   <Button
                     type="submit"
                     disabled={submitting || pristine}
-                    className={CLASSES.emailNotifications.updateButton}
+                    className={CLASSES.notifications.updateButton}
                     upperCase
                   >
                     Update

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -2,12 +2,11 @@ import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
 import { FORM_ERROR } from "final-form";
 import React, { FunctionComponent, useCallback, useState } from "react";
-import { Field, Form, FormSpy } from "react-final-form";
+import { Field, Form } from "react-final-form";
 import { graphql } from "react-relay";
 
 import { InvalidRequestError } from "coral-framework/lib/errors";
 import { useMutation, withFragmentContainer } from "coral-framework/lib/relay";
-import { GQLDIGEST_FREQUENCY } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
 import {
   AlertTriangleIcon,
@@ -20,27 +19,26 @@ import {
   FormField,
   HorizontalGutter,
   HorizontalRule,
-  Option,
-  SelectField,
 } from "coral-ui/components/v2";
 import { Button, CallOut } from "coral-ui/components/v3";
 
-import { NotificationSettingsContainer_viewer } from "coral-stream/__generated__/NotificationSettingsContainer_viewer.graphql";
+import { InPageNotificationSettingsContainer_viewer } from "coral-stream/__generated__/InPageNotificationSettingsContainer_viewer.graphql";
 
-import UpdateNotificationSettingsMutation from "./UpdateNotificationSettingsMutation";
+import UpdateInPageNotificationSettingsMutation from "./UpdateInPageNotificationSettingsMutation";
 
 import styles from "./NotificationSettingsContainer.css";
 
 interface Props {
-  viewer: NotificationSettingsContainer_viewer;
+  viewer: InPageNotificationSettingsContainer_viewer;
 }
 
-type FormProps = NotificationSettingsContainer_viewer["notifications"];
+type FormProps =
+  InPageNotificationSettingsContainer_viewer["inPageNotifications"];
 
-const NotificationSettingsContainer: FunctionComponent<Props> = ({
-  viewer: { notifications },
+const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
+  viewer: { inPageNotifications },
 }) => {
-  const mutation = useMutation(UpdateNotificationSettingsMutation);
+  const mutation = useMutation(UpdateInPageNotificationSettingsMutation);
   const [showSuccess, setShowSuccess] = useState(false);
   const [showError, setShowError] = useState(false);
   const closeSuccess = useCallback(() => {
@@ -72,12 +70,12 @@ const NotificationSettingsContainer: FunctionComponent<Props> = ({
 
   return (
     <HorizontalGutter
-      data-testid="profile-account-notifications"
+      // data-testid="profile-account-notifications"
       className={CLASSES.emailNotifications.$root}
       container="section"
-      aria-labelledby="profile-account-notifications-emailNotifications-title"
+      // aria-labelledby="profile-account-notifications-emailNotifications-title"
     >
-      <Form initialValues={{ ...notifications }} onSubmit={onSubmit}>
+      <Form initialValues={{ ...inPageNotifications }} onSubmit={onSubmit}>
         {({
           handleSubmit,
           submitting,
@@ -88,31 +86,31 @@ const NotificationSettingsContainer: FunctionComponent<Props> = ({
           <form onSubmit={handleSubmit}>
             <HorizontalGutter>
               <HorizontalGutter>
-                <Localized id="profile-account-notifications-emailNotifications">
+                <Localized id="">
                   <h2
                     className={cn(
                       styles.title,
                       CLASSES.emailNotifications.heading
                     )}
-                    id="profile-account-notifications-emailNotifications-title"
+                    id=""
                   >
-                    Email Notifications
+                    In-page Notifications
                   </h2>
                 </Localized>
               </HorizontalGutter>
               <HorizontalGutter>
-                <Localized id="profile-account-notifications-receiveWhen">
+                <Localized id="">
                   <div
                     className={cn(
                       styles.header,
                       CLASSES.emailNotifications.label
                     )}
-                    id="profile-account-notifications-receiveWhen"
+                    id="profile-account-notifications-includeWhen"
                   >
-                    Receive notifications when:
+                    Include notifications when
                   </div>
                 </Localized>
-                <FieldSet aria-labelledby="profile-account-notifications-receiveWhen">
+                <FieldSet aria-labelledby="profile-account-notifications-includeWhen">
                   <FormField>
                     <Field name="onReply" type="checkbox">
                       {({ input }) => (
@@ -177,55 +175,52 @@ const NotificationSettingsContainer: FunctionComponent<Props> = ({
                       )}
                     </Field>
                   </FormField>
+                </FieldSet>
+              </HorizontalGutter>
+              <HorizontalGutter>
+                <Localized id="profile-account-notifications-interface">
+                  <div
+                    className={cn(
+                      styles.header,
+                      CLASSES.emailNotifications.label
+                    )}
+                    id="profile-account-notifications-interface"
+                  >
+                    Interface preferences
+                  </div>
+                </Localized>
+                <FieldSet aria-labelledby="profile-account-notifications-interface">
                   <FormField>
-                    <Localized id="profile-account-notifications-sendNotifications">
-                      <label
-                        className={cn(
-                          styles.header,
-                          styles.sendNotifications,
-                          CLASSES.emailNotifications.label
-                        )}
-                        htmlFor="digestFrequency"
-                      >
-                        Send Notifications:
-                      </label>
-                    </Localized>
-                    <FormSpy subscription={{ values: true }}>
-                      {({ values }) => (
-                        <Field name="digestFrequency">
-                          {({ input }) => (
-                            <div>
-                              <SelectField
-                                {...input}
-                                id={input.name}
-                                disabled={
-                                  !values.onReply &&
-                                  !values.onStaffReplies &&
-                                  !values.onFeatured &&
-                                  !values.onModeration
-                                }
-                              >
-                                <Localized id="profile-account-notifications-sendNotifications-immediately">
-                                  <Option value={GQLDIGEST_FREQUENCY.NONE}>
-                                    Immediately
-                                  </Option>
-                                </Localized>
-                                <Localized id="profile-account-notifications-sendNotifications-daily">
-                                  <Option value={GQLDIGEST_FREQUENCY.DAILY}>
-                                    Daily
-                                  </Option>
-                                </Localized>
-                                <Localized id="profile-account-notifications-sendNotifications-hourly">
-                                  <Option value={GQLDIGEST_FREQUENCY.HOURLY}>
-                                    Hourly
-                                  </Option>
-                                </Localized>
-                              </SelectField>
-                            </div>
-                          )}
-                        </Field>
+                    <Field name="includeCountInBadge" type="checkbox">
+                      {({ input }) => (
+                        <Localized id="">
+                          <CheckBox
+                            {...input}
+                            id={input.name}
+                            className={styles.checkBox}
+                            variant="streamBlue"
+                          >
+                            Include count in badge
+                          </CheckBox>
+                        </Localized>
                       )}
-                    </FormSpy>
+                    </Field>
+                  </FormField>
+                  <FormField>
+                    <Field name="bellRemainsVisible" type="checkbox">
+                      {({ input }) => (
+                        <Localized id="">
+                          <CheckBox
+                            {...input}
+                            id={input.name}
+                            className={styles.checkBox}
+                            variant="streamBlue"
+                          >
+                            Bell remains visible as I scroll
+                          </CheckBox>
+                        </Localized>
+                      )}
+                    </Field>
                   </FormField>
                 </FieldSet>
               </HorizontalGutter>
@@ -288,16 +283,17 @@ const NotificationSettingsContainer: FunctionComponent<Props> = ({
 
 const enhanced = withFragmentContainer<Props>({
   viewer: graphql`
-    fragment NotificationSettingsContainer_viewer on User {
-      notifications {
+    fragment InPageNotificationSettingsContainer_viewer on User {
+      inPageNotifications {
         onReply
         onFeatured
         onStaffReplies
         onModeration
-        digestFrequency
+        includeCountInBadge
+        bellRemainsVisible
       }
     }
   `,
-})(NotificationSettingsContainer);
+})(InPageNotificationSettingsContainer);
 
 export default enhanced;

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -9,6 +9,7 @@ import { InvalidRequestError } from "coral-framework/lib/errors";
 import { useMutation, withFragmentContainer } from "coral-framework/lib/relay";
 import CLASSES from "coral-stream/classes";
 import {
+  ActiveNotificationBellIcon,
   AlertTriangleIcon,
   CheckCircleIcon,
   SvgIcon,
@@ -16,6 +17,7 @@ import {
 import {
   CheckBox,
   FieldSet,
+  Flex,
   FormField,
   HorizontalGutter,
   HorizontalRule,
@@ -26,7 +28,7 @@ import { InPageNotificationSettingsContainer_viewer } from "coral-stream/__gener
 
 import UpdateInPageNotificationSettingsMutation from "./UpdateInPageNotificationSettingsMutation";
 
-import styles from "./NotificationSettingsContainer.css";
+import styles from "./InPageNotificationSettingsContainer.css";
 
 interface Props {
   viewer: InPageNotificationSettingsContainer_viewer;
@@ -84,7 +86,12 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
         }) => (
           <form onSubmit={handleSubmit}>
             <HorizontalGutter>
-              <HorizontalGutter>
+              <Flex alignItems="center">
+                <SvgIcon
+                  className={styles.bellIcon}
+                  size="md"
+                  Icon={ActiveNotificationBellIcon}
+                ></SvgIcon>
                 <Localized id="profile-account-notifications-inPageNotifications">
                   <h2
                     className={cn(styles.title, CLASSES.notifications.heading)}
@@ -93,7 +100,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                     In-page Notifications
                   </h2>
                 </Localized>
-              </HorizontalGutter>
+              </Flex>
               <HorizontalGutter>
                 <Localized id="profile-account-notifications-includeInPageWhen">
                   <div

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -72,6 +72,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
 
   return (
     <HorizontalGutter
+      data-testid="profile-account-inPageNotifications"
       className={CLASSES.notifications.$root}
       container="section"
       aria-labelledby="profile-account-notifications-inPageNotifications-title"

--- a/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
@@ -2,15 +2,17 @@ import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import { withFragmentContainer } from "coral-framework/lib/relay";
+import { GQLFEATURE_FLAG } from "coral-framework/schema";
 import { HorizontalGutter } from "coral-ui/components/v2";
 
 import { PreferencesContainer_settings } from "coral-stream/__generated__/PreferencesContainer_settings.graphql";
 import { PreferencesContainer_viewer } from "coral-stream/__generated__/PreferencesContainer_viewer.graphql";
 
 import BioContainer from "./BioContainer";
+import EmailNotificationSettingsContainer from "./EmailNotificationSettingsContainer";
 import IgnoreUserSettingsContainer from "./IgnoreUserSettingsContainer";
+import InPageNotificationSettingsContainer from "./InPageNotificationSettingsContainer";
 import MediaSettingsContainer from "./MediaSettingsContainer";
-import NotificationSettingsContainer from "./NotificationSettingsContainer";
 
 interface Props {
   viewer: PreferencesContainer_viewer;
@@ -18,10 +20,17 @@ interface Props {
 }
 
 const PreferencesContainer: FunctionComponent<Props> = (props) => {
+  const showInPageNotificationSettings = props.settings.featureFlags.includes(
+    GQLFEATURE_FLAG.Z_KEY
+  );
   return (
     <HorizontalGutter spacing={4}>
       <BioContainer viewer={props.viewer} settings={props.settings} />
-      <NotificationSettingsContainer viewer={props.viewer} />
+      {showInPageNotificationSettings ? (
+        <InPageNotificationSettingsContainer viewer={props.viewer} />
+      ) : (
+        <EmailNotificationSettingsContainer viewer={props.viewer} />
+      )}
       <MediaSettingsContainer viewer={props.viewer} settings={props.settings} />
       <IgnoreUserSettingsContainer viewer={props.viewer} />
     </HorizontalGutter>
@@ -31,13 +40,15 @@ const PreferencesContainer: FunctionComponent<Props> = (props) => {
 const enhanced = withFragmentContainer<Props>({
   settings: graphql`
     fragment PreferencesContainer_settings on Settings {
+      featureFlags
       ...MediaSettingsContainer_settings
       ...BioContainer_settings
     }
   `,
   viewer: graphql`
     fragment PreferencesContainer_viewer on User {
-      ...NotificationSettingsContainer_viewer
+      ...EmailNotificationSettingsContainer_viewer
+      ...InPageNotificationSettingsContainer_viewer
       ...IgnoreUserSettingsContainer_viewer
       ...MediaSettingsContainer_viewer
       ...BioContainer_viewer

--- a/client/src/core/client/stream/tabs/Profile/Preferences/UpdateEmailNotificationSettingsMutation.ts
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/UpdateEmailNotificationSettingsMutation.ts
@@ -1,0 +1,74 @@
+import { graphql } from "react-relay";
+import { Environment } from "relay-runtime";
+
+import { CoralContext } from "coral-framework/lib/bootstrap";
+import {
+  commitMutationPromiseNormalized,
+  createMutation,
+  MutationInput,
+} from "coral-framework/lib/relay";
+import { UpdateNotificationSettingsEvent } from "coral-stream/events";
+
+import { UpdateEmailNotificationSettingsMutation as MutationTypes } from "coral-stream/__generated__/UpdateEmailNotificationSettingsMutation.graphql";
+
+let clientMutationId = 0;
+
+const UpdateEmailNotificationSettingsMutation = createMutation(
+  "updateEmailNotificationSettings",
+  async (
+    environment: Environment,
+    input: MutationInput<MutationTypes>,
+    { eventEmitter }: CoralContext
+  ) => {
+    const updateEmailNotificationSettings =
+      UpdateNotificationSettingsEvent.begin(eventEmitter, {
+        digestFrequency: input.digestFrequency,
+        onFeatured: input.onFeatured,
+        onModeration: input.onModeration,
+        onStaffReplies: input.onStaffReplies,
+        onReply: input.onReply,
+      });
+    try {
+      const result = await commitMutationPromiseNormalized<MutationTypes>(
+        environment,
+        {
+          mutation: graphql`
+            mutation UpdateEmailNotificationSettingsMutation(
+              $input: UpdateEmailNotificationSettingsInput!
+            ) {
+              updateEmailNotificationSettings(input: $input) {
+                user {
+                  id
+                  notifications {
+                    onReply
+                    onFeatured
+                    onStaffReplies
+                    onModeration
+                    digestFrequency
+                  }
+                }
+                clientMutationId
+              }
+            }
+          `,
+          variables: {
+            input: {
+              ...input,
+              clientMutationId: (clientMutationId++).toString(),
+            },
+          },
+        }
+      );
+      updateEmailNotificationSettings.success();
+      return result;
+    } catch (error) {
+      updateEmailNotificationSettings.error({
+        message: error.message,
+        code: error.code,
+      });
+      throw error;
+    }
+  }
+);
+
+export default UpdateEmailNotificationSettingsMutation;

--- a/client/src/core/client/stream/tabs/Profile/Preferences/UpdateEmailNotificationSettingsMutation.ts
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/UpdateEmailNotificationSettingsMutation.ts
@@ -7,7 +7,7 @@ import {
   createMutation,
   MutationInput,
 } from "coral-framework/lib/relay";
-import { UpdateNotificationSettingsEvent } from "coral-stream/events";
+import { UpdateEmailNotificationSettingsEvent } from "coral-stream/events";
 
 import { UpdateEmailNotificationSettingsMutation as MutationTypes } from "coral-stream/__generated__/UpdateEmailNotificationSettingsMutation.graphql";
 
@@ -21,7 +21,7 @@ const UpdateEmailNotificationSettingsMutation = createMutation(
     { eventEmitter }: CoralContext
   ) => {
     const updateEmailNotificationSettings =
-      UpdateNotificationSettingsEvent.begin(eventEmitter, {
+      UpdateEmailNotificationSettingsEvent.begin(eventEmitter, {
         digestFrequency: input.digestFrequency,
         onFeatured: input.onFeatured,
         onModeration: input.onModeration,

--- a/client/src/core/client/stream/tabs/Profile/Preferences/UpdateInPageNotificationSettingsMutation.ts
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/UpdateInPageNotificationSettingsMutation.ts
@@ -9,44 +9,43 @@ import {
 } from "coral-framework/lib/relay";
 import { UpdateNotificationSettingsEvent } from "coral-stream/events";
 
-import { UpdateNotificationSettingsMutation as MutationTypes } from "coral-stream/__generated__/UpdateNotificationSettingsMutation.graphql";
+import { UpdateInPageNotificationSettingsMutation as MutationTypes } from "coral-stream/__generated__/UpdateInPageNotificationSettingsMutation.graphql";
 
 let clientMutationId = 0;
 
-const UpdateNotificationSettingsMutation = createMutation(
-  "updateNotificationSettings",
+const UpdateInPageNotificationSettingsMutation = createMutation(
+  "updateInPageNotificationSettings",
   async (
     environment: Environment,
     input: MutationInput<MutationTypes>,
     { eventEmitter }: CoralContext
   ) => {
-    const updateNofitificationSettings = UpdateNotificationSettingsEvent.begin(
-      eventEmitter,
-      {
-        digestFrequency: input.digestFrequency,
+    const updateInPageNotificationSettings =
+      // TODO: Update this event to specific in-page event
+      UpdateNotificationSettingsEvent.begin(eventEmitter, {
         onFeatured: input.onFeatured,
         onModeration: input.onModeration,
         onStaffReplies: input.onStaffReplies,
         onReply: input.onReply,
-      }
-    );
+      });
     try {
       const result = await commitMutationPromiseNormalized<MutationTypes>(
         environment,
         {
           mutation: graphql`
-            mutation UpdateNotificationSettingsMutation(
-              $input: UpdateNotificationSettingsInput!
+            mutation UpdateInPageNotificationSettingsMutation(
+              $input: UpdateInPageNotificationSettingsInput!
             ) {
-              updateNotificationSettings(input: $input) {
+              updateInPageNotificationSettings(input: $input) {
                 user {
                   id
-                  notifications {
+                  inPageNotifications {
                     onReply
                     onFeatured
                     onStaffReplies
                     onModeration
-                    digestFrequency
+                    includeCountInBadge
+                    bellRemainsVisible
                   }
                 }
                 clientMutationId
@@ -55,16 +54,21 @@ const UpdateNotificationSettingsMutation = createMutation(
           `,
           variables: {
             input: {
-              ...input,
+              onReply: input.onReply,
+              onFeatured: input.onFeatured,
+              onStaffReplies: input.onStaffReplies,
+              onModeration: input.onModeration,
+              includeCountInBadge: input.includeCountInBadge,
+              bellRemainsVisible: input.bellRemainsVisible,
               clientMutationId: (clientMutationId++).toString(),
             },
           },
         }
       );
-      updateNofitificationSettings.success();
+      updateInPageNotificationSettings.success();
       return result;
     } catch (error) {
-      updateNofitificationSettings.error({
+      updateInPageNotificationSettings.error({
         message: error.message,
         code: error.code,
       });
@@ -73,4 +77,4 @@ const UpdateNotificationSettingsMutation = createMutation(
   }
 );
 
-export default UpdateNotificationSettingsMutation;
+export default UpdateInPageNotificationSettingsMutation;

--- a/client/src/core/client/stream/tabs/Profile/Preferences/UpdateInPageNotificationSettingsMutation.ts
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/UpdateInPageNotificationSettingsMutation.ts
@@ -7,7 +7,7 @@ import {
   createMutation,
   MutationInput,
 } from "coral-framework/lib/relay";
-import { UpdateNotificationSettingsEvent } from "coral-stream/events";
+import { UpdateInPageNotificationSettingsEvent } from "coral-stream/events";
 
 import { UpdateInPageNotificationSettingsMutation as MutationTypes } from "coral-stream/__generated__/UpdateInPageNotificationSettingsMutation.graphql";
 
@@ -21,8 +21,7 @@ const UpdateInPageNotificationSettingsMutation = createMutation(
     { eventEmitter }: CoralContext
   ) => {
     const updateInPageNotificationSettings =
-      // TODO: Update this event to specific in-page event
-      UpdateNotificationSettingsEvent.begin(eventEmitter, {
+      UpdateInPageNotificationSettingsEvent.begin(eventEmitter, {
         onFeatured: input.onFeatured,
         onModeration: input.onModeration,
         onStaffReplies: input.onStaffReplies,

--- a/client/src/core/client/stream/test/fixtures.ts
+++ b/client/src/core/client/stream/test/fixtures.ts
@@ -237,6 +237,14 @@ export const baseUser = createFixture<GQLUser>({
     onFeatured: false,
     digestFrequency: GQLDIGEST_FREQUENCY.NONE,
   },
+  inPageNotifications: {
+    onReply: true,
+    onModeration: true,
+    onStaffReplies: true,
+    onFeatured: true,
+    includeCountInBadge: true,
+    bellRemainsVisible: true,
+  },
   ignoreable: true,
   profiles: [
     {

--- a/client/src/core/client/stream/test/fixtures.ts
+++ b/client/src/core/client/stream/test/fixtures.ts
@@ -240,7 +240,7 @@ export const baseUser = createFixture<GQLUser>({
   inPageNotifications: {
     onReply: true,
     onModeration: true,
-    onStaffReplies: true,
+    onStaffReplies: false,
     onFeatured: true,
     includeCountInBadge: true,
     bellRemainsVisible: true,

--- a/client/src/core/client/stream/test/profile/preferences.spec.tsx
+++ b/client/src/core/client/stream/test/profile/preferences.spec.tsx
@@ -146,7 +146,7 @@ it("render and update in-page notifications form", async () => {
         expectAndFail(inPageNotifications).toMatchObject({
           onReply: false,
           onFeatured: false,
-          onStaffReplies: false,
+          onStaffReplies: true,
           onModeration: false,
           includeCountInBadge: true,
           bellRemainsVisible: true,

--- a/client/src/core/client/stream/test/profile/preferences.spec.tsx
+++ b/client/src/core/client/stream/test/profile/preferences.spec.tsx
@@ -4,7 +4,7 @@ import { axe } from "jest-axe";
 import sinon from "sinon";
 
 import { pureMerge } from "coral-common/common/lib/utils";
-import { GQLResolver } from "coral-framework/schema";
+import { GQLFEATURE_FLAG, GQLResolver } from "coral-framework/schema";
 import {
   createResolversStub,
   CreateTestRendererParams,
@@ -46,8 +46,8 @@ async function createTestRenderer(
   };
 }
 
-it("render notifications form", async () => {
-  const updateNotificationSettings = sinon
+it("render email notifications form", async () => {
+  const updateEmailNotificationSettings = sinon
     .stub()
     .callsFake((_: any, { input: { clientMutationId, ...notifications } }) => {
       expectAndFail(notifications).toMatchObject({
@@ -68,7 +68,7 @@ it("render notifications form", async () => {
     await createTestRenderer({
       resolvers: createResolversStub<GQLResolver>({
         Mutation: {
-          updateNotificationSettings,
+          updateEmailNotificationSettings,
         },
       }),
     });
@@ -120,7 +120,110 @@ it("render notifications form", async () => {
 
   // Ensure that the mutation was called and that the save button is now
   // disabled.
-  expect(updateNotificationSettings.calledOnce).toEqual(true);
+  expect(updateEmailNotificationSettings.calledOnce).toEqual(true);
+  expect(save).toBeDisabled();
+
+  // Change a notification option.
+  userEvent.click(onReply);
+
+  // The save button should now be enabled.
+  expect(save).toBeEnabled();
+
+  // Change a notification back (making it pristine).
+  await act(async () => {
+    userEvent.click(onReply);
+  });
+
+  // The save button should now be disabled.
+  expect(save).toBeDisabled();
+});
+
+it("render and update in-page notifications form", async () => {
+  const updateInPageNotificationSettings = sinon
+    .stub()
+    .callsFake(
+      (_: any, { input: { clientMutationId, ...inPageNotifications } }) => {
+        expectAndFail(inPageNotifications).toMatchObject({
+          onReply: false,
+          onFeatured: false,
+          onStaffReplies: false,
+          onModeration: false,
+          includeCountInBadge: true,
+          bellRemainsVisible: true,
+        });
+        return {
+          user: pureMerge<typeof viewer>(viewer, {
+            inPageNotifications,
+          }),
+          clientMutationId,
+        };
+      }
+    );
+  await act(async () => {
+    await createTestRenderer({
+      resolvers: createResolversStub<GQLResolver>({
+        Mutation: {
+          updateInPageNotificationSettings,
+        },
+        Query: {
+          settings: () => {
+            return { ...settings, featureFlags: [GQLFEATURE_FLAG.Z_KEY] };
+          },
+          viewer: () => viewer,
+          stream: () => story,
+        },
+      }),
+    });
+  });
+
+  const container = await screen.findByTestId(
+    "profile-account-inPageNotifications"
+  );
+  expect(await axe(container)).toHaveNoViolations();
+
+  // Get the form fields.
+  const onReply = within(container).getByRole("checkbox", {
+    name: "My comment receives a reply",
+  });
+  const onStaffReplies = within(container).getByRole("checkbox", {
+    name: "A staff member replies to my comment",
+  });
+  const onModeration = within(container).getByRole("checkbox", {
+    name: "My pending comment has been reviewed",
+  });
+  const onFeatured = within(container).getByRole("checkbox", {
+    name: "My comment is featured",
+  });
+
+  expect(within(container).getByText("Interface preferences")).toBeVisible();
+  expect(
+    within(container).getByRole("checkbox", { name: "Include count in badge" })
+  ).toBeVisible();
+  expect(
+    within(container).getByRole("checkbox", {
+      name: "Bell remains visible as I scroll",
+    })
+  ).toBeVisible();
+
+  const save = within(container).getByRole("button", { name: "Update" });
+
+  // The save button should be disabled for unchanged fields.
+  expect(save).toBeDisabled();
+
+  // Disable the options.
+  userEvent.click(onReply);
+  userEvent.click(onStaffReplies);
+  userEvent.click(onModeration);
+  userEvent.click(onFeatured);
+
+  // Submit the form.
+  await act(async () => {
+    userEvent.click(save);
+  });
+
+  // Ensure that the mutation was called and that the save button is now
+  // disabled.
+  expect(updateInPageNotificationSettings.calledOnce).toEqual(true);
   expect(save).toBeDisabled();
 
   // Change a notification option.

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -724,6 +724,12 @@ profile-account-notifications-updated = Your notification settings have been upd
 profile-account-notifications-button = Update Notification Settings
 profile-account-notifications-button-update = Update
 
+profile-account-notifications-inPageNotifications = In-page Notifications
+profile-account-notifications-includeInPageWhen = Include notifications when
+profile-account-notifications-interfacePreferences = Interface preferences
+profile-account-notifications-includeCountInBadge = Include count in badge
+profile-account-notifications-bellRemainsVisible = Bell remains visible as I scroll
+
 ## Report Comment Popover
 comments-reportPopover =
   .description = A dialog for reporting comments

--- a/server/src/core/server/app/handlers/api/account/notifications.ts
+++ b/server/src/core/server/app/handlers/api/account/notifications.ts
@@ -1,6 +1,6 @@
 import { AppOptions } from "coral-server/app";
 import { RequestLimiter } from "coral-server/app/request/limiter";
-import { updateUserNotificationSettings } from "coral-server/models/user";
+import { updateUserEmailNotificationSettings } from "coral-server/models/user";
 import { decodeJWT, extractTokenFromRequest } from "coral-server/services/jwt";
 import { verifyUnsubscribeTokenString } from "coral-server/services/notifications/email/categories/unsubscribe";
 import { RequestHandler, TenantCoralRequest } from "coral-server/types/express";
@@ -123,7 +123,7 @@ export const unsubscribeHandler = ({
       );
 
       // Unsubscribe the user from all notification types.
-      await updateUserNotificationSettings(mongo, tenant.id, user.id, {
+      await updateUserEmailNotificationSettings(mongo, tenant.id, user.id, {
         onFeatured: false,
         onModeration: false,
         onReply: false,

--- a/server/src/core/server/graph/mutators/Users.ts
+++ b/server/src/core/server/graph/mutators/Users.ts
@@ -34,10 +34,11 @@ import {
   updateBio,
   updateEmail,
   updateEmailByID,
+  updateEmailNotificationSettings,
+  updateInPageNotificationSettings,
   updateMediaSettings,
   updateMembershipScopes,
   updateModerationScopes,
-  updateNotificationSettings,
   updatePassword,
   updateRole,
   updateSSOProfileID,
@@ -79,7 +80,8 @@ import {
   GQLSuspendUserInput,
   GQLUpdateBioInput,
   GQLUpdateEmailInput,
-  GQLUpdateNotificationSettingsInput,
+  GQLUpdateEmailNotificationSettingsInput,
+  GQLUpdateInPageNotificationSettingsInput,
   GQLUpdatePasswordInput,
   GQLUpdateSSOProfileIDInput,
   GQLUpdateUserAvatarInput,
@@ -244,10 +246,20 @@ export const Users = (ctx: GraphContext) => ({
       input.email,
       input.password
     ),
-  updateNotificationSettings: async (
-    input: WithoutMutationID<GQLUpdateNotificationSettingsInput>
+  updateEmailNotificationSettings: async (
+    input: WithoutMutationID<GQLUpdateEmailNotificationSettingsInput>
   ) =>
-    updateNotificationSettings(
+    updateEmailNotificationSettings(
+      ctx.mongo,
+      ctx.cache,
+      ctx.tenant,
+      ctx.user!,
+      input
+    ),
+  updateInPageNotificationSettings: async (
+    input: WithoutMutationID<GQLUpdateInPageNotificationSettingsInput>
+  ) =>
+    updateInPageNotificationSettings(
       ctx.mongo,
       ctx.cache,
       ctx.tenant,

--- a/server/src/core/server/graph/resolvers/Mutation.ts
+++ b/server/src/core/server/graph/resolvers/Mutation.ts
@@ -23,12 +23,20 @@ export const Mutation: Required<GQLMutationTypeResolver<void>> = {
     },
     clientMutationId: input.clientMutationId,
   }),
-  updateNotificationSettings: async (
+  updateEmailNotificationSettings: async (
     source,
     { input: { clientMutationId, ...input } },
     ctx
   ) => ({
-    user: await ctx.mutators.Users.updateNotificationSettings(input),
+    user: await ctx.mutators.Users.updateEmailNotificationSettings(input),
+    clientMutationId,
+  }),
+  updateInPageNotificationSettings: async (
+    source,
+    { input: { clientMutationId, ...input } },
+    ctx
+  ) => ({
+    user: await ctx.mutators.Users.updateInPageNotificationSettings(input),
     clientMutationId,
   }),
   updateUserMediaSettings: async (

--- a/server/src/core/server/graph/resolvers/User.ts
+++ b/server/src/core/server/graph/resolvers/User.ts
@@ -93,7 +93,7 @@ export const User: GQLUserTypeResolver<user.User> = {
       onReply: true,
       onFeatured: true,
       onModeration: true,
-      onStaffReplies: true,
+      onStaffReplies: false,
       includeCountInBadge: true,
       bellRemainsVisible: true,
     },

--- a/server/src/core/server/graph/resolvers/User.ts
+++ b/server/src/core/server/graph/resolvers/User.ts
@@ -88,6 +88,16 @@ export const User: GQLUserTypeResolver<user.User> = {
     // Get the Stories!
     return ctx.loaders.Stories.story.loadMany(results.map(({ _id }) => _id));
   },
+  inPageNotifications: ({
+    inPageNotifications = {
+      onReply: true,
+      onFeatured: true,
+      onModeration: true,
+      onStaffReplies: true,
+      includeCountInBadge: true,
+      bellRemainsVisible: true,
+    },
+  }) => inPageNotifications,
   mediaSettings: ({ mediaSettings = {} }) => mediaSettings,
   hasNewNotifications: ({ lastSeenNotificationDate }, input, ctx) => {
     if (!ctx.user) {

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -2902,23 +2902,23 @@ type UserMediaSettings {
 }
 
 """
-UserNotificationSettings stores the notification settings for a given User.
+UserEmailNotificationSettings stores the email notification settings for a given User.
 """
-type UserNotificationSettings {
+type UserEmailNotificationSettings {
   """
-  onReply, when true, will enable notifications to be sent to users that have
+  onReply, when true, will enable email notifications to be sent to users that have
   replies to their comments.
   """
   onReply: Boolean!
 
   """
-  onFeatured, when true, will enable notifications to be sent to users that have
+  onFeatured, when true, will enable email notifications to be sent to users that have
   their comment's featured.
   """
   onFeatured: Boolean!
 
   """
-  onStaffReplies when true, will enable notifications to be sent to users that
+  onStaffReplies when true, will enable email notifications to be sent to users that
   have a staff member reply to their comments. These notifications will
   supercede notifications that would have been sent for a basic reply
   notification.
@@ -2926,16 +2926,58 @@ type UserNotificationSettings {
   onStaffReplies: Boolean!
 
   """
-  onModeration when true, will enable notifications to be sent to users when a
+  onModeration when true, will enable email notifications to be sent to users when a
   comment that they wrote that was previously unpublished, becomes published due
   to a moderator action.
   """
   onModeration: Boolean!
 
   """
-  digestFrequency is the frequency to send notifications.
+  digestFrequency is the frequency to send email notifications.
   """
   digestFrequency: DIGEST_FREQUENCY!
+}
+
+"""
+UserInPageNotificationSettings stores the in-page notification settings for a given User.
+"""
+type UserInPageNotificationSettings {
+  """
+  onReply, when true, will enable in-page notifications to be sent to users that have
+  replies to their comments.
+  """
+  onReply: Boolean!
+
+  """
+  onFeatured, when true, will enable in-page notifications to be sent to users that have
+  their comment's featured.
+  """
+  onFeatured: Boolean!
+
+  """
+  onStaffReplies when true, will enable in-page notifications to be sent to users that
+  have a staff member reply to their comments. These notifications will
+  supercede notifications that would have been sent for a basic reply
+  notification.
+  """
+  onStaffReplies: Boolean!
+
+  """
+  onModeration when true, will enable in-page notifications to be sent to users when a
+  comment that they wrote that was previously unpublished, becomes published due
+  to a moderator action.
+  """
+  onModeration: Boolean!
+
+  """
+  includeCountInBadge when true, will show a count of new notifications in the interface
+  """
+  includeCountInBadge: Boolean!
+
+  """
+  bellRemainsVisible when true, will show the bell as visible when the user scrolls
+  """
+  bellRemainsVisible: Boolean!
 }
 
 """
@@ -3187,9 +3229,19 @@ type User {
     )
 
   """
-  notifications stores the notification settings for the given User.
+  notifications stores the email notification settings for the given User.
   """
-  notifications: UserNotificationSettings!
+  notifications: UserEmailNotificationSettings!
+    @auth(
+      userIDField: "id"
+      roles: [ADMIN]
+      permit: [SUSPENDED, BANNED, PENDING_DELETION, WARNED]
+    )
+
+  """
+  inPageNotifications stores the in-page notification settings for the given User.
+  """
+  inPageNotifications: UserInPageNotificationSettings!
     @auth(
       userIDField: "id"
       roles: [ADMIN]
@@ -5201,24 +5253,24 @@ type Query {
 ################################################################################
 
 ##################
-## updateNotificationSettings
+## updateEmailNotificationSettings
 ##################
 
-input UpdateNotificationSettingsInput {
+input UpdateEmailNotificationSettingsInput {
   """
-  onReply, when true, will enable notifications to be sent to users that have
+  onReply, when true, will enable email notifications to be sent to users that have
   replies to their comments.
   """
   onReply: Boolean
 
   """
-  onFeatured, when true, will enable notifications to be sent to users that have
+  onFeatured, when true, will enable email notifications to be sent to users that have
   their comment's featured.
   """
   onFeatured: Boolean
 
   """
-  onStaffReplies when true, will enable notifications to be sent to users that
+  onStaffReplies when true, will enable email notifications to be sent to users that
   have a staff member reply to their comments. These notifications will
   supercede notifications that would have been sent for a basic reply
   notification.
@@ -5226,14 +5278,14 @@ input UpdateNotificationSettingsInput {
   onStaffReplies: Boolean
 
   """
-  onModeration when true, will enable notifications to be sent to users when a
+  onModeration when true, will enable email notifications to be sent to users when a
   comment that they wrote that was previously unpublished, becomes published due
   to a moderator action.
   """
   onModeration: Boolean
 
   """
-  digestFrequency is the frequency to send notifications.
+  digestFrequency is the frequency to send email notifications.
   """
   digestFrequency: DIGEST_FREQUENCY
 
@@ -5243,7 +5295,67 @@ input UpdateNotificationSettingsInput {
   clientMutationId: String!
 }
 
-type UpdateNotificationSettingsPayload {
+type UpdateEmailNotificationSettingsPayload {
+  """
+  user is the possibly modified User.
+  """
+  user: User!
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+##################
+## updateInPageNotificationSettings
+##################
+
+input UpdateInPageNotificationSettingsInput {
+  """
+  onReply, when true, will enable in-page notifications to be sent to users that have
+  replies to their comments.
+  """
+  onReply: Boolean
+
+  """
+  onFeatured, when true, will enable in-page notifications to be sent to users that have
+  their comment's featured.
+  """
+  onFeatured: Boolean
+
+  """
+  onStaffReplies when true, will enable in-page notifications to be sent to users that
+  have a staff member reply to their comments. These notifications will
+  supercede notifications that would have been sent for a basic reply
+  notification.
+  """
+  onStaffReplies: Boolean
+
+  """
+  onModeration when true, will enable in-page notifications to be sent to users when a
+  comment that they wrote that was previously unpublished, becomes published due
+  to a moderator action.
+  """
+  onModeration: Boolean
+
+  """
+  includeCountInBadge when true, will show a count of new notifications in the interface
+  """
+  includeCountInBadge: Boolean
+
+  """
+  bellRemainsVisible when true, will show the bell as visible when the user scrolls
+  """
+  bellRemainsVisible: Boolean
+
+  """
+  clientMutationId is required for Relay support.
+  """
+  clientMutationId: String!
+}
+
+type UpdateInPageNotificationSettingsPayload {
   """
   user is the possibly modified User.
   """
@@ -10327,12 +10439,21 @@ type Mutation {
     @rate(seconds: 10)
 
   """
-  updateNotificationSettings can be used to update the notification settings for
+  updateEmailNotificationSettings can be used to update the email notification settings for
   the current logged in user.
   """
-  updateNotificationSettings(
-    input: UpdateNotificationSettingsInput!
-  ): UpdateNotificationSettingsPayload!
+  updateEmailNotificationSettings(
+    input: UpdateEmailNotificationSettingsInput!
+  ): UpdateEmailNotificationSettingsPayload!
+    @auth(permit: [SUSPENDED, BANNED, PENDING_DELETION, WARNED])
+
+  """
+  updateInPageNotificationSettings can be used to update the in-page notification settings for
+  the current logged in user.
+  """
+  updateInPageNotificationSettings(
+    input: UpdateInPageNotificationSettingsInput!
+  ): UpdateInPageNotificationSettingsPayload!
     @auth(permit: [SUSPENDED, BANNED, PENDING_DELETION, WARNED])
 
   """

--- a/server/src/core/server/models/user/user.ts
+++ b/server/src/core/server/models/user/user.ts
@@ -693,7 +693,7 @@ export async function findOrCreateUserInput(
       onReply: true,
       onFeatured: true,
       onModeration: true,
-      onStaffReplies: true,
+      onStaffReplies: false,
       includeCountInBadge: true,
       bellRemainsVisible: true,
     },

--- a/server/src/core/server/services/users/users.ts
+++ b/server/src/core/server/services/users/users.ts
@@ -58,13 +58,14 @@ import {
   createUserToken,
   deactivateUserToken,
   deleteModeratorNote,
+  EmailNotificationSettingsInput,
   findOrCreateUser,
   FindOrCreateUserInput,
   ignoreUser,
+  InPageNotificationSettingsInput,
   linkUsers,
   mergeUserMembershipScopes,
   mergeUserSiteModerationScopes,
-  NotificationSettingsInput,
   premodUser,
   PremodUserReason,
   pullUserMembershipScopes,
@@ -89,11 +90,12 @@ import {
   updateUserAvatar,
   updateUserBio,
   updateUserEmail,
+  updateUserEmailNotificationSettings,
+  updateUserInPageNotificationSettings,
   updateUserMediaSettings,
   UpdateUserMediaSettingsInput,
   updateUserMembershipScopes,
   updateUserModerationScopes,
-  updateUserNotificationSettings,
   updateUserPassword,
   updateUserRole,
   updateUserSSOProfileID,
@@ -2326,14 +2328,36 @@ export async function requestUserCommentsDownload(
   return downloadUrl;
 }
 
-export async function updateNotificationSettings(
+export async function updateEmailNotificationSettings(
   mongo: MongoContext,
   cache: DataCache,
   tenant: Tenant,
   user: User,
-  settings: NotificationSettingsInput
+  settings: EmailNotificationSettingsInput
 ) {
-  const updatedUser = await updateUserNotificationSettings(
+  const updatedUser = await updateUserEmailNotificationSettings(
+    mongo,
+    tenant.id,
+    user.id,
+    settings
+  );
+
+  const cacheAvailable = await cache.available(tenant.id);
+  if (cacheAvailable) {
+    await cache.users.update(updatedUser);
+  }
+
+  return updatedUser;
+}
+
+export async function updateInPageNotificationSettings(
+  mongo: MongoContext,
+  cache: DataCache,
+  tenant: Tenant,
+  user: User,
+  settings: InPageNotificationSettingsInput
+) {
+  const updatedUser = await updateUserInPageNotificationSettings(
     mongo,
     tenant.id,
     user.id,

--- a/server/src/core/server/test/fixtures.ts
+++ b/server/src/core/server/test/fixtures.ts
@@ -241,7 +241,7 @@ export const createUserFixture = (defaults: Defaults<User> = {}): User => {
       onReply: true,
       onFeatured: true,
       onModeration: true,
-      onStaffReplies: true,
+      onStaffReplies: false,
       includeCountInBadge: true,
       bellRemainsVisible: true,
     },

--- a/server/src/core/server/test/fixtures.ts
+++ b/server/src/core/server/test/fixtures.ts
@@ -237,6 +237,14 @@ export const createUserFixture = (defaults: Defaults<User> = {}): User => {
       onStaffReplies: false,
       digestFrequency: GQLDIGEST_FREQUENCY.NONE,
     },
+    inPageNotifications: {
+      onReply: true,
+      onFeatured: true,
+      onModeration: true,
+      onStaffReplies: true,
+      includeCountInBadge: true,
+      bellRemainsVisible: true,
+    },
     digests: [],
     hasDigests: false,
     status: {


### PR DESCRIPTION
## What does this PR do?

These changes update the user preferences to show in-page notification settings (with provided defaults) as well as the ability for the user to update their in-page notification settings.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

These changes add `inPageNotifications` to the user model with 6 initial configuration fields. They also add in the `updateUserInPageNotificationSettings` mutation to change a user's `inPageNotifications` settings.

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Make sure that `Z_KEY` isn't enabled. See that email notification settings are showing in user preferences for a logged-in user. See that they can still be updated, etc., as expected.

Enable `Z_KEY`. See that now in-page notification settings are showing. You should see an active bell icon beside the `In-page notifications` header in user preferences. Enable/disable the settings and see that the changes are correctly persisted to the user model for the commenter you are logged in as.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
