### PR TITLE
[CORL-3207] update wording for media links configuration

### DIFF
--- a/client/src/core/client/admin/routes/Configure/sections/General/MediaLinksConfig.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/General/MediaLinksConfig.tsx
@@ -67,10 +67,10 @@ const MediaLinksConfig: FunctionComponent<Props> = ({ disabled }) => {
       }
       container={<FieldSet />}
     >
-      <Localized id="configure-general-embedLinks-description">
+      <Localized id="configure-general-embedLinks-description-addASinglePiece">
         <FormFieldDescription>
-          Allow commenters to add a YouTube video, X post or GIF's to the end of
-          their comment
+          Allow commenters to add a single piece of embedded media to the end of
+          a comment
         </FormFieldDescription>
       </Localized>
       <FormField>

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -433,7 +433,8 @@ configure-general-sitewideCommenting-messageExplanation =
 configure-general-embedLinks-title = Embedded media
 configure-general-embedLinks-desc =
 configure-general-embedLinks-description = 
-  Allow commenters to add a YouTube video, X post or GIF's to the end of their comment
+configure-general-embedLinks-description-addASinglePiece =
+  Allow commenters to add a single piece of embedded media to the end of a comment
 configure-general-embedLinks-enableTwitterEmbeds = Allow X post embeds
 configure-general-embedLinks-enableBlueskyEmbeds = Allow Bluesky post embeds
 configure-general-embedLinks-enableYouTubeEmbeds = Allow YouTube embeds


### PR DESCRIPTION
## What does this PR do?

Under `Configure > General` for embeds, change:

- "Allow commenters to add a YouTube video, X post or GIF's to the end of their comment"
to
- "Allow commenters to add a single piece of embedded media to the end of a comment"

## These changes will impact:

- [ ] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

Check wording in `Config > General`

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
