### PR TITLE
Fix: make `rejectComment` work for archived comments

### DIFF
--- a/server/src/core/server/graph/mutators/Actions.ts
+++ b/server/src/core/server/graph/mutators/Actions.ts
@@ -62,7 +62,7 @@ export const Actions = (ctx: GraphContext) => ({
       input.reason,
       undefined,
       undefined,
-      false,
+      true,
       story.isArchived || story.isArchiving
     );
   },

--- a/server/src/core/server/graph/mutators/Actions.ts
+++ b/server/src/core/server/graph/mutators/Actions.ts
@@ -61,7 +61,7 @@ export const Actions = (ctx: GraphContext) => ({
       ctx.now,
       input.reason,
       undefined,
-      undefined,
+      ctx.req,
       true,
       story.isArchived || story.isArchiving
     );


### PR DESCRIPTION
## What does this PR do?

- passes archived state to reject comment during api mutation

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- Setup Coral with live and archived databases
- Comment on a story
- Archive that story
- Reject the comment via mutation that you posted to the story
- See that the comment is correctly found and rejected via the API mutation call

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into `develop`
- Cut a release
