### PR TITLE
[CORL-3221] Add an SSO token testing endpoint to Coral

### DIFF
--- a/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
+++ b/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
@@ -18,7 +18,7 @@ enum AnalysisMessageType {
   Message = "Message",
   Warning = "Warning",
   Error = "Error",
-  Positive = "Positive",
+  Success = "Success",
 }
 
 const renderIndex = (
@@ -88,7 +88,7 @@ const analyseId = (id: string | undefined): PayloadComment[] => {
   const uuidResult = uuidRegex.test(id);
   if (uuidResult) {
     messages.push({
-      type: AnalysisMessageType.Positive,
+      type: AnalysisMessageType.Success,
       message: "`user.id` appears to be a uuid.",
     });
   }
@@ -97,7 +97,7 @@ const analyseId = (id: string | undefined): PayloadComment[] => {
   const hashResult = hashRegex.test(id);
   if (hashResult) {
     messages.push({
-      type: AnalysisMessageType.Positive,
+      type: AnalysisMessageType.Success,
       message: "`user.id` appears to be a hash value.",
     });
   }
@@ -106,7 +106,7 @@ const analyseId = (id: string | undefined): PayloadComment[] => {
   const integerResult = integerRegex.test(id);
   if (integerResult) {
     messages.push({
-      type: AnalysisMessageType.Positive,
+      type: AnalysisMessageType.Success,
       message: "`user.id` appears to be an integer value.",
     });
   }
@@ -138,7 +138,7 @@ const analyseEmail = (email: string | undefined): PayloadComment[] => {
   const result = regex.test(email);
   if (result) {
     messages.push({
-      type: AnalysisMessageType.Positive,
+      type: AnalysisMessageType.Success,
       message: "`user.email` appears to be valid.",
     });
   } else {
@@ -164,7 +164,7 @@ const analyseUsername = (username: string | undefined): PayloadComment[] => {
 
   return [
     {
-      type: AnalysisMessageType.Positive,
+      type: AnalysisMessageType.Success,
       message: "`user.username` appears to be valid.",
     },
   ];
@@ -187,7 +187,7 @@ const analyseRole = (role: string | undefined): PayloadComment[] => {
   if (roleEntries.includes(role)) {
     return [
       {
-        type: AnalysisMessageType.Positive,
+        type: AnalysisMessageType.Success,
         message: "`user.role` appears to be valid.",
       },
     ];

--- a/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
+++ b/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
@@ -93,17 +93,17 @@ const analyseId = (id: string | undefined): PayloadComment[] => {
     });
   }
 
-  const hashRegex = new RegExp(/^[0-9a-zA-Z]{16-256}$/);
-  const hashResult = hashRegex.test(id);
-  if (hashResult) {
-    messages.push({
-      type: AnalysisMessageType.Success,
-      message: "`user.id` appears to be a hash value.",
-    });
+  const nonDigitsRegex = new RegExp(/[^0-9]/);
+  let integerResult = false;
+  try {
+    const value = parseInt(id, 10);
+    const hasNonNumbers = nonDigitsRegex.test(id);
+
+    integerResult = value >= 0 && !hasNonNumbers;
+  } catch {
+    integerResult = false;
   }
 
-  const integerRegex = new RegExp(/^[0-9]{16-256}$/);
-  const integerResult = integerRegex.test(id);
   if (integerResult) {
     messages.push({
       type: AnalysisMessageType.Success,
@@ -111,7 +111,16 @@ const analyseId = (id: string | undefined): PayloadComment[] => {
     });
   }
 
-  if (!uuidResult && !hashResult && !integerRegex) {
+  const hashRegex = new RegExp(/^[0-9a-zA-Z]{16,512}$/);
+  const hashResult = hashRegex.test(id);
+  if (!integerResult && hashResult) {
+    messages.push({
+      type: AnalysisMessageType.Success,
+      message: "`user.id` appears to be a hash value.",
+    });
+  }
+
+  if (!uuidResult && !hashResult && !integerResult) {
     messages.push({
       type: AnalysisMessageType.Warning,
       message:

--- a/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
+++ b/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
@@ -195,7 +195,7 @@ const analyseRole = (role: string | undefined): PayloadComment[] => {
     return [
       {
         type: AnalysisMessageType.Error,
-        message: `\`user.role\` is invalid. Value must be one of ${roleEntries.join(
+        message: `\`user.role\` is invalid. Value must be one of: ${roleEntries.join(
           ", "
         )}`,
       },

--- a/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
+++ b/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
@@ -175,7 +175,7 @@ const analyseRole = (role: string | undefined): PayloadComment[] => {
     return [
       {
         type: AnalysisMessageType.Warning,
-        message: `\`user.role\` is undefined. It will default to "${GQLUSER_ROLE.COMMENTER}."`,
+        message: `\`user.role\` is undefined. It will default to "${GQLUSER_ROLE.COMMENTER}".`,
       },
     ];
   }

--- a/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
+++ b/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
@@ -6,16 +6,32 @@ import nunjucks from "nunjucks";
 
 import { AppOptions } from "coral-server/app";
 import { RequestLimiter } from "coral-server/app/request/limiter";
+import { GQLUSER_ROLE } from "coral-server/graph/schema/__generated__/types";
 import {
   AsyncRequestHandler,
   TenantCoralRequest,
 } from "coral-server/types/express";
 
-const renderIndex = (messages?: string[], token?: string, payload?: string) => {
+// eslint-disable-next-line no-shadow
+enum AnalysisMessageType {
+  Unknown = "Unknown",
+  Message = "Message",
+  Warning = "Warning",
+  Error = "Error",
+  Positive = "Positive",
+}
+
+const renderIndex = (
+  messages?: string[],
+  token?: string,
+  payload?: string,
+  analysis: PayloadComment[] = []
+) => {
   return nunjucks.render("tokenTest/index.html", {
     messages,
     token,
     payload,
+    analysis,
   });
 };
 
@@ -37,6 +53,193 @@ export const indexHandler = ({
     const html = nunjucks.render("tokenTest/index.html", {});
     res.status(200).send(html);
   };
+};
+
+interface PayloadComment {
+  type: AnalysisMessageType;
+  message: string;
+}
+
+interface PossibleSSOPayloadStructure {
+  user?: {
+    id?: string;
+    username?: string;
+    email?: string;
+    role?: string;
+  };
+}
+
+const analyseId = (id: string | undefined): PayloadComment[] => {
+  if (!id) {
+    return [
+      {
+        type: AnalysisMessageType.Error,
+        message: "`user.id` is missing. This is required.",
+      },
+    ];
+  }
+
+  const messages: PayloadComment[] = [];
+
+  // see if it looks like a UUID
+  const uuidRegex = new RegExp(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+  );
+  const uuidResult = uuidRegex.test(id);
+  if (uuidResult) {
+    messages.push({
+      type: AnalysisMessageType.Positive,
+      message: "`user.id` appears to be a uuid.",
+    });
+  }
+
+  const hashRegex = new RegExp(/^[0-9a-zA-Z]{16-256}$/);
+  const hashResult = hashRegex.test(id);
+  if (hashResult) {
+    messages.push({
+      type: AnalysisMessageType.Positive,
+      message: "`user.id` appears to be a hash value.",
+    });
+  }
+
+  const integerRegex = new RegExp(/^[0-9]{16-256}$/);
+  const integerResult = integerRegex.test(id);
+  if (integerResult) {
+    messages.push({
+      type: AnalysisMessageType.Positive,
+      message: "`user.id` appears to be an integer value.",
+    });
+  }
+
+  if (!uuidResult && !hashResult && !integerRegex) {
+    messages.push({
+      type: AnalysisMessageType.Warning,
+      message:
+        "Unable to determine if `user.id` is a valid identifier. This could be fine, but we recommend using a unique uuid, hash, or integer value.",
+    });
+  }
+
+  return messages;
+};
+
+const analyseEmail = (email: string | undefined): PayloadComment[] => {
+  if (!email) {
+    return [
+      {
+        type: AnalysisMessageType.Error,
+        message: "`user.email` is missing. This is required.",
+      },
+    ];
+  }
+
+  const messages: PayloadComment[] = [];
+
+  const regex = new RegExp(/^((?!\.)[\w-_.]*[^.])(@\w+)(\.\w+(\.\w+)?[^.\W])$/);
+  const result = regex.test(email);
+  if (result) {
+    messages.push({
+      type: AnalysisMessageType.Positive,
+      message: "`user.email` appears to be valid.",
+    });
+  } else {
+    messages.push({
+      type: AnalysisMessageType.Warning,
+      message: "Unable to determine if `user.email` is a valid email.",
+    });
+  }
+
+  return messages;
+};
+
+const analyseUsername = (username: string | undefined): PayloadComment[] => {
+  if (!username) {
+    return [
+      {
+        type: AnalysisMessageType.Warning,
+        message:
+          "`user.username` is undefined. This is not required, but highly recommended.",
+      },
+    ];
+  }
+
+  return [
+    {
+      type: AnalysisMessageType.Positive,
+      message: "`user.username` appears to be valid.",
+    },
+  ];
+};
+
+const analyseRole = (role: string | undefined): PayloadComment[] => {
+  if (!role) {
+    return [
+      {
+        type: AnalysisMessageType.Warning,
+        message: `\`user.role\` is undefined. It will default to "${GQLUSER_ROLE.COMMENTER}."`,
+      },
+    ];
+  }
+
+  const roleEntries = Object.entries(GQLUSER_ROLE).map(
+    ([label, value]) => label
+  );
+
+  if (roleEntries.includes(role)) {
+    return [
+      {
+        type: AnalysisMessageType.Positive,
+        message: "`user.role` appears to be valid.",
+      },
+    ];
+  } else {
+    return [
+      {
+        type: AnalysisMessageType.Error,
+        message: `\`user.role\` is invalid. Value must be one of ${roleEntries.join(
+          ", "
+        )}`,
+      },
+    ];
+  }
+};
+
+const analyseTokenPayload = (
+  payload: string | jwt.JwtPayload | undefined | null
+): PayloadComment[] => {
+  if (!payload) {
+    return [
+      { type: AnalysisMessageType.Error, message: "Payload is null or empty" },
+    ];
+  }
+
+  const possible = payload as PossibleSSOPayloadStructure;
+  if (!possible) {
+    return [
+      {
+        type: AnalysisMessageType.Error,
+        message:
+          "Payload does not match expect structure of a Coral SSO token.",
+      },
+    ];
+  }
+
+  if (!possible.user) {
+    return [
+      {
+        type: AnalysisMessageType.Error,
+        message: "Payload does not define a `user` object.",
+      },
+    ];
+  }
+
+  const analysis: PayloadComment[] = [];
+
+  analysis.push(...analyseId(possible.user.id));
+  analysis.push(...analyseEmail(possible.user.email));
+  analysis.push(...analyseUsername(possible.user.username));
+  analysis.push(...analyseRole(possible.user.role));
+
+  return analysis;
 };
 
 const submitSchema = Joi.object({
@@ -81,8 +284,15 @@ export const submitHandler = ({
       return;
     }
 
+    const analysis = analyseTokenPayload(decodedToken);
+
     res.send(
-      renderIndex([], cleanToken, JSON.stringify(decodedToken, null, 2).trim())
+      renderIndex(
+        [],
+        cleanToken,
+        JSON.stringify(decodedToken, null, 2).trim(),
+        analysis
+      )
     );
   };
 };

--- a/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
+++ b/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
@@ -1,0 +1,97 @@
+import bodyParser from "body-parser";
+import { Router } from "express";
+import Joi from "joi";
+import jwt from "jsonwebtoken";
+import nunjucks from "nunjucks";
+
+import { AppOptions } from "coral-server/app";
+import { RequestLimiter } from "coral-server/app/request/limiter";
+import {
+  AsyncRequestHandler,
+  TenantCoralRequest,
+} from "coral-server/types/express";
+
+const renderIndex = (messages?: string[], token?: string, payload?: string) => {
+  return nunjucks.render("tokenTest/index.html", {
+    messages,
+    token,
+    payload,
+  });
+};
+
+export const indexHandler = ({
+  redis,
+  config,
+}: AppOptions): AsyncRequestHandler<TenantCoralRequest> => {
+  const ipLimiter = new RequestLimiter({
+    redis,
+    ttl: "1m",
+    max: 100,
+    prefix: "ip",
+    config,
+  });
+
+  return async (req, res, next) => {
+    await ipLimiter.test(req, req.ip);
+
+    const html = nunjucks.render("tokenTest/index.html", {});
+    res.status(200).send(html);
+  };
+};
+
+const submitSchema = Joi.object({
+  token: Joi.string().required(),
+});
+
+interface SubmitBody {
+  token: string;
+}
+
+export const submitHandler = ({
+  redis,
+  config,
+}: AppOptions): AsyncRequestHandler<TenantCoralRequest> => {
+  const ipLimiter = new RequestLimiter({
+    redis,
+    ttl: "1m",
+    max: 100,
+    prefix: "ip",
+    config,
+  });
+
+  return async (req, res, next) => {
+    await ipLimiter.test(req, req.ip);
+
+    const result = submitSchema.validate(req.body);
+    if (result.error) {
+      res.send(renderIndex([result.error.message]));
+      return;
+    }
+
+    const body = result.value as SubmitBody;
+    if (!body) {
+      res.send(renderIndex());
+      return;
+    }
+
+    const cleanToken = body.token.trim();
+    const decodedToken = jwt.decode(cleanToken);
+    if (!decodedToken) {
+      res.send(renderIndex(["Token is invalid."]));
+      return;
+    }
+
+    res.send(
+      renderIndex([], cleanToken, JSON.stringify(decodedToken, null, 2).trim())
+    );
+  };
+};
+
+export const createTokenTestRouter = (options: AppOptions) => {
+  const router = Router();
+
+  router.get("/", indexHandler(options));
+  router.post("/", bodyParser.urlencoded(), submitHandler(options));
+
+  return router;
+};

--- a/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
+++ b/server/src/core/server/app/handlers/api/auth/tokenTest/index.ts
@@ -227,7 +227,7 @@ const analyseTokenPayload = (
       {
         type: AnalysisMessageType.Error,
         message:
-          "Payload does not match expect structure of a Coral SSO token.",
+          "Payload does not match expected structure of a Coral SSO token.",
       },
     ];
   }

--- a/server/src/core/server/app/router/api/index.ts
+++ b/server/src/core/server/app/router/api/index.ts
@@ -8,6 +8,7 @@ import {
   oembedHandler,
   oembedProviderHandler,
 } from "coral-server/app/handlers";
+import { createTokenTestRouter } from "coral-server/app/handlers/api/auth/tokenTest";
 import {
   apolloGraphQLMiddleware,
   authenticate,
@@ -125,6 +126,12 @@ export function createAPIRouter(app: AppOptions, options: RouterOptions) {
     corsWhitelisted(app.mongo),
     authenticate(options.passport),
     createTenorRouter(app)
+  );
+
+  router.use(
+    "/tokenTest",
+    authenticate(options.passport),
+    createTokenTestRouter(app)
   );
 
   // General API error handler.

--- a/server/src/core/server/app/views/tokenTest/index.html
+++ b/server/src/core/server/app/views/tokenTest/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Coral Token Test</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        font-size: 18px;
+
+        display: flex;
+        justify-content: center;
+      }
+
+      .tokenForm {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 8px;
+
+        width: 400px;
+      }
+
+      .wideText {
+        /* text areas append controls and sliders to right */
+        width: calc(100% - 7px);
+        min-height: 175px;
+        max-width: calc(100% - 7px);
+      }
+
+      .submitButton {
+        font-size: 18px;
+        width: 100%;
+        padding: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <form class="tokenForm" action="/api/tokenTest" method="post">
+      <label for="token">Paste token below:</label>
+      <textarea class="wideText" name="token" id="token">{% if token %}{{token}}{% endif %}</textarea>
+      <input class="submitButton" type="submit" value="Validate" />
+      {% if payload %}
+        <label>Payload:</label>
+        <textarea class="wideText" readonly>{{payload}}</textarea>
+      {% endif %}
+      {% if messages %}
+        {% for message in messages %}
+        <div>{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    </form>
+  </body>
+</html>

--- a/server/src/core/server/app/views/tokenTest/index.html
+++ b/server/src/core/server/app/views/tokenTest/index.html
@@ -33,6 +33,14 @@
         width: 100%;
         padding: 4px;
       }
+
+      .analysis {
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-start;
+        align-items: flex-start;
+        gap: 12px;
+      }
     </style>
   </head>
   <body>
@@ -47,6 +55,14 @@
       {% if messages %}
         {% for message in messages %}
         <div>{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+      {% if analysis %}
+        {% for message in analysis %}
+        <div class="analysis">
+          <div>{{message.type}}</div>
+          <div>{{message.message}}</div>
+        </div>
         {% endfor %}
       {% endif %}
     </form>

--- a/server/src/core/server/app/views/tokenTest/index.html
+++ b/server/src/core/server/app/views/tokenTest/index.html
@@ -34,12 +34,17 @@
         padding: 4px;
       }
 
-      .analysis {
-        display: flex;
-        flex-direction: row;
-        justify-content: flex-start;
-        align-items: flex-start;
-        gap: 12px;
+      table, th, td {
+        border: 1px solid rgb(95, 95, 95);
+        border-collapse: collapse;
+      }
+
+      td {
+        padding: 4px;
+      }
+
+      .typeHeader {
+        width: 80px;
       }
     </style>
   </head>
@@ -58,12 +63,19 @@
         {% endfor %}
       {% endif %}
       {% if analysis %}
-        {% for message in analysis %}
-        <div class="analysis">
-          <div>{{message.type}}</div>
-          <div>{{message.message}}</div>
-        </div>
-        {% endfor %}
+        <label>Analysis:</label>
+        <table>
+          <tr>
+            <th class="typeHeader">Type</th>
+            <th>Message</th>
+          </tr>
+          {% for message in analysis %}
+            <tr>
+              <td>{{message.type}}</td>
+              <td>{{message.message}}</td>
+            </tr>
+          {% endfor %}
+        </table>
       {% endif %}
     </form>
   </body>

--- a/server/src/core/server/app/views/tokenTest/index.html
+++ b/server/src/core/server/app/views/tokenTest/index.html
@@ -46,15 +46,35 @@
       .typeHeader {
         width: 80px;
       }
+
+      .Message {
+        color: black;
+        background-color: aliceblue;
+      }
+
+      .Warning {
+        color: black;
+        background-color: rgb(251, 251, 102);
+      }
+
+      .Error {
+        color: white;
+        background-color: rgb(208, 1, 1);
+      }
+
+      .Success {
+        color: black;
+        background-color: rgb(30, 182, 30);
+      }
     </style>
   </head>
   <body>
     <form class="tokenForm" action="/api/tokenTest" method="post">
-      <label for="token">Paste token below:</label>
+      <label for="token">Paste token below</label>
       <textarea class="wideText" name="token" id="token">{% if token %}{{token}}{% endif %}</textarea>
       <input class="submitButton" type="submit" value="Validate" />
       {% if payload %}
-        <label>Payload:</label>
+        <label>Payload</label>
         <textarea class="wideText" readonly>{{payload}}</textarea>
       {% endif %}
       {% if messages %}
@@ -63,7 +83,7 @@
         {% endfor %}
       {% endif %}
       {% if analysis %}
-        <label>Analysis:</label>
+        <label>Payload Analysis</label>
         <table>
           <tr>
             <th class="typeHeader">Type</th>
@@ -71,7 +91,7 @@
           </tr>
           {% for message in analysis %}
             <tr>
-              <td>{{message.type}}</td>
+              <td class="{{message.type}}">{{message.type}}</td>
               <td>{{message.message}}</td>
             </tr>
           {% endfor %}


### PR DESCRIPTION
## What does this PR do?

Adds an SSO token testing endpoint at: `/api/tokenTest`

i.e. http://localhost:3000/api/tokenTest

<img width="416" alt="image" src="https://github.com/user-attachments/assets/bf924900-d97c-4b73-842e-35b7d0cdf0ae" />

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- go to: http://localhost:3000/api/tokenTest
- paste in a jwt
- see the analysis and payload results

You can use https://jwt.io/ to modify and generate new tokens for testing.

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into `develop`
