### PR TITLE
Notifications: show different rejection message for rejected pending comments

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/RejectedCommentNotificationBody.tsx
@@ -7,6 +7,7 @@ import { useCoralContext } from "coral-framework/lib/bootstrap";
 import { getMessage } from "coral-framework/lib/i18n";
 import { withFragmentContainer } from "coral-framework/lib/relay";
 import {
+  GQLCOMMENT_STATUS,
   GQLDSAReportDecisionLegality,
   GQLNOTIFICATION_TYPE,
   GQLREJECTION_REASON_CODE,
@@ -160,8 +161,14 @@ const stringIsNullOrEmpty = (value: string) => {
 const RejectedCommentNotificationBody: FunctionComponent<Props> = ({
   notification,
 }) => {
-  const { type, decisionDetails, rejectionReason, customReason, comment } =
-    notification;
+  const {
+    type,
+    decisionDetails,
+    rejectionReason,
+    customReason,
+    comment,
+    previousStatus,
+  } = notification;
 
   const { localeBundles } = useCoralContext();
 
@@ -174,12 +181,20 @@ const RejectedCommentNotificationBody: FunctionComponent<Props> = ({
 
   return (
     <div className={styles.body}>
-      <Localized id="notifications-rejectedComment-body">
-        <p>
-          The content of your comment was against our community guidelines. The
-          comment has been removed.
-        </p>
-      </Localized>
+      {previousStatus === GQLCOMMENT_STATUS.PREMOD ? (
+        <Localized id="notifications-rejectedComment-wasPending-body">
+          <p>
+            The content of your comment was against our community guidelines.
+          </p>
+        </Localized>
+      ) : (
+        <Localized id="notifications-rejectedComment-body">
+          <p>
+            The content of your comment was against our community guidelines.
+            The comment has been removed.
+          </p>
+        </Localized>
+      )}
       {type === GQLNOTIFICATION_TYPE.COMMENT_REJECTED &&
         rejectionReason &&
         decisionDetails && (
@@ -264,6 +279,7 @@ const enhanced = withFragmentContainer<Props>({
       type
       rejectionReason
       customReason
+      previousStatus
       decisionDetails {
         legality
         grounds

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1083,6 +1083,8 @@ notifications-defaultTitle = Notification
 
 notifications-rejectedComment-body =
   The content of your comment was against our community guidelines. The comment has been removed.
+notifications-rejectedComment-wasPending-body =
+  The content of your comment was against our community guidelines.
 notifications-reasonForRemoval = Reason for removal
 notifications-legalGrounds = Legal grounds
 notifications-additionalExplanation = Additional explanation

--- a/server/src/core/server/graph/resolvers/Notification.ts
+++ b/server/src/core/server/graph/resolvers/Notification.ts
@@ -27,6 +27,7 @@ export const NotificationResolver: Required<
     return await ctx.loaders.Comments.comment.load(replyID);
   },
   commentStatus: ({ commentStatus }) => commentStatus,
+  previousStatus: ({ previousStatus }) => previousStatus,
   dsaReport: async ({ reportID }, input, ctx) => {
     if (!reportID) {
       return null;

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -5004,6 +5004,13 @@ type Notification {
   commentStatus: COMMENT_STATUS
 
   """
+  previousStatus is the optional prior status of the comment when the notification
+  was created. This allows us to determine if a comment was previously pending
+  review, or reported to compare against the current status (rejected, approved, etc).
+  """
+  previousStatus: COMMENT_STATUS
+
+  """
   rejectionReason is an optional field that defines why a comment was rejected.
   """
   rejectionReason: REJECTION_REASON_CODE

--- a/server/src/core/server/models/notifications/notification.ts
+++ b/server/src/core/server/models/notifications/notification.ts
@@ -24,6 +24,7 @@ export interface Notification extends TenantResource {
 
   commentID?: string;
   commentStatus?: GQLCOMMENT_STATUS;
+  previousStatus?: GQLCOMMENT_STATUS;
 
   replyID?: string;
 

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -44,6 +44,7 @@ export interface CreateNotificationInput {
 
   comment?: Readonly<Comment> | null;
   reply?: Readonly<Comment> | null;
+  previousStatus?: GQLCOMMENT_STATUS;
 
   rejectionReason?: RejectionReasonInput | null;
   report?: Readonly<DSAReport> | null;
@@ -102,6 +103,7 @@ export class InternalNotificationContext {
       rejectionReason,
       report,
       legal,
+      previousStatus,
     } = input;
 
     const targetUser = await retrieveUser(this.mongo, tenantID, targetUserID);
@@ -145,7 +147,8 @@ export class InternalNotificationContext {
         targetUserID,
         comment,
         rejectionReason,
-        now
+        now,
+        previousStatus
       );
       result.attempted = true;
     } else if (type === GQLNOTIFICATION_TYPE.ILLEGAL_REJECTED && comment) {
@@ -187,7 +190,8 @@ export class InternalNotificationContext {
         targetUserID,
         comment,
         reply,
-        now
+        now,
+        previousStatus
       );
       result.attempted = true;
     } else if (type === GQLNOTIFICATION_TYPE.REPLY_STAFF && comment && reply) {
@@ -322,7 +326,8 @@ export class InternalNotificationContext {
     targetUserID: string,
     comment: Readonly<Comment>,
     rejectionReason?: RejectionReasonInput | null,
-    now = new Date()
+    now = new Date(),
+    previousStatus?: GQLCOMMENT_STATUS
   ) {
     const notification = await createNotification(this.mongo, {
       id: uuid(),
@@ -332,6 +337,7 @@ export class InternalNotificationContext {
       ownerID: targetUserID,
       commentID: comment.id,
       commentStatus: comment.status,
+      previousStatus,
       rejectionReason: rejectionReason?.code ?? undefined,
       customReason: rejectionReason?.customReason ?? undefined,
       decisionDetails: {
@@ -390,7 +396,8 @@ export class InternalNotificationContext {
     targetUserID: string,
     comment: Readonly<Comment>,
     reply: Readonly<Comment>,
-    now: Date
+    now: Date,
+    previousStatus?: GQLCOMMENT_STATUS
   ) {
     const notification = await createNotification(this.mongo, {
       id: uuid(),
@@ -401,6 +408,7 @@ export class InternalNotificationContext {
       commentID: comment.id,
       replyID: reply.id,
       commentStatus: comment.status,
+      previousStatus,
     });
 
     return notification;

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -183,6 +183,7 @@ const rejectComment = async (
       comment: result.after,
       rejectionReason: reason,
       type: GQLNOTIFICATION_TYPE.COMMENT_REJECTED,
+      previousStatus: result.before.status,
     });
   }
 


### PR DESCRIPTION
## What does this PR do?

When a comment is in the pending state (not visible stream side due to pre-moderation) and is then rejected, show a slightly different text that indicates it was never visible stream side (does not say it was removed from stream).

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Adds a `previousStatus` field to notifications.

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

None

## How do I test this PR?

- post a comment as a commenter
- using an admin/mod, reject the comment
- check the commenter's notifications and see they have a rejected notification saying their comment violated guidelines and was removed
- set a commenter to `always premoderate` in the community tab
- post a comment as that commenter
- using an admin/mod, reject this comment
- check the commenter's notifications and see that they have a different message that says it violated guidelines, but does not say it was removed from the stream

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into epic branch.
