### PR TITLE
[CORL-3159]: Change footer link text to Top of page

### DIFF
--- a/client/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/CommentsLinks/CommentsLinks.tsx
@@ -172,12 +172,12 @@ const CommentsLinks: FunctionComponent<Props> = ({
         >
           <FooterButton
             className={CLASSES.streamFooter.articleTopLink}
-            title="Go to top of article"
+            title="Go to top of page"
             onClick={onGoToArticleTop}
             classes={classes}
             Icon={CommonFileTextIcon}
           >
-            Top of article
+            Top of page
           </FooterButton>
         </Localized>
       </nav>

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1040,8 +1040,8 @@ comments-addAReviewForm-rte =
 comments-addAReviewFormFake-rte =
   .placeholder = { comments-addAReviewForm-rteLabel }
 
-stream-footer-links-top-of-article = Top of article
-  .title = Go to top of article
+stream-footer-links-top-of-article = Top of page
+  .title = Go to top of page
 stream-footer-links-top-of-comments = Top of comments
   .title = Go to top of comments
 stream-footer-links-profile = Profile & Replies


### PR DESCRIPTION
## What does this PR do?

Updates the footer text for the `Top of article` link to say `Top of page` since that's more accurate.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

See that the link now says `Top of page`

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
