### PR TITLE
[CORL-3049]: add x.com to media links

### DIFF
--- a/common/lib/helpers/findMediaLinks.spec.ts
+++ b/common/lib/helpers/findMediaLinks.spec.ts
@@ -9,13 +9,14 @@ it("can detect links", () => {
     "https://www.youtube.com/watch?v=o3LJPaYBqgU",
     "https://youtube.com/watch?v=o3LJPaYBqgU",
     "https://youtu.be/o3LJPaYBqgU",
-    // Twitter
+    // Twitter / X
     "http://twitter.com/coralproject/status/1280903734478987265",
     "http://www.twitter.com/coralproject/status/1280903734478987265",
     "http://mobile.twitter.com/coralproject/status/1280903734478987265",
     "https://twitter.com/coralproject/status/1280903734478987265",
     "https://www.twitter.com/coralproject/status/1280903734478987265",
     "https://mobile.twitter.com/coralproject/status/1280903734478987265",
+    "https://x.com/voxdotcom/status/1753419545681727640",
   ];
 
   for (const body of bodies) {

--- a/common/lib/helpers/findMediaLinks.ts
+++ b/common/lib/helpers/findMediaLinks.ts
@@ -38,6 +38,11 @@ const patterns: ReadonlyArray<{ type: MediaType; pattern: RegExp }> = [
     pattern:
       /(https?:\/\/)?(www\.|mobile\.)?(twitter\.com\/[a-zA-z0-9]+\/status\/[0-9]+)/g,
   },
+  {
+    type: "twitter",
+    pattern:
+      /(https?:\/\/)?(www\.|mobile\.)?(x\.com\/[a-zA-z0-9]+\/status\/[0-9]+)/g,
+  },
 ];
 
 export function findMediaLinks(body: string): MediaLink[] {


### PR DESCRIPTION
## What does this PR do?

Adds `x.com` to media links that are supported as media embeds when included in a comment.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test these changes by grabbing an X post url using the share button. This will be an `x.com` url. Paste it into the comment box. See that you are asked if you would like to add the post to the end of your comment.

Also confirm that `twitter.com` urls are still supported and work as expected, too.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
