### PR TITLE
allow `maxPoolSize` to be configurable by env var (defaults to 50)

### DIFF
--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -186,6 +186,12 @@ const config = convict({
     env: "MONGODB_ARCHIVE_URI",
     sensitive: true,
   },
+  mongodb_max_pool_size: {
+    doc: "Max pool size for the MongoDB driver.",
+    format: Number,
+    default: 50,
+    env: "MONGODB_MAX_POOL_SIZE",
+  },
   redis: {
     doc: "The Redis database to connect to.",
     format: "redis-uri",

--- a/server/src/core/server/data/context.ts
+++ b/server/src/core/server/data/context.ts
@@ -140,9 +140,11 @@ export function isArchivingEnabled(config: Config): boolean {
 export async function createMongoContext(
   config: Config
 ): Promise<MongoContext> {
+  const maxPoolSize = config.get("mongodb_max_pool_size");
+
   // Setup MongoDB.
   const liveURI = config.get("mongodb");
-  const live = (await createMongoDB(liveURI)).db;
+  const live = (await createMongoDB(liveURI, maxPoolSize)).db;
 
   // If we have an archive URI, use it, otherwise, default
   // to using the live database
@@ -154,7 +156,7 @@ export async function createMongoContext(
   ) {
     archive = live;
   } else {
-    archive = (await createMongoDB(archiveURI)).db;
+    archive = (await createMongoDB(archiveURI, maxPoolSize)).db;
   }
 
   return new MongoContextImpl(live, archive);

--- a/server/src/core/server/services/mongodb/index.ts
+++ b/server/src/core/server/services/mongodb/index.ts
@@ -3,7 +3,10 @@ import { Db, MongoClient } from "mongodb";
 import { WrappedInternalError } from "coral-server/errors";
 import logger from "coral-server/logger";
 
-async function createMongoClient(mongoURI: string): Promise<MongoClient> {
+async function createMongoClient(
+  mongoURI: string,
+  maxPoolSize = 50
+): Promise<MongoClient> {
   try {
     return await MongoClient.connect(mongoURI, {
       // believe we don't need this since the new driver only uses
@@ -11,6 +14,7 @@ async function createMongoClient(mongoURI: string): Promise<MongoClient> {
       // issues with URL's and want to investigate into it.
       // useNewUrlParser: true,
       ignoreUndefined: true,
+      maxPoolSize,
     });
   } catch (err) {
     throw new WrappedInternalError(
@@ -45,10 +49,11 @@ interface CreateMongoDbResult {
  * @param config application configuration.
  */
 export async function createMongoDB(
-  mongoURI: string
+  mongoURI: string,
+  maxPoolSize?: number
 ): Promise<CreateMongoDbResult> {
   // Connect and create a client for MongoDB.
-  const client = await createMongoClient(mongoURI);
+  const client = await createMongoClient(mongoURI, maxPoolSize);
 
   logger.info("mongodb has connected");
 


### PR DESCRIPTION
## What does this PR do?

- allows `maxPoolSize` in the MongoDB client to be configurable by env var (defaults to 50)
- env is defined as `MONGODB_MAX_POOL_SIZE`

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

- `MONGODB_MAX_POOL_SIZE`
    - type: `Number`
    - defaults to: `50`

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- Start up Coral
- See that it runs fine

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge to `develop`
- Create release
- Deploy wherever you think makes sense
