### PR TITLE
fix: check for dsa enabled when sending rejection notifications

### DIFF
--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -176,7 +176,8 @@ const rejectComment = async (
 
   if (
     sendNotification &&
-    !(reason?.code === GQLREJECTION_REASON_CODE.BANNED_WORD)
+    !(reason?.code === GQLREJECTION_REASON_CODE.BANNED_WORD) &&
+    tenant.dsa?.enabled
   ) {
     await notifications.create(tenant.id, tenant.locale, {
       targetUserID: result.after.authorID!,


### PR DESCRIPTION
## What does this PR do?

Only send rejected comment notifications if DSA is enabled.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Reject comments by a user with DSA enabled and not enabled. See that when enabled, you get a notification as that user. When disabled, you should not get a notification as that user.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
