### PR TITLE
[CORL-3060]: In-page notifications configuration

### DIFF
--- a/client/src/core/client/admin/routes/Configure/sections/General/GeneralConfigContainer.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/General/GeneralConfigContainer.tsx
@@ -21,6 +21,7 @@ import FeaturedByConfig from "./FeaturedByConfig";
 import FlairBadgeConfigContainer from "./FlairBadgeConfigContainer";
 import FlattenRepliesConfig from "./FlattenRepliesConfig";
 import GuidelinesConfig from "./GuidelinesConfig";
+import InPageNotificationsConfig from "./InPageNotificationsConfig";
 import LocaleConfig from "./LocaleConfig";
 import MediaLinksConfig from "./MediaLinksConfig";
 import MemberBioConfig from "./MemberBioConfig";
@@ -50,6 +51,7 @@ const GeneralConfigContainer: React.FunctionComponent<Props> = ({
     >
       <LocaleConfig disabled={submitting} />
       <DSAConfigContainer disabled={submitting} settings={settings} />
+      <InPageNotificationsConfig disabled={submitting} />
       <FlattenRepliesConfig disabled={submitting} />
       <SitewideCommentingConfig disabled={submitting} />
       <AnnouncementConfigContainer disabled={submitting} settings={settings} />
@@ -75,6 +77,7 @@ const enhanced = withFragmentContainer<Props>({
     fragment GeneralConfigContainer_settings on Settings {
       ...AnnouncementConfigContainer_settings
       ...FlattenRepliesConfig_formValues @relay(mask: false)
+      ...InPageNotificationsConfig_formValues @relay(mask: false)
       ...LocaleConfig_formValues @relay(mask: false)
       ...DSAConfigContainer_formValues @relay(mask: false)
       ...DSAConfigContainer_settings

--- a/client/src/core/client/admin/routes/Configure/sections/General/InPageNotificationsConfig.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/General/InPageNotificationsConfig.tsx
@@ -1,0 +1,54 @@
+import { Localized } from "@fluent/react/compat";
+import React, { FunctionComponent } from "react";
+import { graphql } from "react-relay";
+
+import {
+  FieldSet,
+  FormField,
+  FormFieldDescription,
+  Label,
+} from "coral-ui/components/v2";
+
+import ConfigBox from "../../ConfigBox";
+import Header from "../../Header";
+import OnOffField from "../../OnOffField";
+
+// eslint-disable-next-line no-unused-expressions
+graphql`
+  fragment InPageNotificationsConfig_formValues on Settings {
+    inPageNotifications {
+      enabled
+    }
+  }
+`;
+
+interface Props {
+  disabled: boolean;
+}
+
+const InPageNotificationsConfig: FunctionComponent<Props> = ({ disabled }) => (
+  <ConfigBox
+    title={
+      <Localized id="configure-general-inPageNotifications-title">
+        <Header container="h2">In-page notifications</Header>
+      </Localized>
+    }
+  >
+    <Localized id="configure-general-inPageNotifications-explanation">
+      <FormFieldDescription>
+        Add notifications to Coral. When enabled, commenters can receive
+        notifications when they receive all replies, replies only from members
+        of your team, when a Pending comment is published. Commenters can
+        disable visual notification indicators in their Profile preferences.
+      </FormFieldDescription>
+    </Localized>
+    <FormField container={<FieldSet />}>
+      <Localized id="configure-general-inPageNotifications-enabled">
+        <Label component="legend">In-page notifications enabled</Label>
+      </Localized>
+      <OnOffField name="inPageNotifications.enabled" disabled={disabled} />
+    </FormField>
+  </ConfigBox>
+);
+
+export default InPageNotificationsConfig;

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -118,7 +118,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                         <Localized id="profile-account-notifications-onReply">
                           <CheckBox
                             {...input}
-                            id={input.name}
+                            id={`${input.name}-inPage`}
                             className={styles.checkBox}
                             variant="streamBlue"
                           >
@@ -134,7 +134,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                         <Localized id="profile-account-notifications-onFeatured">
                           <CheckBox
                             {...input}
-                            id={input.name}
+                            id={`${input.name}-inPage`}
                             className={styles.checkBox}
                             variant="streamBlue"
                           >
@@ -150,7 +150,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                         <Localized id="profile-account-notifications-onStaffReplies">
                           <CheckBox
                             {...input}
-                            id={input.name}
+                            id={`${input.name}-inPage`}
                             className={styles.checkBox}
                             variant="streamBlue"
                           >
@@ -166,7 +166,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                         <Localized id="profile-account-notifications-onModeration">
                           <CheckBox
                             {...input}
-                            id={input.name}
+                            id={`${input.name}-inPage`}
                             className={styles.checkBox}
                             variant="streamBlue"
                           >
@@ -194,7 +194,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                         <Localized id="profile-account-notifications-includeCountInBadge">
                           <CheckBox
                             {...input}
-                            id={input.name}
+                            id={`${input.name}-inPage`}
                             className={styles.checkBox}
                             variant="streamBlue"
                           >
@@ -210,7 +210,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                         <Localized id="profile-account-notifications-bellRemainsVisible">
                           <CheckBox
                             {...input}
-                            id={input.name}
+                            id={`${input.name}-inPage`}
                             className={styles.checkBox}
                             variant="streamBlue"
                           >

--- a/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 const PreferencesContainer: FunctionComponent<Props> = (props) => {
   const showInPageNotificationSettings =
-    !!props.settings.inPageNotifications.enabled;
+    !!props.settings.inPageNotifications?.enabled;
   return (
     <HorizontalGutter spacing={4}>
       <BioContainer viewer={props.viewer} settings={props.settings} />

--- a/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
 import { withFragmentContainer } from "coral-framework/lib/relay";
-import { GQLFEATURE_FLAG } from "coral-framework/schema";
 import { HorizontalGutter } from "coral-ui/components/v2";
 
 import { PreferencesContainer_settings } from "coral-stream/__generated__/PreferencesContainer_settings.graphql";
@@ -20,17 +19,15 @@ interface Props {
 }
 
 const PreferencesContainer: FunctionComponent<Props> = (props) => {
-  const showInPageNotificationSettings = props.settings.featureFlags.includes(
-    GQLFEATURE_FLAG.Z_KEY
-  );
+  const showInPageNotificationSettings =
+    !!props.settings.inPageNotifications.enabled;
   return (
     <HorizontalGutter spacing={4}>
       <BioContainer viewer={props.viewer} settings={props.settings} />
-      {showInPageNotificationSettings ? (
+      {showInPageNotificationSettings && (
         <InPageNotificationSettingsContainer viewer={props.viewer} />
-      ) : (
-        <EmailNotificationSettingsContainer viewer={props.viewer} />
       )}
+      <EmailNotificationSettingsContainer viewer={props.viewer} />
       <MediaSettingsContainer viewer={props.viewer} settings={props.settings} />
       <IgnoreUserSettingsContainer viewer={props.viewer} />
     </HorizontalGutter>
@@ -40,7 +37,9 @@ const PreferencesContainer: FunctionComponent<Props> = (props) => {
 const enhanced = withFragmentContainer<Props>({
   settings: graphql`
     fragment PreferencesContainer_settings on Settings {
-      featureFlags
+      inPageNotifications {
+        enabled
+      }
       ...MediaSettingsContainer_settings
       ...BioContainer_settings
     }

--- a/client/src/core/client/stream/test/fixtures.ts
+++ b/client/src/core/client/stream/test/fixtures.ts
@@ -142,6 +142,9 @@ export const settings = createFixture<GQLSettings>({
       method: GQLDSA_METHOD_OF_REDRESS.NONE,
     },
   },
+  inPageNotifications: {
+    enabled: false,
+  },
 });
 
 export const site = createFixtures<GQLSite>([

--- a/client/src/core/client/stream/test/profile/preferences.spec.tsx
+++ b/client/src/core/client/stream/test/profile/preferences.spec.tsx
@@ -4,7 +4,7 @@ import { axe } from "jest-axe";
 import sinon from "sinon";
 
 import { pureMerge } from "coral-common/common/lib/utils";
-import { GQLFEATURE_FLAG, GQLResolver } from "coral-framework/schema";
+import { GQLResolver } from "coral-framework/schema";
 import {
   createResolversStub,
   CreateTestRendererParams,
@@ -167,7 +167,7 @@ it("render and update in-page notifications form", async () => {
         },
         Query: {
           settings: () => {
-            return { ...settings, featureFlags: [GQLFEATURE_FLAG.Z_KEY] };
+            return { ...settings, inPageNotifications: { enabled: true } };
           },
           viewer: () => viewer,
           stream: () => story,

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -539,6 +539,14 @@ configure-general-flairBadge-table-preview = Preview
 configure-general-flairBadge-table-deleteButton = <icon></icon> Delete
 configure-general-flairBadge-table-empty = No custom flair added for this site
 
+#### In-page notifications
+configure-general-inPageNotifications-title = In-page notifications
+configure-general-inPageNotifications-explanation = Add notifications to Coral. When enabled, commenters can receive
+  notifications when they receive all replies, replies only from members
+  of your team, when a Pending comment is published. Commenters can
+  disable visual notification indicators in their Profile preferences.
+configure-general-inPageNotifications-enabled = In-page notifications enabled
+
 #### Closed Stream Message
 configure-general-closedStreamMessage-title = Closed comment stream message
 configure-general-closedStreamMessage-explanation = Write a message to appear when a story is closed for commenting.

--- a/server/src/core/server/graph/resolvers/Settings.ts
+++ b/server/src/core/server/graph/resolvers/Settings.ts
@@ -79,4 +79,6 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
     return flairBadges;
   },
   dsa: ({ dsa = defaultDSAConfiguration }) => dsa,
+  inPageNotifications: ({ inPageNotifications = { enabled: false } }) =>
+    inPageNotifications,
 };

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -1981,6 +1981,10 @@ type PremoderateEmailAddressConfiguration {
   tooManyPeriods: TooManyPeriodsConfig
 }
 
+type InPageNotificationsConfiguration {
+  enabled: Boolean
+}
+
 input TooManyPeriodsConfigInput {
   """
   enabled decides whether the too many periods config is enabled or not.
@@ -2346,6 +2350,12 @@ type Settings @cacheControl(maxAge: 30) {
   addresses at sign up and premoderating them according to various rules.
   """
   premoderateEmailAddress: PremoderateEmailAddressConfiguration
+
+  """
+  inPageNotifcations is the configuration for in-page notifications, including
+  whether it's enabled as an option for commenters.
+  """
+  inPageNotifications: InPageNotificationsConfiguration
 }
 
 ################################################################################
@@ -6372,6 +6382,16 @@ input RTEConfigurationInput {
 }
 
 """
+InPageNotificationsConfigurationInput specifies the configuration for in-page notifications.
+"""
+input InPageNotificationsConfigurationInput {
+  """
+  enabled when true turns on in-page notifications as an option for commenters.
+  """
+  enabled: Boolean
+}
+
+"""
 FlairBadgeConfigurationInput specifies the configuration for flair badges,
 including whether they are enabled and their image urls.
 """
@@ -6642,6 +6662,11 @@ input SettingsInput {
   addresses at sign up and premoderating them according to various rules.
   """
   premoderateEmailAddress: PremoderateEmailAddressConfigurationInput
+
+  """
+  inPageNotifications specifies the configuration for in-page notifications
+  """
+  inPageNotifications: InPageNotificationsConfigurationInput
 }
 
 """

--- a/server/src/core/server/models/settings/settings.ts
+++ b/server/src/core/server/models/settings/settings.ts
@@ -314,6 +314,10 @@ export interface TopCommenterConfig {
   enabled?: boolean;
 }
 
+export interface InPageNotificationsConfig {
+  enabled?: boolean;
+}
+
 export interface PremoderateEmailAddressConfig {
   tooManyPeriods?: {
     enabled?: boolean;
@@ -436,6 +440,12 @@ export type Settings = GlobalModerationSettings &
      * with comments featured within the last 10 days are top commenters
      */
     topCommenter?: TopCommenterConfig;
+
+    /**
+     * inPageNotifications specifies whether or not in-page notifications are enabled
+     * as an option for commenters
+     */
+    inPageNotifications?: InPageNotificationsConfig;
   };
 
 export const defaultRTEConfiguration: RTEConfiguration = {

--- a/server/src/core/server/models/tenant/tenant.ts
+++ b/server/src/core/server/models/tenant/tenant.ts
@@ -303,6 +303,9 @@ export const combineTenantDefaultsAndInput = (
     topCommenter: {
       enabled: false,
     },
+    inPageNotifications: {
+      enabled: false,
+    },
   };
 
   // Create the new Tenant by merging it together with the defaults.

--- a/server/src/core/server/test/fixtures.ts
+++ b/server/src/core/server/test/fixtures.ts
@@ -195,6 +195,9 @@ export const createTenantFixture = (
       allowReplies: true,
       oEmbedAllowedOrigins: [],
     },
+    inPageNotifications: {
+      enabled: false,
+    },
   };
 
   return merge(fixture, defaults);


### PR DESCRIPTION
## What does this PR do?

These changes add in-page notifications configuration (enabled or not) to admin general configuration. This is used to determine whether users see preferences for in-page notifications in their Stream profile preferences.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

This adds `inPageNotifications` to settings.

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can go into admin configuration -> general and enable/disable in-page notifications. See that it updates as expected. See that when it's enabled, a user sees the option to adjust their in-page notification preferences.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
