### PR TITLE
update mobile app docs to point to app-proxy example

### DIFF
--- a/docs/docs/mobile.md
+++ b/docs/docs/mobile.md
@@ -5,7 +5,7 @@ sidebar_label: Native Mobile Apps
 
 Integration with native mobile applications is done through web view, you will need to host an HTML page which contains your embed code and open a web view to this page. There are many approaches to integrating native and web applications across different mobile operating systems, but any integration will involve the following steps:
 
-1. Host your embed code (find your **Embed code** under **Configure** > **Organization** > **Site Details**) in an HTML page served over HTTPS. For example, `https://yoursitename.com/coral.html`
+1. Host your embed code (find your **Embed code** under **Configure** > **Organization** > **Site Details**) in an HTML page served over HTTPS. For example, `https://yoursitename.com/coral.html`. Alternately, host a [proxy service](https://github.com/coralproject/app-proxy) to return the HTML for your embed code. 
 2. Add the domain to the list of permitted domains for your site under **Configure** > **Organization** > **Site Details**
 3. Create a web view in your native application which points to this URL
 4. Pass an SSO access token through to the embed code to log in your user. See [Single Sign On](/sso) for information on how to generate an SSO token. There are multiple ways to pass data from a native application to a web view, one method is to encode the access token in a query parameter on the URL hash (ex. `https://yoursitename.com/coral.html#accessToken=ssoToken`) and retrieve the token from the embed code. You can then pass through the `accessToken` option passed to `createStreamEmbed`:


### PR DESCRIPTION
## What does this PR do?
Adds a link to new app-proxy example service to the docs for native mobile development

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers
