### PR TITLE
[CORL-3077]: DSA - Anonymous reports show on moderate cards

### DIFF
--- a/client/src/core/client/admin/components/ModerateCard/FlagDetails.tsx
+++ b/client/src/core/client/admin/components/ModerateCard/FlagDetails.tsx
@@ -1,3 +1,4 @@
+import { Localized } from "@fluent/react/compat";
 import React, { FunctionComponent } from "react";
 
 import NotAvailable from "coral-admin/components/NotAvailable";
@@ -33,10 +34,16 @@ const FlagDetails: FunctionComponent<Props> = ({
             flag.flagger ? onUsernameClick(flag.flagger.id) : null
           }
           user={
-            flag.flagger && flag.flagger.username ? (
-              flag.flagger.username
+            flag.flagger ? (
+              flag.flagger.username ? (
+                flag.flagger.username
+              ) : (
+                <NotAvailable />
+              )
             ) : (
-              <NotAvailable />
+              <Localized id="moderate-card-flag-details-anonymousUser">
+                <span>Anonymous user</span>
+              </Localized>
             )
           }
           details={flag.additionalDetails}

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -1060,6 +1060,8 @@ moderate-flagDetails-other = Other
 moderate-flagDetails-illegalContent = Illegal content
 moderate-flagDetails-viewDSAReport = View DSA Report
 
+moderate-card-flag-details-anonymousUser = Anonymous user
+
 moderate-flagDetails-toxicityScore = Toxicity Score
 moderate-toxicityLabel-likely = Likely <score></score>
 moderate-toxicityLabel-unlikely = Unlikely <score></score>

--- a/server/src/core/server/graph/mutators/DSAReports.ts
+++ b/server/src/core/server/graph/mutators/DSAReports.ts
@@ -35,21 +35,19 @@ export const DSAReports = (ctx: GraphContext) => ({
       submissionID,
     });
 
-    if (ctx.user) {
-      await createIllegalContent(
-        ctx.mongo,
-        ctx.redis,
-        ctx.config,
-        ctx.i18n,
-        ctx.cache.commentActions,
-        ctx.broker,
-        ctx.tenant,
-        ctx.user,
-        await ctx.loaders.Comments.comment.load(commentID),
-        { commentID, commentRevisionID, reportID: report.id },
-        ctx.now
-      );
-    }
+    await createIllegalContent(
+      ctx.mongo,
+      ctx.redis,
+      ctx.config,
+      ctx.i18n,
+      ctx.cache.commentActions,
+      ctx.broker,
+      ctx.tenant,
+      ctx.user ?? null,
+      await ctx.loaders.Comments.comment.load(commentID),
+      { commentID, commentRevisionID, reportID: report.id },
+      ctx.now
+    );
   },
   addDSAReportNote: ({ userID, body, reportID }: GQLAddDSAReportNoteInput) =>
     addDSAReportNote(ctx.mongo, ctx.tenant, { userID, body, reportID }),

--- a/server/src/core/server/services/comments/actions.ts
+++ b/server/src/core/server/services/comments/actions.ts
@@ -108,7 +108,7 @@ async function addCommentAction(
   broker: CoralEventPublisherBroker,
   tenant: Tenant,
   input: Omit<CreateActionInput, "storyID" | "siteID" | "userID">,
-  author: User,
+  author: User | null,
   now = new Date()
 ): Promise<AddCommentAction> {
   let oldComment = await retrieveComment(
@@ -143,7 +143,7 @@ async function addCommentAction(
   // Check if the user is banned on this site, if they are, throw an error right
   // now.
   // NOTE: this should be removed with attribute based auth checks.
-  if (isSiteBanned(author, siteID)) {
+  if (author && isSiteBanned(author, siteID)) {
     // Get the site in question.
     const site = await retrieveSite(mongo, tenant.id, siteID);
     if (!site) {
@@ -158,7 +158,7 @@ async function addCommentAction(
     ...input,
     storyID,
     siteID,
-    userID: author.id,
+    userID: author ? author.id : null,
     section,
   };
 
@@ -446,7 +446,7 @@ export async function createIllegalContent(
   commentActionsCache: CommentActionsCache,
   broker: CoralEventPublisherBroker,
   tenant: Tenant,
-  user: User,
+  user: User | null,
   comment: Readonly<Comment> | null,
   input: CreateIllegalContent,
   now = new Date()


### PR DESCRIPTION
## What does this PR do?

These changes ensure that any anonymous DSA reports show on moderate cards, both in the marker count and beneath `INFO` with a link to the relevant DSA report.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can report a comment while logged out as an anonymous user. Then go find its moderate cards in the admin. See that its illegal content marker appears / is correctly incremented. Click `INFO`. See that it's represented as `Anonymous user` with a link to the relevant DSA report beside it.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
