### PR TITLE
add a development docker compose to root of project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  redis:
+    image: redis:7.2.5
+    container_name: coral-redis
+    restart: always
+    ports:
+      - "6379:6379"
+  mongo:
+    image: mongo:8.0.3
+    container_name: coral-mongo
+    restart: always
+    ports:
+      - "27017:27017"

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -22,16 +22,23 @@ sh scripts/pnpm-i.sh
 
 Running Coral with default settings assumes that you have:
 
-- MongoDB ^4.2 running on `127.0.0.1:27017`
-- Redis ^3.2 running on `127.0.0.1:6379`
+- MongoDB ^8.0.3 running on `127.0.0.1:27017`
+- Redis ^7.2.5 running on `127.0.0.1:6379`
 
-If you don't already have these databases running, you can execute the following
-assuming you have Docker installed on your local machine:
+If you don't already have these databases running, you can do either of the following:
 
-```bash
-docker run -d -p 27017:27017 --restart always --name mongo mongo:4.2
-docker run -d -p 6379:6379 --restart always --name redis redis:3.2
-```
+
+- from the root of the `talk` repository, use our development compose file to stand up the Docker images you need:
+
+  ```bash
+  docker compose up -d
+  ```
+- or if you prefer total control over your Docker images, you can manually spawn the needed images:
+
+  ```bash
+  docker run -d -p 27017:27017 --restart always --name mongo mongo:8.0.3
+  docker run -d -p 6379:6379 --restart always --name redis redis:7.2.5
+  ```
 
 Then initialize Coral using the helper script:
 


### PR DESCRIPTION
## What does this PR do?

allows devs to perform a `docker compose up -d` at any time to create their mongo, redis in docker immediately without having to go grab the details from docs.coralproject.net

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- perform `docker compose up -d`
- perform `docker compose down`
- see that containers are created properly

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into `develop`
