### PR TITLE
[CORL-3212]: throw no username included error for sso with url for setting username

### DIFF
--- a/client/src/core/client/framework/lib/errors/relayNetworkRequestError.ts
+++ b/client/src/core/client/framework/lib/errors/relayNetworkRequestError.ts
@@ -11,6 +11,14 @@ interface DupErrorObj {
   };
 }
 
+interface UsernameNotProvidedErrorObj {
+  error?: {
+    traceID: string;
+    code: string;
+    message: string;
+  };
+}
+
 const parseDuplicateEmailError = (
   error: RRNLRequestError
 ): DupErrorObj | null => {
@@ -21,6 +29,25 @@ const parseDuplicateEmailError = (
   try {
     const json = JSON.parse(error.res.text) as DupErrorObj;
     if (!json || !json.error || json.error.code !== "DUPLICATE_EMAIL") {
+      return null;
+    }
+
+    return json;
+  } catch {
+    return null;
+  }
+};
+
+const parseUsernameNotProvidedError = (
+  error: RRNLRequestError
+): UsernameNotProvidedErrorObj | null => {
+  if (!error.res || error.res.status !== 403 || !error.res.text) {
+    return null;
+  }
+
+  try {
+    const json = JSON.parse(error.res.text) as UsernameNotProvidedErrorObj;
+    if (!json || !json.error || json.error.code !== "USERNAME_NOT_PROVIDED") {
       return null;
     }
 
@@ -68,6 +95,11 @@ const computeMessage = (
   const dupeEmail = parseDuplicateEmailError(error);
   if (dupeEmail && dupeEmail.error) {
     return dupeEmail.error.message;
+  }
+
+  const usernameNotProvided = parseUsernameNotProvidedError(error);
+  if (usernameNotProvided && usernameNotProvided.error) {
+    return usernameNotProvided.error.message;
   }
 
   if (error.res) {

--- a/client/src/core/client/ui/components/v3/QueryError/QueryError.tsx
+++ b/client/src/core/client/ui/components/v3/QueryError/QueryError.tsx
@@ -2,6 +2,7 @@ import { Localized } from "@fluent/react/compat";
 import React, { FunctionComponent } from "react";
 
 import TraceableError from "coral-framework/lib/errors/traceableError";
+import HTMLContent from "coral-stream/common/HTMLContent";
 
 import CallOut from "../CallOut";
 
@@ -38,7 +39,7 @@ const QueryError: FunctionComponent<Props> = ({ error }) => {
         <div className={styles.heading}>Message</div>
       </Localized>
       <div className={styles.section} aria-live={"polite"}>
-        {error.message}
+        <HTMLContent>{error.message}</HTMLContent>
       </div>
     </CallOut>
   );

--- a/common/lib/errors.ts
+++ b/common/lib/errors.ts
@@ -4,6 +4,7 @@ export enum ERROR_TYPES {
 }
 
 export enum ERROR_CODES {
+  USERNAME_NOT_PROVIDED = "USERNAME_NOT_PROVIDED",
   /**
    * STORY_CLOSED is used when submitting a comment on a closed story.
    */

--- a/server/src/core/server/app/middleware/passport/strategies/jwt.ts
+++ b/server/src/core/server/app/middleware/passport/strategies/jwt.ts
@@ -6,6 +6,7 @@ import {
   JWTRevokedError,
   TenantNotFoundError,
   TokenInvalidError,
+  UsernameNotProvidedError,
 } from "coral-server/errors";
 import { Tenant } from "coral-server/models/tenant";
 import { User } from "coral-server/models/user";
@@ -124,6 +125,12 @@ export async function verifyAndRetrieveUser(
     }
 
     throw err;
+  }
+
+  if (validationErrors.includes('SSO: "user.username" is required')) {
+    if ((token as SSOToken).user?.url) {
+      throw new UsernameNotProvidedError((token as SSOToken).user?.url!);
+    }
   }
 
   // If no verifier could be found, throw an error. Include validation errors for all enabled

--- a/server/src/core/server/app/middleware/passport/strategies/jwt.ts
+++ b/server/src/core/server/app/middleware/passport/strategies/jwt.ts
@@ -128,8 +128,9 @@ export async function verifyAndRetrieveUser(
   }
 
   if (validationErrors.includes('SSO: "user.username" is required')) {
-    if ((token as SSOToken).user?.url) {
-      throw new UsernameNotProvidedError((token as SSOToken).user?.url!);
+    const ssoToken = token as SSOToken;
+    if (ssoToken && ssoToken.user?.url) {
+      throw new UsernameNotProvidedError(ssoToken.user.url);
     }
   }
 

--- a/server/src/core/server/app/middleware/passport/strategies/jwt.ts
+++ b/server/src/core/server/app/middleware/passport/strategies/jwt.ts
@@ -127,6 +127,9 @@ export async function verifyAndRetrieveUser(
     throw err;
   }
 
+  // If SSO token does not include a username but does include a url for user account
+  // management, then throw a username not found error with information on where the username
+  // can be set to comment.
   if (validationErrors.includes('SSO: "user.username" is required')) {
     const ssoToken = token as SSOToken;
     if (ssoToken && ssoToken.user?.url) {

--- a/server/src/core/server/errors/index.ts
+++ b/server/src/core/server/errors/index.ts
@@ -326,6 +326,16 @@ export class DuplicateEmailError extends CoralError {
   }
 }
 
+export class UsernameNotProvidedError extends CoralError {
+  constructor(url: string) {
+    super({
+      code: ERROR_CODES.USERNAME_NOT_PROVIDED,
+      context: { pub: { url } },
+      status: 403,
+    });
+  }
+}
+
 export class DuplicateDSAReportError extends CoralError {
   constructor(reportID: string) {
     super({

--- a/server/src/core/server/errors/translations.ts
+++ b/server/src/core/server/errors/translations.ts
@@ -1,6 +1,7 @@
 import { ERROR_CODES } from "coral-common/common/lib/errors";
 
 export const ERROR_TRANSLATIONS: Record<ERROR_CODES, string> = {
+  USERNAME_NOT_PROVIDED: "error-usernameNotProvided",
   COMMENT_BODY_EXCEEDS_MAX_LENGTH: "error-commentBodyExceedsMaxLength",
   COMMENT_BODY_TOO_SHORT: "error-commentBodyTooShort",
   COMMENT_NOT_FOUND: "error-commentNotFound",

--- a/server/src/core/server/locales/en-US/errors.ftl
+++ b/server/src/core/server/locales/en-US/errors.ftl
@@ -5,7 +5,7 @@ error-parentCommentRejected = A comment earlier in this conversation thread was 
 error-ancestorRejected = A comment earlier in this conversation thread was removed. No additional replies can be submitted.
 error-commentBodyExceedsMaxLength =
   Comment body exceeds maximum length of {$max} characters.
-error-usernameNotProvided = Username not provided. Go to {$url} to set your username to comment.
+error-usernameNotProvided = Username not provided. Go to <a href="{$url}">{$url}</a> to set your username to comment.
 error-storyURLNotPermitted =
   The specified story URL does not exist in the permitted domains list.
 error-duplicateStoryURL =  The specified story URL already exists.

--- a/server/src/core/server/locales/en-US/errors.ftl
+++ b/server/src/core/server/locales/en-US/errors.ftl
@@ -5,6 +5,7 @@ error-parentCommentRejected = A comment earlier in this conversation thread was 
 error-ancestorRejected = A comment earlier in this conversation thread was removed. No additional replies can be submitted.
 error-commentBodyExceedsMaxLength =
   Comment body exceeds maximum length of {$max} characters.
+error-usernameNotProvided = Username not provided. Go to {$url} to set your username to comment.
 error-storyURLNotPermitted =
   The specified story URL does not exist in the permitted domains list.
 error-duplicateStoryURL =  The specified story URL already exists.


### PR DESCRIPTION
## What does this PR do?

These changes make it so that if an sso token does not include a username for a user, but does include a url for account management to set a username, a helpful error will be thrown letting the user know how to set their username to be able to comment.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can use multi site test to send through an sso user who does not have a username set but does have a url for account management. You should see that 

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
