### PR TITLE
[CORL-3171] fix tenor search fetch's on prod

### DIFF
--- a/client/src/core/client/stream/common/useFetchWithAuth.ts
+++ b/client/src/core/client/stream/common/useFetchWithAuth.ts
@@ -1,9 +1,16 @@
 import { useCallback } from "react";
 import { graphql } from "react-relay";
 
+import { buildURL, parseURL } from "coral-framework/utils";
+
 import { useFetchWithAuth_local } from "coral-stream/__generated__/useFetchWithAuth_local.graphql";
 
 import { useLocal } from "../../framework/lib/relay";
+
+const processURL = (url: string) => {
+  const parsedURL = parseURL(url);
+  return buildURL(parsedURL);
+};
 
 const useFetchWithAuth = () => {
   const [{ accessToken }] = useLocal<useFetchWithAuth_local>(graphql`
@@ -13,7 +20,7 @@ const useFetchWithAuth = () => {
   `);
 
   const fetchWithAuth = useCallback(
-    async (input: RequestInfo, init?: RequestInit) => {
+    async (url: string, init?: RequestInit) => {
       const params = {
         ...init,
         headers: new Headers({
@@ -21,7 +28,8 @@ const useFetchWithAuth = () => {
         }),
       };
 
-      const response = await fetch(input, params);
+      const processedURL = processURL(url);
+      const response = await fetch(processedURL, params);
 
       return response;
     },

--- a/client/src/core/client/stream/tabs/Comments/TenorInput/TenorInput.tsx
+++ b/client/src/core/client/stream/tabs/Comments/TenorInput/TenorInput.tsx
@@ -199,7 +199,7 @@ const TenorInput: FunctionComponent<Props> = ({ onSelect }) => {
                 </button>
               );
             })}
-          {next && gifs && gifs.length > 0 && (
+          {next && gifs && gifs.length > 0 && query?.length > 0 && (
             <div className={styles.gridControls}>
               <Localized id="comments-postComment-gifSearch-search-loadMore">
                 <Button color="stream" onClick={onLoadMore}>

--- a/client/src/core/client/stream/tabs/Comments/TenorInput/TenorInput.tsx
+++ b/client/src/core/client/stream/tabs/Comments/TenorInput/TenorInput.tsx
@@ -21,6 +21,8 @@ import TenorAttribution from "./TenorAttribution";
 
 import styles from "./TenorInput.css";
 
+const DEBOUNCE_DELAY_MS = 1250;
+
 interface Props {
   onSelect: (gif: GifResult) => void;
   forwardRef?: Ref<HTMLInputElement>;
@@ -99,7 +101,7 @@ const TenorInput: FunctionComponent<Props> = ({ onSelect }) => {
     setNext(response.next ?? null);
   }, [fetchGifs, gifs, query]);
 
-  const debounceFetchGifs = useDebounce(loadGifs, 650);
+  const debounceFetchGifs = useDebounce(loadGifs, DEBOUNCE_DELAY_MS);
 
   const onChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     async (e) => {

--- a/client/src/core/client/stream/tabs/Comments/TenorInput/TenorInput.tsx
+++ b/client/src/core/client/stream/tabs/Comments/TenorInput/TenorInput.tsx
@@ -53,7 +53,7 @@ const TenorInput: FunctionComponent<Props> = ({ onSelect }) => {
   const { ref } = useResizeObserver<HTMLDivElement>();
 
   const fetchGifs = useCallback(
-    async (q: string, n?: string) => {
+    async (q: string, n?: string | null) => {
       if (!q || q.length === 0) {
         return null;
       }
@@ -92,14 +92,14 @@ const TenorInput: FunctionComponent<Props> = ({ onSelect }) => {
   }, [query, fetchGifs]);
 
   const loadMoreGifs = useCallback(async () => {
-    const response = await fetchGifs(query);
+    const response = await fetchGifs(query, next);
     if (!response) {
       return;
     }
 
     setGifs([...gifs, ...response.results]);
     setNext(response.next ?? null);
-  }, [fetchGifs, gifs, query]);
+  }, [fetchGifs, gifs, query, next]);
 
   const debounceFetchGifs = useDebounce(loadGifs, DEBOUNCE_DELAY_MS);
 


### PR DESCRIPTION
## What does this PR do?

- Fixing the problem with missing protocol on tenor search queries
- Updates `useFetchWithAuth` to  use the framework url utilities to process url's.
    - This ensures that we set the protocol properly on `useFetchWithAuth` (among other things) as the `rootURL` does not come through with a protocol in prod.
    - This is quietly already being done for relay via the `modifyQuery` util's that also include `parseURL` and `buildURL` for the underlying fetch utility that is performing relay requests. It is also being similarly used to generate a redirect url in the `CommentPane`.

- Fixing the rate limit issues when searching
    - Setting the debounce when typing to 1250 ms
    - Does not do anything for when users spam `Load more` and don't get results due to rate limiting, but that's less likely to happen 

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- Head to `dev1` and test posting tenor gifs in a prod-like environment
    - only way to easily test url protocol as Coral dev passes `http://...` through in its `rootURL`

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into `develop`
