### PR TITLE
[CORL-3109] Set screen reader accessible titles for notifications buttons/tabs

### DIFF
--- a/client/src/core/client/stream/App/TabBar.tsx
+++ b/client/src/core/client/stream/App/TabBar.tsx
@@ -79,6 +79,7 @@ const AppTabBar: FunctionComponent<Props> = (props) => {
   );
   const myProfileText = getMessage("general-tabBar-myProfileTab", "My Profile");
   const configureText = getMessage("general-tabBar-configure", "Configure");
+  const notificationsText = getMessage("notifications-title", "Notifications");
 
   return (
     <MatchMedia gteWidth="sm">
@@ -199,6 +200,7 @@ const AppTabBar: FunctionComponent<Props> = (props) => {
               tabID="NOTIFICATIONS"
               variant="notifications"
               float="right"
+              title={notificationsText}
             >
               <div className={cn(styles.notificationsIcon)}>
                 <LiveBellIcon

--- a/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationButton.tsx
@@ -9,6 +9,7 @@ import React, {
 import { graphql } from "relay-runtime";
 
 import { useCoralContext } from "coral-framework/lib/bootstrap";
+import { useGetMessage } from "coral-framework/lib/i18n";
 import { useLocal } from "coral-framework/lib/relay";
 import { MatchMedia } from "coral-ui/components/v2";
 
@@ -42,6 +43,9 @@ const FloatingNotificationButton: FunctionComponent<Props> = ({
   const [topPos, setTopPos] = useState<number>(0);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const getMessage = useGetMessage();
+  const title = getMessage("notifications-title", "Notifications");
 
   const onWindowResize = useCallback(() => {
     const element = window.document.getElementById("coral-shadow-container");
@@ -115,6 +119,7 @@ const FloatingNotificationButton: FunctionComponent<Props> = ({
                 [styles.buttonOpen]: isOpen,
               })}
               onClick={onToggleOpen}
+              title={title}
             >
               {isOpen && (
                 <div className={styles.buttonText}>

--- a/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from "react";
 
+import { useGetMessage } from "coral-framework/lib/i18n";
 import { ButtonSvgIcon, RemoveIcon } from "coral-ui/components/icons";
 
 import { LiveBellIcon } from "../LiveBellIcon";
@@ -22,6 +23,9 @@ export const MobileNotificationButton: FunctionComponent<Props> = ({
   viewerID,
   enabled,
 }) => {
+  const getMessage = useGetMessage();
+  const title = getMessage("notifications-title", "Notifications");
+
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const onToggleOpen = useCallback(() => {
@@ -71,7 +75,7 @@ export const MobileNotificationButton: FunctionComponent<Props> = ({
           </div>
         </div>
       )}
-      <button className={styles.button} onClick={onToggleOpen}>
+      <button className={styles.button} onClick={onToggleOpen} title={title}>
         <LiveBellIcon size="lg" style="tray" enabled={enabled} />
       </button>
     </>


### PR DESCRIPTION
## What does this PR do?

Adds a localized title to the notifications tabs and buttons.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- load up the stream in various modes (3 buttons/tabs total)
- check that the `title` property is set on the button action for all tabs/buttons that represent notifications

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into epic branch.
