### PR TITLE
[CORL-3140] Fix admin secondary tabs

### DIFF
--- a/client/src/core/client/ui/components/v2/Tabs/TabBar.css
+++ b/client/src/core/client/ui/components/v2/Tabs/TabBar.css
@@ -29,3 +29,7 @@ $moderateCardTabSecondaryColor: var(--palette-divider);
 .streamPrimary {
   border-bottom: 1px solid $moderateCardTabPrimaryColor;
 }
+
+.notifications {
+  border-bottom: 1px solid $moderateCardTabPrimaryColor;
+}

--- a/client/src/core/client/ui/components/v2/Tabs/TabBar.tsx
+++ b/client/src/core/client/ui/components/v2/Tabs/TabBar.tsx
@@ -22,7 +22,8 @@ export interface TabBarProps {
     | "secondary"
     | "default"
     | "streamSecondary"
-    | "streamPrimary";
+    | "streamPrimary"
+    | "notifications";
   /**
    * Active tab id/name
    */
@@ -74,14 +75,18 @@ const TabBar: FunctionComponent<TabBarProps> = (props) => {
           defaultActiveTab && !activeTab
             ? child.props.tabID === defaultActiveTab
             : child.props.tabID === activeTab,
-        variant: child.props.variant,
+        variant: child.props.variant ? child.props.variant : variant,
         float: child.props.float,
         onTabClick,
       })
   );
 
-  return (
+  return forwardRef ? (
     <ul className={rootClassName} role="tablist" ref={forwardRef}>
+      {tabs}
+    </ul>
+  ) : (
+    <ul className={rootClassName} role="tablist">
       {tabs}
     </ul>
   );

--- a/client/src/core/client/ui/components/v2/Tabs/TabBar.tsx
+++ b/client/src/core/client/ui/components/v2/Tabs/TabBar.tsx
@@ -61,6 +61,7 @@ const TabBar: FunctionComponent<TabBarProps> = (props) => {
         [classes.secondary]: variant === "secondary",
         [classes.streamSecondary]: variant === "streamSecondary",
         [classes.streamPrimary]: variant === "streamPrimary",
+        [classes.notifications]: variant === "notifications",
         [classes.default]: variant === "default",
       },
     ],

--- a/client/src/core/client/ui/components/v2/Tabs/TabBar.tsx
+++ b/client/src/core/client/ui/components/v2/Tabs/TabBar.tsx
@@ -81,12 +81,8 @@ const TabBar: FunctionComponent<TabBarProps> = (props) => {
       })
   );
 
-  return forwardRef ? (
+  return (
     <ul className={rootClassName} role="tablist" ref={forwardRef}>
-      {tabs}
-    </ul>
-  ) : (
-    <ul className={rootClassName} role="tablist">
       {tabs}
     </ul>
   );

--- a/client/src/core/client/ui/components/v2/Tabs/__snapshots__/TabBar.spec.tsx.snap
+++ b/client/src/core/client/ui/components/v2/Tabs/__snapshots__/TabBar.spec.tsx.snap
@@ -13,7 +13,7 @@ exports[`sets initial tab as active 1`] = `
     <button
       aria-controls="tabPane-one"
       aria-selected={true}
-      className="BaseButton-root Tab-button Tab-active"
+      className="BaseButton-root Tab-button Tab-default Tab-active"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -41,7 +41,7 @@ exports[`sets initial tab as active 1`] = `
     <button
       aria-controls="tabPane-two"
       aria-selected={false}
-      className="BaseButton-root Tab-button"
+      className="BaseButton-root Tab-button Tab-default"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
@@ -69,7 +69,7 @@ exports[`sets initial tab as active 1`] = `
     <button
       aria-controls="tabPane-three"
       aria-selected={false}
-      className="BaseButton-root Tab-button"
+      className="BaseButton-root Tab-button Tab-default"
       onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}


### PR DESCRIPTION
## What does this PR do?

Repairs the CSS styling for the secondary tabs in the admin areas:

<img width="553" alt="image" src="https://github.com/coralproject/talk/assets/5751504/71292543-2702-408f-9ee0-2a4b026f2fcc">

<img width="498" alt="image" src="https://github.com/coralproject/talk/assets/5751504/871f9574-5360-45bd-b4f2-ac70496bc075">

## These changes will impact:

- [ ] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- navigate to the admin
- view the user history drawer for a user
- see that the tabs are rendering properly
- view the moderation card details for a comment
- see that the tabs are rendering properly

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into develop, then release.
