### PR TITLE
[CORL-3189]: Add support for non-latin character range for urls for comment counts

### DIFF
--- a/client/src/core/client/count/index.ts
+++ b/client/src/core/client/count/index.ts
@@ -1,6 +1,9 @@
 import { COUNT_SELECTOR } from "coral-framework/constants";
-import detectCountScript from "coral-framework/helpers/detectCountScript";
-import resolveStoryURL from "coral-framework/helpers/resolveStoryURL";
+import {
+  bytesToBase64,
+  detectCountScript,
+  resolveStoryURL,
+} from "coral-framework/helpers";
 import jsonp from "coral-framework/utils/jsonp";
 
 import injectJSONPCallback from "./injectJSONPCallback";
@@ -13,7 +16,7 @@ interface CountQueryArgs {
 
 /** createCountQueryRef creates a unique reference from the query args */
 function createCountQueryRef(args: CountQueryArgs) {
-  return btoa(`${args.url}`);
+  return bytesToBase64(new TextEncoder().encode(`${args.url}`));
 }
 
 interface DetectAndInjectArgs {

--- a/client/src/core/client/count/index.ts
+++ b/client/src/core/client/count/index.ts
@@ -1,5 +1,3 @@
-import { TextEncoder } from "util";
-
 import { COUNT_SELECTOR } from "coral-framework/constants";
 import {
   bytesToBase64,

--- a/client/src/core/client/count/index.ts
+++ b/client/src/core/client/count/index.ts
@@ -1,3 +1,5 @@
+import { TextEncoder } from "util";
+
 import { COUNT_SELECTOR } from "coral-framework/constants";
 import {
   bytesToBase64,

--- a/client/src/core/client/framework/helpers/bytesToBase64.ts
+++ b/client/src/core/client/framework/helpers/bytesToBase64.ts
@@ -1,0 +1,6 @@
+export default function bytesToBase64(bytes: Uint8Array) {
+  const binString = Array.from(bytes, (byte) =>
+    String.fromCodePoint(byte)
+  ).join("");
+  return btoa(binString);
+}

--- a/client/src/core/client/framework/helpers/index.ts
+++ b/client/src/core/client/framework/helpers/index.ts
@@ -1,3 +1,4 @@
+export { default as bytesToBase64 } from "./bytesToBase64";
 export { default as clearHash } from "./clearHash";
 export { default as createContextHOC } from "./createContextHOC";
 export { default as detectCommentEmbedScript } from "./detectCommentEmbedScript";

--- a/client/src/core/client/test/setupTestFramework.ts
+++ b/client/src/core/client/test/setupTestFramework.ts
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 import { toHaveNoViolations } from "jest-axe";
+import { TextEncoder } from "util";
 
 import expectAndFail from "./expectAndFail";
 
@@ -13,6 +14,9 @@ import "./setupConsole";
 // when assertion fails. This works even inside of an try-catch block
 // to get around: https://github.com/facebook/jest/issues/3917
 (global as any).expectAndFail = expectAndFail;
+
+// we need to have this for count script
+(global as any).TextEncoder = TextEncoder;
 
 // Log unhandled rejections.
 // eslint-disable-next-line no-console


### PR DESCRIPTION
## What does this PR do?

These changes add support for non-Latin characters in story urls for comment counts. Previously, we were getting `Uncaught InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.` when attempting to create a count query ref with characters outside of the range. This updates as recommended [here](https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem) to address this issue.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test that comment counts still work as expected. You can also run these changes--the new `bytesToBase64` function and `bytesToBase64(new TextEncoder().encode(URL))`--in the console with a story url such as is mentioned in [this issue](https://github.com/coralproject/talk/issues/4662) and confirm that you get a ref that can be used back and not an error.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
