### PR TITLE
[CORL-3214] add `persistedQueries` query

### DIFF
--- a/server/src/core/server/graph/resolvers/Query.ts
+++ b/server/src/core/server/graph/resolvers/Query.ts
@@ -109,4 +109,7 @@ export const Query: Required<GQLQueryTypeResolver<void>> = {
 
     return ctx.notifications.retrieveCount(ctx.tenant.id, userID);
   },
+  persistedQueries: async (source, args, ctx) => {
+    return await ctx.mongo.queries().find().sort({ version: -1 }).toArray();
+  },
 };

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -5250,6 +5250,15 @@ type NotificationDecisionDetails {
   explanation: String
 }
 
+type PersistedQuery {
+  id: String!
+  operation: String!
+  operationName: String!
+  query: String!
+  bundle: String!
+  version: String!
+}
+
 ################################################################################
 ## Query
 ################################################################################
@@ -5443,6 +5452,11 @@ type Query {
   ): NotificationsConnection!
 
   notificationCount(userID: ID!): Int
+
+  """
+  persistedQueries returns all the persisted query records in the database
+  """
+  persistedQueries: [PersistedQuery!] @auth(roles: [ADMIN])
 }
 
 ################################################################################


### PR DESCRIPTION
## What does this PR do?

- adds a `persistedQueries` field to the `Query` object on the `schema.graphql`

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

- adds a `persistedQueries` field to the `Query` object on the `schema.graphql`

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- issue the following query with an admin token in the `Bearer`
  ```
  query {
    persistedQueries {
      id
      operation
      operationName
      bundle
      version
    }
  }
  ```
- see the list of queries sorted by version

## Were any tests migrated to React Testing Library?

N/A

## How do we deploy this PR?

- merge into `develop`
