### PR TITLE
[CORL-3035] Create a notifications expiry index (TTL)

### DIFF
--- a/INDEXES.md
+++ b/INDEXES.md
@@ -6,6 +6,16 @@ The goal of this document is to date-mark the indexes you add to support the cha
 
 If you are releasing, you can use this readme to check all the indexes prior to the release you are deploying and have a good idea of what indexes you might need to deploy to Mongo along with your release of a new Coral Docker image to kubernetes.
 
+## 2024-02-02
+
+```
+db.notifications.createIndex({ createdAt: 1 }, { partialFilterExpression: { isDSA: { $eq: null } }, expireAfterSeconds: 30 * 24 * 60 * 60 });
+```
+
+- This creates a TTL on non-DSA marked notifications that will delete them after 30 days
+  - The `partialFilterExpression` finds any notifications that aren't marked as `isDSA` so we don't delete important DSA notifications
+  - You can modify the expiry time by changing `expireAfterSeconds`
+
 ## 2023-11-24
 
 ```

--- a/server/src/core/server/models/notifications/notification.ts
+++ b/server/src/core/server/models/notifications/notification.ts
@@ -30,6 +30,8 @@ export interface Notification extends TenantResource {
   rejectionReason?: GQLREJECTION_REASON_CODE;
   decisionDetails?: GQLNotificationDecisionDetails;
   customReason?: string;
+
+  isDSA?: boolean;
 }
 
 type BaseConnectionInput = ConnectionInput<Notification>;

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -402,6 +402,7 @@ export class InternalNotificationContext {
         grounds: legal ? legal.grounds : undefined,
         explanation: legal ? legal.explanation : undefined,
       },
+      isDSA: true,
     });
 
     return notification;
@@ -438,6 +439,7 @@ export class InternalNotificationContext {
         grounds: legal.grounds,
         explanation: legal.explanation,
       },
+      isDSA: true,
     });
 
     return notification;


### PR DESCRIPTION
## What does this PR do?

- creates a TTL index that allows notification documents to expire over time so they don't pile up in our database
    - has a filter for DSA type notifications to never delete them so we are nice to our European clients
- adds a flag to mark some notifications as DSA specific

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

The following was added to `INDEXES.md`:
```
db.notifications.createIndex({ createdAt: 1 }, { partialFilterExpression: { isDSA: { $eq: null } }, expireAfterSeconds: 30 * 24 * 60 * 60 });
```

## How do I test this PR?

- Add the above index but set the `expireAfterSeconds` to `30` (or similar)
- Post some comments and reply to them with other commenters
- See your notifications show up
- When the expiry time has passed, check again, they should now be gone
    - Can also check in Mongo that they have been deleted

- Report some comments as illegal
- Process the reports by rejecting or completing the DSA reports
- See the notifications appear in the notification area for the respective users
- Wait the TTL for deletion
- See the DSA notifications are never deleted

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into epic branch.
Deploy the above mentioned index when deploying the notifications release to clients.
