### PR TITLE
notifications: hide system withheld comments from the notification feed

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationsPaginator.tsx
@@ -107,6 +107,7 @@ const NotificationsPaginator: FunctionComponent<Props> = (props) => {
         return (
           n.node.commentReply?.status !== GQLCOMMENT_STATUS.REJECTED &&
           n.node.commentReply?.status !== GQLCOMMENT_STATUS.PREMOD &&
+          n.node.commentReply?.status !== GQLCOMMENT_STATUS.SYSTEM_WITHHELD &&
           !n.node.commentReply?.deleted
         );
       }

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -260,9 +260,11 @@ export class InternalNotificationContext {
       }
 
       // Don't increment the count if the reply is still in pre-mod
+      // or is system withheld
       if (
         type === GQLNOTIFICATION_TYPE.REPLY &&
-        reply?.status === GQLCOMMENT_STATUS.PREMOD
+        (reply?.status === GQLCOMMENT_STATUS.PREMOD ||
+          reply?.status === GQLCOMMENT_STATUS.SYSTEM_WITHHELD)
       ) {
         shouldIncrementCount = false;
       }

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -102,11 +102,14 @@ const approveComment = async (
     });
   }
 
-  // if comment was previously rejected or in pre-mod, and there is a reply notification for it, increment
-  // the notificationCount for that notification's owner since it was decremented upon original rejection
+  // if comment was previously rejected, system withheld, or in pre-mod,
+  // and there is a reply notification for it, increment the notificationCount
+  // for that notification's owner since it was decremented upon original
+  // rejection
   if (
     previousComment?.status === GQLCOMMENT_STATUS.REJECTED ||
-    previousComment?.status === GQLCOMMENT_STATUS.PREMOD
+    previousComment?.status === GQLCOMMENT_STATUS.PREMOD ||
+    previousComment?.status === GQLCOMMENT_STATUS.SYSTEM_WITHHELD
   ) {
     const replyNotification = await retrieveNotificationByCommentReply(
       mongo,


### PR DESCRIPTION
## What does this PR do?

Hides system withheld reply notifications the same way pre-moderated replies are hidden.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- ensure you have some words in the banned word list
- post a comment as a commenter (user A)
- reply to the comment with another user (user B) using a word in the banned word list
- see that the reply does not show up in user A's notification feed

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into develop.
