### PR TITLE
[CORL-3108] update mobile tool bar to match v3 wireframes

### DIFF
--- a/client/src/core/client/stream/classes.ts
+++ b/client/src/core/client/stream/classes.ts
@@ -1147,7 +1147,12 @@ const CLASSES = {
     },
   },
 
-  mobileToolbar: "coral coral-mobileToolbar",
+  mobileToolbar: {
+    $root: "coral coral-mobileToolbar",
+    close: "coral coral-mobileToolbar-close",
+    markAllAsRead: "coral coral-mobileToolbar-markAllAsRead",
+    nextUnread: "coral coral-mobileToolbar-nextUnread",
+  },
 
   viewersWatching: {
     $root: "coral coral-viewersWatching",

--- a/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.css
+++ b/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.css
@@ -14,6 +14,45 @@
 .unmarkAllContainer {
 }
 
+.actionButton {
+  border-radius: 8px;
+  background-color: var(--palette-primary-600);
+
+  border-style: none;
+
+  color: var(--palette-text-000);
+  font-family: var(--font-family-primary);
+  font-size: var(--font-size-2);
+  font-weight: var(--font-weight-primary-semi-bold);
+
+  padding: var(--spacing-1);
+  padding-right: var(--spacing-2);
+  padding-left: var(--spacing-2);
+
+  &.disabled {
+    color: var(--palette-primary-300);
+    background-color: var(--palette-primary-600);
+  }
+
+  &:hover:not(.disabled)  {
+    color: var(--palette-text-000);
+    background-color: var(--palette-primary-400);
+  }
+
+  &:active:not(.disabled)  {
+    color: var(--palette-text-000);
+    background-color: var(--palette-primary-400);
+  }
+}
+
+.unmarkAllIcon {
+  margin-right: var(--spacing-1);
+}
+
+.nextUnreadIcon {
+  margin-left: var(--spacing-1);
+}
+
 .nextActionContainer {
 }
 

--- a/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -10,6 +10,8 @@ import React, {
 } from "react";
 import { Environment, graphql } from "react-relay";
 
+import CLASSES from "coral-stream/classes";
+
 import { useInMemoryState } from "coral-framework/hooks";
 import { useCoralContext } from "coral-framework/lib/bootstrap";
 import { globalErrorReporter } from "coral-framework/lib/errors";
@@ -1403,7 +1405,10 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
                   <button
                     onClick={handleCloseToolbarButton}
                     aria-label="Close"
-                    className={styles.closeButton}
+                    className={cn(
+                      styles.closeButton,
+                      CLASSES.mobileToolbar.close
+                    )}
                   >
                     <ButtonSvgIcon Icon={RemoveIcon} />
                   </button>
@@ -1412,9 +1417,13 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
 
               <div className={styles.unmarkAllContainer}>
                 <button
-                  className={cn(styles.actionButton, {
-                    [styles.disabled]: disableUnreadButtons,
-                  })}
+                  className={cn(
+                    styles.actionButton,
+                    CLASSES.mobileToolbar.markAllAsRead,
+                    {
+                      [styles.disabled]: disableUnreadButtons,
+                    }
+                  )}
                   disabled={disableUnreadButtons}
                   onClick={handleUnmarkAllButton}
                 >
@@ -1431,9 +1440,13 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
               </div>
               <div className={styles.nextActionContainer}>
                 <button
-                  className={cn(styles.actionButton, {
-                    [styles.disabled]: disableUnreadButtons,
-                  })}
+                  className={cn(
+                    styles.actionButton,
+                    CLASSES.mobileToolbar.nextUnread,
+                    {
+                      [styles.disabled]: disableUnreadButtons,
+                    }
+                  )}
                   disabled={disableUnreadButtons}
                   onClick={handleZKeyButton}
                 >

--- a/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -1,4 +1,5 @@
 import { Localized } from "@fluent/react/compat";
+import cn from "classnames";
 import { ListenerFn } from "eventemitter2";
 import React, {
   FunctionComponent,
@@ -43,7 +44,7 @@ import {
   ControlsNextIcon,
   RemoveIcon,
 } from "coral-ui/components/icons";
-import { Button, Flex } from "coral-ui/components/v2";
+import { Flex } from "coral-ui/components/v2";
 import { MatchMedia } from "coral-ui/components/v2/MatchMedia/MatchMedia";
 import { useShadowRootOrDocument } from "coral-ui/encapsulation";
 
@@ -430,6 +431,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
         setDisableUnreadButtons(true);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     comments,
     newCommentsAreStillMarkedUnseen,
@@ -1095,6 +1097,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
         return true;
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       eventEmitter,
       relayEnvironment,
@@ -1173,6 +1176,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
       // search through comments to find and navigate to next unseen
       findAndNavigateToNextUnseen(undefined, source);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       findAndNavigateToNextUnseen,
       traverse,
@@ -1407,34 +1411,42 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
               </div>
 
               <div className={styles.unmarkAllContainer}>
-                <Button
-                  variant="regular"
-                  color="stream"
-                  size="regular"
-                  uppercase={false}
+                <button
+                  className={cn(styles.actionButton, {
+                    [styles.disabled]: disableUnreadButtons,
+                  })}
                   disabled={disableUnreadButtons}
                   onClick={handleUnmarkAllButton}
                 >
-                  <ButtonSvgIcon Icon={CheckDoubleIcon} />
-                  <Localized id="comments-mobileToolbar-unmarkAll">
-                    <span>Mark all as read</span>
-                  </Localized>
-                </Button>
+                  <Flex justifyContent="center" alignItems="center">
+                    <ButtonSvgIcon
+                      Icon={CheckDoubleIcon}
+                      className={styles.unmarkAllIcon}
+                    />
+                    <Localized id="comments-mobileToolbar-unmarkAll">
+                      <span>Mark all as read</span>
+                    </Localized>
+                  </Flex>
+                </button>
               </div>
               <div className={styles.nextActionContainer}>
-                <Button
-                  variant="regular"
-                  color="stream"
-                  size="regular"
-                  uppercase={false}
+                <button
+                  className={cn(styles.actionButton, {
+                    [styles.disabled]: disableUnreadButtons,
+                  })}
                   disabled={disableUnreadButtons}
                   onClick={handleZKeyButton}
                 >
-                  <Localized id="comments-mobileToolbar-nextUnread">
-                    <span>Next unread</span>
-                  </Localized>
-                  <ButtonSvgIcon Icon={ControlsNextIcon} />
-                </Button>
+                  <Flex justifyContent="center" alignItems="center">
+                    <Localized id="comments-mobileToolbar-nextUnread">
+                      <span>Next unread</span>
+                    </Localized>
+                    <ButtonSvgIcon
+                      Icon={ControlsNextIcon}
+                      className={styles.nextUnreadIcon}
+                    />
+                  </Flex>
+                </button>
               </div>
               <div className={styles.notificationActionContainer}>
                 <MobileNotificationButton

--- a/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -1410,7 +1410,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
                       CLASSES.mobileToolbar.close
                     )}
                   >
-                    <ButtonSvgIcon Icon={RemoveIcon} />
+                    <ButtonSvgIcon size="md" Icon={RemoveIcon} />
                   </button>
                 </Localized>
               </div>

--- a/client/src/core/client/stream/common/KeyboardShortcuts/MobileToolbar.tsx
+++ b/client/src/core/client/stream/common/KeyboardShortcuts/MobileToolbar.tsx
@@ -20,7 +20,7 @@ const MobileToolbar: FunctionComponent<Props> = ({
   <Portal>
     <ReactShadowRoot modal>
       <Flex justifyContent="center" className={cn(className, styles.root)}>
-        <div className={cn(styles.bar, CLASSES.mobileToolbar)} {...rest}>
+        <div className={cn(styles.bar, CLASSES.mobileToolbar.$root)} {...rest}>
           {children}
         </div>
       </Flex>

--- a/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.css
+++ b/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.css
@@ -40,7 +40,7 @@
 
   font-family: var(--font-family-primary);
   font-weight: var(--font-weight-primary-semi-bold);
-  font-size: var(--font-size-4);
+  font-size: var(--font-size-3);
 
   word-break: break-word;
 

--- a/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.tsx
@@ -61,7 +61,7 @@ export const MobileNotificationButton: FunctionComponent<Props> = ({
                   aria-label="Close notifications"
                   className={styles.closeButton}
                 >
-                  <ButtonSvgIcon size="lg" Icon={RemoveIcon} />
+                  <ButtonSvgIcon size="md" Icon={RemoveIcon} />
                 </button>
               </Localized>
             </div>


### PR DESCRIPTION
## What does this PR do?

Updates the styles of the mobile toolbar to match the latest wireframes in Figma (v3).

<img width="409" alt="image" src="https://github.com/coralproject/talk/assets/5751504/93b61e6d-8032-4b69-ae7e-105d27425e25">

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- enable `Z_KEY` and `COMMENT_SEEN`
- navigate to the stream on mobile
- see the new tray show up
- see that styles match the Figma docs for wireframes v3

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into epic branch.
