### PR TITLE
[CORL-3105] increase rate limit for flagging comments in API

### DIFF
--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -10218,7 +10218,7 @@ type Mutation {
   """
   createCommentFlag(input: CreateCommentFlagInput!): CreateCommentFlagPayload!
     @auth
-    @rate(seconds: 3)
+    @rate(max: 2, seconds: 3)
 
   """
   featureComment will mark a given Comment as featured.


### PR DESCRIPTION
## What does this PR do?

Adjust the rate limiting for `createCommentFlag` so it can execute twice as often for the same interval.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Changes the `@rate(...)` for `createCommentFlag` from `@rate(seconds: 3)` to `@rate(max: 2, seconds: 3)` which increases the max from a default of 1 to 2.

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- ensure you do not have `DISABLE_RATE_LIMITERS` set to true in your env vars
- find a comment in your database
- get its `id` and latest revision's `id`
- using the following mutation with an admin user bearer token, issue the mutation

```
mutation {
	createCommentFlag(input: {
		commentID: "<some-comment-id>",
		commentRevisionID: "<comments-latest-revision-id>",
		reason: COMMENT_REPORTED_OTHER,
		additionalDetails: "additional details",
		clientMutationId: "1"
	}) {
		comment {
			id
		}
	}
}
```

- check that you can do 2 of these every 3 seconds, otherwise you get rate limited

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

No special considerations.
