### PR TITLE
Fix build-tag-push step in GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.REPO_PATCHED_DEPLOY_KEY }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,20 +83,9 @@ jobs:
         run: sh scripts/build.sh
       - name: Verify Bundle Size
         run: cd client && ./node_modules/.bin/bundlesize --enable-github-checks
-      # Debugging
-      - name: Build, Tag, Push (Debug)
-        uses: docker/build-push-action@v5
-        if: github.ref == 'refs/heads/fix/build-tag-push'
-        with:
-          push: true
-          tags: ${{ env.IMAGE_REPOSITORY }}:debug-test
-          build-args: |
-            REVISION_HASH=${GITHUB_SHA}
-          cache-from: type=registry,ref=${{ env.IMAGE_CACHE_REPOSITORY }}:cache-debug
-          cache-to: type=registry,ref=${{ env.IMAGE_CACHE_REPOSITORY }}:cache-debug
       # Build tag push the image after a merge to develop
       - name: Build, Tag, Push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         if: github.ref == 'refs/heads/develop'
         with:
           push: true
@@ -107,7 +96,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.IMAGE_CACHE_REPOSITORY }}:cache-develop
       # Build tag push the release candidate image when the branch name begins with release-
       - name: Build, Tag, Push RC
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         if: startsWith( github.ref, 'refs/heads/release-')
         with:
           push: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,6 +83,17 @@ jobs:
         run: sh scripts/build.sh
       - name: Verify Bundle Size
         run: cd client && ./node_modules/.bin/bundlesize --enable-github-checks
+      # Debugging
+      - name: Build, Tag, Push (Debug)
+        uses: docker/build-push-action@v5
+        if: github.ref == 'refs/heads/fix/build-tag-push'
+        with:
+          push: true
+          tags: ${{ env.IMAGE_REPOSITORY }}:debug-test
+          build-args: |
+            REVISION_HASH=${GITHUB_SHA}
+          cache-from: type=registry,ref=${{ env.IMAGE_CACHE_REPOSITORY }}:cache-debug
+          cache-to: type=registry,ref=${{ env.IMAGE_CACHE_REPOSITORY }}:cache-debug
       # Build tag push the image after a merge to develop
       - name: Build, Tag, Push
         uses: docker/build-push-action@v4

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.REPO_PATCHED_DEPLOY_KEY }}
@@ -98,7 +98,7 @@ jobs:
           echo "MINOR_TAG=${MAJOR}.${MINOR}" >> $GITHUB_ENV
           echo "PATCH_TAG=${MAJOR}.${MINOR}.${PATCH}" >> $GITHUB_ENV
       - name: Build, Tag, Push Major Tag
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.MAJOR_TAG }}
@@ -107,7 +107,7 @@ jobs:
           cache-from: type=registry,ref=${{ env.IMAGE_CACHE_REPOSITORY }}:cache-major
           cache-to: type=registry,ref=${{ env.IMAGE_CACHE_REPOSITORY }}:cache-major
       - name: Build, Tag, Push Minor Tag
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.MINOR_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18-alpine
 ENV NODE_OPTIONS="--max-old-space-size=8192 --openssl-legacy-provider --no-experimental-fetch"
 
 # Install build dependancies.
-RUN apk --no-cache --update add g++ make git python3 \
+RUN apk --no-cache --update add g++ make git python3 py3-pip py3-setuptools \
   && rm -rf /var/cache/apk/*
 
 RUN npm install -g pnpm@8.14.3


### PR DESCRIPTION
## What does this PR do?

- updates the `setup-buildx` and `build-tag-push` steps in our actions runners
- fixes the missing `distutils` packages for `pnpm` to install our dependencies

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

Check the build steps/actions in GitHub and see they passed

Proof of it working here: https://github.com/coralproject/talk/actions/runs/9307222322/job/25618059747

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

Merge into `develop`
