### PR TITLE
Fix: ssoURL not updated from sso token

### DIFF
--- a/server/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
+++ b/server/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
@@ -201,6 +201,7 @@ export async function findOrCreateSSOUser(
           // not affected by this update feature.
           role: role || user.role,
           avatar,
+          ssoURL: user.ssoURL,
         },
         lastIssuedAt
       );

--- a/server/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
+++ b/server/src/core/server/app/middleware/passport/strategies/verifiers/sso.ts
@@ -201,7 +201,7 @@ export async function findOrCreateSSOUser(
           // not affected by this update feature.
           role: role || user.role,
           avatar,
-          ssoURL: user.ssoURL,
+          ssoURL: url,
         },
         lastIssuedAt
       );

--- a/server/src/core/server/models/user/user.ts
+++ b/server/src/core/server/models/user/user.ts
@@ -1317,6 +1317,7 @@ export interface UpdateUserInput {
   badges?: string[];
   role?: GQLUSER_ROLE;
   avatar?: string;
+  ssoURL?: string;
 }
 
 export async function updateUserFromSSO(


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please note that by contributing to
Coral, you agree to our Code of Conduct: http://code-of-conduct.voxmedia.com/

Before submitting your Pull Request (or PR), please verify that:

* [ ] Your code is up-to-date with the base branch
* [ ] You've successfully run `npm run test` locally

Refer to CONTRIBUTING.MD for more details.

  https://github.com/coralproject/talk/blob/main/CONTRIBUTING.md

-->

## What does this PR do?

The user `ssoURL`  is currently not updated via an sso token, so existing users on The Verge that were created for Chorus still opens the old chorus profile page when clicking on `Account`.

![image](https://github.com/user-attachments/assets/4ea1b2e7-2b08-4a00-ba6a-cb10ee92089a)

The Coral SSO Token that we send has the correct `url` set: 

![image](https://github.com/user-attachments/assets/3d037e97-9682-4100-bcbe-bce3bd42c2a4)

but Coral is still using the old link `https://www.theverge.com/users/cvle/account` instead.




<!--

In this section, you should be describing what other Github issues or tickets
that this PR is designed to addressed.

Any related Github issue should be linked by adding its URL to this section.

-->

## These changes will impact:

- [x] commenters
- [x] moderators
- [x] admins
- [ ] developers

## How do I test this PR?
Help me test this :-)

## Were any tests migrated to React Testing Library?
No
<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?
Help me with this :-)