### PR TITLE
Feature: allow linking sso and oidc profiles

### DIFF
--- a/server/src/core/server/models/tenant/helpers.ts
+++ b/server/src/core/server/models/tenant/helpers.ts
@@ -95,7 +95,9 @@ export function linkUsersAvailable(
   return (
     hasEnabledAuthIntegration(config, tenant, "local") &&
     (hasEnabledAuthIntegration(config, tenant, "facebook") ||
-      hasEnabledAuthIntegration(config, tenant, "google"))
+      hasEnabledAuthIntegration(config, tenant, "google") ||
+      hasEnabledAuthIntegration(config, tenant, "sso") ||
+      hasEnabledAuthIntegration(config, tenant, "oidc"))
   );
 }
 


### PR DESCRIPTION
## What does this PR do?

Add capability to link OIDC and SSO profiles.

Resolves 
- https://github.com/coralproject/talk/issues/3947
- https://github.com/coralproject/talk/issues/3976

## These changes will impact:

- [x] commenters
- [x] moderators
- [x] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## How do I test this PR?

**For OIDC**
1. setup any OIDC provider and enable it in coral admin UI
2. register a new user via email / password
3. logout
4. login with the OIDC provider
5. link your accounts

**For SSO**
1. create a user (not with SSO)
2. create an SSO token according to https://docs.coralproject.net/sso with the email of the previously created user
3. use the SSO token for requests against the API
4. check the user's profiles (will now have an SSO entry)

## Open Questions to discuss:

- [ ] would this change introduce any problems 
  The change is quite simple and I wonder why this hasn't been implemented yet. What were the reasons to restrict linking to `google` and `facebook` so far ?
- [ ] do you consider it problematic to not request the user to link their existing account with an SSO profile? Since the user does already exist and there is not really an authentication flow tied to Coral (since we're manually issuing the SSO token), I don't see where this should take place.
