### PR TITLE
[CORL-3165]: only notify on approval when comment previously pending

### DIFF
--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -7,7 +7,10 @@ import { retrieveNotificationByCommentReply } from "coral-server/models/notifica
 import { Tenant } from "coral-server/models/tenant";
 import { retrieveUser } from "coral-server/models/user";
 import { retrieveComment } from "coral-server/services/comments";
-import { moderate } from "coral-server/services/comments/moderation";
+import {
+  PENDING_STATUS,
+  moderate,
+} from "coral-server/services/comments/moderation";
 import { I18n } from "coral-server/services/i18n";
 import { InternalNotificationContext } from "coral-server/services/notifications/internal/context";
 import { AugmentedRedis } from "coral-server/services/redis";
@@ -99,11 +102,8 @@ const approveComment = async (
     }
   }
 
-  if (
-    createNotification &&
-    previousComment &&
-    notVisibleStatuses.includes(previousComment?.status)
-  ) {
+  // only create notification upon approval of comments with previous pending status
+  if (createNotification && PENDING_STATUS.includes(result.before.status)) {
     await notifications.create(tenant.id, tenant.locale, {
       targetUserID: result.after.authorID!,
       comment: result.after,
@@ -116,7 +116,11 @@ const approveComment = async (
   // and there is a reply notification for it, increment the notificationCount
   // for that notification's owner since it was decremented upon original
   // rejection
-  if (previousComment && notVisibleStatuses.includes(previousComment?.status)) {
+  if (
+    previousComment?.status === GQLCOMMENT_STATUS.REJECTED ||
+    previousComment?.status === GQLCOMMENT_STATUS.PREMOD ||
+    previousComment?.status === GQLCOMMENT_STATUS.SYSTEM_WITHHELD
+  ) {
     const replyNotification = await retrieveNotificationByCommentReply(
       mongo,
       tenant.id,

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -8,8 +8,8 @@ import { Tenant } from "coral-server/models/tenant";
 import { retrieveUser } from "coral-server/models/user";
 import { retrieveComment } from "coral-server/services/comments";
 import {
-  PENDING_STATUS,
   moderate,
+  PENDING_STATUS,
 } from "coral-server/services/comments/moderation";
 import { I18n } from "coral-server/services/i18n";
 import { InternalNotificationContext } from "coral-server/services/notifications/internal/context";
@@ -23,12 +23,6 @@ import {
 } from "coral-server/graph/schema/__generated__/types";
 
 import { publishChanges } from "./helpers";
-
-const notVisibleStatuses = [
-  GQLCOMMENT_STATUS.PREMOD,
-  GQLCOMMENT_STATUS.SYSTEM_WITHHELD,
-  GQLCOMMENT_STATUS.REJECTED,
-];
 
 const approveComment = async (
   mongo: MongoContext,


### PR DESCRIPTION
## What does this PR do?

This checks that the previous status of the comment was a `PENDING_STATUS` (premod or system withheld) and only creates a notification when a comment is approved in this case.

## These changes will impact:

- [x] commenters
- [x] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Create pending comments as a user (put the user on premod, for example). As another user, approve these comments. See that you get the expected notification of approval.

Report a user's comment. Then approve that comment as another user. See that there is no notification.

Create a comment with a suspect word. Then approve that comment as another user. See that there is no notification.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
