### PR TITLE
[CORL-3162]: remove extra Event from end of viewNotificationsFeed event being emitted

### DIFF
--- a/client/src/core/client/stream/events.ts
+++ b/client/src/core/client/stream/events.ts
@@ -463,7 +463,7 @@ export const ViewConversationEvent = createViewerEvent<{
  */
 export const ViewNotificationsFeedEvent = createViewerEvent<{
   userID?: string;
-}>("viewNotificationsFeedEvent");
+}>("viewNotificationsFeed");
 
 /**
  * This event is emitted when the viewer clicks


### PR DESCRIPTION
## What does this PR do?

These changes remove the extra `Event` from the end of `viewNotificationsFeed` event being sent through.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can add a `console.log` inside of `useViewerEvent` to get the viewerEvent name in `client/src/core/client/framework/lib/events.ts`. Then click on the notifications tab. See that the event name `viewNotificationsFeed` without an extra `Event` on the end is being emitted.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
