### PR TITLE
[Hotfix] Add error handling around `tokenTest` endpoint

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "9.9.2",
+  "version": "9.9.3",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "9.9.2",
+  "version": "9.9.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "9.9.2",
+  "version": "9.9.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "9.9.2",
+  "version": "9.9.3",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [


### PR DESCRIPTION
## What does this PR do?

- wraps a `try/catch` + `next(err)` forwarding around the submit handler on `/tokenTest` handler

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- go to the token test endpoint
- analyse an access token from your `localStorage` (or other values, it has validation to check for invalid tokens)
- see that it works and returns token suggestions and details

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `main` (hotfix flow)
- release to clients running 9.9.2
- merge `main` back into `develop`
