### PR TITLE
Feature: Link OIDC providers

### DIFF
--- a/server/src/core/server/models/tenant/helpers.ts
+++ b/server/src/core/server/models/tenant/helpers.ts
@@ -95,7 +95,8 @@ export function linkUsersAvailable(
   return (
     hasEnabledAuthIntegration(config, tenant, "local") &&
     (hasEnabledAuthIntegration(config, tenant, "facebook") ||
-      hasEnabledAuthIntegration(config, tenant, "google"))
+      hasEnabledAuthIntegration(config, tenant, "google") ||
+      hasEnabledAuthIntegration(config, tenant, "oidc"))
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

Add OIDC as valid identity link target.

Resolves https://github.com/coralproject/talk/issues/3947

## These changes will impact:

- [x] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## How do I test this PR?

1. setup any OIDC provider and enable it in coral admin UI
2. register a new user via email / password
3. logout
4. login with the OIDC provider
5. link your accounts

## Open Questions to discuss:

- [ ] would this change introduce any problems 
  The change is quite simple and I wonder why this hasn't been implemented yet. What were the reasons to restrict linking to `google` and `facebook` so far ?
