### PR TITLE
Create a live icon for showing notification counts

### DIFF
--- a/client/src/core/client/stream/App/TabBar.css
+++ b/client/src/core/client/stream/App/TabBar.css
@@ -11,7 +11,6 @@
 
 .notificationsIcon {
   height: var(--spacing-5);
-  overflow: hidden;
 }
 
 .notificationsIconSmall {
@@ -20,7 +19,6 @@
      using this, allowing all the other padding styles to
      remain consistent */
   height: 22.5px;
-  overflow: hidden;
 }
 
 .notificationsTabSmall {

--- a/client/src/core/client/stream/App/TabBar.tsx
+++ b/client/src/core/client/stream/App/TabBar.tsx
@@ -4,13 +4,12 @@ import React, { FunctionComponent } from "react";
 import useGetMessage from "coral-framework/lib/i18n/useGetMessage";
 import { GQLSTORY_MODE } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
+import { LiveBellIcon } from "coral-stream/tabs/Notifications/LiveBellIcon";
 import {
-  ActiveNotificationBellIcon,
   CogIcon,
   ConversationChatIcon,
   ConversationQuestionWarningIcon,
   MessagesBubbleSquareIcon,
-  NotificationBellIcon,
   RatingStarIcon,
   SingleNeutralCircleIcon,
   SvgIcon,
@@ -185,14 +184,7 @@ const AppTabBar: FunctionComponent<Props> = (props) => {
                   [styles.notificationsIconSmall]: !matches,
                 })}
               >
-                <SvgIcon
-                  size="md"
-                  Icon={
-                    props.hasNewNotifications
-                      ? ActiveNotificationBellIcon
-                      : NotificationBellIcon
-                  }
-                ></SvgIcon>
+                <LiveBellIcon size="md" />
               </div>
             </Tab>
           )}

--- a/client/src/core/client/stream/classes.ts
+++ b/client/src/core/client/stream/classes.ts
@@ -1066,6 +1066,12 @@ const CLASSES = {
     label: "coral coral-emailNotifications-label coral-notifications-label",
     updateButton:
       "coral coral-emailNotifications-updateButton coral-notifications-updateButton",
+
+    live: {
+      root: "coral coral-notifications-live-root",
+      icon: "coral coral-notifications-live-icon",
+      counter: "coral coral-notifications-live-counter",
+    },
   },
 
   mediaPreferences: {
@@ -1160,14 +1166,6 @@ const CLASSES = {
   },
 
   icon: "coral coral-icon",
-
-  notifications: {
-    live: {
-      root: "coral coral-notifications-live-root",
-      icon: "coral coral-notifications-live-icon",
-      counter: "coral coral-notifications-live-counter",
-    },
-  },
 };
 
 export default CLASSES;

--- a/client/src/core/client/stream/classes.ts
+++ b/client/src/core/client/stream/classes.ts
@@ -1158,6 +1158,14 @@ const CLASSES = {
   },
 
   icon: "coral coral-icon",
+
+  notifications: {
+    live: {
+      root: "coral coral-notifications-live-root",
+      icon: "coral coral-notifications-live-icon",
+      counter: "coral coral-notifications-live-counter",
+    },
+  },
 };
 
 export default CLASSES;

--- a/client/src/core/client/stream/local/initLocalState.ts
+++ b/client/src/core/client/stream/local/initLocalState.ts
@@ -21,6 +21,7 @@ interface ResolvedConfig {
   readonly featureFlags: string[];
   readonly flattenReplies?: boolean | null;
   readonly dsaFeaturesEnabled?: boolean;
+  readonly notificationsPollRate: number;
 }
 
 async function resolveConfig(
@@ -55,11 +56,14 @@ async function resolveConfig(
       flattenReplies: settings.flattenReplies,
       featureFlags: settings.featureFlags,
       dsaFeaturesEnabled: settings.dsa.enabled ?? false,
+      notificationsPollRate: 3000,
     } as ResolvedConfig;
   }
+
   return {
     featureFlags: [],
     flattenReplies: false,
+    notificationsPollRate: 3000,
   };
 }
 
@@ -93,10 +97,8 @@ export const createInitLocalState: (options: Options) => InitLocalState =
       ...rest,
     });
 
-    const { featureFlags, flattenReplies } = await resolveConfig(
-      environment,
-      staticConfig
-    );
+    const { featureFlags, flattenReplies, notificationsPollRate } =
+      await resolveConfig(environment, staticConfig);
 
     const commentsOrderBy =
       (await context.localStorage.getItem(COMMENTS_ORDER_BY)) ||
@@ -182,5 +184,7 @@ export const createInitLocalState: (options: Options) => InitLocalState =
 
       localRecord.setValue(null, "hasNewNotifications");
       localRecord.setValue(0, "notificationCount");
+
+      localRecord.setValue(notificationsPollRate, "notificationsPollRate");
     });
   };

--- a/client/src/core/client/stream/local/initLocalState.ts
+++ b/client/src/core/client/stream/local/initLocalState.ts
@@ -184,7 +184,6 @@ export const createInitLocalState: (options: Options) => InitLocalState =
 
       localRecord.setValue(null, "hasNewNotifications");
       localRecord.setValue(0, "notificationCount");
-
       localRecord.setValue(notificationsPollRate, "notificationsPollRate");
     });
   };

--- a/client/src/core/client/stream/local/initLocalState.ts
+++ b/client/src/core/client/stream/local/initLocalState.ts
@@ -181,5 +181,6 @@ export const createInitLocalState: (options: Options) => InitLocalState =
       localRecord.setValue(dsaFeaturesEnabled, "dsaFeaturesEnabled");
 
       localRecord.setValue(null, "hasNewNotifications");
+      localRecord.setValue(0, "notificationCount");
     });
   };

--- a/client/src/core/client/stream/local/local.graphql
+++ b/client/src/core/client/stream/local/local.graphql
@@ -131,4 +131,5 @@ extend type Local {
   dsaFeaturesEnabled: Boolean
 
   hasNewNotifications: Boolean
+  notificationCount: Int
 }

--- a/client/src/core/client/stream/local/local.graphql
+++ b/client/src/core/client/stream/local/local.graphql
@@ -132,4 +132,5 @@ extend type Local {
 
   hasNewNotifications: Boolean
   notificationCount: Int
+  notificationsPollRate: Int!
 }

--- a/client/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -30,6 +30,7 @@ import {
   SetCommentsOrderByEvent,
   SetCommentsTabEvent,
 } from "coral-stream/events";
+import useLiveNotificationsPolling from "coral-stream/tabs/Notifications/polling/useLiveNotificationsPolling";
 import { RatingStarIcon, SvgIcon } from "coral-ui/components/icons";
 import {
   AriaInfo,
@@ -75,8 +76,6 @@ import useCommentCountEvent from "./useCommentCountEvent";
 import ViewersWatchingContainer from "./ViewersWatchingContainer";
 import WarningContainer from "./Warning";
 
-import { LiveBellIcon } from "coral-stream/tabs/Notifications/LiveBellIcon";
-import useLiveNotificationsPolling from "coral-stream/tabs/Notifications/polling/useLiveNotificationsPolling";
 import styles from "./StreamContainer.css";
 
 interface Props {
@@ -278,8 +277,6 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
             />
           </div>
         </Flex>
-        <LiveBellIcon size="lg" />
-        <LiveBellIcon size="md" />
         <AnnouncementContainer settings={props.settings} />
         {props.viewer && (
           <StreamDeletionRequestCalloutContainer viewer={props.viewer} />

--- a/client/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -75,6 +75,7 @@ import useCommentCountEvent from "./useCommentCountEvent";
 import ViewersWatchingContainer from "./ViewersWatchingContainer";
 import WarningContainer from "./Warning";
 
+import useLiveNotificationsPolling from "coral-stream/tabs/Notifications/polling/useLiveNotificationsPolling";
 import styles from "./StreamContainer.css";
 
 interface Props {
@@ -131,6 +132,8 @@ const AccessibleCounter: FunctionComponent<PropTypesOf<typeof Counter>> = (
 );
 
 export const StreamContainer: FunctionComponent<Props> = (props) => {
+  useLiveNotificationsPolling(props.viewer?.id);
+
   const emitSetCommentsTabEvent = useViewerEvent(SetCommentsTabEvent);
   const emitSetCommentsOrderByEvent = useViewerEvent(SetCommentsOrderByEvent);
   const { localStorage, browserInfo } = useCoralContext();

--- a/client/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -75,6 +75,7 @@ import useCommentCountEvent from "./useCommentCountEvent";
 import ViewersWatchingContainer from "./ViewersWatchingContainer";
 import WarningContainer from "./Warning";
 
+import { LiveBellIcon } from "coral-stream/tabs/Notifications/LiveBellIcon";
 import useLiveNotificationsPolling from "coral-stream/tabs/Notifications/polling/useLiveNotificationsPolling";
 import styles from "./StreamContainer.css";
 
@@ -277,6 +278,7 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
             />
           </div>
         </Flex>
+        <LiveBellIcon />
         <AnnouncementContainer settings={props.settings} />
         {props.viewer && (
           <StreamDeletionRequestCalloutContainer viewer={props.viewer} />

--- a/client/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/StreamContainer.tsx
@@ -278,7 +278,8 @@ export const StreamContainer: FunctionComponent<Props> = (props) => {
             />
           </div>
         </Flex>
-        <LiveBellIcon />
+        <LiveBellIcon size="lg" />
+        <LiveBellIcon size="md" />
         <AnnouncementContainer settings={props.settings} />
         {props.viewer && (
           <StreamDeletionRequestCalloutContainer viewer={props.viewer} />

--- a/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.css
+++ b/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.css
@@ -1,32 +1,57 @@
-.icon {
+.root {
   position: relative;
+}
 
+.rootMed {
   width: 20px;
-  height: 16px;
+  height: 18px;
+}
+
+.rootLarge {
+  width: 24px;
+  height: 20px;
 }
 
 .counter {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-regular);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: var(--palette-primary-500);
+  color: var(--palette-text-000);
+}
+
+.counterMed {
+  position: absolute;
+  top: -2px;
+  left: 11px;
+
+  font-size: 8px;
+
+  min-width: 8px;
+
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 2px;
+  padding-right: 2px;
+  border-radius: 12px;
+}
+
+.counterLarge {
   position: absolute;
   top: -2px;
   left: 14px;
 
+  font-size: 10px;
+
   min-width: 8px;
-  min-height: 8px;
 
   padding-top: 2px;
   padding-bottom: 2px;
   padding-left: var(--spacing-1);
   padding-right: var(--spacing-1);
   border-radius: 12px;
-
-  background-color: var(--palette-primary-500);
-  color: var(--palette-text-000);
-
-  font-family: var(--font-family-primary);
-  font-weight: var(--font-weight-regular);
-  font-size: 10px;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
 }

--- a/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.css
+++ b/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.css
@@ -1,0 +1,32 @@
+.icon {
+  position: relative;
+
+  width: 20px;
+  height: 16px;
+}
+
+.counter {
+  position: absolute;
+  top: -2px;
+  left: 14px;
+
+  min-width: 8px;
+  min-height: 8px;
+
+  padding-top: 2px;
+  padding-bottom: 2px;
+  padding-left: var(--spacing-1);
+  padding-right: var(--spacing-1);
+  border-radius: 12px;
+
+  background-color: var(--palette-primary-500);
+  color: var(--palette-text-000);
+
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-regular);
+  font-size: 10px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
@@ -1,8 +1,12 @@
+import cn from "classnames";
 import { useLocal } from "coral-framework/lib/relay";
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useMemo } from "react";
 import { graphql } from "relay-runtime";
 
 import { LiveBellIconLocal } from "coral-stream/__generated__/LiveBellIconLocal.graphql";
+import CLASSES from "coral-stream/classes";
+import { NotificationBellIcon, SvgIcon } from "coral-ui/components/icons";
+import styles from "./LiveBellIcon.css";
 
 interface Props {
   userID?: string;
@@ -15,5 +19,35 @@ export const LiveBellIcon: FunctionComponent<Props> = () => {
     }
   `);
 
-  return <div>{notificationCount ?? 0}</div>;
+  const count = useMemo(() => {
+    if (!notificationCount) {
+      return "";
+    }
+
+    if (notificationCount <= 0) {
+      return "";
+    }
+
+    if (notificationCount > 20) {
+      return "20+";
+    }
+
+    return `${notificationCount}`;
+  }, [notificationCount]);
+
+  return (
+    <div className={cn(CLASSES.notifications.live.root, styles.icon)}>
+      <SvgIcon
+        className={CLASSES.notifications.live.icon}
+        strokeWidth="thin"
+        size="lg"
+        Icon={NotificationBellIcon}
+      />
+      {notificationCount && notificationCount > 0 && (
+        <div className={cn(CLASSES.notifications.live.counter, styles.counter)}>
+          {count}
+        </div>
+      )}
+    </div>
+  );
 };

--- a/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
@@ -10,9 +10,10 @@ import styles from "./LiveBellIcon.css";
 
 interface Props {
   userID?: string;
+  size?: "md" | "lg";
 }
 
-export const LiveBellIcon: FunctionComponent<Props> = () => {
+export const LiveBellIcon: FunctionComponent<Props> = ({ size = "md" }) => {
   const [{ notificationCount }] = useLocal<LiveBellIconLocal>(graphql`
     fragment LiveBellIconLocal on Local {
       notificationCount
@@ -36,15 +37,25 @@ export const LiveBellIcon: FunctionComponent<Props> = () => {
   }, [notificationCount]);
 
   return (
-    <div className={cn(CLASSES.notifications.live.root, styles.icon)}>
+    <div
+      className={cn(CLASSES.notifications.live.root, styles.root, {
+        [styles.rootMed]: size === "md",
+        [styles.rootLarge]: size === "lg",
+      })}
+    >
       <SvgIcon
         className={CLASSES.notifications.live.icon}
         strokeWidth="thin"
-        size="lg"
+        size={size}
         Icon={NotificationBellIcon}
       />
       {count !== "" && (
-        <div className={cn(CLASSES.notifications.live.counter, styles.counter)}>
+        <div
+          className={cn(CLASSES.notifications.live.counter, styles.counter, {
+            [styles.counterMed]: size === "md",
+            [styles.counterLarge]: size === "lg",
+          })}
+        >
           {count}
         </div>
       )}

--- a/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
@@ -22,11 +22,11 @@ export const LiveBellIcon: FunctionComponent<Props> = ({ size = "md" }) => {
 
   const count = useMemo(() => {
     if (!notificationCount) {
-      return "";
+      return null;
     }
 
     if (notificationCount <= 0) {
-      return "";
+      return null;
     }
 
     if (notificationCount > 20) {
@@ -49,7 +49,7 @@ export const LiveBellIcon: FunctionComponent<Props> = ({ size = "md" }) => {
         size={size}
         Icon={NotificationBellIcon}
       />
-      {count !== "" && (
+      {count && (
         <div
           className={cn(CLASSES.notifications.live.counter, styles.counter, {
             [styles.counterMed]: size === "md",

--- a/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
@@ -43,7 +43,7 @@ export const LiveBellIcon: FunctionComponent<Props> = () => {
         size="lg"
         Icon={NotificationBellIcon}
       />
-      {notificationCount && notificationCount > 0 && (
+      {count !== "" && (
         <div className={cn(CLASSES.notifications.live.counter, styles.counter)}>
           {count}
         </div>

--- a/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/LiveBellIcon.tsx
@@ -1,0 +1,19 @@
+import { useLocal } from "coral-framework/lib/relay";
+import React, { FunctionComponent } from "react";
+import { graphql } from "relay-runtime";
+
+import { LiveBellIconLocal } from "coral-stream/__generated__/LiveBellIconLocal.graphql";
+
+interface Props {
+  userID?: string;
+}
+
+export const LiveBellIcon: FunctionComponent<Props> = () => {
+  const [{ notificationCount }] = useLocal<LiveBellIconLocal>(graphql`
+    fragment LiveBellIconLocal on Local {
+      notificationCount
+    }
+  `);
+
+  return <div>{notificationCount ?? 0}</div>;
+};

--- a/client/src/core/client/stream/tabs/Notifications/polling/useLiveNotificationsPolling.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/polling/useLiveNotificationsPolling.tsx
@@ -1,0 +1,69 @@
+import { useFetch, useLocal } from "coral-framework/lib/relay";
+
+import { Environment, graphql } from "relay-runtime";
+
+import {
+  createFetch,
+  fetchQuery,
+  FetchVariables,
+} from "coral-framework/lib/relay";
+
+import { useLiveNotificationsPollingLocal } from "coral-stream/__generated__/useLiveNotificationsPollingLocal.graphql";
+import { useLiveNotificationsPollingQuery } from "coral-stream/__generated__/useLiveNotificationsPollingQuery.graphql";
+import { useCallback, useEffect } from "react";
+
+export const FetchLiveNotificationsCached = createFetch(
+  "useLiveNotificationsPollingQuery",
+  (
+    environment: Environment,
+    variables: FetchVariables<useLiveNotificationsPollingQuery>
+  ) => {
+    return fetchQuery<useLiveNotificationsPollingQuery>(
+      environment,
+      graphql`
+        query useLiveNotificationsPollingQuery($userID: ID!) {
+          notificationCount(userID: $userID)
+        }
+      `,
+      variables,
+      { force: true }
+    );
+  }
+);
+
+export default function useLiveNotificationsPolling(
+  userID?: string,
+  intervalMs = 3000
+) {
+  const fetchNotifications = useFetch(FetchLiveNotificationsCached);
+
+  const [, setLocal] = useLocal<useLiveNotificationsPollingLocal>(graphql`
+    fragment useLiveNotificationsPollingLocal on Local {
+      notificationCount
+    }
+  `);
+
+  const updater = useCallback(async () => {
+    if (!userID) {
+      return;
+    }
+
+    const result = await fetchNotifications({ userID });
+
+    if (
+      result.notificationCount === undefined ||
+      result.notificationCount === null
+    ) {
+      setLocal({ notificationCount: 0 });
+    }
+
+    setLocal({ notificationCount: result.notificationCount });
+  }, [fetchNotifications, setLocal, userID]);
+
+  useEffect(() => {
+    const interval = setInterval(updater, intervalMs);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [intervalMs, updater]);
+}

--- a/client/src/core/client/stream/tabs/Notifications/polling/useLiveNotificationsPolling.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/polling/useLiveNotificationsPolling.tsx
@@ -31,17 +31,16 @@ export const FetchLiveNotificationsCached = createFetch(
   }
 );
 
-export default function useLiveNotificationsPolling(
-  userID?: string,
-  intervalMs = 3000
-) {
+export default function useLiveNotificationsPolling(userID?: string) {
   const fetchNotifications = useFetch(FetchLiveNotificationsCached);
 
-  const [, setLocal] = useLocal<useLiveNotificationsPollingLocal>(graphql`
-    fragment useLiveNotificationsPollingLocal on Local {
-      notificationCount
-    }
-  `);
+  const [{ notificationsPollRate }, setLocal] =
+    useLocal<useLiveNotificationsPollingLocal>(graphql`
+      fragment useLiveNotificationsPollingLocal on Local {
+        notificationCount
+        notificationsPollRate
+      }
+    `);
 
   const updater = useCallback(async () => {
     if (!userID) {
@@ -61,9 +60,10 @@ export default function useLiveNotificationsPolling(
   }, [fetchNotifications, setLocal, userID]);
 
   useEffect(() => {
-    const interval = setInterval(updater, intervalMs);
+    const interval = setInterval(updater, notificationsPollRate);
+
     return () => {
       clearInterval(interval);
     };
-  }, [intervalMs, updater]);
+  }, [notificationsPollRate, updater]);
 }

--- a/client/src/core/client/stream/test/create.tsx
+++ b/client/src/core/client/stream/test/create.tsx
@@ -41,6 +41,8 @@ const initLocalState = (
     params.initLocalState(localRecord, source, environment);
   }
   localRecord.setValue(false, "hasNewNotifications");
+  localRecord.setValue(0, "notificationCount");
+  localRecord.setValue(3000, "notificationsPollRate");
 };
 
 export default function create(params: CreateTestRendererParams<GQLResolver>) {

--- a/client/src/core/client/ui/components/icons/SvgIcon/SvgIcon.css
+++ b/client/src/core/client/ui/components/icons/SvgIcon/SvgIcon.css
@@ -59,6 +59,10 @@
   stroke: var(--palette-primary-500);
 }
 
+.strokeWidthThin svg {
+  stroke-width: 1;
+}
+
 .strokeWidthRegular svg {
   stroke-width: 2;
 }

--- a/client/src/core/client/ui/components/icons/SvgIcon/SvgIcon.tsx
+++ b/client/src/core/client/ui/components/icons/SvgIcon/SvgIcon.tsx
@@ -8,7 +8,7 @@ export interface SvgIconProps {
   Icon: ComponentType;
   size?: "xxs" | "xs" | "sm" | "md" | "lg" | "xl";
   color?: "stream" | "teal" | "tealLight" | "error" | "success";
-  strokeWidth?: "regular" | "bold" | "semibold";
+  strokeWidth?: "thin" | "regular" | "bold" | "semibold";
   filled?: "none" | "currentColor" | "teal" | "tealLight";
   className?: string;
   /** Internal: Forwarded Ref */
@@ -66,6 +66,9 @@ const SvgIcon: React.FC<SvgIconProps> = ({
 
   let strokeWidthStyle;
   switch (strokeWidth) {
+    case "thin":
+      strokeWidthStyle = styles.strokeWidthThin;
+      break;
     case "regular":
       strokeWidthStyle = styles.strokeWidthRegular;
       break;

--- a/config/lib/config.ts
+++ b/config/lib/config.ts
@@ -79,7 +79,7 @@ export interface StaticConfig {
   dsaFeaturesEnabled?: boolean;
 
   /**
-   * notificationsPollRate determins the polling rate at which the client checks
+   * notificationsPollRate determines the polling rate at which the client checks
    * for notifications updates (milliseconds).
    */
   notificationsPollRate: number;

--- a/config/lib/config.ts
+++ b/config/lib/config.ts
@@ -77,6 +77,12 @@ export interface StaticConfig {
    * moderation and illegal reporting are enabled on the tenant.
    */
   dsaFeaturesEnabled?: boolean;
+
+  /**
+   * notificationsPollRate determins the polling rate at which the client checks
+   * for notifications updates (milliseconds).
+   */
+  notificationsPollRate: number;
 }
 
 export interface EmbedBootstrapConfig {

--- a/server/src/core/server/app/router/index.ts
+++ b/server/src/core/server/app/router/index.ts
@@ -36,6 +36,9 @@ export async function createRouter(app: AppOptions, options: RouterOptions) {
     forceAdminLocalAuth: app.config.get("force_admin_local_auth"),
     archivingEnabled: isArchivingEnabled(app.config),
     autoArchiveOlderThanMs: app.config.get("auto_archive_older_than"),
+
+    // convert from micro (μs) to milliseconds via divide by 1000
+    notificationsPollRate: app.config.get("notifications_poll_rate") / 1000,
   };
 
   // If sentry is configured, then add it's config to the config.

--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -493,6 +493,12 @@ const config = convict({
     default: ms("86400s"),
     env: "REDIS_CACHE_EXPIRY",
   },
+  notifications_poll_rate: {
+    doc: "rate at which live notification updates should poll client side.",
+    format: "ms",
+    default: ms("3000s"),
+    env: "NOTIFICATIONS_POLL_RATE",
+  },
 });
 
 export type Config = typeof config;

--- a/server/src/core/server/graph/resolvers/Query.ts
+++ b/server/src/core/server/graph/resolvers/Query.ts
@@ -100,6 +100,13 @@ export const Query: Required<GQLQueryTypeResolver<void>> = {
     return connection;
   },
   notificationCount: async (source, { userID }, ctx) => {
+    if (!ctx.user) {
+      return 0;
+    }
+    if (ctx.user.id !== userID) {
+      return 0;
+    }
+
     return ctx.notifications.retrieveCount(ctx.tenant.id, userID);
   },
 };

--- a/server/src/core/server/graph/resolvers/Query.ts
+++ b/server/src/core/server/graph/resolvers/Query.ts
@@ -95,6 +95,8 @@ export const Query: Required<GQLQueryTypeResolver<void>> = {
       connection.nodes.map((n) => n.createdAt)
     );
 
+    await ctx.notifications.clearCountForUser(ctx.tenant.id, ownerID);
+
     return connection;
   },
   notificationCount: async (source, { userID }, ctx) => {

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -5245,7 +5245,6 @@ type Query {
   ): NotificationsConnection!
 
   notificationCount(userID: ID!): Int
-    @auth(userIDField: "userID", roles: [ADMIN, MODERATOR])
 }
 
 ################################################################################

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -172,6 +172,11 @@ export class InternalNotificationContext {
     await this.redis.incr(key);
   }
 
+  public async clearCountForUser(tenantID: string, userID: string) {
+    const key = this.computeCountKey(tenantID, userID);
+    await this.redis.del(key);
+  }
+
   public async retrieveCount(tenantID: string, userID: string) {
     const key = this.computeCountKey(tenantID, userID);
 


### PR DESCRIPTION
## What does this PR do?

Adds a live icon that shows notification counts.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None, piggybacks on existing `notificationCount(...)` query.

## Does this PR introduce any new environment variables or feature flags?

Adds the `notificationsPollRate` env var.

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- post a comment
- have another account reply to it
- see the little bell icon increment a count

## Were any tests migrated to React Testing Library?

None

## How do we deploy this PR?

Merge into epic branch and release that.
