### PR TITLE
add helper function for checking if user is ignored

### DIFF
--- a/server/src/core/server/models/user/helpers.ts
+++ b/server/src/core/server/models/user/helpers.ts
@@ -6,7 +6,7 @@ import { GQLUSER_ROLE } from "coral-server/graph/schema/__generated__/types";
 import { isSiteModerationScoped } from "coral-common/common/lib/permissions";
 
 import { MODERATOR_ROLES, STAFF_ROLES } from "./constants";
-import { LocalProfile, Profile, SSOProfile, User } from "./user";
+import { IgnoredUser, LocalProfile, Profile, SSOProfile, User } from "./user";
 
 export function roleIsStaff(role: GQLUSER_ROLE) {
   if (STAFF_ROLES.includes(role)) {
@@ -188,4 +188,17 @@ export function hasLocalProfile(
 export function hasSSOProfile(user: Pick<User, "profiles">): boolean {
   const profile = getUserProfile(user, "sso") as SSOProfile | null;
   return profile ? true : false;
+}
+
+/**
+ *  authorIsIgnored will return true if the author is ignored by the viewer
+ * @param authorID id of the author of the comment
+ * @param viewer the User who attempting to access the comment
+ */
+
+export function authorIsIgnored(authorID: string, viewer: User): boolean {
+  return (
+    viewer.ignoredUsers &&
+    viewer.ignoredUsers.some((user: IgnoredUser) => user.id === authorID)
+  );
 }

--- a/server/src/core/server/models/user/user.ts
+++ b/server/src/core/server/models/user/user.ts
@@ -54,7 +54,12 @@ import {
   createEmptyCommentStatusCounts,
   updateRelatedCommentCounts,
 } from "../comment";
-import { getLocalProfile, getSSOProfile, hasLocalProfile } from "./helpers";
+import {
+  authorIsIgnored,
+  getLocalProfile,
+  getSSOProfile,
+  hasLocalProfile,
+} from "./helpers";
 
 export interface LocalProfile {
   type: "local";
@@ -3154,11 +3159,7 @@ export async function ignoreUser(
       throw new UserNotFoundError(id);
     }
 
-    // TODO: extract function
-    if (
-      user.ignoredUsers &&
-      user.ignoredUsers.some((u) => u.id === ignoreUserID)
-    ) {
+    if (authorIsIgnored(ignoreUserID, user)) {
       // TODO: improve error
       throw new Error("user already ignored");
     }

--- a/server/src/core/server/services/notifications/email/categories/reply.ts
+++ b/server/src/core/server/services/notifications/email/categories/reply.ts
@@ -7,7 +7,8 @@ import { mapErrorsToNull } from "coral-server/helpers/dataloader";
 import { hasPublishedStatus } from "coral-server/models/comment";
 import { PUBLISHED_STATUSES } from "coral-server/models/comment/constants";
 import { getStoryTitle, getURLWithCommentID } from "coral-server/models/story";
-import { IgnoredUser, User } from "coral-server/models/user";
+import { User } from "coral-server/models/user";
+import { authorIsIgnored } from "coral-server/models/user/helpers";
 
 import { NotificationCategory } from "./category";
 
@@ -70,11 +71,7 @@ export const reply: NotificationCategory<Payloads> = {
 
     // Check to see if this user is ignoring the user who replied to their
     // comment.
-    if (
-      parentAuthor.ignoredUsers.some(
-        (ignoredUser: IgnoredUser) => ignoredUser.id === author.id
-      )
-    ) {
+    if (authorIsIgnored(author.id, parentAuthor)) {
       return null;
     }
 

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -14,6 +14,7 @@ import {
   retrieveUser,
   User,
 } from "coral-server/models/user";
+import { authorIsIgnored } from "coral-server/models/user/helpers";
 import { I18n } from "coral-server/services/i18n";
 
 import {
@@ -66,7 +67,7 @@ const shouldSendReplyNotification = (
       return false;
     }
     // don't notify when ignored users reply
-    return !targetUser.ignoredUsers.some((user) => user.id === replyAuthorID);
+    return !authorIsIgnored(replyAuthorID, targetUser);
   }
 
   return false;

--- a/server/src/core/server/services/users/users.ts
+++ b/server/src/core/server/services/users/users.ts
@@ -106,6 +106,7 @@ import {
   warnUser,
 } from "coral-server/models/user";
 import {
+  authorIsIgnored,
   getLocalProfile,
   hasLocalProfile,
   hasStaffRole,
@@ -2299,8 +2300,7 @@ export async function ignore(
     throw new UserCannotBeIgnoredError(userID);
   }
 
-  // TODO: extract function
-  if (user.ignoredUsers && user.ignoredUsers.some((u) => u.id === userID)) {
+  if (authorIsIgnored(userID, user)) {
     // TODO: improve error
     throw new Error("user already ignored");
   }


### PR DESCRIPTION
## What does this PR do?

We were getting errors `Cannot read properties of null (reading 'some')` from [here](https://github.com/coralproject/talk/blob/develop/server/src/core/server/services/notifications/internal/context.ts#L69). Obviously we need to add a check for `user.ignoredUsers` before checking `.some` on that array, but when I looked for this pattern elsewhere, I noticed multiple `// TODO: extract function` notes, so I extracted it into a function. 

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?
none

## Does this PR introduce any new environment variables or feature flags?
NA

## If any indexes were added, were they added to `INDEXES.md`?
NA

## How do I test this PR?
- with notifications enabled, as user 1, reply to user 2
- as user 2, ensure you have received a notification
- as user 1, ignore user 2
- as user 2, reply to user 1
- as user 1, ensure that you DO NOT receive a notification
- as user 1, un-ignore user 2
- as user 2, reply to user 1
- as user 1, ensure you DO receive a notification
