### PR TITLE
[CORL-3064] create a tenant data downloader utility

### DIFF
--- a/utilities/download/.gitignore
+++ b/utilities/download/.gitignore
@@ -4,3 +4,4 @@ output/
 
 .DS_Store
 config.json
+config-*.json

--- a/utilities/download/.gitignore
+++ b/utilities/download/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+output/
+
+.DS_Store
+config.json

--- a/utilities/download/README.md
+++ b/utilities/download/README.md
@@ -1,0 +1,31 @@
+# utilities/download
+
+This script allows users to download tenant data from a Mongo database by `tenantID`.
+
+# Getting started
+
+Navigate into the `utilities/download` folder and install the dependencies:
+
+```
+cd utilities/download
+npm i
+```
+
+Then create a config file named `config.json` in the `utilities/download` folder following a similar format to the config file defined below:
+
+```
+{
+  "mongoURI": "mongodb://localhost:27017",
+  "mongoDBName": "coral",
+  "outputDir": "output/test/",
+  "tenantIDs": [
+    "60b9be43-e0ab-4145-8532-5b0d761016fd"
+  ]
+}
+```
+
+Then you can download from the database via the following command:
+
+```
+npm run start -- -c config.json
+```

--- a/utilities/download/package-lock.json
+++ b/utilities/download/package-lock.json
@@ -1,0 +1,467 @@
+{
+  "name": "download",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "download",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "mongodb": "^3.5.9",
+        "uuid": "^9.0.1"
+      },
+      "devDependencies": {
+        "@types/mongodb": "^3.1.22",
+        "@types/node": "^12.12.34",
+        "@types/uuid": "^9.0.7",
+        "typescript": "^5.2.2"
+      }
+    },
+    "../../common/dist": {
+      "extraneous": true
+    },
+    "../../server/dist": {
+      "extraneous": true
+    },
+    "node_modules/@types/bson": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
+      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
+      "deprecated": "This is a stub types definition. bson provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "dependencies": {
+        "bson": "*"
+      }
+    },
+    "node_modules/@types/mongodb": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
+      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/bson": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
+    },
+    "node_modules/bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.3.0.tgz",
+      "integrity": "sha512-balJfqwwTBddxfnidJZagCBPP/f48zj9Sdp3OJswREOgsJzHiQSaOIAtApSgDQFYgHqAvFkp53AFSqjMDZoTFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
+    "node_modules/mongodb": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.4.tgz",
+      "integrity": "sha512-K5q8aBqEXMwWdVNh94UQTwZ6BejVbFhh1uB6c5FKtPE9eUMZPUO3sRZdgIEcHSrAWmxzpG/FeODDKL388sqRmw==",
+      "dependencies": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.1.8",
+        "safe-buffer": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "optionalDependencies": {
+        "saslprep": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws4": {
+          "optional": true
+        },
+        "bson-ext": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "mongodb-extjson": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb/node_modules/bson": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
+    "node_modules/optional-require": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "dependencies": {
+        "require-at": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/bson": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.0.tgz",
+      "integrity": "sha512-ELCPqAdroMdcuxqwMgUpifQyRoTpyYCNr1V9xKyF40VsBobsj+BbWNRvwGchMgBPGqkw655ypkjj2MEF5ywVwg==",
+      "dev": true,
+      "requires": {
+        "bson": "*"
+      }
+    },
+    "@types/mongodb": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
+      "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
+      "dev": true,
+      "requires": {
+        "@types/bson": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
+    },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "bson": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.3.0.tgz",
+      "integrity": "sha512-balJfqwwTBddxfnidJZagCBPP/f48zj9Sdp3OJswREOgsJzHiQSaOIAtApSgDQFYgHqAvFkp53AFSqjMDZoTFw==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
+    "mongodb": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.4.tgz",
+      "integrity": "sha512-K5q8aBqEXMwWdVNh94UQTwZ6BejVbFhh1uB6c5FKtPE9eUMZPUO3sRZdgIEcHSrAWmxzpG/FeODDKL388sqRmw==",
+      "requires": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.1.8",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+        }
+      }
+    },
+    "optional-require": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "requires": {
+        "require-at": "^1.0.6"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+    }
+  }
+}

--- a/utilities/download/package.json
+++ b/utilities/download/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "download",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "npm run build && node dist/main.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/mongodb": "^3.1.22",
+    "@types/node": "^12.12.34",
+    "@types/uuid": "^9.0.7",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "mongodb": "^3.5.9",
+    "uuid": "^9.0.1"
+  }
+}

--- a/utilities/download/src/args.ts
+++ b/utilities/download/src/args.ts
@@ -1,0 +1,181 @@
+export enum ArgumentValueType {
+  Boolean = "boolean",
+  Integer = "integer",
+  String = "string",
+  Command = "command",
+}
+
+export interface ArgumentDefinition {
+  fullName: string;
+  shortName: string;
+  valueType: ArgumentValueType;
+}
+
+interface Result {
+  ok: boolean;
+  errors: Error[];
+  args: ArgumentResult<any>[];
+}
+
+export interface ArgumentResult<T> {
+  definition: ArgumentDefinition;
+  value: T;
+}
+
+interface ParseResult<T> {
+  ok: boolean;
+  value: ArgumentResult<T>;
+  err?: Error;
+}
+
+export const parseBool = (value: string) => {
+  const lower = value.toLowerCase();
+  if (
+    lower === "true" ||
+    lower === "t" ||
+    lower === "1" ||
+    lower === "yes" ||
+    lower === "y"
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+const parseArgument = (value: string, definition: ArgumentDefinition) => {
+  const { valueType: type } = definition;
+
+  if (type === ArgumentValueType.Boolean) {
+    try {
+      const v = parseBool(value);
+      const r: ParseResult<boolean> = {
+        ok: true,
+        value: {
+          definition,
+          value: v,
+        },
+      };
+      return r;
+    } catch {
+      const r: ParseResult<boolean> = {
+        ok: false,
+        value: {
+          definition,
+          value: false,
+        },
+        err: new Error(`unable to parse ${value}`),
+      };
+      return r;
+    }
+  }
+  if (type === ArgumentValueType.Integer) {
+    try {
+      const v = parseInt(value);
+      const r: ParseResult<number> = {
+        ok: true,
+        value: {
+          definition,
+          value: v,
+        },
+      };
+      return r;
+    } catch {
+      const r: ParseResult<number> = {
+        ok: false,
+        value: {
+          definition,
+          value: 0,
+        },
+        err: new Error(`unable to parse ${value}`),
+      };
+      return r;
+    }
+  }
+  if (type === ArgumentValueType.String) {
+    try {
+      const r: ParseResult<string> = {
+        ok: true,
+        value: {
+          definition,
+          value,
+        },
+      };
+      return r;
+    } catch {
+      const r: ParseResult<string> = {
+        ok: false,
+        value: {
+          definition,
+          value: "",
+        },
+        err: new Error(`unable to parse ${value}`),
+      };
+      return r;
+    }
+  }
+};
+
+export const getArgs = (argv: string[], definition: ArgumentDefinition[]) => {
+  const result: Result = {
+    ok: true,
+    errors: [],
+    args: [],
+  };
+
+  for (let a = 0; a < argv.length; a++) {
+    const arg = argv[a];
+    const lowerArg = arg.toLowerCase();
+
+    for (const def of definition) {
+      const lowerFullName = def.fullName.toLowerCase().trim();
+
+      const matchShort = arg.trim() === def.shortName.trim();
+      const matchFull = lowerArg.startsWith(lowerFullName);
+      const isMatch = matchShort || matchFull;
+
+      if (!isMatch) {
+        continue;
+      }
+
+      if (def.valueType === ArgumentValueType.Command) {
+        result.args.push({
+          definition: def,
+          value: def.valueType.toString(),
+        });
+      } else {
+        if (argv.length >= a + 2) {
+          const value = argv[a + 1];
+
+          const parseResult = parseArgument(value, def);
+          if (!parseResult) {
+            result.ok = false;
+            result.errors.push(
+              new Error(`unable to parse value for ${arg} with input ${value}`)
+            );
+            continue;
+          }
+
+          if (!parseResult.ok) {
+            result.ok = false;
+
+            result.errors.push(
+              new Error(`unable to parse value for ${arg} with input ${value}`)
+            );
+            if (parseResult.err) {
+              result.errors.push(parseResult.err);
+            }
+            continue;
+          }
+
+          result.args.push(parseResult.value);
+        } else {
+          result.ok = false;
+          result.errors.push(new Error(`unable to find value for ${arg}`));
+        }
+      }
+    }
+  }
+
+  return result;
+};

--- a/utilities/download/src/config.ts
+++ b/utilities/download/src/config.ts
@@ -1,0 +1,38 @@
+import fs from "fs";
+
+export class Config {
+  private filePath: string;
+
+  public readonly mongoURI: string;
+  public readonly mongoDBName: string;
+  public readonly outputDir: string;
+  public readonly tenantIDs: string[];
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+
+    const raw = fs.readFileSync(this.filePath).toString();
+    const json = JSON.parse(raw);
+
+    this.mongoURI =
+      json.mongoURI && typeof json.mongoURI === "string"
+        ? json.mongoURI
+        : "mongodb://localhost:27017";
+    this.mongoDBName =
+      json.mongoDBName && typeof json.mongoDBName === "string"
+        ? json.mongoDBName
+        : "coral";
+
+    this.outputDir =
+      json.outputDir && typeof json.outputDir === "string"
+        ? json.outputDir
+        : "output/";
+
+    this.tenantIDs =
+      json.tenantIDs &&
+      Array.isArray(json.tenantIDs) &&
+      json.tenantIDs.length > 0
+        ? json.tenantIDs
+        : [];
+  }
+}

--- a/utilities/download/src/main.ts
+++ b/utilities/download/src/main.ts
@@ -1,0 +1,113 @@
+import fs from "fs";
+import { Db } from "mongodb";
+import path from "path";
+import { argv } from "process";
+
+import {
+  ArgumentDefinition,
+  ArgumentResult,
+  ArgumentValueType,
+  getArgs,
+} from "./args";
+import { Config } from "./config";
+import { createMongo } from "./mongo";
+
+interface Tenant {
+  id: string;
+  organization: {
+    name: string;
+  };
+}
+
+const argumentDefinitions: ArgumentDefinition[] = [
+  {
+    shortName: "-c",
+    fullName: "--config",
+    valueType: ArgumentValueType.String,
+  },
+];
+
+const ensureDirectoryExists = (dir: string) => {
+  if (fs.existsSync(dir)) {
+    return;
+  }
+
+  fs.mkdirSync(dir, { recursive: true });
+};
+
+const getNiceTenantName = (name: string) => {
+  const regex = / /g;
+  const niceTenantName = name.replace(regex, "");
+
+  return niceTenantName;
+};
+
+const downloadDocuments = async (db: Db, tenantID: string, collectionName: string, outputDir: string) => {
+  const collection = db.collection(collectionName);
+  const cursor = collection.find({ tenantID });
+
+  const outputPath = path.join(outputDir, `${collectionName}.json`);
+  const stream = fs.createWriteStream(outputPath);
+
+  while (await cursor.hasNext()) {
+    const doc = await cursor.next();
+    if (!doc) {
+      continue;
+    }
+
+    stream.write(`${JSON.stringify(doc)}\n`);
+  }
+
+  stream.close();
+}
+
+const run = async () => {
+  const result = getArgs(argv, argumentDefinitions);
+  const configPath: ArgumentResult<any> = result.args.find(
+    (a) => a.definition.fullName === "--config"
+  ) ?? {
+    definition: argumentDefinitions[0],
+    value: "config.json",
+  };
+
+  const config = new Config(configPath.value as string);
+
+  const { db } = await createMongo(config.mongoURI, config.mongoDBName);
+
+  ensureDirectoryExists(config.outputDir);
+
+  const tenants = db.collection<Readonly<Tenant>>("tenants");
+
+  for (const tenantID of config.tenantIDs) {
+    const tenant = await tenants.findOne({ id: tenantID });
+    if (!tenant) {
+      console.warn(`unable to find tenant: ${tenantID}`);
+      continue;
+    }
+
+    const niceTenantName = getNiceTenantName(tenant.organization.name);
+    const relOutputDir = path.join(config.outputDir, niceTenantName);
+    ensureDirectoryExists(relOutputDir);
+
+    await downloadDocuments(db, tenantID, "archivedCommentModerationActions", relOutputDir);
+    await downloadDocuments(db, tenantID, "archivedCommentActions", relOutputDir);
+    await downloadDocuments(db, tenantID, "archivedComments", relOutputDir);
+    await downloadDocuments(db, tenantID, "commentActions", relOutputDir);
+    await downloadDocuments(db, tenantID, "commentModerationActions", relOutputDir);
+    await downloadDocuments(db, tenantID, "comments", relOutputDir);
+    await downloadDocuments(db, tenantID, "dsaReports", relOutputDir);
+    await downloadDocuments(db, tenantID, "invites", relOutputDir);
+    await downloadDocuments(db, tenantID, "migrations", relOutputDir);
+    await downloadDocuments(db, tenantID, "notifications", relOutputDir);
+    await downloadDocuments(db, tenantID, "queries", relOutputDir);
+    await downloadDocuments(db, tenantID, "seenComments", relOutputDir);
+    await downloadDocuments(db, tenantID, "sites", relOutputDir);
+    await downloadDocuments(db, tenantID, "stories", relOutputDir);
+    await downloadDocuments(db, tenantID, "tenants", relOutputDir);
+    await downloadDocuments(db, tenantID, "users", relOutputDir);
+  }
+
+  process.exit();
+};
+
+void run();

--- a/utilities/download/src/mongo.ts
+++ b/utilities/download/src/mongo.ts
@@ -1,0 +1,21 @@
+import { Db, MongoClient } from "mongodb";
+
+export interface MongoContext {
+  db: Db;
+  client: MongoClient;
+}
+
+export const createMongo = async (
+  uri: string,
+  dbName: string
+): Promise<MongoContext> => {
+  const client = new MongoClient(uri);
+  await client.connect();
+
+  const db = client.db(dbName);
+
+  return {
+    db,
+    client,
+  };
+};

--- a/utilities/download/tsconfig.json
+++ b/utilities/download/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+  },
+  "include": [
+    "./src/**/.*.js",
+    "./src/**/*.ts",
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What does this PR do?

Adds a CLI script under `utilities/download` that allows admins/support to backup all data for tenants on a MongoDB instance.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- follow the instructions in the `README` inside `utilities/download`
- set up the config described in the `README` for your local coral instance (i.e. `mongodb://localhost:27017`)
- run the script pointing to the config file you created
- check the output folder to make sure it downloaded everything inside your Coral database

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
