### PR TITLE
[CORL-3042]: Fix feature/unfeature counts bug

### DIFF
--- a/server/src/core/server/graph/mutators/Comments.ts
+++ b/server/src/core/server/graph/mutators/Comments.ts
@@ -248,7 +248,7 @@ export const Comments = (ctx: GraphContext) => ({
     // Validate that this user is allowed to moderate this comment
     await validateUserModerationScopes(ctx, ctx.user!, { commentID });
 
-    const comment = await addTag(
+    const { comment, alreadyFeatured } = await addTag(
       ctx.mongo,
       ctx.tenant,
       commentID,
@@ -257,6 +257,11 @@ export const Comments = (ctx: GraphContext) => ({
       GQLTAG.FEATURED,
       ctx.now
     );
+
+    // The comment is already featured; we don't need to feature again
+    if (alreadyFeatured) {
+      return comment;
+    }
 
     if (comment.status !== GQLCOMMENT_STATUS.APPROVED) {
       await approveComment(
@@ -319,12 +324,17 @@ export const Comments = (ctx: GraphContext) => ({
     // Validate that this user is allowed to moderate this comment
     await validateUserModerationScopes(ctx, ctx.user!, { commentID });
 
-    const comment = await removeTag(
+    const { comment, alreadyUnfeatured } = await removeTag(
       ctx.mongo,
       ctx.tenant,
       commentID,
       GQLTAG.FEATURED
     );
+
+    // The comment is already unfeatured; we don't need to unfeature again
+    if (alreadyUnfeatured) {
+      return comment;
+    }
 
     // If the tag is sucessfully removed (the tag is
     // no longer present on the comment) then we can

--- a/server/src/core/server/services/comments/comments.ts
+++ b/server/src/core/server/services/comments/comments.ts
@@ -91,14 +91,17 @@ export async function addTag(
 
   // Check to see if this tag is already on this comment.
   if (comment.tags.some(({ type }) => type === tagType)) {
-    return comment;
+    return { comment, alreadyFeatured: true };
   }
 
-  return addCommentTag(mongo, tenant.id, commentID, {
-    type: tagType,
-    createdBy: user.id,
-    createdAt: now,
-  });
+  return {
+    comment: await addCommentTag(mongo, tenant.id, commentID, {
+      type: tagType,
+      createdBy: user.id,
+      createdAt: now,
+    }),
+    alreadyFeatured: false,
+  };
 }
 
 /**
@@ -126,10 +129,13 @@ export async function removeTag(
 
   // Check to see if this tag is even on this comment.
   if (comment.tags.every(({ type }) => type !== tagType)) {
-    return comment;
+    return { comment, alreadyUnfeatured: true };
   }
 
-  return removeCommentTag(mongo, tenant.id, commentID, tagType);
+  return {
+    comment: await removeCommentTag(mongo, tenant.id, commentID, tagType),
+    alreadyUnfeatured: false,
+  };
 }
 
 /**

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -49,7 +49,12 @@ const stripTag = async (
     return comment;
   }
 
-  const tagResult = await removeTag(mongo, tenant, comment.id, tag);
+  const { comment: tagResult } = await removeTag(
+    mongo,
+    tenant,
+    comment.id,
+    tag
+  );
 
   await updateTagCommentCounts(
     tenant.id,


### PR DESCRIPTION
## What does this PR do?

These changes address a bug where if a comment was featured or unfeatured multiple times by different mods, then the count would be updated. This makes it so that if a comment is already featured and someone tries to feature it again, it doesn't update counts or otherwise re-feature. If a comment is already unfeatured and someone tries to unfeature it again, it doesn't update counts or otherwise re-unfeature.

## These changes will impact:

- [x] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/main/server/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/tree/main/server/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## Does this PR introduce any new environment variables or feature flags?

<!--

In this section, note any new environment variables or feature flags introduced. Ensure you add them to internal documentation when your PR is merged.

-->

## If any indexes were added, were they added to `INDEXES.md`?

<!--

In this section, check the `INDEXES.md` at the root of the repo and make sure you have added and commited any index changes necessary for this PR to be deployed. If you added any entries, indicate `Yes`in this section and list the index entries you added here.

-->

## How do I test this PR?

See that if you have two windows open with different logged-in mods, and each mod features the same comment, the count will increment by 1 in both cases and it will say "featured". On refresh, the count will still be the same and the comment will still be featured.

See that if you have two windows open with different logged-in mods, and each mod unfeatures the same comment, the count will decrement by 1 in both cases and it will say "unfeatured". On refresh, the count will still be the same and the comment will be unfeatured.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
