### PR TITLE
[CORL-3208] Display SSO duplicate email errors in the Relay network error prompt

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,7 @@
   "description": "A better commenting experience from Vox Media.",
   "scripts": {
     "build:client": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" ts-node --transpile-only ./scripts/build.ts",
-    "build:development": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" NODE_ENV=development pnpm run --parallel generate build:client",
+    "build:development": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" NODE_ENV=development pnpm run generate && pnpm run build:client",
     "build:withProfiler": "NODE_ENV=production REACT_PROFILER=true pnpm run --parallel generate build:client",
     "build": "NODE_OPTIONS=\"--openssl-legacy-provider --no-experimental-fetch\" NODE_ENV=production pnpm run generate-persist && pnpm run build:client",
     "docs:css-variables": "ts-node ./scripts/generateCSSVariablesDocs.ts ./src/core/client/ui/theme/streamVariables.ts ./CSS_VARIABLES.md",

--- a/client/src/core/client/framework/lib/errors/relayNetworkRequestError.ts
+++ b/client/src/core/client/framework/lib/errors/relayNetworkRequestError.ts
@@ -3,6 +3,80 @@ import { RRNLRequestError } from "react-relay-network-modern/es";
 
 import { getMessage } from "../i18n";
 
+interface DupErrorObj {
+  error?: {
+    traceID: string;
+    code: string;
+    message: string;
+  };
+}
+
+const parseDuplicateEmailError = (
+  error: RRNLRequestError
+): DupErrorObj | null => {
+  if (!error.res || error.res.status !== 403 || !error.res.text) {
+    return null;
+  }
+
+  try {
+    const json = JSON.parse(error.res.text) as DupErrorObj;
+    if (!json || !json.error || json.error.code !== "DUPLICATE_EMAIL") {
+      return null;
+    }
+
+    return json;
+  } catch {
+    return null;
+  }
+};
+
+const computeCodeMessage = (
+  error: RRNLRequestError,
+  localeBundles: FluentBundle[]
+) => {
+  if (!error.res) {
+    return "";
+  }
+
+  const codePrefix = getMessage(
+    localeBundles,
+    "framework-error-relayNetworkRequestError-code",
+    "Code"
+  );
+
+  let msg = `[${codePrefix}]`;
+  if (error.res && error.res.status) {
+    msg += ` ${error.res.status.toString()}`;
+  }
+  if (error.res && error.res.statusText) {
+    msg += ` ${error.res.statusText}`;
+  }
+
+  return msg;
+};
+
+const computeMessage = (
+  error: RRNLRequestError,
+  localeBundles: FluentBundle[]
+): string => {
+  const defaultMessage = getMessage(
+    localeBundles,
+    "framework-error-relayNetworkRequestError-anUnexpectedNetworkError",
+    "An unexpected network error occured, please try again later."
+  );
+
+  const dupeEmail = parseDuplicateEmailError(error);
+  if (dupeEmail && dupeEmail.error) {
+    return dupeEmail.error.message;
+  }
+
+  if (error.res) {
+    return `${defaultMessage} ${computeCodeMessage(error, localeBundles)}`;
+  }
+
+  return defaultMessage;
+};
+
 /**
  * RelayNetworkRequestError wraps Request errors thrown by Relay Network Layer.
  */
@@ -11,26 +85,7 @@ export default class RelayNetworkRequestError extends Error {
   public origin: RRNLRequestError;
 
   constructor(error: RRNLRequestError, localeBundles: FluentBundle[]) {
-    let msg = getMessage(
-      localeBundles,
-      "framework-error-relayNetworkRequestError-anUnexpectedNetworkError",
-      "An unexpected network error occured, please try again later."
-    );
-
-    if (error.res) {
-      const codePrefix = getMessage(
-        localeBundles,
-        "framework-error-relayNetworkRequestError-code",
-        "Code"
-      );
-
-      msg += ` [${codePrefix}: ${error.res.status.toString()}`;
-      if (error.res.statusText) {
-        msg += " " + error.res.statusText;
-      }
-      msg += "]";
-    }
-    super(msg);
+    super(computeMessage(error, localeBundles));
 
     // Maintains proper stack trace for where our error was thrown.
     if (Error.captureStackTrace) {

--- a/server/src/core/server/errors/index.ts
+++ b/server/src/core/server/errors/index.ts
@@ -318,7 +318,11 @@ export class DuplicateSiteAllowedOriginError extends CoralError {
 
 export class DuplicateEmailError extends CoralError {
   constructor(email: string) {
-    super({ code: ERROR_CODES.DUPLICATE_EMAIL, context: { pvt: { email } } });
+    super({
+      code: ERROR_CODES.DUPLICATE_EMAIL,
+      context: { pvt: { email } },
+      status: 403,
+    });
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Displays the `Specified email address is already in use` message when a new SSO token has a conflicting email with an existing user.

<img width="396" alt="image" src="https://github.com/user-attachments/assets/6e6c5173-1d5e-49f8-9ec4-cb2e290895a1" />

## These changes will impact:

- [X] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

Using `multi-site-test`, set up an SSO secret and two unique users with the same `email` payload:

```
"sso": {
        "secret": "ssosec_f73a2830f6285...",
        "users": [
          {
            "id": "95b83d1d-c15b-40e6-adbe-d4f07ace3fae",
            "username": "dupe1",
            "email": "dupe@test.com",
            "role": "COMMENTER",
            "badges": []
          },
          {
            "id": "4d7d6d87-769c-40cd-8550-8ea0537d29ee",
            "username": "dupe2",
            "email": "dupe@test.com",
            "role": "COMMENTER",
            "badges": []
          },
         ...
```

- run the site and ensure it's allowed in Coral allowed domains (under organization, sites)
    - be sure to allow registration
- see that when you view the first user, then second user (or vice versa) it shows that the second user you try and sign in as receives the dupe email error

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge to `develop`
