### PR TITLE
[CORL-3107]: adjust preferences in-page notification settings

### DIFF
--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.css
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.css
@@ -2,6 +2,37 @@
   margin-right: var(--spacing-1);
 }
 
+.bellWrapper {
+  position: relative;
+  margin-right: var(--spacing-2);
+}
+
+.bellCounter {
+  font-family: var(--font-family-primary);
+  font-weight: var(--font-weight-regular);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: var(--palette-primary-500);
+  color: var(--palette-text-000);
+
+  position: absolute;
+  top: -2px;
+  left: 11px;
+
+  font-size: 8px;
+
+  min-width: 8px;
+
+  padding-top: 1px;
+  padding-bottom: 1px;
+  padding-left: 2px;
+  padding-right: 2px;
+  border-radius: 12px;
+}
+
 .title {
   font-family: var(--font-family-primary);
   font-weight: var(--font-weight-primary-semi-bold);

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.css
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.css
@@ -25,6 +25,8 @@
   color: var(--palette-text-500);
 
   padding-bottom: var(--spacing-1);
+
+  margin-top: var(--spacing-2) !important;
 }
 
 .disabledHeader {

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.css
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.css
@@ -42,8 +42,14 @@
   line-height: 1.125;
 
   color: var(--palette-text-500);
+}
 
-  padding-bottom: var(--spacing-2);
+.featuredCheckbox {
+  margin-bottom: var(--spacing-3) !important;
+}
+
+.showReplies {
+  margin-left: var(--spacing-2);
 }
 
 .updateButton {

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -8,6 +8,7 @@ import { graphql } from "react-relay";
 import { InvalidRequestError } from "coral-framework/lib/errors";
 import { formatBool, parseStringBool } from "coral-framework/lib/form";
 import { useMutation, withFragmentContainer } from "coral-framework/lib/relay";
+import { GQLInPageNotificationReplyType } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
 import {
   ActiveNotificationBellIcon,
@@ -22,7 +23,9 @@ import {
   FormField,
   HorizontalGutter,
   HorizontalRule,
+  Option,
   RadioButton,
+  SelectField,
 } from "coral-ui/components/v2";
 import { Button, CallOut } from "coral-ui/components/v3";
 
@@ -124,7 +127,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                       {({ input }) => (
                         <RadioButton {...input} id={`${input.name}-true`}>
                           <Localized id="profile-account-notifications-inPageNotifications-on">
-                            <span>On</span>
+                            <span>Badges on</span>
                           </Localized>
                         </RadioButton>
                       )}
@@ -140,7 +143,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                         return (
                           <RadioButton {...input} id={`${input.name}-false`}>
                             <Localized id="profile-account-notifications-inPageNotifications-off">
-                              <span>Off</span>
+                              <span>Badges off</span>
                             </Localized>
                           </RadioButton>
                         );
@@ -148,7 +151,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                     </Field>
                   </FormField>
                 </HorizontalGutter>
-                <HorizontalGutter>
+                <HorizontalGutter marginTop={2}>
                   <Localized id="profile-account-notifications-includeInPageWhen">
                     <div
                       className={
@@ -162,78 +165,96 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                       }
                       id="profile-account-notifications-includeInPageWhen"
                     >
-                      Include notifications when
+                      Alert me when
                     </div>
                   </Localized>
                   <FieldSet aria-labelledby="profile-account-notifications-includeInPageWhen">
-                    <FormField>
-                      <Field name="onReply" type="checkbox">
-                        {({ input }) => (
-                          <Localized id="profile-account-notifications-onReply">
-                            <CheckBox
-                              {...input}
-                              id={`${input.name}-inPage`}
-                              className={styles.checkBox}
-                              variant="streamBlue"
-                              disabled={disableWhenSection}
-                            >
-                              My comment receives a reply
-                            </CheckBox>
-                          </Localized>
-                        )}
-                      </Field>
-                    </FormField>
-                    <FormField>
-                      <Field name="onFeatured" type="checkbox">
-                        {({ input }) => (
-                          <Localized id="profile-account-notifications-onFeatured">
-                            <CheckBox
-                              {...input}
-                              id={`${input.name}-inPage`}
-                              className={styles.checkBox}
-                              variant="streamBlue"
-                              disabled={disableWhenSection}
-                            >
-                              My comment is featured
-                            </CheckBox>
-                          </Localized>
-                        )}
-                      </Field>
-                    </FormField>
-                    <FormField>
-                      <Field name="onStaffReplies" type="checkbox">
-                        {({ input }) => (
-                          <Localized id="profile-account-notifications-onStaffReplies">
-                            <CheckBox
-                              {...input}
-                              id={`${input.name}-inPage`}
-                              className={styles.checkBox}
-                              variant="streamBlue"
-                              disabled={disableWhenSection}
-                            >
-                              A staff member replies to my comment
-                            </CheckBox>
-                          </Localized>
-                        )}
-                      </Field>
-                    </FormField>
-                    <FormField>
-                      <Field name="onModeration" type="checkbox">
-                        {({ input }) => (
-                          <Localized id="profile-account-notifications-onModeration">
-                            <CheckBox
-                              {...input}
-                              id={`${input.name}-inPage`}
-                              className={styles.checkBox}
-                              variant="streamBlue"
-                              disabled={disableWhenSection}
-                            >
-                              My pending comment has been reviewed
-                            </CheckBox>
-                          </Localized>
-                        )}
-                      </Field>
-                    </FormField>
+                    <HorizontalGutter>
+                      <FormField>
+                        <Flex alignItems="center">
+                          <Field name="onReply.enabled" type="checkbox">
+                            {({ input }) => (
+                              <>
+                                <Localized id="profile-account-notifications-onReply">
+                                  <CheckBox
+                                    {...input}
+                                    id={`${input.name}-inPage`}
+                                    className={styles.checkBox}
+                                    variant="streamBlue"
+                                    disabled={disableWhenSection}
+                                  >
+                                    My comment receives a reply
+                                  </CheckBox>
+                                </Localized>
+                              </>
+                            )}
+                          </Field>
+                          <span className={styles.showReplies}>
+                            <Field name="onReply.showReplies">
+                              {({ input }) => (
+                                <SelectField
+                                  {...input}
+                                  id={input.name}
+                                  disabled={disableWhenSection}
+                                  aria-label="Show replies"
+                                >
+                                  <Localized id="profile-account-notifications-showReplies-fromAnyone">
+                                    <Option
+                                      value={GQLInPageNotificationReplyType.ALL}
+                                    >
+                                      from anyone
+                                    </Option>
+                                  </Localized>
+                                  <Localized id="profile-account-notifications-showReplies-fromStaff">
+                                    <Option
+                                      value={
+                                        GQLInPageNotificationReplyType.STAFF
+                                      }
+                                    >
+                                      from a staff member
+                                    </Option>
+                                  </Localized>
+                                </SelectField>
+                              )}
+                            </Field>
+                          </span>
+                        </Flex>
+                      </FormField>
+                      <FormField className={styles.featuredCheckbox}>
+                        <Field name="onFeatured" type="checkbox">
+                          {({ input }) => (
+                            <Localized id="profile-account-notifications-onFeatured">
+                              <CheckBox
+                                {...input}
+                                id={`${input.name}-inPage`}
+                                className={styles.checkBox}
+                                variant="streamBlue"
+                                disabled={disableWhenSection}
+                              >
+                                My comment is featured
+                              </CheckBox>
+                            </Localized>
+                          )}
+                        </Field>
+                      </FormField>
+                      <FormField>
+                        <Field name="onModeration" type="checkbox">
+                          {({ input }) => (
+                            <Localized id="profile-account-notifications-onModeration">
+                              <CheckBox
+                                {...input}
+                                id={`${input.name}-inPage`}
+                                className={styles.checkBox}
+                                variant="streamBlue"
+                                disabled={disableWhenSection}
+                              >
+                                My pending comment has been reviewed
+                              </CheckBox>
+                            </Localized>
+                          )}
+                        </Field>
+                      </FormField>
+                    </HorizontalGutter>
                   </FieldSet>
                 </HorizontalGutter>
                 <div
@@ -299,9 +320,11 @@ const enhanced = withFragmentContainer<Props>({
     fragment InPageNotificationSettingsContainer_viewer on User {
       inPageNotifications {
         enabled
-        onReply
+        onReply {
+          enabled
+          showReplies
+        }
         onFeatured
-        onStaffReplies
         onModeration
       }
     }

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -192,29 +192,39 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                           <span className={styles.showReplies}>
                             <Field name="onReply.showReplies">
                               {({ input }) => (
-                                <SelectField
-                                  {...input}
-                                  id={input.name}
-                                  disabled={disableWhenSection}
-                                  aria-label="Show replies"
+                                <Localized
+                                  id="profile-account-notifications-showReplies"
+                                  attrs={{ "aria-label": true }}
                                 >
-                                  <Localized id="profile-account-notifications-showReplies-fromAnyone">
-                                    <Option
-                                      value={GQLInPageNotificationReplyType.ALL}
-                                    >
-                                      from anyone
-                                    </Option>
-                                  </Localized>
-                                  <Localized id="profile-account-notifications-showReplies-fromStaff">
-                                    <Option
-                                      value={
-                                        GQLInPageNotificationReplyType.STAFF
-                                      }
-                                    >
-                                      from a staff member
-                                    </Option>
-                                  </Localized>
-                                </SelectField>
+                                  <SelectField
+                                    {...input}
+                                    id={input.name}
+                                    disabled={
+                                      disableWhenSection ||
+                                      !values.onReply.enabled
+                                    }
+                                    aria-label="Show replies from"
+                                  >
+                                    <Localized id="profile-account-notifications-showReplies-fromAnyone">
+                                      <Option
+                                        value={
+                                          GQLInPageNotificationReplyType.ALL
+                                        }
+                                      >
+                                        from anyone
+                                      </Option>
+                                    </Localized>
+                                    <Localized id="profile-account-notifications-showReplies-fromStaff">
+                                      <Option
+                                        value={
+                                          GQLInPageNotificationReplyType.STAFF
+                                        }
+                                      >
+                                        from a staff member
+                                      </Option>
+                                    </Localized>
+                                  </SelectField>
+                                </Localized>
                               )}
                             </Field>
                           </span>

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -151,7 +151,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                     </Field>
                   </FormField>
                 </HorizontalGutter>
-                <HorizontalGutter marginTop={2}>
+                <HorizontalGutter>
                   <Localized id="profile-account-notifications-includeInPageWhen">
                     <div
                       className={

--- a/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/InPageNotificationSettingsContainer.tsx
@@ -11,9 +11,9 @@ import { useMutation, withFragmentContainer } from "coral-framework/lib/relay";
 import { GQLInPageNotificationReplyType } from "coral-framework/schema";
 import CLASSES from "coral-stream/classes";
 import {
-  ActiveNotificationBellIcon,
   AlertTriangleIcon,
   CheckCircleIcon,
+  NotificationBellIcon,
   SvgIcon,
 } from "coral-ui/components/icons";
 import {
@@ -98,11 +98,16 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
             <form onSubmit={handleSubmit}>
               <HorizontalGutter>
                 <Flex alignItems="center">
-                  <SvgIcon
-                    className={styles.bellIcon}
-                    size="md"
-                    Icon={ActiveNotificationBellIcon}
-                  ></SvgIcon>
+                  <div className={styles.bellWrapper}>
+                    <SvgIcon
+                      className={styles.bellIcon}
+                      size="md"
+                      Icon={NotificationBellIcon}
+                    ></SvgIcon>
+                    {!disableWhenSection && (
+                      <div className={styles.bellCounter}>2</div>
+                    )}
+                  </div>
                   <Localized id="profile-account-notifications-inPageNotifications">
                     <h2
                       className={cn(
@@ -111,7 +116,7 @@ const InPageNotificationSettingsContainer: FunctionComponent<Props> = ({
                       )}
                       id="profile-account-notifications-inPageNotifications-title"
                     >
-                      In-page Notifications
+                      Notifications
                     </h2>
                   </Localized>
                 </Flex>

--- a/client/src/core/client/stream/tabs/Profile/Preferences/UpdateInPageNotificationSettingsMutation.ts
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/UpdateInPageNotificationSettingsMutation.ts
@@ -24,8 +24,6 @@ const UpdateInPageNotificationSettingsMutation = createMutation(
       UpdateInPageNotificationSettingsEvent.begin(eventEmitter, {
         onFeatured: input.onFeatured,
         onModeration: input.onModeration,
-        onStaffReplies: input.onStaffReplies,
-        onReply: input.onReply,
       });
     try {
       const result = await commitMutationPromiseNormalized<MutationTypes>(
@@ -39,9 +37,11 @@ const UpdateInPageNotificationSettingsMutation = createMutation(
                 user {
                   id
                   inPageNotifications {
-                    onReply
+                    onReply {
+                      enabled
+                      showReplies
+                    }
                     onFeatured
-                    onStaffReplies
                     onModeration
                     enabled
                   }
@@ -54,7 +54,6 @@ const UpdateInPageNotificationSettingsMutation = createMutation(
             input: {
               onReply: input.onReply,
               onFeatured: input.onFeatured,
-              onStaffReplies: input.onStaffReplies,
               onModeration: input.onModeration,
               enabled: input.enabled,
               clientMutationId: (clientMutationId++).toString(),

--- a/client/src/core/client/stream/test/fixtures.ts
+++ b/client/src/core/client/stream/test/fixtures.ts
@@ -5,6 +5,7 @@ import {
   GQLDIGEST_FREQUENCY,
   GQLDSA_METHOD_OF_REDRESS,
   GQLFEATURE_FLAG,
+  GQLInPageNotificationReplyType,
   GQLMODERATION_MODE,
   GQLSettings,
   GQLSite,
@@ -241,9 +242,8 @@ export const baseUser = createFixture<GQLUser>({
     digestFrequency: GQLDIGEST_FREQUENCY.NONE,
   },
   inPageNotifications: {
-    onReply: true,
+    onReply: { enabled: true, showReplies: GQLInPageNotificationReplyType.ALL },
     onModeration: true,
-    onStaffReplies: false,
     onFeatured: true,
     enabled: true,
   },

--- a/client/src/core/client/stream/test/profile/preferences.spec.tsx
+++ b/client/src/core/client/stream/test/profile/preferences.spec.tsx
@@ -148,9 +148,8 @@ it("render and update in-page notifications form", async () => {
     .callsFake(
       (_: any, { input: { clientMutationId, ...inPageNotifications } }) => {
         expectAndFail(inPageNotifications).toMatchObject({
-          onReply: false,
+          onReply: { enabled: false, showReplies: "ALL" },
           onFeatured: false,
-          onStaffReplies: true,
           onModeration: false,
           enabled: true,
         });
@@ -190,9 +189,6 @@ it("render and update in-page notifications form", async () => {
   const onReply = within(container).getByRole("checkbox", {
     name: "My comment receives a reply",
   });
-  const onStaffReplies = within(container).getByRole("checkbox", {
-    name: "A staff member replies to my comment",
-  });
   const onModeration = within(container).getByRole("checkbox", {
     name: "My pending comment has been reviewed",
   });
@@ -207,7 +203,6 @@ it("render and update in-page notifications form", async () => {
 
   // Disable the options.
   userEvent.click(onReply);
-  userEvent.click(onStaffReplies);
   userEvent.click(onModeration);
   userEvent.click(onFeatured);
 

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -735,6 +735,8 @@ profile-account-notifications-inPageNotifications-off = Badges off
 
 profile-account-notifications-showReplies-fromAnyone = from anyone
 profile-account-notifications-showReplies-fromStaff = from a staff member
+profile-account-notifications-showReplies
+  .aria-label = Show replies from
 
 ## Report Comment Popover
 comments-reportPopover =

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -727,7 +727,7 @@ profile-account-notifications-updated = Your notification settings have been upd
 profile-account-notifications-button = Update Notification Settings
 profile-account-notifications-button-update = Update
 
-profile-account-notifications-inPageNotifications = In-page Notifications
+profile-account-notifications-inPageNotifications = Notifications
 profile-account-notifications-includeInPageWhen = Alert me when
 
 profile-account-notifications-inPageNotifications-on = Badges on

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -735,7 +735,7 @@ profile-account-notifications-inPageNotifications-off = Badges off
 
 profile-account-notifications-showReplies-fromAnyone = from anyone
 profile-account-notifications-showReplies-fromStaff = from a staff member
-profile-account-notifications-showReplies
+profile-account-notifications-showReplies =
   .aria-label = Show replies from
 
 ## Report Comment Popover

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -728,10 +728,13 @@ profile-account-notifications-button = Update Notification Settings
 profile-account-notifications-button-update = Update
 
 profile-account-notifications-inPageNotifications = In-page Notifications
-profile-account-notifications-includeInPageWhen = Include notifications when
+profile-account-notifications-includeInPageWhen = Alert me when
 
-profile-account-notifications-inPageNotifications-on = On
-profile-account-notifications-inPageNotifications-off = Off
+profile-account-notifications-inPageNotifications-on = Badges on
+profile-account-notifications-inPageNotifications-off = Badges off
+
+profile-account-notifications-showReplies-fromAnyone = from anyone
+profile-account-notifications-showReplies-fromStaff = from a staff member
 
 ## Report Comment Popover
 comments-reportPopover =

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -2986,12 +2986,27 @@ type UserEmailNotificationSettings {
 }
 
 enum InPageNotificationReplyType {
+  """
+  The user wishes to receive in-page notifications from everyone
+  """
   ALL
+
+  """
+  The user wishes to receive in-page notifications from staff members only
+  """
   STAFF
 }
 
 type OnReplySettings {
+  """
+  In-page notifications for replies is enabled
+  """
   enabled: Boolean!
+
+  """
+  This keeps track of what type of reply the user would like to be notified on when
+  in-page reply notifications is enabled
+  """
   showReplies: InPageNotificationReplyType!
 }
 
@@ -5358,7 +5373,15 @@ type UpdateEmailNotificationSettingsPayload {
 }
 
 input OnReplySettingsInput {
+  """
+  In-page notifications for replies is enabled
+  """
   enabled: Boolean!
+
+  """
+  This keeps track of what type of reply the user would like to be notified on when
+  in-page reply notifications is enabled
+  """
   showReplies: InPageNotificationReplyType!
 }
 

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -2985,6 +2985,16 @@ type UserEmailNotificationSettings {
   digestFrequency: DIGEST_FREQUENCY!
 }
 
+enum InPageNotificationReplyType {
+  ALL
+  STAFF
+}
+
+type OnReplySettings {
+  enabled: Boolean!
+  showReplies: InPageNotificationReplyType!
+}
+
 """
 UserInPageNotificationSettings stores the in-page notification settings for a given User.
 """
@@ -2999,21 +3009,13 @@ type UserInPageNotificationSettings {
   onReply, when true, will enable in-page notifications to be sent to users that have
   replies to their comments.
   """
-  onReply: Boolean!
+  onReply: OnReplySettings!
 
   """
   onFeatured, when true, will enable in-page notifications to be sent to users that have
   their comment's featured.
   """
   onFeatured: Boolean!
-
-  """
-  onStaffReplies when true, will enable in-page notifications to be sent to users that
-  have a staff member reply to their comments. These notifications will
-  supercede notifications that would have been sent for a basic reply
-  notification.
-  """
-  onStaffReplies: Boolean!
 
   """
   onModeration when true, will enable in-page notifications to be sent to users when a
@@ -5355,6 +5357,11 @@ type UpdateEmailNotificationSettingsPayload {
   clientMutationId: String!
 }
 
+input OnReplySettingsInput {
+  enabled: Boolean!
+  showReplies: InPageNotificationReplyType!
+}
+
 ##################
 ## updateInPageNotificationSettings
 ##################
@@ -5364,21 +5371,13 @@ input UpdateInPageNotificationSettingsInput {
   onReply, when true, will enable in-page notifications to be sent to users that have
   replies to their comments.
   """
-  onReply: Boolean
+  onReply: OnReplySettingsInput
 
   """
   onFeatured, when true, will enable in-page notifications to be sent to users that have
   their comment's featured.
   """
   onFeatured: Boolean
-
-  """
-  onStaffReplies when true, will enable in-page notifications to be sent to users that
-  have a staff member reply to their comments. These notifications will
-  supercede notifications that would have been sent for a basic reply
-  notification.
-  """
-  onStaffReplies: Boolean
 
   """
   onModeration when true, will enable in-page notifications to be sent to users when a

--- a/server/src/core/server/models/user/user.ts
+++ b/server/src/core/server/models/user/user.ts
@@ -34,6 +34,7 @@ import { dotize } from "coral-server/utils/dotize";
 import {
   GQLBanStatus,
   GQLDIGEST_FREQUENCY,
+  GQLInPageNotificationReplyType,
   GQLModMessageStatus,
   GQLPremodStatus,
   GQLSuspensionStatus,
@@ -119,9 +120,8 @@ export interface Token {
 export const defaultInPageNotificationSettings: GQLUserInPageNotificationSettings =
   {
     enabled: true,
-    onReply: true,
+    onReply: { enabled: true, showReplies: GQLInPageNotificationReplyType.ALL },
     onFeatured: true,
-    onStaffReplies: true,
     onModeration: true,
   };
 
@@ -747,10 +747,12 @@ export async function findOrCreateUserInput(
       digestFrequency: GQLDIGEST_FREQUENCY.NONE,
     },
     inPageNotifications: {
-      onReply: true,
+      onReply: {
+        enabled: true,
+        showReplies: GQLInPageNotificationReplyType.ALL,
+      },
       onFeatured: true,
       onModeration: true,
-      onStaffReplies: false,
       enabled: true,
     },
     moderatorNotes: [],

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -18,6 +18,7 @@ import { I18n } from "coral-server/services/i18n";
 
 import {
   GQLDSAReportDecisionLegality,
+  GQLInPageNotificationReplyType,
   GQLNOTIFICATION_TYPE,
   GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
@@ -230,12 +231,19 @@ export class InternalNotificationContext {
       ) {
         shouldIncrementCount = false;
       }
-      if (type === GQLNOTIFICATION_TYPE.REPLY && !preferences?.onReply) {
+      if (
+        type === GQLNOTIFICATION_TYPE.REPLY &&
+        (!preferences?.onReply?.enabled ||
+          !(
+            preferences?.onReply?.showReplies ===
+            GQLInPageNotificationReplyType.ALL
+          ))
+      ) {
         shouldIncrementCount = false;
       }
       if (
         type === GQLNOTIFICATION_TYPE.REPLY_STAFF &&
-        !preferences?.onStaffReplies
+        !preferences?.onReply?.enabled
       ) {
         shouldIncrementCount = false;
       }

--- a/server/src/core/server/test/fixtures.ts
+++ b/server/src/core/server/test/fixtures.ts
@@ -12,6 +12,7 @@ import {
   GQLCOMMENT_STATUS,
   GQLDIGEST_FREQUENCY,
   GQLDSA_METHOD_OF_REDRESS,
+  GQLInPageNotificationReplyType,
   GQLMODERATION_MODE,
   GQLUSER_ROLE,
 } from "coral-server/graph/schema/__generated__/types";
@@ -241,13 +242,13 @@ export const createUserFixture = (defaults: Defaults<User> = {}): User => {
       digestFrequency: GQLDIGEST_FREQUENCY.NONE,
     },
     inPageNotifications: {
-      onReply: true,
+      onReply: {
+        enabled: true,
+        showReplies: GQLInPageNotificationReplyType.ALL,
+      },
       onFeatured: true,
       onModeration: true,
-      onStaffReplies: false,
       enabled: true,
-      includeCountInBadge: true,
-      bellRemainsVisible: true,
     },
     digests: [],
     hasDigests: false,


### PR DESCRIPTION
## What does this PR do?

These changes update a commenter's in-page notification settings so that they can select to receive replies `from everyone` or `from a staff member`. It also updates copy to `Badges on`/`Badges off` and `Alert me when`. It updates the schema for the `onReplies` setting and updates where this is used.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Updates `inPageNotifications.onReplies` settings for users.

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?


n/a

## How do I test this PR?

You can test this PR by going into a user's Preferences --> In-page Notifications. See the updated copy. Change settings for when a comment receives a reply and whether it's from everyone or a staff member. See everything saves and is enabled/disabled as expected.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
