### PR TITLE
[Notifications] Increment notificationCount based on user in-page notification preferences

### DIFF
--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -210,16 +210,28 @@ export class InternalNotificationContext {
     if (result.notification && result.attempted) {
       // Determine whether to increment notificationCount based on user's in-page notification settings
       let shouldIncrementCount = true;
-      if ((type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED) && !targetUser.inPageNotifications.onModeration) {
+      if (
+        type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED &&
+        !targetUser.inPageNotifications.onModeration
+      ) {
         shouldIncrementCount = false;
       }
-      if ((type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED) && !targetUser.inPageNotifications.onFeatured) {
+      if (
+        type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED &&
+        !targetUser.inPageNotifications.onFeatured
+      ) {
         shouldIncrementCount = false;
       }
-      if ((type === GQLNOTIFICATION_TYPE.REPLY) && !targetUser.inPageNotifications.onReply) {
-          shouldIncrementCount = false;
+      if (
+        type === GQLNOTIFICATION_TYPE.REPLY &&
+        !targetUser.inPageNotifications.onReply
+      ) {
+        shouldIncrementCount = false;
       }
-      if ((type === GQLNOTIFICATION_TYPE.REPLY_STAFF) && !targetUser.inPageNotifications.onStaffReplies) {
+      if (
+        type === GQLNOTIFICATION_TYPE.REPLY_STAFF &&
+        !targetUser.inPageNotifications.onStaffReplies
+      ) {
         shouldIncrementCount = false;
       }
       if (shouldIncrementCount) {

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -208,7 +208,23 @@ export class InternalNotificationContext {
     }
 
     if (result.notification && result.attempted) {
-      await this.incrementCountForUser(tenantID, targetUserID);
+      // Determine whether to increment notificationCount based on user's in-page notification settings
+      let shouldIncrementCount = true;
+      if ((type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED) && !targetUser.inPageNotifications.onModeration) {
+        shouldIncrementCount = false;
+      }
+      if ((type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED) && !targetUser.inPageNotifications.onFeatured) {
+        shouldIncrementCount = false;
+      }
+      if ((type === GQLNOTIFICATION_TYPE.REPLY) && !targetUser.inPageNotifications.onReply) {
+          shouldIncrementCount = false;
+      }
+      if ((type === GQLNOTIFICATION_TYPE.REPLY_STAFF) && !targetUser.inPageNotifications.onStaffReplies) {
+        shouldIncrementCount = false;
+      }
+      if (shouldIncrementCount) {
+        await this.incrementCountForUser(tenantID, targetUserID);
+      }
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

 Increment notificationCount based on user in-page notification preferences.
 
## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Enable/disable these settings for a user in `My profile` > `Preferences` and see that you do/don't get a notification count showing up on the bell tab.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
