### PR TITLE
[CORL-3204] set optional flags on OIDC validator schema

### DIFF
--- a/server/src/core/server/services/oidc/oidc.ts
+++ b/server/src/core/server/services/oidc/oidc.ts
@@ -50,10 +50,10 @@ export const OIDCIDTokenSchema = Joi.object()
     exp: Joi.number().required(),
     email: Joi.string().lowercase().email(),
     email_verified: Joi.boolean().default(false),
-    picture: Joi.string(),
-    name: Joi.string(),
-    nickname: Joi.string(),
-    preferred_username: Joi.string(),
+    picture: Joi.string().optional(),
+    name: Joi.string().optional(),
+    nickname: Joi.string().optional(),
+    preferred_username: Joi.string().optional(),
     nonce: Joi.string(),
   })
   .fork(


### PR DESCRIPTION
## What does this PR do?

Sets the optionals for the JWT processed during the OIDC verifier flow.

- Different providers give different fields for name, username, preferred_username, picture, etc
- Handle these optionals so that folks can use `Sign in with Apple`

## These changes will impact:

- [X] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- Create an Apple ID with developer access
- Hook up a `Sign in with Apple` api key with provider url's
- Set the configuration under `Admin > Configure > Authentication > Login with OpenID Connect`
- Attempt to login/register with Apple via the new OIDC login button that is now available in stream
- See that it works

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into `develop`
