### PR TITLE
fix: allow coral to render even if not all custom css loads

### DIFF
--- a/client/src/core/client/stream/stream.tsx
+++ b/client/src/core/client/stream/stream.tsx
@@ -2,6 +2,7 @@ import { EventEmitter2 } from "eventemitter2";
 /* eslint-disable no-restricted-globals */
 import React, {
   FunctionComponent,
+  ReactEventHandler,
   useCallback,
   useMemo,
   useState,
@@ -79,6 +80,13 @@ const hideStyle: React.CSSProperties = {
   border: "0",
 };
 
+interface LoadedCssResult {
+  id: string;
+  url: string;
+  succeed?: boolean;
+  error?: Error | string;
+}
+
 /**
  * Insert link tag is called by css loaders like style-loader or mini-css-extract plugin.
  * See webpack config.
@@ -124,47 +132,69 @@ export async function attach(options: AttachOptions) {
     onAuthError: onContextAuthError,
   });
 
-  // Amount of initial css files to be loaded.
-  let initialCSSFileNumber = options.cssAssets.length;
+  const internalCssUrls = options.cssAssets;
+  const customCssUrls: string[] = [];
 
   if (options.customCSSURL) {
-    initialCSSFileNumber++;
-  }
-  if (options.customFontsCSSURL) {
-    initialCSSFileNumber++;
+    customCssUrls.push(options.customCSSURL);
   }
   if (!options.disableDefaultFonts && options.defaultFontsCSSURL) {
-    initialCSSFileNumber++;
+    customCssUrls.push(options.defaultFontsCSSURL);
+  }
+  if (options.customFontsCSSURL) {
+    customCssUrls.push(options.customFontsCSSURL);
   }
 
-  // Current amount of loaded css files.
-  let cssLoaded = 0;
+  const expectedCssFiles = internalCssUrls.length + customCssUrls.length;
+  const processCssResults: LoadedCssResult[] = [];
 
   const Index: FunctionComponent = () => {
     // Determine whether css has finished loading, before rendering the stream to prevent
     // flash of unstyled content.
     const [isCSSLoaded, setIsCSSLoaded] = useState(false);
-    const [loadError, setLoadError] = useState(false);
+    const [hasCssLoadErrors, setHasCssLoadErrors] = useState(false);
 
     const handleLoadError = useCallback((href: string) => {
+      const message = `Failed to load CSS ${encodeURIComponent(href)}`;
+
       globalErrorReporter.report(
         // encode href, otherwise sentry will not send it.
-        `Failed to load CSS ${encodeURIComponent(href)}`
+        message
       );
-      setLoadError(true);
-      cssLoaded++;
-      // When amount of css loaded equals initial css file number, mark as ready.
-      if (cssLoaded === initialCSSFileNumber) {
+
+      // eslint-disable-next-line no-console
+      console.warn(message);
+
+      processCssResults.push({
+        id: href,
+        url: href,
+        succeed: false,
+        error: message,
+      });
+
+      setHasCssLoadErrors(true);
+
+      if (processCssResults.length >= expectedCssFiles) {
         setIsCSSLoaded(true);
       }
     }, []);
-    const handleCSSLoad = useCallback(() => {
-      cssLoaded++;
-      // When amount of css loaded equals initial css file number, mark as ready.
-      if (cssLoaded === initialCSSFileNumber) {
-        setIsCSSLoaded(true);
-      }
-    }, []);
+
+    const handleCSSLoad: ReactEventHandler<HTMLLinkElement> = useCallback(
+      (event) => {
+        const el = event.target as HTMLLinkElement;
+
+        processCssResults.push({
+          id: el.href,
+          url: el.href,
+          succeed: true,
+        });
+
+        if (processCssResults.length >= expectedCssFiles) {
+          setIsCSSLoaded(true);
+        }
+      },
+      []
+    );
 
     // CSS assets to be loaded inside of the shadow dom.
     const [shadowCSSAssets, setShadowCSSAssets] = useState<CSSAsset[]>(
@@ -222,7 +252,7 @@ export async function attach(options: AttachOptions) {
             if (linkTag.onload) {
               linkTag.onload(event.nativeEvent);
             }
-            handleCSSLoad();
+            handleCSSLoad(event);
           },
           handleLoadError
         ),
@@ -243,7 +273,7 @@ export async function attach(options: AttachOptions) {
       <EncapsulationContext.Provider value={encapsulationContext}>
         <ReactShadowRoot loadFonts>
           <ManagedCoralContextProvider>
-            {loadError && (
+            {hasCssLoadErrors && (
               // TODO: (cvle) localization?
               <CSSLoadError>
                 <div>Apologies, we weren't able to load some styles</div>


### PR DESCRIPTION
## What does this PR do?

- still prevents flashing during loading styles
- will warn of failed css loading as well as post to the `globalErrorReporter`
- if CSS fails, continue loading Coral so the CSS can more easily be debugged
- show appropriate css loading error messages above stream if they happen
  - this was how it was intended to work originally

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

N/A

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- spin up Coral
- create a static page with a coral embed
   - add to the allowed origins in Coral
- specify the custom css in Coral options
   ```
   ...
   Coral.createStreamEmbed({
          id: "coral_thread",
          autoRender: true,
          rootURL: 'http://localhost:3000',
          customCSSURL: "http://localhost:3001/coral.css",
          customFontsCSSURL: "http://localhost:3001/coralFonts.css",
          ...
   ```
- go to the page and make sure it works and loads the custom css

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
