### PR TITLE
[CORL-3190]: remove extra Tab definition for screen readers

### DIFF
--- a/client/src/core/client/admin/test/community/userHistoryDrawer.spec.tsx
+++ b/client/src/core/client/admin/test/community/userHistoryDrawer.spec.tsx
@@ -152,13 +152,13 @@ it("user drawer is open and user can be scheduled for deletion and have deletion
     "userHistoryDrawer-modal"
   );
   const historyTab = await within(isabelleUserHistory).findByRole("tab", {
-    name: "Tab: time-reverse Account History",
+    name: "time-reverse Account History",
   });
   await act(async () => {
     userEvent.click(historyTab);
   });
   const tabRegion = screen.getByRole("region", {
-    name: "Tab: time-reverse Account History",
+    name: "time-reverse Account History",
   });
   const deleteAccountButton = within(tabRegion).getByRole("button", {
     name: "Delete account",

--- a/client/src/core/client/admin/test/moderate/regularQueue.spec.tsx
+++ b/client/src/core/client/admin/test/moderate/regularQueue.spec.tsx
@@ -445,7 +445,7 @@ it("show reaction details for a comment with reactions", async () => {
   });
   userEvent.click(detailsButton);
   const reactionsButton = within(reported).getByRole("tab", {
-    name: "Tab: Reactions",
+    name: "Reactions",
   });
   await act(async () => {
     userEvent.click(reactionsButton);

--- a/client/src/core/client/stream/test/comments/featured/renderAnsweredStream.spec.tsx
+++ b/client/src/core/client/stream/test/comments/featured/renderAnsweredStream.spec.tsx
@@ -63,9 +63,7 @@ it("renders comment stream with answered comments", async () => {
     "comments-featuredComments-log"
   );
   expect(answeredComments).toBeVisible();
-  expect(
-    screen.getByRole("tab", { name: "Tab: Answered ( 2 )" })
-  ).toBeVisible();
+  expect(screen.getByRole("tab", { name: "Answered ( 2 )" })).toBeVisible();
   expect(
     screen.getByRole("article", {
       name: "Answer from Markus 2018-07-06T18:24:00.000Z",
@@ -88,9 +86,7 @@ it("renders oldest first sort answered comments tab with post comment form", asy
     "comments-featuredComments-log"
   );
   expect(answeredComments).toBeVisible();
-  expect(
-    screen.getByRole("tab", { name: "Tab: Answered ( 2 )" })
-  ).toBeVisible();
+  expect(screen.getByRole("tab", { name: "Answered ( 2 )" })).toBeVisible();
   expect(
     screen.getByRole("article", {
       name: "Answer from Markus 2018-07-06T18:24:00.000Z",

--- a/client/src/core/client/ui/components/v2/Tabs/Tab.tsx
+++ b/client/src/core/client/ui/components/v2/Tabs/Tab.tsx
@@ -1,11 +1,8 @@
-import { Localized } from "@fluent/react/compat";
 import cn from "classnames";
 import React from "react";
 
 import BaseButton from "coral-ui/components/v2/BaseButton";
 import { withStyles } from "coral-ui/hocs";
-
-import AriaInfo from "../AriaInfo";
 
 import styles from "./Tab.css";
 
@@ -103,14 +100,7 @@ class Tab extends React.Component<TabProps> {
           title={title}
           onClick={this.handleTabClick}
         >
-          <>
-            <AriaInfo>
-              <Localized id="ui-tabAriaPrefix">
-                <span>Tab:</span>
-              </Localized>
-            </AriaInfo>
-            {children}
-          </>
+          {children}
         </BaseButton>
       </li>
     );

--- a/client/src/core/client/ui/components/v2/Tabs/__snapshots__/TabBar.spec.tsx.snap
+++ b/client/src/core/client/ui/components/v2/Tabs/__snapshots__/TabBar.spec.tsx.snap
@@ -23,13 +23,6 @@ exports[`sets initial tab as active 1`] = `
       role="tab"
       type="button"
     >
-      <div
-        className="AriaInfo-root"
-      >
-        <span>
-          Tab:
-        </span>
-      </div>
       One
     </button>
   </li>
@@ -51,13 +44,6 @@ exports[`sets initial tab as active 1`] = `
       role="tab"
       type="button"
     >
-      <div
-        className="AriaInfo-root"
-      >
-        <span>
-          Tab:
-        </span>
-      </div>
       Two
     </button>
   </li>
@@ -79,13 +65,6 @@ exports[`sets initial tab as active 1`] = `
       role="tab"
       type="button"
     >
-      <div
-        className="AriaInfo-root"
-      >
-        <span>
-          Tab:
-        </span>
-      </div>
       Three
     </button>
   </li>


### PR DESCRIPTION
## What does this PR do?

As mentioned in issue https://github.com/coralproject/talk/issues/4664, we shouldn't need the aria info span that says `Tab:` since we have `role="tab"` on the tabs.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can use a screen reader. For example, you can test this by pressing Command-F5 to enable `VoiceOver`. Then you can use caps lock + right arrow to navigate through the page and hear that tab is only said once (without this change, `tab` is said twice).

## Were any tests migrated to React Testing Library?

no

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
