### PR TITLE
[CORL-3048] allow users who are pending deletion to view their profile without being logged out

### DIFF
--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -4291,7 +4291,7 @@ type Comment @cacheControl(maxAge: 5) {
   reactions(
     first: Int = 10 @constraint(max: 50)
     after: Cursor
-  ): ReactionsConnection! @auth
+  ): ReactionsConnection! @auth(permit: [PENDING_DELETION])
 
   """
   flags is the actual Flags that were left by the Users or the system.


### PR DESCRIPTION
## What does this PR do?

- Update schema permissions to allow users who are pending deletion to view their profile without being logged out
- Does so by allowing users who are pending deletion to view comment reactions

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds a `permit: [PENDING_DELETION]` to `reactions` field on the `Comment` schema type.

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- enable account deletion under `Admin > Configure > Authentication > Commenter account management features`
- create a new user
- post a few comments as this user
- request to delete your account with the new user
- refresh the page
- attempt to navigate to `My Profile` tab
- see that user is able to view their profile and not immediately logged out

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
