### PR TITLE
[CORL-3096]: fix mobile go to reply links for notification bodies

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.tsx
@@ -30,7 +30,6 @@ export const MobileNotificationButton: FunctionComponent<Props> = ({
 
   const stopPropagation = useCallback((ev: MouseEvent) => {
     ev.stopPropagation();
-    ev.preventDefault();
   }, []);
 
   if (!viewerID) {


### PR DESCRIPTION
## What does this PR do?

These changes update so that reply links in notification bodies are clickable and open the reply comment in a new tab now.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?
no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

View a reply notification for a user at a mobile size. Try to click on the `Go to reply` link in the notification body. See that a new tab opens with that reply. See that the notifications tray is still open in your original tab.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
