### PR TITLE
Update Tenor gifs to use the new string based `contentFilter`

### DIFF
--- a/server/src/core/server/app/handlers/api/tenor/index.ts
+++ b/server/src/core/server/app/handlers/api/tenor/index.ts
@@ -57,26 +57,26 @@ interface SearchPayload {
 
 export const convertGiphyContentRatingToTenorLevel = (
   rating: string | null | undefined
-) => {
+): string => {
   if (!rating) {
-    return 1;
+    return "high";
   }
 
   const lowerRating = rating.toLowerCase();
   if (lowerRating === "g") {
-    return 1;
+    return "high";
   }
   if (lowerRating === "pg") {
-    return 2;
+    return "medium";
   }
   if (lowerRating === "pg-13") {
-    return 3;
+    return "low";
   }
   if (lowerRating === "r") {
-    return 4;
+    return "off";
   }
 
-  return 1;
+  return "high";
 };
 
 export const tenorSearchHandler =
@@ -126,7 +126,7 @@ export const tenorSearchHandler =
     url.searchParams.set("q", params.query);
     url.searchParams.set("key", apiKey);
     url.searchParams.set("limit", `${SEARCH_LIMIT}`);
-    url.searchParams.set("ContentFilter", `${contentFilter}`);
+    url.searchParams.set("contentfilter", contentFilter);
 
     const response = await fetch(url.toString(), {
       method: "GET",


### PR DESCRIPTION
## What does this PR do?

Tenor deprecated the numeric content ratings and moved to a string based (high, med, low, none) format. This updates the mappings to account for that.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- set content filters in Admin > Config > General
- see that the gif content search results is filtered as such

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into `develop`
