### PR TITLE
[CORL-3166] Prime comment cache when loading single conversation view

### DIFF
--- a/common/lib/errors.ts
+++ b/common/lib/errors.ts
@@ -467,4 +467,10 @@ export enum ERROR_CODES {
    * to a DSA report that is too long
    */
   DSA_REPORT_ADDITIONAL_INFO_TOO_LONG = "DSA_REPORT_ADDITIONAL_INFO_TOO_LONG",
+  /**
+   * UNABLE_TO_PRIME_CACHED_COMMENTS_FOR_STORY is thrown when DATA_CACHE is enabled and the
+   * priming of comments for the story in the data caches `commentCache` returns an undefined
+   * result. This usually means something went very wrong loading from Redis or Mongo.
+   */
+  UNABLE_TO_PRIME_CACHED_COMMENTS_FOR_STORY = "UNABLE_TO_PRIME_CACHED_COMMENTS_FOR_STORY"
 }

--- a/server/src/core/server/data/cache/commentCache.spec.ts
+++ b/server/src/core/server/data/cache/commentCache.spec.ts
@@ -3,6 +3,7 @@ import RedisClient from "ioredis";
 import { waitFor } from "coral-common/common/lib/helpers";
 import { CommentCache } from "coral-server/data/cache/commentCache";
 import { MongoContext, MongoContextImpl } from "coral-server/data/context";
+import { UnableToPrimeCachedCommentsForStory } from "coral-server/errors";
 import logger from "coral-server/logger";
 import { Comment } from "coral-server/models/comment";
 import { createMongoDB } from "coral-server/services/mongodb";
@@ -84,6 +85,10 @@ it("can load root comments from commentCache", async () => {
     story.id,
     false
   );
+  if (!primeResult) {
+    throw new UnableToPrimeCachedCommentsForStory(story.tenantID, story.id);
+  }
+
   const results = await comments.rootComments(
     story.tenantID,
     story.id,
@@ -144,6 +149,10 @@ it("can load replies from commentCache", async () => {
     story.id,
     false
   );
+  if (!primeResult) {
+    throw new UnableToPrimeCachedCommentsForStory(story.tenantID, story.id);
+  }
+
   const rootResults = await comments.rootComments(
     story.tenantID,
     story.id,
@@ -211,6 +220,9 @@ it("cache expires appropriately", async () => {
     story.id,
     false
   );
+  if (!primeResult) {
+    throw new UnableToPrimeCachedCommentsForStory(story.tenantID, story.id);
+  }
   expect(primeResult.retrievedFrom).toEqual("redis");
 
   let lockExists = await redis.exists(lockKey);

--- a/server/src/core/server/errors/index.ts
+++ b/server/src/core/server/errors/index.ts
@@ -1064,3 +1064,12 @@ export class InvalidFlairBadgeName extends CoralError {
     });
   }
 }
+
+export class UnableToPrimeCachedCommentsForStory extends CoralError {
+  constructor(tenantID: string, storyID: string) {
+    super({
+      code: ERROR_CODES.UNABLE_TO_PRIME_CACHED_COMMENTS_FOR_STORY,
+      context: { pub: { tenantID } },
+    });
+  }
+}

--- a/server/src/core/server/errors/translations.ts
+++ b/server/src/core/server/errors/translations.ts
@@ -84,4 +84,6 @@ export const ERROR_TRANSLATIONS: Record<ERROR_CODES, string> = {
   INVALID_FLAIR_BADGE_NAME: "error-invalidFlairBadgeName",
   DSA_REPORT_LAW_BROKEN_TOO_LONG: "error-dsaReportLawBrokenTooLong",
   DSA_REPORT_ADDITIONAL_INFO_TOO_LONG: "error-dsaReportAdditionalInfoTooLong",
+  UNABLE_TO_PRIME_CACHED_COMMENTS_FOR_STORY:
+    "error-unableToPrimeCachedCommentsForStory",
 };

--- a/server/src/core/server/graph/resolvers/Comment.ts
+++ b/server/src/core/server/graph/resolvers/Comment.ts
@@ -155,7 +155,10 @@ export const Comment: GQLCommentTypeResolver<comment.Comment> = {
     }
 
     const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
-    if (cacheAvailable) {
+    if (
+      cacheAvailable &&
+      ctx.cache.comments.shouldPrimeForStory(ctx.tenant.id, c.storyID)
+    ) {
       const story = await ctx.loaders.Stories.find.load({ id: c.storyID });
       await ctx.cache.comments.primeCommentsForStory(
         ctx.tenant.id,

--- a/server/src/core/server/graph/resolvers/Comment.ts
+++ b/server/src/core/server/graph/resolvers/Comment.ts
@@ -147,12 +147,26 @@ export const Comment: GQLCommentTypeResolver<comment.Comment> = {
   },
   statusHistory: ({ id }, input, ctx) =>
     ctx.loaders.CommentModerationActions.forComment(input, id),
-  replies: (c, input, ctx) =>
+  replies: async (c, input, ctx) => {
     // If there is at least one reply, then use the connection loader, otherwise
     // return a blank connection.
-    c.childCount > 0
-      ? ctx.loaders.Comments.forParent(c.storyID, c.id, input)
-      : createConnection(),
+    if (c.childCount === 0) {
+      return createConnection();
+    }
+
+    const cacheAvailable = await ctx.cache.available(ctx.tenant.id);
+    if (cacheAvailable) {
+      const story = await ctx.loaders.Stories.find.load({ id: c.storyID });
+      await ctx.cache.comments.primeCommentsForStory(
+        ctx.tenant.id,
+        c.storyID,
+        !!story?.isArchived
+      );
+    }
+
+    const result = await ctx.loaders.Comments.forParent(c.storyID, c.id, input);
+    return result;
+  },
   replyCount: async ({ storyID, childIDs }, input, ctx) => {
     // TODO: (wyattjoh) the childCount should be used eventually, but it should be managed with the status so it's only a count of published comments
     if (childIDs.length === 0) {

--- a/server/src/core/server/locales/en-US/errors.ftl
+++ b/server/src/core/server/locales/en-US/errors.ftl
@@ -85,3 +85,4 @@ error-dataCachingNotAvailable = Data caching is not available at this time.
 error-invalidFlairBadgeName = Only letters, numbers, and the special characters - . are permitted in flair badge names.
 error-dsaReportLawBrokenTooLong = What law do you believe has been broken for DSA report exceeds maximum length.
 error-dsaReportAdditionalInfoTooLong = Additional information for DSA report exceeds maximum length.
+error-unableToPrimeCachedCommentsForStory = Unable to prime cached comments for story.


### PR DESCRIPTION
## What does this PR do?

Adds a check to see if the comment cache has been primed when loading a single conversation view's comment replies.

Ensures that the whole story is primed into Redis before trying to use the cache to load the single conversation view with its parents and replies around the target shared comment.

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

See the reproduction steps laid out in the reporting issue:
https://github.com/coralproject/talk/issues/4609

Useful mutations when testing:

POST: `http://localhost:3000/api/graphql`
```
mutation {
  enableFeatureFlag(input: {
    clientMutationId: "1",
    flag: DATA_CACHE
  }) {
    flags
  }
}

```

POST: `http://localhost:3000/api/graphql`
```
mutation {
  disableFeatureFlag(input: {
    clientMutationId: "1",
    flag: DATA_CACHE
  }) {
    flags
  }
}
```

You can flush redis using: http://localhost:3000/admin/controlpanel

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into `develop` and add to upcoming release.
