### PR TITLE
[CORL-3110] Add further static classnames across notifications components

### DIFF
--- a/client/src/core/client/stream/classes.ts
+++ b/client/src/core/client/stream/classes.ts
@@ -1072,6 +1072,19 @@ const CLASSES = {
       icon: "coral coral-notifications-live-icon",
       counter: "coral coral-notifications-live-counter",
     },
+
+    floating: {
+      root: "coral coral-notifications-floating-root",
+      action: "coral coral-notifications-floating-action",
+      close: "coral coral-notifications-floating-close",
+      icon: "coral coral-notifications-floating-icon",
+      feed: {
+        root: "coral coral-notifications-floating-feed-root",
+        panel: "coral coral-notifications-floating-feed-panel",
+        title: "coral coral-notifications-floating-feed-root",
+        container: "coral coral-notifications-floating-feed-container",
+      },
+    },
   },
 
   mediaPreferences: {

--- a/client/src/core/client/stream/classes.ts
+++ b/client/src/core/client/stream/classes.ts
@@ -1081,9 +1081,17 @@ const CLASSES = {
       feed: {
         root: "coral coral-notifications-floating-feed-root",
         panel: "coral coral-notifications-floating-feed-panel",
-        title: "coral coral-notifications-floating-feed-root",
+        title: "coral coral-notifications-floating-feed-title",
         container: "coral coral-notifications-floating-feed-container",
       },
+    },
+
+    mobileToolBar: {
+      root: "coral coral-notifications-mobileToolBar-root",
+      tray: "coral coral-notifications-mobileToolBar-tray",
+      header: "coral coral-notifications-mobileToolBar-header",
+      close: "coral coral-notifications-mobileToolBar-close",
+      list: "coral coral-notifications-mobileToolBar-list",
     },
   },
 
@@ -1165,6 +1173,7 @@ const CLASSES = {
     close: "coral coral-mobileToolbar-close",
     markAllAsRead: "coral coral-mobileToolbar-markAllAsRead",
     nextUnread: "coral coral-mobileToolbar-nextUnread",
+    notificationsAction: "coral coral-mobileToolbar-notifications",
   },
 
   viewersWatching: {

--- a/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -1461,7 +1461,12 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
                   </Flex>
                 </button>
               </div>
-              <div className={styles.notificationActionContainer}>
+              <div
+                className={cn(
+                  styles.notificationActionContainer,
+                  CLASSES.mobileToolbar.notificationsAction
+                )}
+              >
                 <MobileNotificationButton
                   viewerID={viewerID}
                   enabled={userNotificationsEnabled}

--- a/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationButton.tsx
@@ -11,6 +11,7 @@ import { graphql } from "relay-runtime";
 import { useCoralContext } from "coral-framework/lib/bootstrap";
 import { useGetMessage } from "coral-framework/lib/i18n";
 import { useLocal } from "coral-framework/lib/relay";
+import CLASSES from "coral-stream/classes";
 import { MatchMedia } from "coral-ui/components/v2";
 
 import { FloatingNotificationButton_local } from "coral-stream/__generated__/FloatingNotificationButton_local.graphql";
@@ -110,19 +111,28 @@ const FloatingNotificationButton: FunctionComponent<Props> = ({
       {(matches) =>
         !matches && enableZKey && enableCommentSeen ? null : (
           <div
-            className={styles.root}
+            className={cn(CLASSES.notifications.floating.root, styles.root)}
             style={{ left: `${leftPos}px`, top: `${topPos}px` }}
           >
             <button
-              className={cn(styles.button, {
-                [styles.buttonClosed]: !isOpen,
-                [styles.buttonOpen]: isOpen,
-              })}
+              className={cn(
+                CLASSES.notifications.floating.action,
+                styles.button,
+                {
+                  [styles.buttonClosed]: !isOpen,
+                  [styles.buttonOpen]: isOpen,
+                }
+              )}
               onClick={onToggleOpen}
               title={title}
             >
               {isOpen && (
-                <div className={styles.buttonText}>
+                <div
+                  className={cn(
+                    CLASSES.notifications.floating.close,
+                    styles.buttonText
+                  )}
+                >
                   <Localized id="notifications-floatingIcon-close">
                     close
                   </Localized>
@@ -131,14 +141,34 @@ const FloatingNotificationButton: FunctionComponent<Props> = ({
               <LiveBellIcon size="md" style={iconStyle} enabled={enabled} />
             </button>
             {isOpen && (
-              <div className={styles.feedRoot}>
-                <div className={styles.feedPanel}>
-                  <div className={styles.title}>
+              <div
+                className={cn(
+                  CLASSES.notifications.floating.feed.root,
+                  styles.feedRoot
+                )}
+              >
+                <div
+                  className={cn(
+                    CLASSES.notifications.floating.feed.panel,
+                    styles.feedPanel
+                  )}
+                >
+                  <div
+                    className={cn(
+                      CLASSES.notifications.floating.feed.title,
+                      styles.title
+                    )}
+                  >
                     <Localized id="notifications-title">
                       Notifications
                     </Localized>
                   </div>
-                  <div className={styles.feed}>
+                  <div
+                    className={cn(
+                      CLASSES.notifications.floating.feed.container,
+                      styles.feed
+                    )}
+                  >
                     <FloatingNotificationsQuery
                       showUserBox={false}
                       showTitle={false}

--- a/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/mobileButton/MobileNotificationButton.tsx
@@ -1,4 +1,5 @@
 import { Localized } from "@fluent/react/compat";
+import cn from "classnames";
 import React, {
   FunctionComponent,
   MouseEvent,
@@ -7,6 +8,7 @@ import React, {
 } from "react";
 
 import { useGetMessage } from "coral-framework/lib/i18n";
+import CLASSES from "coral-stream/classes";
 import { ButtonSvgIcon, RemoveIcon } from "coral-ui/components/icons";
 
 import { LiveBellIcon } from "../LiveBellIcon";
@@ -45,16 +47,27 @@ export const MobileNotificationButton: FunctionComponent<Props> = ({
       {isOpen && (
         <div
           id="MobileNotificationButton-container"
-          className={styles.container}
+          className={cn(
+            CLASSES.notifications.mobileToolBar.root,
+            styles.container
+          )}
           aria-hidden="true"
           onClick={onToggleOpen}
         >
           <div
-            className={styles.tray}
+            className={cn(
+              CLASSES.notifications.mobileToolBar.tray,
+              styles.tray
+            )}
             aria-hidden="true"
             onClick={stopPropagation}
           >
-            <div className={styles.header}>
+            <div
+              className={cn(
+                CLASSES.notifications.mobileToolBar.header,
+                styles.header
+              )}
+            >
               <Localized id="notifications-title">Notifications</Localized>
               <Localized
                 id="comments-mobileToolbar-notifications-closeButton"
@@ -63,13 +76,21 @@ export const MobileNotificationButton: FunctionComponent<Props> = ({
                 <button
                   onClick={onToggleOpen}
                   aria-label="Close notifications"
-                  className={styles.closeButton}
+                  className={cn(
+                    CLASSES.notifications.mobileToolBar.close,
+                    styles.closeButton
+                  )}
                 >
                   <ButtonSvgIcon size="md" Icon={RemoveIcon} />
                 </button>
               </Localized>
             </div>
-            <div className={styles.list}>
+            <div
+              className={cn(
+                CLASSES.notifications.mobileToolBar.list,
+                styles.list
+              )}
+            >
               <MobileNotificationsQuery showUserBox={false} showTitle={false} />
             </div>
           </div>


### PR DESCRIPTION
## What does this PR do?

Adds static classnames across various notifications buttons, trays, feeds, and actions.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

Inspect the modified notification icons, buttons, trays, tabs, etc and see they have static class names to bind external CSS to.

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into epic branch.
