### PR TITLE
add a guard clause to protect against story url redirect attacks

### DIFF
--- a/server/src/core/server/services/stories/index.ts
+++ b/server/src/core/server/services/stories/index.ts
@@ -93,6 +93,8 @@ export async function findOrCreate(
   scraper: ScraperQueue,
   now = new Date()
 ) {
+  let siteID = null;
+
   // validate that the input url's origin matches our allowed
   // origins table
   //
@@ -120,6 +122,8 @@ export async function findOrCreate(
           tenantDomain: tenant.domain,
         });
       }
+
+      siteID = site.id;
     } catch (err) {
       logger.warn(
         { storyID: input.id, storyURL: input.url, err },
@@ -138,25 +142,11 @@ export async function findOrCreate(
     validateStoryMode(tenant, input.mode);
   }
 
-  let siteID = null;
   if (input.id) {
     const story = await findStory(mongo, tenant.id, { id: input.id });
     if (story) {
       siteID = story.siteID;
     }
-  }
-
-  if (input.url && siteID === null) {
-    const site = await findSiteByURL(mongo, tenant.id, input.url);
-    // If the URL is provided, and the url is not associated with a site, then refuse
-    // to create the Asset.
-    if (!site) {
-      throw new StoryURLInvalidError({
-        storyURL: input.url,
-        tenantDomain: tenant.domain,
-      });
-    }
-    siteID = site.id;
   }
 
   const { story, wasUpserted } = await findOrCreateStory(


### PR DESCRIPTION
## What does this PR do?

- add a guard clause to protect against story url redirect attacks
- ensure that the incoming story url upsert is within our allowed origins set, otherwise, throw an error and block the request

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- See if Coral works as expected now that we're more rigid on story `findOrCreate`
    - Test with as many differently shaped allowed origins in your sites config as possible to make sure this won't blow up on SBN, Vox, SaaS clients, etc

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- Merge to `develop`
- Merge to `develop` into `main` (since this is an important fix)
