### PR TITLE
Finnish translations: Fix notification email footer issues

### DIFF
--- a/server/src/core/server/locales/fi-FI/email.ftl
+++ b/server/src/core/server/locales/fi-FI/email.ftl
@@ -13,7 +13,7 @@ email-template-accountNotificationForgotPassword =
 email-subject-accountNotificationBan = Sinut on asetettu kirjoituskieltoon
 email-template-accountNotificationBan =
   { $customMessage }<br /><br />
-  Jos kielto on mielestäsi aiheeton, ota yhteyttä ylläpitoon 
+  Jos kielto on mielestäsi aiheeton, ota yhteyttä ylläpitoon
   <a data-l10n-name="organizationContactEmail" >{ $organizationContactEmail }</a>.
 
 email-subject-accountNotificationPasswordChange = Salasanasi on päivitetty
@@ -32,16 +32,16 @@ email-template-accountNotificationUpdateUsername =
 email-subject-accountNotificationSuspend = Sinut on asetettu kirjoituskieltoon
 email-template-accountNotificationSuspend =
   { $customMessage }<br/><br/>
-  Jos kielto on mielestäsi aiheeton, ota yhteyttä ylläpitoon 
+  Jos kielto on mielestäsi aiheeton, ota yhteyttä ylläpitoon
   <a data-l10n-name="organizationContactEmail" >{ $organizationContactEmail }</a>.
 
 email-subject-accountNotificationConfirmEmail = Vahvista sähköpostiosoite
 email-template-accountNotificationConfirmEmail =
   Hei { $username },<br/><br/>
-  Vahvista sähköpostiosoite { $organizationName } keskustelun kirjoittajatiliisi 
+  Vahvista sähköpostiosoite { $organizationName } keskustelun kirjoittajatiliisi
   <a data-l10n-name="confirmYourEmail">klikkaamalla tätä linkkiä</a><br/><br/>.
   Jos et ole äskettäin luonut tiliä { $organizationName } keskusteluun,
-  voit jättää tämän viestin huomiotta.  
+  voit jättää tämän viestin huomiotta.
 
 email-subject-accountNotificationInvite = Kutsu Coral ryhmään
 email-template-accountNotificationInvite =
@@ -84,8 +84,8 @@ email-template-accountNotificationDeleteRequestCompleted =
 # Notification
 
 email-footer-notification =
-  <br /><br />Ystävällisin terveisin<br />$organizationName<br /><br />
-  <i>Etkö enää halua tällaisia viestejä? <a data-l10n-name="unsubscribeLink">Paina tästä</a></i>
+  <br /><br />Ystävällisin terveisin<br />{ $organizationName }<br /><br />Etkö enää halua tällaisia viestejä? <a data-l10n-name="unsubscribeLink">Paina tästä</a>
+
 ## On Reply
 
 email-subject-notificationOnReply = Kirjoittamaasi kommenttiin on vastattu
@@ -108,7 +108,7 @@ email-template-notificationOnStaffReply =
 
 email-subject-notificationOnCommentApproved = Kommenttisi on julkaistu
 email-template-notificationOnCommentApproved =
-  Kiitos lähettämästäsi kommentista! Olemme nyt tarkastaneet kommenttisi ja 
+  Kiitos lähettämästäsi kommentista! Olemme nyt tarkastaneet kommenttisi ja
   julkaisseet sen <a data-l10n-name="commentPermalink">täällä</a>.
 
 ## On Comment Rejected

--- a/server/src/core/server/locales/fi-FI/email.ftl
+++ b/server/src/core/server/locales/fi-FI/email.ftl
@@ -84,7 +84,7 @@ email-template-accountNotificationDeleteRequestCompleted =
 # Notification
 
 email-footer-notification =
-  <br /><br />Ystävällisin terveisin<br />{ $organizationName }<br /><br />Etkö enää halua tällaisia viestejä? <a data-l10n-name="unsubscribeLink">Paina tästä</a>
+  <br /><br />Ystävällisin terveisin<br /><a data-l10n-name="organizationLink">{ $organizationName }</a><br /><br />Etkö enää halua tällaisia viestejä? <a data-l10n-name="unsubscribeLink">Paina tästä</a>
 
 ## On Reply
 


### PR DESCRIPTION
## What does this PR do?

Finnish language notification emails are missing both the organization name and the unsubscribe link. As described in issue https://github.com/coralproject/talk/issues/4522.

This PR fixes both of those issues. Also, this PR removes unnecessary trailing white-space from some lines in the translations file.

| Before | After |
|--------|--------|
| ![email_footer](https://github.com/coralproject/talk/assets/1115979/9580fce2-a84a-4413-ba3c-f8d4d05b34be) | ![email fix](https://github.com/coralproject/talk/assets/1115979/21a4e26c-d751-488d-8a58-faf4bc3c34ce) | 
