### PR TITLE
[CORL-3104]: Email domain ban confirmation

### DIFF
--- a/client/src/core/client/admin/components/BanModal.css
+++ b/client/src/core/client/admin/components/BanModal.css
@@ -48,3 +48,17 @@ $ban-modal-text: var(--palette-text-500);
 .rejectExistingReason {
   background-color: var(--palette-grey-100);
 }
+
+.domainBanCallOut {
+  padding: var(--spacing-1);
+}
+
+.alertIcon {
+  margin-right: var(--spacing-1);
+}
+
+.domainBanConfirmationInput {
+  font-family: var(--font-family-primary);
+  line-height: 2.25;
+  padding-left: var(--spacing-2);
+}

--- a/client/src/core/client/admin/components/BanModal.css
+++ b/client/src/core/client/admin/components/BanModal.css
@@ -51,6 +51,7 @@ $ban-modal-text: var(--palette-text-500);
 
 .domainBanCallOut {
   padding: var(--spacing-1);
+  margin-bottom: var(--spacing-2);
 }
 
 .alertIcon {
@@ -61,4 +62,8 @@ $ban-modal-text: var(--palette-text-500);
   font-family: var(--font-family-primary);
   line-height: 2.25;
   padding-left: var(--spacing-2);
+}
+
+.domainBanConfirmationLabel {
+  margin-bottom: var(--spacing-1);
 }

--- a/client/src/core/client/admin/components/BanModal.spec.tsx
+++ b/client/src/core/client/admin/components/BanModal.spec.tsx
@@ -136,11 +136,21 @@ it("creates domain ban for unmoderated domain while updating user ban status", a
   const modal = getBanModal(container, user);
 
   const banDomainButton = within(modal).getByLabelText(
-    `Ban all new commenter accounts from test.com`
+    `Ban all commenter accounts from test.com`
   );
   userEvent.click(banDomainButton);
-  screen.debug(banDomainButton);
-  userEvent.click(within(modal).getByRole("button", { name: "Ban" }));
+
+  const banSaveButton = within(modal).getByRole("button", { name: "Ban" });
+
+  expect(banSaveButton).toBeDisabled();
+
+  const domainBanConfirmation = within(modal).getByTestId(
+    "domainBanConfirmation"
+  );
+  userEvent.type(domainBanConfirmation, "ban");
+
+  expect(banSaveButton).toBeEnabled();
+  userEvent.click(banSaveButton);
 
   await waitFor(() =>
     expect(resolvers.Mutation!.createEmailDomain!.called).toBeTruthy()
@@ -172,7 +182,7 @@ test.each(gteOrgMods)(
     const modal = getBanModal(container, commenterUser);
 
     const banDomainButton = within(modal).getByLabelText(
-      `Ban all new commenter accounts from test.com`
+      `Ban all commenter accounts from test.com`
     );
 
     expect(banDomainButton).toBeInTheDocument();
@@ -198,7 +208,7 @@ test.each(siteMods)(
     const modal = getBanModal(container, commenterUser);
 
     const banDomainButton = within(modal).queryByText(
-      `Ban all new commenter accounts from test.com`
+      `Ban new commenter accounts from test.com`
     );
 
     expect(banDomainButton).toBeNull();
@@ -233,7 +243,7 @@ it("does not display ban domain option for moderated domain", async () => {
   const modal = getBanModal(container, user);
 
   const banDomainButton = within(modal).queryByText(
-    `Ban all new commenter accounts from test.com`
+    `Ban all commenter accounts from test.com`
   );
 
   expect(banDomainButton).not.toBeInTheDocument();
@@ -279,7 +289,7 @@ it("does not display ban domain option for protected domain", async () => {
   const modal = getBanModal(container, user);
 
   const banDomainButton = within(modal).queryByText(
-    `Ban all new commenter accounts from test.com`
+    `Ban all commenter accounts from test.com`
   );
 
   expect(banDomainButton).not.toBeInTheDocument();

--- a/client/src/core/client/admin/components/BanModal.spec.tsx
+++ b/client/src/core/client/admin/components/BanModal.spec.tsx
@@ -208,7 +208,7 @@ test.each(siteMods)(
     const modal = getBanModal(container, commenterUser);
 
     const banDomainButton = within(modal).queryByText(
-      `Ban new commenter accounts from test.com`
+      `Ban all commenter accounts from test.com`
     );
 
     expect(banDomainButton).toBeNull();

--- a/client/src/core/client/admin/components/BanModal.tsx
+++ b/client/src/core/client/admin/components/BanModal.tsx
@@ -29,7 +29,6 @@ import {
 } from "coral-ui/components/icons";
 import {
   Button,
-  CallOut,
   CheckBox,
   Flex,
   FormField,
@@ -38,6 +37,7 @@ import {
   RadioButton,
   Textarea,
 } from "coral-ui/components/v2";
+import { CallOut } from "coral-ui/components/v3";
 
 import { BanModalLocal } from "coral-admin/__generated__/BanModalLocal.graphql";
 import { UserStatusChangeContainer_settings } from "coral-admin/__generated__/UserStatusChangeContainer_settings.graphql";
@@ -549,9 +549,7 @@ const BanModal: FunctionComponent<Props> = ({
                     <>
                       <CallOut
                         className={styles.domainBanCallOut}
-                        color="error"
-                        fullWidth
-                        borderless
+                        color="warning"
                       >
                         <SvgIcon
                           size="xs"

--- a/client/src/core/client/admin/components/BanModal.tsx
+++ b/client/src/core/client/admin/components/BanModal.tsx
@@ -546,7 +546,7 @@ const BanModal: FunctionComponent<Props> = ({
                     </Flex>
                   )}
                   {canBanDomain && banDomain && (
-                    <>
+                    <Flex direction="column">
                       <CallOut
                         className={styles.domainBanCallOut}
                         color="warning"
@@ -563,11 +563,12 @@ const BanModal: FunctionComponent<Props> = ({
                           </span>
                         </Localized>
                       </CallOut>
+
                       <Localized
                         id="community-banModal-banEmailDomain-confirmationText"
                         vars={{ text: domainBanConfirmationText }}
                       >
-                        <div>
+                        <div className={styles.domainBanConfirmationLabel}>
                           Type in "{domainBanConfirmationText}" to confirm
                         </div>
                       </Localized>
@@ -578,7 +579,7 @@ const BanModal: FunctionComponent<Props> = ({
                         placeholder=""
                         onChange={onDomainBanConfirmationTextInputChange}
                       />
-                    </>
+                    </Flex>
                   )}
                   {/* customize message button*/}
                   {updateType !== UpdateType.NO_SITES && (

--- a/client/src/core/client/admin/components/BanModal.tsx
+++ b/client/src/core/client/admin/components/BanModal.tsx
@@ -354,7 +354,7 @@ const BanModal: FunctionComponent<Props> = ({
   const disableForm =
     (requiresSiteBanUpdates && !pendingSiteBanUpdates) ||
     requiresRejectionReasonForDSA ||
-    (canBanDomain &&
+    (!!canBanDomain &&
       banDomain &&
       !(
         domainBanConfirmationTextInput.toLowerCase() ===
@@ -574,7 +574,7 @@ const BanModal: FunctionComponent<Props> = ({
                         </div>
                       </Localized>
                       <input
-                        data-testid="userSpamBanConfirmation"
+                        data-testid="domainBanConfirmation"
                         className={styles.domainBanConfirmationInput}
                         type="text"
                         placeholder=""

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -1420,7 +1420,9 @@ community-userStatus-removePremod = Remove pre-moderate
 
 community-banModal-allSites-title = Are you sure you want to ban <username></username>?
 community-banModal-banEmailDomain-title = Email domain ban
-community-banModal-banEmailDomain = Ban all new commenter accounts from { $domain }
+community-banModal-banEmailDomain = Ban all commenter accounts from { $domain }
+community-banModal-banEmailDomain-callOut = This will prevent any commenter from using this email domain.
+community-banModal-banEmailDomain-confirmationText = Type in "{ $text }" to confirm
 community-banModal-specificSites-title = Are you sure you want to manage the ban status of <username></username>?
 community-banModal-noSites-title = Are you sure you want to unban <username></username>?
 community-banModal-allSites-consequence =


### PR DESCRIPTION
## What does this PR do?

These changes add a confirmation to email domain bans, so that when selecting this option, the moderator must type "ban" to confirm they want to ban all commenter accounts for an email domain.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

As a moderator or admin, go to the Community tab in the admin. In the Status column dropdown for a user, select "Manage Ban". In the ban modal that pops up, see the Email domain ban section. Click the checkbox to `Ban all commenter accounts from { domain }`. See that `Save` is now disabled and a warning shows saying this will prevent any commenter from using this email domain and that the user must type in `ban` to confirm. Once `ban` is typed into the input, then the `Save` button should be enabled. Click `Save` and see that it's applied as expected.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
