### PR TITLE
[CORL-3227]: Add domain alias pre-mod filter

### DIFF
--- a/client/src/core/client/admin/routes/Configure/sections/Moderation/PremoderateEmailAddressConfig.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/Moderation/PremoderateEmailAddressConfig.tsx
@@ -24,6 +24,9 @@ graphql`
       emailAliases {
         enabled
       }
+      domainAliases {
+        enabled
+      }
     }
   }
 `;
@@ -62,6 +65,26 @@ const PremoderateEmailAddressConfig: FunctionComponent<Props> = ({
         </FormFieldHeader>
         <OnOffField
           name="premoderateEmailAddress.tooManyPeriods.enabled"
+          disabled={disabled}
+        />
+      </FormField>
+      <FormField container={<FieldSet />}>
+        <FormFieldHeader>
+          <Localized id="configure-moderation-premoderateDomainAlias-enabled">
+            <Label component="legend">Pre-moderate domain alias</Label>
+          </Localized>
+          <Localized id="configure-moderation-premoderateDomainAlias-enabled-description">
+            <HelperText>
+              If a user signs up for a new account with an email address that
+              contains a subdomain (@subdomain.domain.com), set their status to
+              pre-moderate comments. If the domain is already banned, ban the
+              account. Domain aliases are commonly used by spammers to evade
+              bans.
+            </HelperText>
+          </Localized>
+        </FormFieldHeader>
+        <OnOffField
+          name="premoderateEmailAddress.domainAliases.enabled"
           disabled={disabled}
         />
       </FormField>

--- a/client/src/core/client/admin/routes/Configure/sections/Moderation/PremoderateEmailAddressConfig.tsx
+++ b/client/src/core/client/admin/routes/Configure/sections/Moderation/PremoderateEmailAddressConfig.tsx
@@ -77,9 +77,8 @@ const PremoderateEmailAddressConfig: FunctionComponent<Props> = ({
             <HelperText>
               If a user signs up for a new account with an email address that
               contains a subdomain (@subdomain.domain.com), set their status to
-              pre-moderate comments. If the domain is already banned, ban the
-              account. Domain aliases are commonly used by spammers to evade
-              bans.
+              pre-moderate comments. Domain aliases are commonly used by
+              spammers to evade bans.
             </HelperText>
           </Localized>
         </FormFieldHeader>

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -942,6 +942,9 @@ configure-moderation-premoderateEmailAliases-enabled-description =
   to pre-moderate comments. Email aliases are commonly used by
   spammers and trolls to evade bans.
 
+configure-moderation-premoderateDomainAlias-enabled = Pre-moderate domain alias
+configure-moderation-premoderateDomainAlias-enabled-description = If a user signs up for a new account with an email address that contains a subdomain (@subdomain.domain.com), set their status to pre-moderate comments. If the domain is already banned, ban the account. Domain aliases are commonly used by spammers to evade bans.
+
 #### Banned Words Configuration
 configure-wordList-banned-bannedWordsAndPhrases = Banned words and phrases
 configure-wordList-banned-explanation =

--- a/locales/en-US/admin.ftl
+++ b/locales/en-US/admin.ftl
@@ -943,7 +943,7 @@ configure-moderation-premoderateEmailAliases-enabled-description =
   spammers and trolls to evade bans.
 
 configure-moderation-premoderateDomainAlias-enabled = Pre-moderate domain alias
-configure-moderation-premoderateDomainAlias-enabled-description = If a user signs up for a new account with an email address that contains a subdomain (@subdomain.domain.com), set their status to pre-moderate comments. If the domain is already banned, ban the account. Domain aliases are commonly used by spammers to evade bans.
+configure-moderation-premoderateDomainAlias-enabled-description = If a user signs up for a new account with an email address that contains a subdomain (@subdomain.domain.com), set their status to pre-moderate comments. Domain aliases are commonly used by spammers to evade bans.
 
 #### Banned Words Configuration
 configure-wordList-banned-bannedWordsAndPhrases = Banned words and phrases

--- a/server/src/core/server/graph/resolvers/PremoderateEmailAddress.ts
+++ b/server/src/core/server/graph/resolvers/PremoderateEmailAddress.ts
@@ -9,4 +9,8 @@ export const PremoderateEmailAddressConfiguration: GQLPremoderateEmailAddressCon
       config && config.tooManyPeriods
         ? config.tooManyPeriods
         : { enabled: false },
+    domainAliases: (config) =>
+      config && config.domainAliases
+        ? config.domainAliases
+        : { enabled: false },
   };

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -2029,7 +2029,7 @@ type PremoderateEmailAddressConfiguration {
 
   """
   domainAliases is the configuration for premoderating emails
-  that have too many periods.
+  that are domain aliases.
   """
   domainAliases: DomainAliasesConfig
 

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -2006,6 +2006,13 @@ type TooManyPeriodsConfig {
   enabled: Boolean!
 }
 
+type DomainAliasesConfig {
+  """
+  enabled decides whether the domain aliases config is enabled or not.
+  """
+  enabled: Boolean!
+}
+
 type EmailAliasesConfig {
   """
   enabled decides whether the email aliases config is enabled or not.
@@ -2019,6 +2026,12 @@ type PremoderateEmailAddressConfiguration {
   that have too many periods.
   """
   tooManyPeriods: TooManyPeriodsConfig
+
+  """
+  domainAliases is the configuration for premoderating emails
+  that have too many periods.
+  """
+  domainAliases: DomainAliasesConfig
 
   """
   emailAliases is the configuration for premoderating email aliases that
@@ -2047,12 +2060,25 @@ input EmailAliasesConfigInput {
   enabled: Boolean
 }
 
+input DomainAliasesConfigInput {
+  """
+  enabled decides whether the domain aliases config is enabled or not.
+  """
+  enabled: Boolean
+}
+
 input PremoderateEmailAddressConfigurationInput {
   """
   tooManyPeriods is the configuration for premoderating emails
   that have too many periods.
   """
   tooManyPeriods: TooManyPeriodsConfigInput
+
+  """
+  domainAliases is the configuration for premoderating emails
+  that have domain aliases.
+  """
+  domainAliases: DomainAliasesConfigInput
 
   """
   emailAliases is the configuration for premoderating email aliases that

--- a/server/src/core/server/models/settings/settings.ts
+++ b/server/src/core/server/models/settings/settings.ts
@@ -329,6 +329,9 @@ export interface PremoderateEmailAddressConfig {
   emailAliases?: {
     enabled?: boolean;
   };
+  domainAliases?: {
+    enabled?: boolean;
+  };
 }
 
 export type Settings = GlobalModerationSettings &

--- a/server/src/core/server/services/users/emailPremodFilter.ts
+++ b/server/src/core/server/services/users/emailPremodFilter.ts
@@ -104,6 +104,26 @@ const emailIsAnAliasOfExistingUser = async (
   return similarUsers.length > 0;
 };
 
+const emailIsDomainAlias = (email: string | undefined) => {
+  if (!email) {
+    return false;
+  }
+  const emailSplit = email.split("@");
+  if (emailSplit.length < 2) {
+    return false;
+  }
+
+  const domain = emailSplit[1].trim().toLowerCase();
+
+  let periodCount = 0;
+  for (const char of domain) {
+    if (char === ".") {
+      periodCount++;
+    }
+  }
+  return periodCount > 1;
+};
+
 export const shouldPremodDueToLikelySpamEmail = async (
   mongo: MongoContext | undefined = undefined,
   tenant: Readonly<Tenant>,
@@ -141,6 +161,8 @@ export const shouldPremodDueToLikelySpamEmail = async (
     mongo
       ? await emailIsAnAliasOfExistingUser(mongo, tenant, user.email)
       : false,
+    tenant?.premoderateEmailAddress?.domainAliases?.enabled &&
+      emailIsDomainAlias(user.email),
   ];
 
   return results.some((v) => v === true);

--- a/server/src/core/server/services/users/user.emailPremodFilter.spec.ts
+++ b/server/src/core/server/services/users/user.emailPremodFilter.spec.ts
@@ -12,6 +12,9 @@ const tooManyPeriodsEmail = "this.has.too.many.periods@test.com";
 const justEnoughPeriodsEmail = "just.enough.periods@test.com";
 const noPeriodsEmail = "noperiodshere@test.com";
 
+const isSubdomainEmail = "test@thisisa.subdomain.com";
+const isNotSubdomainEmail = "test@regulardomain.com";
+
 it("does not premod filter emails when feature is disabled", () => {
   const tenant = createTenantFixture({
     premoderateEmailAddress: {
@@ -74,6 +77,57 @@ it(`does premod filter emails when feature is enabled and has too many (${EMAIL_
 
   const user = createUserFixture({
     email: tooManyPeriodsEmail,
+  });
+
+  const result = shouldPremodDueToLikelySpamEmail(undefined, tenant, user);
+  expect(result);
+});
+
+it("does not premod filter emails when domain alias feature is disabled", () => {
+  const tenant = createTenantFixture({
+    premoderateEmailAddress: {
+      domainAliases: {
+        enabled: false,
+      },
+    },
+  });
+
+  const user = createUserFixture({
+    email: isSubdomainEmail,
+  });
+
+  const result = shouldPremodDueToLikelySpamEmail(undefined, tenant, user);
+  expect(!result);
+});
+
+it("does premod filter emails when domain alias feature is enabled and email is subdomain", () => {
+  const tenant = createTenantFixture({
+    premoderateEmailAddress: {
+      domainAliases: {
+        enabled: true,
+      },
+    },
+  });
+
+  const user = createUserFixture({
+    email: isSubdomainEmail,
+  });
+
+  const result = shouldPremodDueToLikelySpamEmail(undefined, tenant, user);
+  expect(result);
+});
+
+it("does not premod filter emails when domain alias feature is enabled and email is not subdomain", () => {
+  const tenant = createTenantFixture({
+    premoderateEmailAddress: {
+      domainAliases: {
+        enabled: true,
+      },
+    },
+  });
+
+  const user = createUserFixture({
+    email: isNotSubdomainEmail,
   });
 
   const result = shouldPremodDueToLikelySpamEmail(undefined, tenant, user);


### PR DESCRIPTION
## What does this PR do?

These changes add a domain alias pre-mod filter. If a new user signs up with a domain alias, they will be set to pre-mod when this is enabled.

## These changes will impact:

- [ ] commenters
- [x] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

adds `domainAliases` to the pre-moderate email address config

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

You can test by having the feature disabled (admin --> configure --> users --> email address --> pre-moderate domain alias) and seeing that regular domains and domain aliases can sign up just fine.

Enable the feature and see that users with domain aliases are pre-moderated. Users with regular domains can sign up just fine.

Domain aliases of banned domains should still be banned (no change in functionality from before here).

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
