### PR TITLE
[CORL-3195]: more error handling and type check fixes

### DIFF
--- a/server/src/core/server/app/handlers/api/tenor/index.ts
+++ b/server/src/core/server/app/handlers/api/tenor/index.ts
@@ -69,7 +69,7 @@ export const tenorSearchHandler =
       return;
     }
 
-    const gifsEnabled = tenant.media?.gifs.enabled ?? false;
+    const gifsEnabled = tenant.media?.gifs?.enabled ?? false;
     if (!gifsEnabled) {
       res.status(200).send({
         results: [],
@@ -77,7 +77,7 @@ export const tenorSearchHandler =
       return;
     }
 
-    const apiKey = tenant.media?.gifs.key ?? null;
+    const apiKey = tenant.media?.gifs?.key ?? null;
     if (!apiKey || apiKey.length === 0) {
       res.status(200).send({
         results: [],
@@ -86,7 +86,7 @@ export const tenorSearchHandler =
     }
 
     const contentFilter = convertGiphyContentRatingToTenorLevel(
-      tenant.media?.gifs.maxRating
+      tenant.media?.gifs?.maxRating
     );
 
     const url = new URL(TENOR_SEARCH_URL);
@@ -133,7 +133,7 @@ export const tenorSearchHandler =
     } catch (e) {
       // Ensure that the API key doesn't get leaked to the logs by accident.
       if (e.message) {
-        e.message = e.message.replace(tenant.media?.gifs.key, "[Sensitive]");
+        e.message = e.message.replace(tenant.media?.gifs?.key, "[Sensitive]");
       }
       throw new WrappedInternalError(e as Error, "tenor search error");
     }

--- a/server/src/core/server/models/tenant/helpers.ts
+++ b/server/src/core/server/models/tenant/helpers.ts
@@ -119,13 +119,13 @@ export function supportsMediaType(
       return !!tenant.media?.youtube.enabled;
     case "giphy":
       return (
-        !!tenant.media?.gifs.enabled &&
+        !!tenant.media?.gifs?.enabled &&
         !!tenant.media.gifs.key &&
         tenant.media.gifs.provider === GQLGIF_MEDIA_SOURCE.GIPHY
       );
     case "tenor":
       return (
-        !!tenant.media?.gifs.enabled &&
+        !!tenant.media?.gifs?.enabled &&
         !!tenant.media.gifs.key &&
         tenant.media.gifs.provider === GQLGIF_MEDIA_SOURCE.TENOR
       );

--- a/server/src/core/server/services/comments/media.ts
+++ b/server/src/core/server/services/comments/media.ts
@@ -77,6 +77,9 @@ async function attachTenorMedia(
       video: data.media_formats.mp4.url,
     };
   } catch (err) {
+    if (!(err instanceof Error)) {
+      throw new Error("cannot attach Tenor Media");
+    }
     throw new WrappedInternalError(err as Error, "cannot attach Tenor Media");
   }
 }

--- a/server/src/core/server/services/comments/media.ts
+++ b/server/src/core/server/services/comments/media.ts
@@ -80,7 +80,7 @@ async function attachTenorMedia(
     if (!(err instanceof Error)) {
       throw new Error("cannot attach Tenor Media");
     }
-    throw new WrappedInternalError(err as Error, "cannot attach Tenor Media");
+    throw new WrappedInternalError(err, "cannot attach Tenor Media");
   }
 }
 

--- a/server/src/core/server/services/errors/sentry/sentry.ts
+++ b/server/src/core/server/services/errors/sentry/sentry.ts
@@ -87,7 +87,13 @@ export class SentryErrorReporter extends ErrorReporter {
     }
 
     // Get the original cause of the error in case that it is wrapped.
-    const errorToReport = getErrorToReport(err as Error);
+    let errorToReport = getErrorToReport(err as Error);
+
+    if (!(errorToReport instanceof Error)) {
+      errorToReport = new Error(
+        "Non-error thrown: " + JSON.stringify(errorToReport)
+      );
+    }
 
     // Capture and report the error to Sentry.
     const id = Sentry.captureException(errorToReport, context);

--- a/server/src/core/server/services/errors/sentry/sentry.ts
+++ b/server/src/core/server/services/errors/sentry/sentry.ts
@@ -87,13 +87,7 @@ export class SentryErrorReporter extends ErrorReporter {
     }
 
     // Get the original cause of the error in case that it is wrapped.
-    let errorToReport = getErrorToReport(err as Error);
-
-    if (!(errorToReport instanceof Error)) {
-      errorToReport = new Error(
-        "Non-error thrown: " + JSON.stringify(errorToReport)
-      );
-    }
+    const errorToReport = getErrorToReport(err as Error);
 
     // Capture and report the error to Sentry.
     const id = Sentry.captureException(errorToReport, context);

--- a/server/src/core/server/services/giphy/giphy.ts
+++ b/server/src/core/server/services/giphy/giphy.ts
@@ -59,7 +59,7 @@ const GiphyRetrieveResponseSchema = Joi.object().keys({
 
 export function ratingIsAllowed(rating: string, tenant: Tenant) {
   const compareRating = rating.toLowerCase();
-  const maxRating = tenant.media?.gifs.maxRating || "g";
+  const maxRating = tenant.media?.gifs?.maxRating || "g";
 
   const compareIndex = RATINGS_ORDER.indexOf(compareRating);
   const maxIndex = RATINGS_ORDER.indexOf(maxRating);
@@ -98,7 +98,7 @@ export async function searchGiphy(
   offset: string,
   tenant: Tenant
 ): Promise<GiphyGifSearchResponse> {
-  if (!supportsMediaType(tenant, "giphy") || !tenant.media.gifs.key) {
+  if (!supportsMediaType(tenant, "giphy") || !tenant.media?.gifs?.key) {
     throw new InternalError("Giphy was not enabled");
   }
 
@@ -137,12 +137,12 @@ export async function retrieveFromGiphy(
   tenant: Tenant,
   id: string
 ): Promise<GiphyGifRetrieveResponse> {
-  if (!supportsMediaType(tenant, "giphy") || !tenant.media.gifs.key) {
+  if (!supportsMediaType(tenant, "giphy") || !tenant.media?.gifs?.key) {
     throw new InternalError("Giphy was not enabled");
   }
 
   const url = new URL(`${GIPHY_FETCH}/${id}`);
-  url.searchParams.set("api_key", tenant.media.gifs.key);
+  url.searchParams.set("api_key", tenant.media?.gifs?.key);
 
   try {
     const res = await fetch(url.toString());
@@ -158,7 +158,7 @@ export async function retrieveFromGiphy(
   } catch (err) {
     // Ensure that the API key doesn't get leaked to the logs by accident.
     if (err.message) {
-      err.message = err.message.replace(tenant.media.gifs.key, "[Sensitive]");
+      err.message = err.message.replace(tenant.media?.gifs?.key, "[Sensitive]");
     }
 
     // Rethrow the error.

--- a/server/src/core/server/services/tenor/tenor.ts
+++ b/server/src/core/server/services/tenor/tenor.ts
@@ -28,7 +28,7 @@ export async function retrieveFromTenor(
   tenant: Tenant,
   id: string
 ): Promise<FetchPayload> {
-  if (!supportsMediaType(tenant, "tenor") || !tenant.media.gifs.key) {
+  if (!supportsMediaType(tenant, "tenor") || !tenant.media?.gifs?.key) {
     throw new InternalError("Tenor was not enabled");
   }
 


### PR DESCRIPTION
## What does this PR do?

These changes:
- Make sure that we're checking that a tenant has `media` and `gifs` defined before checking that it is enabled/supported. This was throwing errors when `gifs` wasn't defined.
- Because non-error exception volume increased after Tenor option was introduced, attempt to check type of new error caught and thrown within these changes, and update what's thrown if it is not an instance of `Error`.

Also, if after these changes we are still seeing issues with non-error exceptions being thrown, we can add a check in `services/errors/sentry` for instance of `Error` and handle accordingly. I kept out of these changes to try one step at a time.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

Check that comments with Tenor gifs still work as expected.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
