### PR TITLE
[CORL-3226] update premoderate email aliases description text

### DIFF
--- a/client/src/core/client/admin/routes/Configure/sections/Moderation/PremoderateEmailAddressConfig.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/Moderation/PremoderateEmailAddressConfig.tsx
@@ -70,12 +70,13 @@ const PremoderateEmailAddressConfig: FunctionComponent<Props> = ({
           <Localized id="configure-moderation-premoderateEmailAliases-enabled">
             <Label component="legend">Pre-moderate email aliases</Label>
           </Localized>
-          <Localized id="configure-moderation-premoderateEmailAliases-enabled-description">
+          <Localized id="configure-moderation-premoderateEmailAliases-enabled-description-ifThePreviousAccountWas">
             <HelperText>
               If a user signs up for a new account with an email address that is
               an alias (using a + sign) of an existing account, set their status
-              to pre-moderate comments. Email aliases are commonly used by
-              spammers and trolls to evade bans.
+              to pre-moderate comments. If the previous account was banned, the
+              new account will be banned as well. Email aliases are commonly
+              used by spammers and trolls to evade bans.
             </HelperText>
           </Localized>
         </FormFieldHeader>

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -937,10 +937,12 @@ configure-moderation-premoderateEmailAddress-enabled-description =
 configure-moderation-premoderateEmailAliases-enabled =
   Pre-moderate email aliases
 configure-moderation-premoderateEmailAliases-enabled-description =
+configure-moderation-premoderateEmailAliases-enabled-description-ifThePreviousAccountWas =
   If a user signs up for a new account with an email address that is
   an alias (using a + sign) of an existing account, set their status
-  to pre-moderate comments. Email aliases are commonly used by
-  spammers and trolls to evade bans.
+  to pre-moderate comments. If the previous account was banned, the
+  new account will be banned as well. Email aliases are commonly
+  used by spammers and trolls to evade bans.
 
 #### Banned Words Configuration
 configure-wordList-banned-bannedWordsAndPhrases = Banned words and phrases


### PR DESCRIPTION
## What does this PR do?

- update premoderate email aliases description text
  - accounts for new prior alias banning/pre-mod rules

## These changes will impact:

- [ ] commenters
- [X] moderators
- [X] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- Head to Admin > Config > Moderation > Users
- See the updated description text

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge into `develop`