### PR TITLE
notifications: design and configuration updates

### DIFF
--- a/client/src/core/client/admin/routes/Configure/sections/General/InPageNotificationsConfig.css
+++ b/client/src/core/client/admin/routes/Configure/sections/General/InPageNotificationsConfig.css
@@ -1,0 +1,3 @@
+.disabledLabel {
+  color: var(--palette-grey-400);
+}

--- a/client/src/core/client/admin/routes/Configure/sections/General/InPageNotificationsConfig.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/General/InPageNotificationsConfig.tsx
@@ -1,5 +1,6 @@
 import { Localized } from "@fluent/react/compat";
 import React, { FunctionComponent } from "react";
+import { FormSpy } from "react-final-form";
 import { graphql } from "react-relay";
 
 import {
@@ -13,11 +14,14 @@ import ConfigBox from "../../ConfigBox";
 import Header from "../../Header";
 import OnOffField from "../../OnOffField";
 
+import styles from "./InPageNotificationsConfig.css";
+
 // eslint-disable-next-line no-unused-expressions
 graphql`
   fragment InPageNotificationsConfig_formValues on Settings {
     inPageNotifications {
       enabled
+      floatingBellIndicator
     }
   }
 `;
@@ -49,6 +53,29 @@ const InPageNotificationsConfig: FunctionComponent<Props> = ({ disabled }) => (
       </Localized>
       <OnOffField name="inPageNotifications.enabled" disabled={disabled} />
     </FormField>
+    <FormSpy subscription={{ values: true }}>
+      {(props) => {
+        const inPageDisabled = !props.values.inPageNotifications?.enabled;
+        return (
+          <FormField container={<FieldSet />}>
+            <Localized id="configure-general-inPageNotifications-floatingBellIndicator">
+              <Label
+                className={
+                  disabled || inPageDisabled ? styles.disabledLabel : ""
+                }
+                component="legend"
+              >
+                Floating bell indicator
+              </Label>
+            </Localized>
+            <OnOffField
+              name="inPageNotifications.floatingBellIndicator"
+              disabled={disabled || inPageDisabled}
+            />
+          </FormField>
+        );
+      }}
+    </FormSpy>
   </ConfigBox>
 );
 

--- a/client/src/core/client/stream/App/TabBar.css
+++ b/client/src/core/client/stream/App/TabBar.css
@@ -30,3 +30,6 @@
   height: var(--spacing-5);
 }
 
+.floatingBellDisabled {
+  border-left: none;
+}

--- a/client/src/core/client/stream/App/TabBar.tsx
+++ b/client/src/core/client/stream/App/TabBar.tsx
@@ -89,7 +89,9 @@ const AppTabBar: FunctionComponent<Props> = (props) => {
     <MatchMedia gteWidth="sm">
       {(matches) => (
         <TabBar
-          className={CLASSES.tabBar.$root}
+          className={cn(CLASSES.tabBar.$root, {
+            [CLASSES.tabBar.mobile]: !matches,
+          })}
           activeTab={props.activeTab}
           onTabClick={props.onTabClick}
           variant="streamPrimary"

--- a/client/src/core/client/stream/App/TabBar.tsx
+++ b/client/src/core/client/stream/App/TabBar.tsx
@@ -201,6 +201,8 @@ const AppTabBar: FunctionComponent<Props> = (props) => {
                   [CLASSES.tabBar.activeTab]:
                     props.activeTab === "NOTIFICATIONS",
                   [styles.notificationsTabSmall]: !matches,
+                  [styles.floatingBellDisabled]:
+                    !props.inPageNotifications?.floatingBellIndicator,
                 }
               )}
               tabID="NOTIFICATIONS"

--- a/client/src/core/client/stream/App/TabBar.tsx
+++ b/client/src/core/client/stream/App/TabBar.tsx
@@ -40,6 +40,10 @@ export interface Props {
   showNotificationsTab: boolean;
   hasNewNotifications: boolean;
   userNotificationsEnabled: boolean;
+  inPageNotifications?: {
+    enabled: boolean | null;
+    floatingBellIndicator: boolean | null;
+  } | null;
   mode:
     | "COMMENTS"
     | "QA"
@@ -199,7 +203,11 @@ const AppTabBar: FunctionComponent<Props> = (props) => {
               )}
               tabID="NOTIFICATIONS"
               variant="notifications"
-              float="right"
+              float={
+                props.inPageNotifications?.floatingBellIndicator
+                  ? "right"
+                  : "none"
+              }
               title={notificationsText}
             >
               <div className={cn(styles.notificationsIcon)}>

--- a/client/src/core/client/stream/App/TabBarContainer.tsx
+++ b/client/src/core/client/stream/App/TabBarContainer.tsx
@@ -94,12 +94,14 @@ export const TabBarContainer: FunctionComponent<Props> = ({
 
   return (
     <>
-      {!!viewer && !!settings?.inPageNotifications?.enabled && (
-        <FloatingNotificationButton
-          viewerID={viewer?.id}
-          enabled={!!viewer?.inPageNotifications?.enabled}
-        />
-      )}
+      {!!viewer &&
+        !!settings?.inPageNotifications?.enabled &&
+        !!settings?.inPageNotifications?.floatingBellIndicator && (
+          <FloatingNotificationButton
+            viewerID={viewer?.id}
+            enabled={!!viewer?.inPageNotifications?.enabled}
+          />
+        )}
       <IntersectionProvider threshold={[0, 1]}>
         <TabBar
           mode={story ? story.settings.mode : GQLSTORY_MODE.COMMENTS}
@@ -112,6 +114,7 @@ export const TabBarContainer: FunctionComponent<Props> = ({
           }
           hasNewNotifications={!!hasNewNotifications}
           userNotificationsEnabled={!!viewer?.inPageNotifications?.enabled}
+          inPageNotifications={settings?.inPageNotifications}
           onTabClick={handleSetActiveTab}
         />
       </IntersectionProvider>
@@ -143,6 +146,7 @@ const enhanced = withSetActiveTabMutation(
         featureFlags
         inPageNotifications {
           enabled
+          floatingBellIndicator
         }
       }
     `,

--- a/client/src/core/client/stream/classes.ts
+++ b/client/src/core/client/stream/classes.ts
@@ -79,6 +79,8 @@ const CLASSES = {
     activeTab: "coral-tabBar-tab-active",
 
     notifications: "coral coral-tabBar-tab coral-tabBar-notifications",
+
+    mobile: "coral-tabBar-tab-mobile",
   },
 
   /**
@@ -1076,6 +1078,8 @@ const CLASSES = {
     floating: {
       root: "coral coral-notifications-floating-root",
       action: "coral coral-notifications-floating-action",
+      actionOpen: "coral coral-notifications-floating-action-open",
+      actionClosed: "coral coral-notifications-floating-action-closed",
       close: "coral coral-notifications-floating-close",
       icon: "coral coral-notifications-floating-icon",
       feed: {

--- a/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.css
+++ b/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.css
@@ -5,12 +5,6 @@
   padding-right: var(--spacing-3);
 }
 
-.closeButton {
-  color: white;
-  border-style: none;
-  background-color: transparent;
-}
-
 .unmarkAllContainer {
 }
 
@@ -34,12 +28,12 @@
     background-color: var(--palette-primary-600);
   }
 
-  &:hover:not(.disabled)  {
+  &:hover:not(.disabled) {
     color: var(--palette-text-000);
     background-color: var(--palette-primary-400);
   }
 
-  &:active:not(.disabled)  {
+  &:active:not(.disabled) {
     color: var(--palette-text-000);
     background-color: var(--palette-primary-400);
   }
@@ -57,7 +51,4 @@
 }
 
 .notificationActionContainer {
-}
-
-.closeContainer {
 }

--- a/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
+++ b/client/src/core/client/stream/common/KeyboardShortcuts/KeyboardShortcuts.tsx
@@ -12,7 +12,6 @@ import { Environment, graphql } from "react-relay";
 
 import CLASSES from "coral-stream/classes";
 
-import { useInMemoryState } from "coral-framework/hooks";
 import { useCoralContext } from "coral-framework/lib/bootstrap";
 import { globalErrorReporter } from "coral-framework/lib/errors";
 import { useLocal, useMutation } from "coral-framework/lib/relay";
@@ -22,7 +21,6 @@ import { GQLCOMMENT_SORT } from "coral-framework/schema";
 import isElementIntersecting from "coral-framework/utils/isElementIntersecting";
 import { NUM_INITIAL_COMMENTS } from "coral-stream/constants";
 import {
-  CloseMobileToolbarEvent,
   JumpToNextCommentEvent,
   JumpToNextUnseenCommentEvent,
   JumpToPreviousCommentEvent,
@@ -44,7 +42,6 @@ import {
   ButtonSvgIcon,
   CheckDoubleIcon,
   ControlsNextIcon,
-  RemoveIcon,
 } from "coral-ui/components/icons";
 import { Flex } from "coral-ui/components/v2";
 import { MatchMedia } from "coral-ui/components/v2/MatchMedia/MatchMedia";
@@ -304,10 +301,6 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
   } = useCoralContext();
 
   const root = useShadowRootOrDocument();
-  const [toolbarClosed, setToolbarClosed] = useInMemoryState(
-    "keyboardShortcutMobileToolbarClosed",
-    false
-  );
 
   const setTraversalFocus = useMutation(SetTraversalFocus);
   const markSeen = useMutation(MarkCommentsAsSeenMutation);
@@ -471,11 +464,6 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
   const handleUnmarkAllButton = useCallback(async () => {
     await unmarkAll({ source: "mobileToolbar" });
   }, [unmarkAll]);
-
-  const handleCloseToolbarButton = useCallback(() => {
-    setToolbarClosed(true);
-    CloseMobileToolbarEvent.emit(eventEmitter);
-  }, [eventEmitter, setToolbarClosed]);
 
   const setFocusAndMarkSeen = useCallback(
     (commentID: string) => {
@@ -1380,7 +1368,7 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
     };
   }, [handleKeypress, handleWindowKeypress, renderWindow, root]);
 
-  if (amp || toolbarClosed || !zKeyEnabled) {
+  if (amp || !zKeyEnabled) {
     return null;
   }
 
@@ -1397,24 +1385,6 @@ const KeyboardShortcuts: FunctionComponent<Props> = ({
               alignItems="center"
               justifyContent="space-around"
             >
-              <div className={styles.closeContainer}>
-                <Localized
-                  id="comments-mobileToolbar-closeButton"
-                  attrs={{ "aria-label": true }}
-                >
-                  <button
-                    onClick={handleCloseToolbarButton}
-                    aria-label="Close"
-                    className={cn(
-                      styles.closeButton,
-                      CLASSES.mobileToolbar.close
-                    )}
-                  >
-                    <ButtonSvgIcon size="md" Icon={RemoveIcon} />
-                  </button>
-                </Localized>
-              </div>
-
               <div className={styles.unmarkAllContainer}>
                 <button
                   className={cn(

--- a/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -520,7 +520,7 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
                     aria-label={refreshCommentsLocalization.text}
                     variant="filled"
                     color="primary"
-                    paddingSize="extraSmall"
+                    paddingSize="small"
                     className={styles.refreshButton}
                     onClick={handleClickRefreshButton}
                   >

--- a/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationButton.css
+++ b/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationButton.css
@@ -40,6 +40,10 @@
   border-bottom-color: #cbd1d2;
   border-right-style: solid;
   border-right-color: #cbd1d2;
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
 .buttonText {

--- a/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationButton.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/floatingButton/FloatingNotificationButton.tsx
@@ -121,7 +121,10 @@ const FloatingNotificationButton: FunctionComponent<Props> = ({
                 {
                   [styles.buttonClosed]: !isOpen,
                   [styles.buttonOpen]: isOpen,
-                }
+                },
+                isOpen
+                  ? CLASSES.notifications.floating.actionOpen
+                  : CLASSES.notifications.floating.actionClosed
               )}
               onClick={onToggleOpen}
               title={title}

--- a/client/src/core/client/stream/test/fixtures.ts
+++ b/client/src/core/client/stream/test/fixtures.ts
@@ -144,7 +144,8 @@ export const settings = createFixture<GQLSettings>({
     },
   },
   inPageNotifications: {
-    enabled: false,
+    enabled: true,
+    floatingBellIndicator: true,
   },
 });
 

--- a/client/src/core/client/stream/test/profile/preferences.spec.tsx
+++ b/client/src/core/client/stream/test/profile/preferences.spec.tsx
@@ -69,6 +69,17 @@ it("render email notifications form", async () => {
   await act(async () => {
     await createTestRenderer({
       resolvers: createResolversStub<GQLResolver>({
+        Query: {
+          settings: () => {
+            return {
+              ...settings,
+              inPageNotifications: {
+                enabled: false,
+                floatingBellIndicator: true,
+              },
+            };
+          },
+        },
         Mutation: {
           updateEmailNotificationSettings,
         },

--- a/client/src/core/client/test/helpers/fixture.ts
+++ b/client/src/core/client/test/helpers/fixture.ts
@@ -90,7 +90,7 @@ export function createUser() {
     },
     ignoreable: true,
     inPageNotifications: {
-      enabled: false,
+      enabled: true,
     },
   });
 }

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -543,6 +543,7 @@ configure-general-inPageNotifications-explanation = Add notifications to Coral. 
   of your team, when a Pending comment is published. Commenters can
   disable visual notification indicators in their Profile preferences. This will remove e-mail notifications.
 configure-general-inPageNotifications-enabled = In-page notifications enabled
+configure-general-inPageNotifications-floatingBellIndicator = Floating bell indicator
 
 #### Closed Stream Message
 configure-general-closedStreamMessage-title = Closed comment stream message

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -358,8 +358,6 @@ comments-reacted =
 comments-jumpToComment-title = Your reply has posted below
 comments-jumpToComment-GoToReply = Go to reply
 
-comments-mobileToolbar-closeButton =
-  .aria-label = Close
 comments-mobileToolbar-unmarkAll = Mark all as read
 comments-mobileToolbar-nextUnread = Next unread
 

--- a/server/src/core/server/graph/resolvers/Settings.ts
+++ b/server/src/core/server/graph/resolvers/Settings.ts
@@ -79,6 +79,7 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
     return flairBadges;
   },
   dsa: ({ dsa = defaultDSAConfiguration }) => dsa,
-  inPageNotifications: ({ inPageNotifications = { enabled: false } }) =>
-    inPageNotifications,
+  inPageNotifications: ({
+    inPageNotifications = { enabled: true, floatingBellIndicator: true },
+  }) => inPageNotifications,
 };

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -1983,6 +1983,8 @@ type PremoderateEmailAddressConfiguration {
 
 type InPageNotificationsConfiguration {
   enabled: Boolean
+
+  floatingBellIndicator: Boolean
 }
 
 input TooManyPeriodsConfigInput {
@@ -6439,6 +6441,12 @@ input InPageNotificationsConfigurationInput {
   enabled when true turns on in-page notifications as an option for commenters.
   """
   enabled: Boolean
+
+  """
+  floatingBellIndicator when true shows a floating bell for notifications; when false,
+  there is no floating bell and the Notifications tab is aligned left.
+  """
+  floatingBellIndicator: Boolean
 }
 
 """

--- a/server/src/core/server/models/settings/settings.ts
+++ b/server/src/core/server/models/settings/settings.ts
@@ -316,6 +316,7 @@ export interface TopCommenterConfig {
 
 export interface InPageNotificationsConfig {
   enabled?: boolean;
+  floatingBellIndicator?: boolean;
 }
 
 export interface PremoderateEmailAddressConfig {

--- a/server/src/core/server/models/tenant/tenant.ts
+++ b/server/src/core/server/models/tenant/tenant.ts
@@ -304,7 +304,8 @@ export const combineTenantDefaultsAndInput = (
       enabled: false,
     },
     inPageNotifications: {
-      enabled: false,
+      enabled: true,
+      floatingBellIndicator: true,
     },
   };
 

--- a/server/src/core/server/test/fixtures.ts
+++ b/server/src/core/server/test/fixtures.ts
@@ -197,7 +197,8 @@ export const createTenantFixture = (
       oEmbedAllowedOrigins: [],
     },
     inPageNotifications: {
-      enabled: false,
+      enabled: true,
+      floatingBellIndicator: true,
     },
   };
 


### PR DESCRIPTION
## What does this PR do?
 
These changes make some design and configuration updates to notifications.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds the `floatingBellIndicator` to `inPageNotifications` settings.

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test these changes by:
1) Hover over the sticky corner bell on desktop. See a pointer cursor. Click the bell. Hover over close/bell icon in upper right. See a pointer cursor here too.
2) View comments in mobile to see the mobile toolbar. See that there is no longer an `X` option and the rest of the buttons have more space now because of that.
3) Load comment stream. Go to another tab/window. Go back. See the `Refresh comments` button. See that it has more padding now.
4) Go to admin configuration --> `General` --> `In-page notifications`. See the new `Floating bell indicator` option. See that when the overall in-page notifications is disabled, these options are disabled. See that when the in-page notifications are overall enabled, this floating bell indicator option is selectable. Enable it and go to the comment stream. See the notifications tab to the right and the floating bell button in the upper right. Disable it and go to the comment stream. See the notifications tab to the left and no floating bell button in the upper right when scrolling down the comment stream.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
