### PR TITLE
[CORL-3219]: Users with staff roles don't get repeat post check

### DIFF
--- a/server/src/core/server/services/comments/pipeline/phases/repeatPost.ts
+++ b/server/src/core/server/services/comments/pipeline/phases/repeatPost.ts
@@ -3,6 +3,7 @@ import { RepeatPostCommentError } from "coral-server/errors";
 import { ACTION_TYPE } from "coral-server/models/action/comment";
 import { getLatestRevision } from "coral-server/models/comment/helpers";
 import { supportsMediaType } from "coral-server/models/tenant";
+import { STAFF_ROLES } from "coral-server/models/user/constants";
 import {
   IntermediateModerationPhase,
   IntermediatePhaseResult,
@@ -51,6 +52,11 @@ export const repeatPost: IntermediateModerationPhase = async ({
     if (action === "EDIT" && comment.id && comment.id === lastComment.id) {
       // The last comment written is this comment because we're editing, so no
       // need to compare against.
+      return;
+    }
+
+    // users who have staff roles are exempt from repeat comment checks
+    if (STAFF_ROLES.includes(author.role)) {
       return;
     }
 


### PR DESCRIPTION
## What does this PR do?

These changes make it so that users with a role of staff, moderator, or admin do not go through the repeat post check.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test this PR by commenting the same thing twice in a row as a user with a role of user and seeing that you are shown the repeat post nudge.

Then comment the same thing twice in a row as a user with a role of staff, moderator, or admin. You should not see the nudge, and your comment should just go through and post with the appropriate badges.

## Were any tests migrated to React Testing Library?

no

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
