### PR TITLE
[CORL-3094]: my profile preferences link styles in notifications container

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationsPaginator.css
+++ b/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationsPaginator.css
@@ -30,6 +30,7 @@
   font-weight: var(--font-weight-primary-regular);
   font-size: var(--font-size-3);
   line-height: 1.14;
+  padding-left: var(--spacing-4);
 }
 
 .preferencesButton {
@@ -38,5 +39,5 @@
   font-weight: var(--font-weight-primary-regular);
   font-size: var(--font-size-3);
   padding: 0;
-  margin-left: var(--spacing-1);
+  vertical-align: baseline;
 }

--- a/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationsPaginator.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationsPaginator.tsx
@@ -18,7 +18,6 @@ import {
 } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
 import Spinner from "coral-stream/common/Spinner";
-import { Flex } from "coral-ui/components/v2";
 import { Button } from "coral-ui/components/v3";
 
 import { GQLDSA_METHOD_OF_REDRESS } from "coral-common/client/src/core/client/framework/schema/__generated__/types";
@@ -181,8 +180,8 @@ const FloatingNotificationsPaginator: FunctionComponent<Props> = (props) => {
           ),
         }}
       >
-        <Flex className={styles.adjustPreferences}>
-          <span>Adjust notification settings in My Profile &gt; </span>
+        <div className={styles.adjustPreferences}>
+          <span>Adjust notification settings in My Profile &gt;</span>
           <Button
             className={styles.preferencesButton}
             variant="none"
@@ -191,7 +190,7 @@ const FloatingNotificationsPaginator: FunctionComponent<Props> = (props) => {
             {" "}
             Preferences.
           </Button>
-        </Flex>
+        </div>
       </Localized>
       <div>
         {notificationsToShow.map(({ node }) => {

--- a/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationsPaginator.css
+++ b/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationsPaginator.css
@@ -30,6 +30,7 @@
   font-weight: var(--font-weight-primary-regular);
   font-size: var(--font-size-3);
   line-height: 1.14;
+  padding-left: var(--spacing-4);
 }
 
 .preferencesButton {
@@ -38,5 +39,5 @@
   font-weight: var(--font-weight-primary-regular);
   font-size: var(--font-size-3);
   padding: 0;
-  margin-left: var(--spacing-1);
+  vertical-align: baseline;
 }

--- a/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationsPaginator.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationsPaginator.tsx
@@ -18,7 +18,6 @@ import {
 } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
 import Spinner from "coral-stream/common/Spinner";
-import { Flex } from "coral-ui/components/v2";
 import { Button } from "coral-ui/components/v3";
 
 import { GQLDSA_METHOD_OF_REDRESS } from "coral-common/client/src/core/client/framework/schema/__generated__/types";
@@ -181,7 +180,7 @@ const MobileNotificationsPaginator: FunctionComponent<Props> = (props) => {
           ),
         }}
       >
-        <Flex className={styles.adjustPreferences}>
+        <div className={styles.adjustPreferences}>
           <span>Adjust notification settings in My Profile &gt; </span>
           <Button
             className={styles.preferencesButton}
@@ -191,7 +190,7 @@ const MobileNotificationsPaginator: FunctionComponent<Props> = (props) => {
             {" "}
             Preferences.
           </Button>
-        </Flex>
+        </div>
       </Localized>
       <div>
         {notificationsToShow.map(({ node }) => {


### PR DESCRIPTION
## What does this PR do?

These changes update styles so that the link to adjust preferences in a user's profile for in-page notifications looks good at smaller sizes too.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can view the floating notifications and the mobile notifications container. See that the link about adjusting notification preferences at the top of the notifications container looks good now on both.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
