### PR TITLE
[CORL-3235] add `commentCounts` field to user queries in GraphQL

### DIFF
--- a/server/src/core/server/graph/resolvers/User.ts
+++ b/server/src/core/server/graph/resolvers/User.ts
@@ -130,4 +130,7 @@ export const User: GQLUserTypeResolver<user.User> = {
 
     return result;
   },
+  commentCounts: ({ commentCounts }) => {
+    return { statuses: commentCounts.status };
+  },
 };

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -3180,6 +3180,13 @@ type UserMembershipScopes {
   siteIDs: [String!]
 }
 
+type UserCommentCounts {
+  """
+  statuses stores the counts of all the statuses against the parent user.
+  """
+  statuses: CommentStatusCounts! @auth(roles: [ADMIN, MODERATOR])
+}
+
 """
 User is someone that leaves Comments, and logs in.
 """
@@ -3520,6 +3527,11 @@ type User {
   newCommenter is whether a user has joined within the last seven days.
   """
   newCommenter: Boolean
+
+  """
+  commentCounts are the tallies for various comment status for this user.
+  """
+  commentCounts: UserCommentCounts
 }
 
 """


### PR DESCRIPTION
## What does this PR do?

- adds `commentCounts` field to user queries in GraphQL

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

- adds `commentCounts` field to `User` type

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- make the following query and see it returns `commentCounts` on the users
    - ensure you are auth'ed in as a user with `ADMIN` or `MODERATOR` permissions

`[POST]`: http://localhost:3000/api/graphql
```
query UserDetailsQuery {
  users {
    edges {
      node {
        id
        email
        commentCounts {
          statuses {
            NONE
            APPROVED
            REJECTED
            PREMOD
            SYSTEM_WITHHELD
          }
        }
      }
    }
  }
}

```

- see that the above query returns similar to:

```
{
  "data": {
    "users": {
      "edges": [
        {
          "node": {
            "id": "a400b261-90bc-4a93-8478-e0ea0700cecf",
            "email": "bad@test.com",
            "commentCounts": {
              "statuses": {
                "NONE": 1,
                "APPROVED": 0,
                "REJECTED": 1,
                "PREMOD": 0,
                "SYSTEM_WITHHELD": 0
              }
            }
          }
        },
        ...
      ]
    }
  }
}
```

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
