### PR TITLE
[CORL-3179]: Create notification on previously rejected comment being approved if DSA is enabled

### DIFF
--- a/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
@@ -48,6 +48,9 @@ const getIcon = (type: NOTIFICATION_TYPE | null): ComponentType => {
   if (type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED) {
     return CheckCircleIcon;
   }
+  if (type === GQLNOTIFICATION_TYPE.PREVIOUSLY_REJECTED_COMMENT_APPROVED) {
+    return CheckCircleIcon;
+  }
   if (type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED) {
     return RatingStarRibbonIcon;
   }
@@ -81,6 +84,13 @@ const getTitle = (
       bundles,
       "notifications-yourCommentHasBeenApproved",
       "Your comment has been published"
+    );
+  }
+  if (type === GQLNOTIFICATION_TYPE.PREVIOUSLY_REJECTED_COMMENT_APPROVED) {
+    return getMessage(
+      bundles,
+      "notifications-yourPreviouslyRejectedCommentHasBeenApproved",
+      "Your comment was previously rejected. It has now been restored to the page."
     );
   }
   if (type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED) {
@@ -200,7 +210,9 @@ const NotificationContainer: FunctionComponent<Props> = ({
         {(type === GQLNOTIFICATION_TYPE.REPLY ||
           type === GQLNOTIFICATION_TYPE.REPLY_STAFF ||
           type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED ||
-          type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED) && (
+          type === GQLNOTIFICATION_TYPE.COMMENT_APPROVED ||
+          type ===
+            GQLNOTIFICATION_TYPE.PREVIOUSLY_REJECTED_COMMENT_APPROVED) && (
           <CommentNotificationBody
             notification={notification}
             reply={

--- a/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
+++ b/client/src/core/client/stream/tabs/Notifications/NotificationContainer.tsx
@@ -90,7 +90,7 @@ const getTitle = (
     return getMessage(
       bundles,
       "notifications-yourPreviouslyRejectedCommentHasBeenApproved",
-      "Your comment was previously rejected. It has now been restored to the page."
+      "Your comment was previously rejected. It has now been approved."
     );
   }
   if (type === GQLNOTIFICATION_TYPE.COMMENT_FEATURED) {

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1083,7 +1083,7 @@ notifications-yourCommentHasBeenRejected =
 notifications-yourCommentHasBeenApproved =
   Your comment has been approved
 notifications-yourPreviouslyRejectedCommentHasBeenApproved =
-  Your comment was previously rejected. It has now been restored to the page.
+  Your comment was previously rejected. It has now been approved.
 notifications-yourCommentHasBeenFeatured =
   Your comment has been featured
 notifications-yourCommentHasReceivedAReply =

--- a/locales/en-US/stream.ftl
+++ b/locales/en-US/stream.ftl
@@ -1082,6 +1082,8 @@ notifications-yourCommentHasBeenRejected =
   Your comment has been rejected
 notifications-yourCommentHasBeenApproved =
   Your comment has been approved
+notifications-yourPreviouslyRejectedCommentHasBeenApproved =
+  Your comment was previously rejected. It has now been restored to the page.
 notifications-yourCommentHasBeenFeatured =
   Your comment has been featured
 notifications-yourCommentHasReceivedAReply =

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -4125,7 +4125,12 @@ type ExternalMedia {
 """
 CommentMedia is the various media types that can be attached to a Comment.
 """
-union CommentMedia = GiphyMedia | TwitterMedia | YouTubeMedia | ExternalMedia | TenorMedia
+union CommentMedia =
+    GiphyMedia
+  | TwitterMedia
+  | YouTubeMedia
+  | ExternalMedia
+  | TenorMedia
 
 type CommentRevision {
   """
@@ -5028,6 +5033,7 @@ enum NOTIFICATION_TYPE {
   DSA_REPORT_DECISION_MADE
   REPLY
   REPLY_STAFF
+  PREVIOUSLY_REJECTED_COMMENT_APPROVED
 }
 
 type Notification {

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -107,8 +107,7 @@ const approveComment = async (
   }
 
   // create notification if dsa enabled upon approval of previously rejected comment
-  if (tenant.dsa?.enabled) {
-    if (previousComment?.status === GQLCOMMENT_STATUS.REJECTED) {
+  if (tenant.dsa?.enabled && previousComment?.status === GQLCOMMENT_STATUS.REJECTED) {
       await notifications.create(tenant.id, tenant.locale, {
         targetUserID: result.after.authorID!,
         comment: result.after,

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -107,14 +107,16 @@ const approveComment = async (
   }
 
   // create notification if dsa enabled upon approval of previously rejected comment
-  if (tenant.dsa?.enabled && previousComment?.status === GQLCOMMENT_STATUS.REJECTED) {
-      await notifications.create(tenant.id, tenant.locale, {
-        targetUserID: result.after.authorID!,
-        comment: result.after,
-        previousStatus: result.before.status,
-        type: GQLNOTIFICATION_TYPE.PREVIOUSLY_REJECTED_COMMENT_APPROVED,
-      });
-    }
+  if (
+    tenant.dsa?.enabled &&
+    previousComment?.status === GQLCOMMENT_STATUS.REJECTED
+  ) {
+    await notifications.create(tenant.id, tenant.locale, {
+      targetUserID: result.after.authorID!,
+      comment: result.after,
+      previousStatus: result.before.status,
+      type: GQLNOTIFICATION_TYPE.PREVIOUSLY_REJECTED_COMMENT_APPROVED,
+    });
   }
 
   // if comment was previously rejected, system withheld, or in pre-mod,

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -106,6 +106,18 @@ const approveComment = async (
     });
   }
 
+  // create notification if dsa enabled upon approval of previously rejected comment
+  if (tenant.dsa?.enabled) {
+    if (previousComment?.status === GQLCOMMENT_STATUS.REJECTED) {
+      await notifications.create(tenant.id, tenant.locale, {
+        targetUserID: result.after.authorID!,
+        comment: result.after,
+        previousStatus: result.before.status,
+        type: GQLNOTIFICATION_TYPE.PREVIOUSLY_REJECTED_COMMENT_APPROVED,
+      });
+    }
+  }
+
   // if comment was previously rejected, system withheld, or in pre-mod,
   // and there is a reply notification for it, increment the notificationCount
   // for that notification's owner since it was decremented upon original


### PR DESCRIPTION
## What does this PR do?

If DSA is enabled, then with these changes, we now create a notification if a comment was previously rejected (whether automatically for including a banned word or by a moderator) and then is approved.

If DSA is not enabled, then there are no changes; no notification is created when a comment is rejected, and there is also no subsequent notification created if it is later approved after rejection.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

This adds a new type to the `NOTIFICATION_TYPE` enum of `PREVIOUSLY_REJECTED_COMMENT_APPROVED`.

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test out these changes by:
- Enabling DSA
- As User A, creating a comment with a banned word in it (or creating a comment and then rejecting it); see that it is rejected and gets a notification about this
- As a User B (with role moderator/admin), approving the rejected comment
- See that User A has a notification that the comment was previously rejected but has been restored to the page

Then, also:
- Disabling DSA
- Repeating the other steps above, but observing that no notifications are created for rejection/approval

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
