### PR TITLE
[CORL-3091/92] load/replace default notifications preferences from Mongo

### DIFF
--- a/server/src/core/server/graph/resolvers/User.ts
+++ b/server/src/core/server/graph/resolvers/User.ts
@@ -88,15 +88,11 @@ export const User: GQLUserTypeResolver<user.User> = {
     // Get the Stories!
     return ctx.loaders.Stories.story.loadMany(results.map(({ _id }) => _id));
   },
-  inPageNotifications: ({
-    inPageNotifications = {
-      onReply: true,
-      onFeatured: true,
-      onModeration: true,
-      onStaffReplies: false,
-      enabled: true,
-    },
-  }) => inPageNotifications,
+  inPageNotifications: ({ inPageNotifications }) => {
+    return inPageNotifications
+      ? inPageNotifications
+      : user.defaultInPageNotificationSettings;
+  },
   mediaSettings: ({ mediaSettings = {} }) => mediaSettings,
   hasNewNotifications: ({ lastSeenNotificationDate }, input, ctx) => {
     if (!ctx.user) {

--- a/server/src/core/server/models/user/user.ts
+++ b/server/src/core/server/models/user/user.ts
@@ -116,6 +116,15 @@ export interface Token {
   createdAt: Date;
 }
 
+export const defaultInPageNotificationSettings: GQLUserInPageNotificationSettings =
+  {
+    enabled: true,
+    onReply: true,
+    onFeatured: true,
+    onStaffReplies: true,
+    onModeration: true,
+  };
+
 /**
  * ModeratorNote ModeratorNote is a note left by a moderator on the subject of a user.
  */

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -9,7 +9,11 @@ import {
   createNotification,
   Notification,
 } from "coral-server/models/notifications/notification";
-import { retrieveUser, User } from "coral-server/models/user";
+import {
+  defaultInPageNotificationSettings,
+  retrieveUser,
+  User,
+} from "coral-server/models/user";
 import { I18n } from "coral-server/services/i18n";
 
 import {
@@ -208,32 +212,34 @@ export class InternalNotificationContext {
     }
 
     if (result.notification && result.attempted) {
+      const preferences = targetUser.inPageNotifications
+        ? targetUser.inPageNotifications
+        : defaultInPageNotificationSettings;
+
       // Determine whether to increment notificationCount based on user's in-page notification settings
       let shouldIncrementCount = true;
       if (
         type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED &&
-        !targetUser.inPageNotifications?.onModeration
+        !preferences?.onModeration
       ) {
         shouldIncrementCount = false;
       }
       if (
         type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED &&
-        !targetUser.inPageNotifications?.onFeatured
+        !preferences?.onFeatured
       ) {
         shouldIncrementCount = false;
       }
-      if (
-        type === GQLNOTIFICATION_TYPE.REPLY &&
-        !targetUser.inPageNotifications?.onReply
-      ) {
+      if (type === GQLNOTIFICATION_TYPE.REPLY && !preferences?.onReply) {
         shouldIncrementCount = false;
       }
       if (
         type === GQLNOTIFICATION_TYPE.REPLY_STAFF &&
-        !targetUser.inPageNotifications?.onStaffReplies
+        !preferences?.onStaffReplies
       ) {
         shouldIncrementCount = false;
       }
+
       if (shouldIncrementCount) {
         await this.incrementCountForUser(tenantID, targetUserID);
       }


### PR DESCRIPTION
## What does this PR do?

- create a default state for notification preferences
- use the default if they are undefined on a user in the resolver
- use the default if they are undefined on a user in the internal notifications context

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- remove a users `inPageNotifications` in Mongo
- post a comment as that user
- with another user, reply to the comment
- on that first user, see they have notification counts (live bell count goes up) even though they don't have any preferences set
- modify the preferences for first user under My Profile to no longer notify for replies
- using another user, again reply to comment
- see count does not increment in notifications (live bell count does not go up/appear)

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into epic branch.
