### PR TITLE
feat: Update notifications items

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/ApprovedCommentNotificationBody.css
+++ b/client/src/core/client/stream/tabs/Notifications/ApprovedCommentNotificationBody.css
@@ -12,8 +12,3 @@
 .commentSection {
   margin-bottom: var(--spacing-3);
 }
-
-.replyInfo {
-  font-size: var(--font-size-2);
-  margin-bottom: var(--spacing-2);
-}

--- a/client/src/core/client/stream/tabs/Notifications/ApprovedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/ApprovedCommentNotificationBody.tsx
@@ -29,15 +29,6 @@ const ApprovedCommentNotificationBody: FunctionComponent<Props> = ({
       {comment && (
         <>
           <div className={styles.commentSection}>
-            <Localized
-              id="notifications-approvedComment-description"
-              vars={{ title: comment.story.metadata?.title }}
-            >
-              <div className={styles.replyInfo}>
-                A member of our team approved it on "
-                {comment.story.metadata?.title}"
-              </div>
-            </Localized>
             <NotificationCommentContainer
               comment={comment}
               openedStateText={
@@ -72,9 +63,6 @@ const enhanced = withFragmentContainer<Props>({
         ...NotificationCommentContainer_comment
         story {
           url
-          metadata {
-            title
-          }
         }
       }
     }

--- a/client/src/core/client/stream/tabs/Notifications/ApprovedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/ApprovedCommentNotificationBody.tsx
@@ -34,8 +34,8 @@ const ApprovedCommentNotificationBody: FunctionComponent<Props> = ({
               vars={{ title: comment.story.metadata?.title }}
             >
               <div className={styles.replyInfo}>
-                Your comment on the article "{comment.story.metadata?.title}"
-                has been approved by a member of our team.
+                A member of our team approved it on "
+                {comment.story.metadata?.title}"
               </div>
             </Localized>
             <NotificationCommentContainer

--- a/client/src/core/client/stream/tabs/Notifications/FeaturedCommentNotificationBody.css
+++ b/client/src/core/client/stream/tabs/Notifications/FeaturedCommentNotificationBody.css
@@ -12,8 +12,3 @@
 .commentSection {
   margin-bottom: var(--spacing-3);
 }
-
-.replyInfo {
-  font-size: var(--font-size-2);
-  margin-bottom: var(--spacing-2);
-}

--- a/client/src/core/client/stream/tabs/Notifications/FeaturedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/FeaturedCommentNotificationBody.tsx
@@ -29,15 +29,6 @@ const FeaturedCommentNotificationBody: FunctionComponent<Props> = ({
       {comment && (
         <>
           <div className={styles.commentSection}>
-            <Localized
-              id="notifications-featuredComment-description"
-              vars={{ title: comment.story.metadata?.title }}
-            >
-              <div className={styles.replyInfo}>
-                A member of our team featured it on "
-                {comment.story.metadata?.title}"
-              </div>
-            </Localized>
             <NotificationCommentContainer
               comment={comment}
               openedStateText={
@@ -72,9 +63,6 @@ const enhanced = withFragmentContainer<Props>({
         ...NotificationCommentContainer_comment
         story {
           url
-          metadata {
-            title
-          }
         }
       }
     }

--- a/client/src/core/client/stream/tabs/Notifications/FeaturedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/FeaturedCommentNotificationBody.tsx
@@ -34,8 +34,8 @@ const FeaturedCommentNotificationBody: FunctionComponent<Props> = ({
               vars={{ title: comment.story.metadata?.title }}
             >
               <div className={styles.replyInfo}>
-                Your comment on the article "{comment.story.metadata?.title}"
-                has been featured by a member of our team.
+                A member of our team featured it on "
+                {comment.story.metadata?.title}"
               </div>
             </Localized>
             <NotificationCommentContainer

--- a/client/src/core/client/stream/tabs/Notifications/GoToCommentButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/GoToCommentButton.tsx
@@ -2,6 +2,10 @@ import { Localized } from "@fluent/react/compat";
 import React, { FunctionComponent } from "react";
 
 import { getURLWithCommentID } from "coral-framework/helpers";
+import {
+  ButtonSvgIcon,
+  ShareExternalLinkIcon,
+} from "coral-ui/components/icons";
 import { Flex } from "coral-ui/components/v2";
 import { Button } from "coral-ui/components/v3";
 
@@ -22,36 +26,17 @@ const GoToCommentButton: FunctionComponent<Props> = ({
       <Localized
         id="notifications-goToCommentButton"
         elems={{
-          button: (
-            <Button
-              className={styles.goToReplyButton}
-              variant="none"
-              href={permalinkURL}
-              target="_blank"
-            >
-              Go to this comment{" "}
-            </Button>
-          ),
-          readInContext: (
-            <div className={styles.readInContext}>
-              to read in context or reply
-            </div>
-          ),
+          icon: <ButtonSvgIcon Icon={ShareExternalLinkIcon} />,
         }}
       >
-        <>
-          <Button
-            className={styles.goToReplyButton}
-            variant="none"
-            href={permalinkURL}
-            target="_blank"
-          >
-            Go to this comment{" "}
-          </Button>
-          <div className={styles.readInContext}>
-            to read in context or reply
-          </div>
-        </>
+        <Button
+          className={styles.goToReplyButton}
+          variant="none"
+          href={permalinkURL}
+          target="_blank"
+        >
+          Go to this comment <ButtonSvgIcon Icon={ShareExternalLinkIcon} />
+        </Button>
       </Localized>
     </Flex>
   );

--- a/client/src/core/client/stream/tabs/Notifications/GoToCommentButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/GoToCommentButton.tsx
@@ -14,17 +14,19 @@ import styles from "./GoToCommentButton.css";
 interface Props {
   commentID: string;
   commentStoryURL: string;
+  type?: "comment" | "reply";
 }
 
 const GoToCommentButton: FunctionComponent<Props> = ({
   commentID,
   commentStoryURL,
+  type = "comment",
 }) => {
   const permalinkURL = getURLWithCommentID(commentStoryURL, commentID);
   return (
     <Flex marginTop={1} marginBottom={2}>
       <Localized
-        id="notifications-goToCommentButton"
+        id={`notifications-goToCommentButton-${type}`}
         elems={{
           icon: <ButtonSvgIcon Icon={ShareExternalLinkIcon} />,
         }}
@@ -35,7 +37,7 @@ const GoToCommentButton: FunctionComponent<Props> = ({
           href={permalinkURL}
           target="_blank"
         >
-          Go to this comment <ButtonSvgIcon Icon={ShareExternalLinkIcon} />
+          Go to this {type} <ButtonSvgIcon Icon={ShareExternalLinkIcon} />
         </Button>
       </Localized>
     </Flex>

--- a/client/src/core/client/stream/tabs/Notifications/NotificationCommentContainer.css
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationCommentContainer.css
@@ -30,6 +30,12 @@
   padding-left: var(--spacing-3);
 }
 
+.author {
+  font-weight: var(--font-weight-primary-semi-bold);
+  margin-right: var(--spacing-2);
+  font-size: var(--font-size-3);
+}
+
 .timestamp {
   font-family: var(--font-family-primary);
   font-style: normal;

--- a/client/src/core/client/stream/tabs/Notifications/NotificationCommentContainer.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationCommentContainer.tsx
@@ -10,7 +10,7 @@ import {
   TwitterMedia,
   YouTubeMedia,
 } from "coral-stream/common/Media";
-import { Timestamp } from "coral-ui/components/v2";
+import { Flex, Timestamp } from "coral-ui/components/v2";
 
 import { NotificationCommentContainer_comment } from "coral-stream/__generated__/NotificationCommentContainer_comment.graphql";
 
@@ -63,9 +63,14 @@ const NotificationCommentContainer: FunctionComponent<Props> = ({
       )}
       {isOpen && (
         <div className={styles.content}>
-          <Timestamp className={styles.timestamp}>
-            {comment.createdAt}
-          </Timestamp>
+          <Flex marginBottom={2}>
+            <div className={styles.author}>
+              {comment.author?.username ?? ""}
+            </div>
+            <Timestamp className={styles.timestamp}>
+              {comment.createdAt}
+            </Timestamp>
+          </Flex>
           <HTMLContent>{comment.body || ""}</HTMLContent>
           <div className={styles.media}>
             {comment.revision?.media?.__typename === "ExternalMedia" && (
@@ -127,6 +132,9 @@ const enhanced = withFragmentContainer<Props>({
       }
       site {
         id
+      }
+      author {
+        username
       }
       revision {
         media {

--- a/client/src/core/client/stream/tabs/Notifications/RepliedCommentNotificationBody.css
+++ b/client/src/core/client/stream/tabs/Notifications/RepliedCommentNotificationBody.css
@@ -16,8 +16,3 @@
 .commentSection {
   margin-bottom: var(--spacing-3);
 }
-
-.replyInfo {
-  font-size: var(--font-size-2);
-  margin-bottom: var(--spacing-2);
-}

--- a/client/src/core/client/stream/tabs/Notifications/RepliedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/RepliedCommentNotificationBody.tsx
@@ -28,23 +28,6 @@ const RepliedCommentNotificationBody: FunctionComponent<Props> = ({
       {comment && (
         <>
           <div className={styles.commentSection}>
-            <Localized
-              id="notifications-repliedComment-description"
-              vars={{
-                title: commentReply.story.metadata?.title,
-                username: commentReply.author?.username ?? "",
-              }}
-              elems={{
-                author: <span className={styles.author}></span>,
-              }}
-            >
-              <div className={styles.replyInfo}>
-                <span className={styles.author}>
-                  {commentReply.author?.username ?? ""}
-                </span>
-                replied on "{commentReply.story.metadata?.title}"
-              </div>
-            </Localized>
             <NotificationCommentContainer
               comment={commentReply}
               openedStateText={
@@ -63,6 +46,7 @@ const RepliedCommentNotificationBody: FunctionComponent<Props> = ({
           <GoToCommentButton
             commentID={commentReply.id}
             commentStoryURL={commentReply.story.url}
+            type="reply"
           />
           <NotificationCommentContainer
             comment={comment}
@@ -93,14 +77,8 @@ const enhanced = withFragmentContainer<Props>({
       commentReply {
         ...NotificationCommentContainer_comment
         id
-        author {
-          username
-        }
         story {
           url
-          metadata {
-            title
-          }
         }
       }
     }

--- a/client/src/core/client/stream/tabs/Notifications/RepliedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/RepliedCommentNotificationBody.tsx
@@ -39,12 +39,10 @@ const RepliedCommentNotificationBody: FunctionComponent<Props> = ({
               }}
             >
               <div className={styles.replyInfo}>
-                Your comment on the article "
-                {commentReply.story.metadata?.title}" received a reply from
                 <span className={styles.author}>
-                  {" "}
                   {commentReply.author?.username ?? ""}
                 </span>
+                replied on "{commentReply.story.metadata?.title}"
               </div>
             </Localized>
             <NotificationCommentContainer

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1073,7 +1073,7 @@ notifications-yourCommentHasReceivedAStaffReply =
   Your comment has received a reply from a member of our team
 notifications-defaultTitle = Notification
 
-notifications-goToCommentButton = <button>Go to this comment </button><readInContext>to read in context or reply</readInContext>
+notifications-goToCommentButton = Go to this comment <icon></icon>
 
 notifications-rejectedComment-body =
   The content of your comment was against our community guidelines. The comment has been removed.
@@ -1081,14 +1081,14 @@ notifications-reasonForRemoval = Reason for removal
 notifications-legalGrounds = Legal grounds
 notifications-additionalExplanation = Additional explanation
 
-notifications-repliedComment-description = Your comment on the article "{ $title }" received a reply from <author>{ $username }</author>
+notifications-repliedComment-description = <author>{ $username }</author> replied on "{ $title }"
 notifications-repliedComment-hideReply = - Hide the reply
 notifications-repliedComment-showReply = + Show the reply
 notifications-repliedComment-hideOriginalComment = - Hide my original comment
 notifications-repliedComment-showOriginalComment = + Show my original comment
 
-notifications-featuredComment-description = Your comment on the article { $title } has been featured by a member of our team.
-notifications-approvedComment-description = Your comment on the article { $title } has been approved by a member of our team.
+notifications-featuredComment-description = A member of our team featured it on "{ $title }"
+notifications-approvedComment-description = A member of our team approved it on "{ $title }"
 
 notifications-dsaReportLegality-legal = Legal content
 notifications-dsaReportLegality-illegal = Illegal content

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1073,22 +1073,19 @@ notifications-yourCommentHasReceivedAStaffReply =
   Your comment has received a reply from a member of our team
 notifications-defaultTitle = Notification
 
-notifications-goToCommentButton = Go to this comment <icon></icon>
-
 notifications-rejectedComment-body =
   The content of your comment was against our community guidelines. The comment has been removed.
 notifications-reasonForRemoval = Reason for removal
 notifications-legalGrounds = Legal grounds
 notifications-additionalExplanation = Additional explanation
 
-notifications-repliedComment-description = <author>{ $username }</author> replied on "{ $title }"
 notifications-repliedComment-hideReply = - Hide the reply
 notifications-repliedComment-showReply = + Show the reply
 notifications-repliedComment-hideOriginalComment = - Hide my original comment
 notifications-repliedComment-showOriginalComment = + Show my original comment
 
-notifications-featuredComment-description = A member of our team featured it on "{ $title }"
-notifications-approvedComment-description = A member of our team approved it on "{ $title }"
+notifications-goToCommentButton-comment = Go to this comment <icon></icon>
+notifications-goToCommentButton-reply = Go to this reply <icon></icon>
 
 notifications-dsaReportLegality-legal = Legal content
 notifications-dsaReportLegality-illegal = Illegal content


### PR DESCRIPTION
## What does this PR do?

Streamlines copy for notification bodies for replies, featured comments, and approved comments. Adds `open in new tab` icon. The comment author's username is now included in embedded comments in notification bodies.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can add some replies, approve comments, and feature comments. Go to the original commenter's notifications and see these notifications in their feed with the updated copy and design.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
