### PR TITLE
[CORL-3234] make `siteID` optional on the active stories endpoint

### DIFF
--- a/server/src/core/server/app/handlers/api/story/active.ts
+++ b/server/src/core/server/app/handlers/api/story/active.ts
@@ -13,13 +13,13 @@ export type Options = Pick<AppOptions, "mongo">;
 
 const ActiveStoriesQuerySchema = Joi.object().keys({
   callback: Joi.string().allow("").optional(),
-  siteID: Joi.string().required(),
+  siteID: Joi.string().optional(),
   count: Joi.number().optional().max(999),
 });
 
 interface ActiveStoriesQuery {
   callback: string;
-  siteID: string;
+  siteID?: string | null;
   count: number;
 }
 
@@ -51,10 +51,13 @@ export const activeJSONPHandler =
         req.query
       );
 
-      // Check to see that this site does exist for this Tenant.
-      const site = await retrieveSite(mongo, tenant.id, siteID);
-      if (!site) {
-        throw new Error("site not found");
+      // If there is a siteID provided, check to see that this site
+      // exists for this Tenant.
+      if (siteID) {
+        const site = await retrieveSite(mongo, tenant.id, siteID);
+        if (!site) {
+          throw new Error("site not found");
+        }
       }
 
       // Find top active stories in the last 24 hours.


### PR DESCRIPTION
## What does this PR do?

- make `siteID` optional on the active stories endpoint

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

No

## How do I test this PR?

- make the following request to the server
- `[GET]`: http://localhost:3000/api/story/active.js
- see that it returns stories even though you did not provide a `siteID` in the query params
- try again with `siteID` in body, see that it also works
    - example: `[GET]`: http://localhost:3000/api/story/active.js?siteID=fa46fe34-6f16-49df-8b96-95655cd5c015

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
