### PR TITLE
fix: refresh comments button shouldn't show on initial load

### DIFF
--- a/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
+++ b/client/src/core/client/stream/tabs/Comments/Stream/AllCommentsTab/AllCommentsTabContainer.tsx
@@ -200,7 +200,7 @@ export const AllCommentsTabContainer: FunctionComponent<Props> = ({
     if (visible && isNotFirstLoad && live) {
       setShowCommentRefreshButton(true);
     }
-  }, [visible, setShowCommentRefreshButton, live, isNotFirstLoad]);
+  }, [visible, setShowCommentRefreshButton, live]);
 
   useEffect(() => {
     if (!topOfCommentsInView && allCommentsInView) {


### PR DESCRIPTION
## What does this PR do?

These changes make it so that the refresh comments button only appears when comments are navigated away from and back to.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

See that upon initial load of the page, the refresh comments button isn't showing. When going to another tab then back to comments, then it shows.

You can test against develop, where you'll see it is showing on initial load.

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
