### PR TITLE
[CORL-3051] Fix padding on user drawer badges

### DIFF
--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserBadgesContainer.css
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserBadgesContainer.css
@@ -1,3 +1,7 @@
+.badgeContainer {
+  padding-right: var(--spacing-1);
+}
+
 .badge {
   padding-top: var(--spacing-1);
   padding-bottom: var(--spacing-1);

--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserBadgesContainer.css
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserBadgesContainer.css
@@ -1,0 +1,4 @@
+.badge {
+  padding-top: var(--spacing-1);
+  padding-bottom: var(--spacing-1);
+}

--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserBadgesContainer.tsx
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserBadgesContainer.tsx
@@ -21,13 +21,14 @@ const UserBadgesContainer: FunctionComponent<Props> = ({ user }) => {
   return (
     <>
       {user.badges.map((badge) => (
-        <Tag
-          key={badge}
-          color="dark"
-          className={cn(styles.badge, CLASSES.comment.topBar.userBadge)}
-        >
-          {badge}
-        </Tag>
+        <span key={badge} className={styles.badgeContainer}>
+          <Tag
+            color="dark"
+            className={cn(styles.badge, CLASSES.comment.topBar.userBadge)}
+          >
+            {badge}
+          </Tag>
+        </span>
       ))}
     </>
   );

--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserBadgesContainer.tsx
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserBadgesContainer.tsx
@@ -1,3 +1,4 @@
+import cn from "classnames";
 import React, { FunctionComponent } from "react";
 import { graphql } from "react-relay";
 
@@ -6,6 +7,8 @@ import CLASSES from "coral-stream/classes";
 import { Tag } from "coral-ui/components/v2";
 
 import { UserBadgesContainer_user as UserData } from "coral-admin/__generated__/UserBadgesContainer_user.graphql";
+
+import styles from "./UserBadgesContainer.css";
 
 interface Props {
   user: UserData;
@@ -21,7 +24,7 @@ const UserBadgesContainer: FunctionComponent<Props> = ({ user }) => {
         <Tag
           key={badge}
           color="dark"
-          className={CLASSES.comment.topBar.userBadge}
+          className={cn(styles.badge, CLASSES.comment.topBar.userBadge)}
         >
           {badge}
         </Tag>

--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerContainer.tsx
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserHistoryDrawerContainer.tsx
@@ -90,7 +90,7 @@ const UserHistoryDrawerContainer: FunctionComponent<Props> = ({
       <HorizontalGutter spacing={4}>
         <HorizontalGutter spacing={3}>
           <HorizontalGutter spacing={2}>
-            <Flex className={styles.username} spacing={2}>
+            <Flex alignItems="center" className={styles.username} spacing={2}>
               {user.username ? (
                 <span>{user.username}</span>
               ) : (


### PR DESCRIPTION
## What does this PR do?

- Add padding to user drawer badges (next to user name)
- Align badges with the user name text

<img width="484" alt="image" src="https://github.com/coralproject/talk/assets/5751504/9096ec00-27f7-45ae-aec3-bfb77b6c97a4">

## These changes will impact:

- [ ] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- modify a user's badges with Mongo compass (or similar)
- sign in as an admin/mod and find the user under `Admin > Community`
- open the user's drawer (click on username)
- see the badges listed beside their name
- see that they are padded and aligned nicely with the user name

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
