### PR TITLE
[CORL-3121]: add domain ban history description to account history

### DIFF
--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
@@ -50,24 +50,31 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
   user,
   viewer,
 }) => {
-  const system = (
-    <Localized
-      id="moderate-user-drawer-account-history-system"
-      elems={{
-        icon: (
+  const system = useMemo(
+    () => (
+      <Localized
+        id="moderate-user-drawer-account-history-system"
+        elems={{
+          icon: (
+            <SvgIcon
+              size="md"
+              className={styles.coralIcon}
+              Icon={CoralMarkIcon}
+            />
+          ),
+        }}
+      >
+        <span>
           <SvgIcon
             size="md"
             className={styles.coralIcon}
             Icon={CoralMarkIcon}
-          />
-        ),
-      }}
-    >
-      <span>
-        <SvgIcon size="md" className={styles.coralIcon} Icon={CoralMarkIcon} />{" "}
-        System
-      </span>
-    </Localized>
+          />{" "}
+          System
+        </span>
+      </Localized>
+    ),
+    []
   );
 
   const { localeBundles } = useCoralContext();
@@ -80,12 +87,12 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
     minute: "numeric",
     second: "numeric",
   });
-  const addSeconds = (date: Date, seconds: number) => {
-    return new Date(date.getTime() + seconds * 1000);
-  };
 
   const deletionDescriptionMapping = useCallback(
     (updateType: string, createdAt: string) => {
+      const addSeconds = (date: Date, seconds: number) => {
+        return new Date(date.getTime() + seconds * 1000);
+      };
       const mapping: { [key: string]: string } = {
         REQUESTED: getMessage(
           localeBundles,
@@ -117,7 +124,7 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
       };
       return mapping[updateType];
     },
-    [localeBundles, addSeconds, deletionFormatter]
+    [localeBundles, deletionFormatter]
   );
 
   const accountDomainBannedMessage = getMessage(

--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
@@ -197,9 +197,11 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
           description:
             isSiteBanned && !!user.status.ban.sites
               ? user.status.ban.sites.map((s) => s.name).join(", ")
-              : record.createdBy
-              ? ""
-              : accountDomainBannedMessage,
+              : record.active
+              ? record.createdBy
+                ? ""
+                : accountDomainBannedMessage
+              : "",
         };
       } else {
         history.push({
@@ -213,9 +215,11 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
             ? record.sites
               ? record.sites.map((s) => s.name).join(", ")
               : ""
-            : record.createdBy
-            ? ""
-            : accountDomainBannedMessage,
+            : record.active
+            ? record.createdBy
+              ? ""
+              : accountDomainBannedMessage
+            : "",
         });
       }
     });

--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
@@ -117,7 +117,7 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
       };
       return mapping[updateType];
     },
-    [getMessage, localeBundles, addSeconds, deletionFormatter]
+    [localeBundles, addSeconds, deletionFormatter]
   );
 
   const accountDomainBannedMessage = getMessage(
@@ -312,7 +312,12 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
     }
 
     return dateSortedHistory;
-  }, [system, user.status, deletionDescriptionMapping]);
+  }, [
+    system,
+    user.status,
+    deletionDescriptionMapping,
+    accountDomainBannedMessage,
+  ]);
   const formatter = useDateTimeFormatter({
     year: "numeric",
     month: "long",

--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
@@ -196,11 +196,15 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
           takenBy: record.createdBy ? record.createdBy.username : system,
           description:
             isSiteBanned && !!user.status.ban.sites
-              ? user.status.ban.sites.map((s) => s.name).join(", ")
-              : record.active
-              ? record.createdBy
+              ? // does the site ban have sites? If so, add to description
+                user.status.ban.sites.map((s) => s.name).join(", ")
+              : // is the ban created?
+              record.active
+              ? // If the ban is created, is it created by the system?
+                record.createdBy
                 ? ""
-                : accountDomainBannedMessage
+                : // If the ban is created by the system, show the account domain banned message
+                  accountDomainBannedMessage
               : "",
         };
       } else {
@@ -212,13 +216,17 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
           date: new Date(record.createdAt),
           takenBy: record.createdBy ? record.createdBy.username : system,
           description: siteBan
-            ? record.sites
+            ? // does the site ban have sites? If so, add to description
+              record.sites
               ? record.sites.map((s) => s.name).join(", ")
               : ""
-            : record.active
-            ? record.createdBy
+            : // is the ban created?
+            record.active
+            ? // If the ban is created, is it created by the system?
+              record.createdBy
               ? ""
-              : accountDomainBannedMessage
+              : // If the ban is created by the system, show the account domain banned message
+                accountDomainBannedMessage
             : "",
         });
       }

--- a/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
+++ b/client/src/core/client/admin/components/UserHistoryDrawer/UserDrawerAccountHistory.tsx
@@ -120,6 +120,12 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
     [getMessage, localeBundles, addSeconds, deletionFormatter]
   );
 
+  const accountDomainBannedMessage = getMessage(
+    localeBundles,
+    "moderate-user-drawer-account-history-account-domain-banned",
+    "Account domain banned"
+  );
+
   const combinedHistory = useMemo(() => {
     // Collect all the different types of history items.
     const history: HistoryRecord[] = [];
@@ -191,7 +197,9 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
           description:
             isSiteBanned && !!user.status.ban.sites
               ? user.status.ban.sites.map((s) => s.name).join(", ")
-              : "",
+              : record.createdBy
+              ? ""
+              : accountDomainBannedMessage,
         };
       } else {
         history.push({
@@ -201,10 +209,13 @@ const UserDrawerAccountHistory: FunctionComponent<Props> = ({
           },
           date: new Date(record.createdAt),
           takenBy: record.createdBy ? record.createdBy.username : system,
-          description:
-            siteBan && record.sites
+          description: siteBan
+            ? record.sites
               ? record.sites.map((s) => s.name).join(", ")
-              : "",
+              : ""
+            : record.createdBy
+            ? ""
+            : accountDomainBannedMessage,
         });
       }
     });

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -1205,6 +1205,7 @@ moderate-user-drawer-account-history-system = <icon></icon> System
 moderate-user-drawer-account-history-suspension-ended = Suspension ended
 moderate-user-drawer-account-history-suspension-removed = Suspension removed
 moderate-user-drawer-account-history-banned = Banned
+moderate-user-drawer-account-history-account-domain-banned = Account domain banned
 moderate-user-drawer-account-history-ban-removed = Ban removed
 moderate-user-drawer-account-history-site-banned = Site banned
 moderate-user-drawer-account-history-site-ban-removed = Site ban removed


### PR DESCRIPTION
## What does this PR do?

These changes update to add to the account history description that an account is domain banned if the ban is done by the system.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can create a new user with an account that uses an email domain that is automatically banned. See that when you go to their account history in their user drawer, it says that they were `Account domain banned` in the description and that the action was taken by `System`.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
