### PR TITLE
[CORL-3076]: Only check protected email domains if banning, not for always premod

### DIFF
--- a/server/src/core/server/services/tenant/tenant.ts
+++ b/server/src/core/server/services/tenant/tenant.ts
@@ -50,6 +50,7 @@ import { discover } from "coral-server/services/oidc/discover";
 
 import {
   GQLFEATURE_FLAG,
+  GQLNEW_USER_MODERATION,
   GQLSettingsInput,
   GQLSettingsWordListInput,
   GQLUSER_ROLE,
@@ -450,7 +451,12 @@ export async function createEmailDomain(
     );
   }
 
-  if (PROTECTED_EMAIL_DOMAINS.has(input.domain)) {
+  // If attempting to set Ban all new commenter accounts, check
+  // protected email domains
+  if (
+    input.newUserModeration === GQLNEW_USER_MODERATION.BAN &&
+    PROTECTED_EMAIL_DOMAINS.has(input.domain)
+  ) {
     throw new OperationForbiddenError(
       ERROR_CODES.EMAIL_DOMAIN_PROTECTED,
       "This email domain may not be moderated",


### PR DESCRIPTION
## What does this PR do?

These changes make it so that protected email domains can be set to always premod, but they still cannot be set for ban new commenter accounts.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?
no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Attempt to set a protected email domain to always premod in Configure > Moderation > Users. See that it works. Attempt to set it to ban new users. See that it still throws an error.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
