### PR TITLE
[CORL-3125]: increment and decrement notificationCount on comment rejection/approval

### DIFF
--- a/INDEXES.md
+++ b/INDEXES.md
@@ -6,6 +6,14 @@ The goal of this document is to date-mark the indexes you add to support the cha
 
 If you are releasing, you can use this readme to check all the indexes prior to the release you are deploying and have a good idea of what indexes you might need to deploy to Mongo along with your release of a new Coral Docker image to kubernetes.
 
+## 2024-03-07
+
+```
+db.notifications.createIndex({ tenantID: 1, replyID: 1 });
+```
+
+- This index speeds up the retrieval of notifications by replyID, which is used to determine whether to decrement/increment notification counts if a comment is rejected/approved in moderation.
+
 ## 2024-02-02
 
 ```

--- a/server/src/core/server/models/notifications/notification.ts
+++ b/server/src/core/server/models/notifications/notification.ts
@@ -59,6 +59,17 @@ export const retrieveNotificationsConnection = async (
   return resolveConnection(query, input, (n) => n.createdAt);
 };
 
+export const retrieveNotificationByCommentReply = async (
+  mongo: MongoContext,
+  tenantID: string,
+  replyCommentID: string
+) => {
+  const notification = await mongo
+    .notifications()
+    .findOne({ replyID: replyCommentID, tenantID });
+  return notification;
+};
+
 export const createNotification = async (
   mongo: MongoContext,
   notification: Notification

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -186,7 +186,7 @@ const rejectComment = async (
     });
   }
 
-  // check comment parent for reply notification
+  // check for a reply notification for the comment being rejected
   // if exists, check that notification user's lastSeenNotificationDate to see if less than reply createdAt
   // decrement notificationCount if so
   const replyNotification = await retrieveNotificationByCommentReply(

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -8,7 +8,9 @@ import {
   hasTag,
   UpdateCommentStatus,
 } from "coral-server/models/comment";
+import { retrieveNotificationByCommentReply } from "coral-server/models/notifications/notification";
 import { Tenant } from "coral-server/models/tenant";
+import { retrieveUser } from "coral-server/models/user";
 import { removeTag } from "coral-server/services/comments";
 import { moderate } from "coral-server/services/comments/moderation";
 import { I18n } from "coral-server/services/i18n";
@@ -182,6 +184,29 @@ const rejectComment = async (
       rejectionReason: reason,
       type: GQLNOTIFICATION_TYPE.COMMENT_REJECTED,
     });
+  }
+
+  // check comment parent for reply notification
+  // if exists, check that notification user's lastSeenNotificationDate to see if less than reply createdAt
+  // decrement notificationCount if so
+  const replyNotification = await retrieveNotificationByCommentReply(
+    mongo,
+    tenant.id,
+    commentID
+  );
+  if (replyNotification) {
+    const { ownerID } = replyNotification;
+    const notificationOwner = await retrieveUser(mongo, tenant.id, ownerID);
+    if (notificationOwner) {
+      if (
+        !notificationOwner.lastSeenNotificationDate ||
+        (notificationOwner.lastSeenNotificationDate &&
+          notificationOwner.lastSeenNotificationDate <
+            replyNotification.createdAt)
+      ) {
+        await notifications.decrementCountForUser(tenant.id, ownerID);
+      }
+    }
   }
 
   // Return the resulting comment.


### PR DESCRIPTION
## What does this PR do?

When a comment is rejected, these changes check for any reply notifications for that comment and decrement the notification count for the relevant user if any are found (only decrement if user has no last seen notification date or one that is before the reply notification for the deleted comment). If a comment is rejected upon initial notification creation, we never decrement the user notification count. If a previously rejected comment is approved, then we want to increment the user count (only increment if user has no last seen notification date or one that is before the reply notification for the newly approved comment). 

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test these changes by:
* replying to a user's comments, with a window open on the stream for the user to whom you are replying. See their notification count increase
* Go in and reject one of the replies. See that user's notification count decrease
* If you submit a comment that is immediately rejected based on including a banned word, the notification count for the user never increments
* approve a reply that you rejected. See that the notification count increments

Also check that these decrements/increments only happen when the user either has no last seen notification date **or** a last seen notification date that is before these reply notifications.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
