### PR TITLE
Notifications: hide pre-mod reply notifications until they are approved

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
@@ -107,6 +107,7 @@ const NotificationsPaginator: FunctionComponent<Props> = (props) => {
         // filter out Rejected comments and deleted comments
         return (
           n.node.commentReply?.status !== GQLCOMMENT_STATUS.REJECTED &&
+          n.node.commentReply?.status !== GQLCOMMENT_STATUS.PREMOD &&
           !n.node.commentReply?.deleted
         );
       }

--- a/server/src/core/server/services/dsaReports/reports.ts
+++ b/server/src/core/server/services/dsaReports/reports.ts
@@ -254,6 +254,7 @@ export async function makeDSAReportDecision(
         targetUserID: rejectedComment.authorID,
         type: GQLNOTIFICATION_TYPE.ILLEGAL_REJECTED,
         comment: rejectedComment,
+        previousStatus: comment.status,
         legal: {
           legality: input.legality,
           grounds: legalGrounds,

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -259,6 +259,14 @@ export class InternalNotificationContext {
         shouldIncrementCount = false;
       }
 
+      // Don't increment the count if the reply is still in pre-mod
+      if (
+        type === GQLNOTIFICATION_TYPE.REPLY &&
+        reply?.status === GQLCOMMENT_STATUS.PREMOD
+      ) {
+        shouldIncrementCount = false;
+      }
+
       if (shouldIncrementCount) {
         await this.incrementCountForUser(tenantID, targetUserID);
       }

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -102,9 +102,12 @@ const approveComment = async (
     });
   }
 
-  // if comment was previously rejected, and there is a reply notification for it, increment
+  // if comment was previously rejected or in pre-mod, and there is a reply notification for it, increment
   // the notificationCount for that notification's owner since it was decremented upon original rejection
-  if (previousComment?.status === GQLCOMMENT_STATUS.REJECTED) {
+  if (
+    previousComment?.status === GQLCOMMENT_STATUS.REJECTED ||
+    previousComment?.status === GQLCOMMENT_STATUS.PREMOD
+  ) {
     const replyNotification = await retrieveNotificationByCommentReply(
       mongo,
       tenant.id,

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -97,6 +97,7 @@ const approveComment = async (
     await notifications.create(tenant.id, tenant.locale, {
       targetUserID: result.after.authorID!,
       comment: result.after,
+      previousStatus: result.before.status,
       type: GQLNOTIFICATION_TYPE.COMMENT_APPROVED,
     });
   }


### PR DESCRIPTION
## What does this PR do?

- Hides pre-mod notifications in the notification feed until they are approved

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

Check that pre-mod replies are hidden:
- post a comment as a user (call them user A for simplicity)
- with another user (user B), who is pre-moderated, reply to A
- check A's notifications that it does not show a count increment, or a new notification in the feed
- approve the reply made by user B
- check the notifications for user A and see the reply shows up

Check that we increment notification count if the user hasn't seen the notifications, but a reply is approved out of pre-mod before they visit notifications:
- have user B reply again to user A
- approve the reply written by B before user A looks at their notifications
- see that the notification count increments for A and if they open the notifications feed, the reply from B is there

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into develop and release with next release.
