### PR TITLE
create a new external notifications service

### DIFF
--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -505,6 +505,18 @@ const config = convict({
     default: ms("3000s"),
     env: "NOTIFICATIONS_POLL_RATE",
   },
+  external_notifications_api_url: {
+    doc: "URL to forward notifications information to an external url.",
+    format: "url",
+    default: null,
+    env: "EXTERNAL_NOTIFICATIONS_API_URL",
+  },
+  external_notifications_api_key: {
+    doc: "API key to use when forwarding notifications to an external url",
+    format: String,
+    default: null,
+    env: "EXTERNAL_NOTIFICATIONS_API_KEY",
+  },
 });
 
 export type Config = typeof config;

--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -508,13 +508,13 @@ const config = convict({
   external_notifications_api_url: {
     doc: "URL to forward notifications information to an external url.",
     format: "url",
-    default: null,
+    default: "",
     env: "EXTERNAL_NOTIFICATIONS_API_URL",
   },
   external_notifications_api_key: {
     doc: "API key to use when forwarding notifications to an external url",
     format: String,
-    default: null,
+    default: "",
     env: "EXTERNAL_NOTIFICATIONS_API_KEY",
   },
 });

--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -508,7 +508,7 @@ const config = convict({
   external_notifications_api_url: {
     doc: "URL to forward notifications information to an external url.",
     format: "url",
-    default: "http://localhost:7003",
+    default: "http://localhost:7003/api",
     env: "EXTERNAL_NOTIFICATIONS_API_URL",
   },
   external_notifications_api_key: {

--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -508,7 +508,7 @@ const config = convict({
   external_notifications_api_url: {
     doc: "URL to forward notifications information to an external url.",
     format: "url",
-    default: "",
+    default: "http://localhost:7003",
     env: "EXTERNAL_NOTIFICATIONS_API_URL",
   },
   external_notifications_api_key: {

--- a/server/src/core/server/graph/context.ts
+++ b/server/src/core/server/graph/context.ts
@@ -29,6 +29,7 @@ import { AugmentedRedis } from "coral-server/services/redis";
 import { TenantCache } from "coral-server/services/tenant/cache";
 import { Request } from "coral-server/types/express";
 
+import { ExternalNotificationsService } from "coral-server/services/notifications/externalService";
 import loaders from "./loaders";
 import mutators from "./mutators";
 import SeenCommentsCollection from "./seenCommentsCollection";
@@ -105,6 +106,7 @@ export default class GraphContext {
   public readonly wordList: WordListService;
 
   public readonly notifications: InternalNotificationContext;
+  public readonly externalNotifications: ExternalNotificationsService;
 
   constructor(options: GraphContextOptions) {
     this.id = options.id || uuid();
@@ -160,6 +162,12 @@ export default class GraphContext {
       this.redis,
       this.i18n,
       this.logger
+    );
+
+    this.externalNotifications = new ExternalNotificationsService(
+      this.config,
+      this.logger,
+      this.mongo
     );
   }
 }

--- a/server/src/core/server/graph/context.ts
+++ b/server/src/core/server/graph/context.ts
@@ -157,17 +157,19 @@ export default class GraphContext {
       this.config.get("redis_cache_expiry") / 1000
     );
 
-    this.notifications = new InternalNotificationContext(
-      this.mongo,
-      this.redis,
-      this.i18n,
-      this.logger
-    );
-
     this.externalNotifications = new ExternalNotificationsService(
       this.config,
       this.logger,
       this.mongo
+    );
+
+    this.notifications = new InternalNotificationContext(
+      this.mongo,
+      this.redis,
+      this.logger,
+      // if external notifications are active, we
+      // turn off the internal notifications
+      !this.externalNotifications.active()
     );
   }
 }

--- a/server/src/core/server/graph/mutators/Comments.ts
+++ b/server/src/core/server/graph/mutators/Comments.ts
@@ -64,6 +64,7 @@ export const Comments = (ctx: GraphContext) => ({
         ctx.i18n,
         ctx.broker,
         ctx.notifications,
+        ctx.externalNotifications,
         ctx.tenant,
         ctx.user!,
         {
@@ -130,6 +131,7 @@ export const Comments = (ctx: GraphContext) => ({
         commentID,
         commentRevisionID,
       },
+      ctx.externalNotifications,
       ctx.now
     ),
   removeReaction: ({

--- a/server/src/core/server/queue/index.ts
+++ b/server/src/core/server/queue/index.ts
@@ -16,6 +16,7 @@ import {
 } from "coral-server/services/redis";
 import { TenantCache } from "coral-server/services/tenant/cache";
 
+import { ExternalNotificationsService } from "coral-server/services/notifications/externalService";
 import { ArchiverQueue, createArchiverTask } from "./tasks/archiver";
 import { createMailerTask, MailerQueue } from "./tasks/mailer";
 import { createNotifierTask, NotifierQueue } from "./tasks/notifier";
@@ -60,6 +61,7 @@ export interface QueueOptions {
   signingConfig: JWTSigningConfig;
   redis: AugmentedRedis;
   notifications: InternalNotificationContext;
+  externalNotifications: ExternalNotificationsService;
 }
 
 export interface TaskQueue {

--- a/server/src/core/server/services/comments/actions.ts
+++ b/server/src/core/server/services/comments/actions.ts
@@ -357,14 +357,15 @@ export async function createReaction(
     });
 
     if (externalNotifications.active()) {
-      const parentAuthor = comment.authorID
+      const reccingUser = author;
+      const reccedUser = comment.authorID
         ? await retrieveUser(mongo, comment.tenantID, comment.authorID)
         : null;
 
-      if (parentAuthor) {
+      if (reccedUser) {
         await externalNotifications.createRec({
-          from: author,
-          to: parentAuthor,
+          from: reccingUser,
+          to: reccedUser,
           comment,
         });
       }

--- a/server/src/core/server/services/comments/actions.ts
+++ b/server/src/core/server/services/comments/actions.ts
@@ -25,7 +25,7 @@ import {
 import { getLatestRevision } from "coral-server/models/comment/helpers";
 import { retrieveSite } from "coral-server/models/site";
 import { Tenant } from "coral-server/models/tenant";
-import { User } from "coral-server/models/user";
+import { retrieveUser, User } from "coral-server/models/user";
 import { isSiteBanned } from "coral-server/models/user/helpers";
 import { AugmentedRedis } from "coral-server/services/redis";
 import {
@@ -41,6 +41,7 @@ import {
   publishCommentReactionCreated,
 } from "../events";
 import { I18n } from "../i18n";
+import { ExternalNotificationsService } from "../notifications/externalService";
 import { submitCommentAsSpam } from "../spam";
 
 export type CreateAction = CreateActionInput;
@@ -320,6 +321,7 @@ export async function createReaction(
   tenant: Tenant,
   author: User,
   input: CreateCommentReaction,
+  externalNotifications: ExternalNotificationsService,
   now = new Date()
 ) {
   const { comment, action } = await addCommentAction(
@@ -353,6 +355,20 @@ export async function createReaction(
     ).catch((err) => {
       logger.error({ err }, "could not publish comment flag created");
     });
+
+    if (externalNotifications.active()) {
+      const parentAuthor = comment.authorID
+        ? await retrieveUser(mongo, comment.tenantID, comment.authorID)
+        : null;
+
+      if (parentAuthor) {
+        await externalNotifications.createRec({
+          from: author,
+          to: parentAuthor,
+          comment,
+        });
+      }
+    }
   }
 
   return comment;

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -4,7 +4,7 @@ import { MongoContext } from "coral-server/data/context";
 import { Comment, getLatestRevision } from "coral-server/models/comment";
 import { getURLWithCommentID, retrieveStory } from "coral-server/models/story";
 import { User } from "coral-server/models/user";
-import htmlToText from "html-to-text";
+import { convert } from "html-to-text";
 
 const NotificationSource = "Coral";
 const ProfileType = "Coral";
@@ -90,7 +90,7 @@ export class ExternalNotificationsService {
 
   private computeSnippetFromComment(comment: Comment): string {
     const latestRevision = getLatestRevision(comment);
-    const formatted = htmlToText.convert(latestRevision.body);
+    const formatted = convert(latestRevision.body);
     const split = formatted.split(/(\s+)/);
 
     if (split.length < 50) {

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -5,6 +5,7 @@ import { Comment, getLatestRevision } from "coral-server/models/comment";
 import { getURLWithCommentID, retrieveStory } from "coral-server/models/story";
 import { User } from "coral-server/models/user";
 import { convert } from "html-to-text";
+import fetch from "node-fetch";
 
 const NotificationSource = "Coral";
 const ProfileType = "Coral";

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -1,0 +1,188 @@
+import Logger from "bunyan";
+import { Config } from "coral-server/config";
+import { MongoContext } from "coral-server/data/context";
+import { Comment, getLatestRevision } from "coral-server/models/comment";
+import { getURLWithCommentID, retrieveStory } from "coral-server/models/story";
+import { User } from "coral-server/models/user";
+import htmlToText from "html-to-text";
+
+const NotificationSource = "Coral";
+const ProfileType = "Coral";
+
+// From Coral input types
+
+interface CreateReplyInput {
+  from: User;
+  to: User;
+  parent: Comment;
+  reply: Comment;
+}
+
+interface CreateRecInput {
+  from: User;
+  to: User;
+  comment: Comment;
+}
+
+// To notifications service types
+
+// eslint-disable-next-line no-shadow
+enum NotificationType {
+  CoralRec = "CoralRec",
+  CoralReply = "CoralReply",
+}
+
+interface ExternalUserProfile {
+  id: string;
+  type: string;
+  username?: string;
+  email?: string;
+  profileUrl?: string;
+  avatarUrl?: string;
+  ssoIds?: string[];
+}
+
+interface CommentPayload {
+  id: string;
+  storyId: string;
+  snippet?: string | null;
+  url?: string | null;
+}
+
+const CreateNotificationsMutation = `
+  mutation CreateNotificationsMutation(
+    $input: CreateNotificationsInput!
+  ) {
+    createNotifications(input: $input) {
+      id
+    }
+  }
+`;
+
+export class ExternalNotificationsService {
+  private url?: string | null;
+  private apiKey?: string | null;
+  private logger: Logger;
+  private mongo: MongoContext;
+
+  constructor(config: Config, logger: Logger, mongo: MongoContext) {
+    this.logger = logger;
+    this.mongo = mongo;
+
+    this.url = config.get("external_notifications_api_url");
+    this.apiKey = config.get("external_notifications_api_key");
+  }
+
+  public active(): boolean {
+    return !!(this.url && this.apiKey);
+  }
+
+  private userToExternalProfile(user: User): ExternalUserProfile {
+    return {
+      id: user.id,
+      type: ProfileType,
+      username: user.username,
+      email: user.email,
+      profileUrl: user.ssoURL,
+      avatarUrl: user.avatar,
+    };
+  }
+
+  private computeSnippetFromComment(comment: Comment): string {
+    const latestRevision = getLatestRevision(comment);
+    const formatted = htmlToText.convert(latestRevision.body);
+    const split = formatted.split(/(\s+)/);
+
+    if (split.length < 50) {
+      return split.join(" ");
+    } else {
+      return split.slice(0, 50).join(" ");
+    }
+  }
+
+  private async commentToPayload(comment: Comment): Promise<CommentPayload> {
+    const story = await retrieveStory(
+      this.mongo,
+      comment.tenantID,
+      comment.storyID
+    );
+    const url = story ? getURLWithCommentID(story.url, comment.id) : null;
+
+    return {
+      id: comment.id,
+      storyId: comment.storyID,
+      snippet: this.computeSnippetFromComment(comment),
+      url,
+    };
+  }
+
+  public async createRec(input: CreateRecInput) {
+    if (!this.active()) {
+      return;
+    }
+
+    const data = {
+      source: NotificationSource,
+      type: NotificationType.CoralRec,
+      from: this.userToExternalProfile(input.from),
+      to: this.userToExternalProfile(input.to),
+      storyId: input.comment.storyID,
+      comment: this.commentToPayload(input.comment),
+    };
+
+    return await this.send(data);
+  }
+
+  public async createReply(input: CreateReplyInput) {
+    if (!this.active()) {
+      return;
+    }
+
+    const data = {
+      source: NotificationSource,
+      type: NotificationType.CoralReply,
+      from: this.userToExternalProfile(input.from),
+      to: this.userToExternalProfile(input.to),
+      storyId: input.parent.storyID,
+      comment: await this.commentToPayload(input.parent),
+      reply: await this.commentToPayload(input.reply),
+    };
+
+    return await this.send(data);
+  }
+
+  private async send(notification: any) {
+    if (!this.active()) {
+      return;
+    }
+
+    const data = {
+      query: CreateNotificationsMutation,
+      variables: {
+        input: {
+          items: [notification],
+        },
+      },
+    };
+
+    const response = await fetch(this.url!, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-notifications-api-key": this.apiKey!,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      this.logger.info(
+        { status: response.status, text: await response.text() },
+        "error while sending external notifications info"
+      );
+
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -122,16 +122,25 @@ export class ExternalNotificationsService {
       return;
     }
 
-    const data = {
-      source: NotificationSource,
-      type: NotificationType.CoralRec,
-      from: this.userToExternalProfile(input.from),
-      to: this.userToExternalProfile(input.to),
-      storyId: input.comment.storyID,
-      comment: this.commentToPayload(input.comment),
-    };
+    try {
+      const data = {
+        source: NotificationSource,
+        type: NotificationType.CoralRec,
+        from: this.userToExternalProfile(input.from),
+        to: this.userToExternalProfile(input.to),
+        storyId: input.comment.storyID,
+        comment: this.commentToPayload(input.comment),
+      };
 
-    return await this.send(data);
+      return await this.send(data);
+    } catch (err) {
+      this.logger.warn(
+        { err, input },
+        "an error occurred while sending a rec notification"
+      );
+    }
+
+    return false;
   }
 
   public async createReply(input: CreateReplyInput) {
@@ -139,22 +148,31 @@ export class ExternalNotificationsService {
       return;
     }
 
-    const data = {
-      source: NotificationSource,
-      type: NotificationType.CoralReply,
-      from: this.userToExternalProfile(input.from),
-      to: this.userToExternalProfile(input.to),
-      storyId: input.parent.storyID,
-      comment: await this.commentToPayload(input.parent),
-      reply: await this.commentToPayload(input.reply),
-    };
+    try {
+      const data = {
+        source: NotificationSource,
+        type: NotificationType.CoralReply,
+        from: this.userToExternalProfile(input.from),
+        to: this.userToExternalProfile(input.to),
+        storyId: input.parent.storyID,
+        comment: await this.commentToPayload(input.parent),
+        reply: await this.commentToPayload(input.reply),
+      };
 
-    return await this.send(data);
+      return await this.send(data);
+    } catch (err) {
+      this.logger.warn(
+        { err, input },
+        "an error occurred while sending a reply notification"
+      );
+    }
+
+    return false;
   }
 
   private async send(notification: any) {
     if (!this.active()) {
-      return;
+      return false;
     }
 
     const data = {

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -15,7 +15,6 @@ import {
   User,
 } from "coral-server/models/user";
 import { authorIsIgnored } from "coral-server/models/user/helpers";
-import { I18n } from "coral-server/services/i18n";
 
 import {
   GQLCOMMENT_STATUS,
@@ -77,18 +76,18 @@ export class InternalNotificationContext {
   private mongo: MongoContext;
   private redis: AugmentedRedis;
   private log: Logger;
-  // private i18n: I18n;
+  private active: boolean;
 
   constructor(
     mongo: MongoContext,
     redis: AugmentedRedis,
-    i18n: I18n,
-    log: Logger
+    log: Logger,
+    active = true
   ) {
     this.mongo = mongo;
     this.redis = redis;
-    // this.i18n = i18n;
     this.log = log;
+    this.active = active;
   }
 
   public async create(
@@ -96,6 +95,10 @@ export class InternalNotificationContext {
     lang: LanguageCode,
     input: CreateNotificationInput
   ) {
+    if (!this.active) {
+      return;
+    }
+
     const {
       type,
       targetUserID,

--- a/server/src/core/server/stacks/createComment.ts
+++ b/server/src/core/server/stacks/createComment.ts
@@ -449,14 +449,15 @@ export default async function create(
       // if we have an external notifications service hooked up
       // send the reply notification out to that
       if (externalNotifications.active()) {
-        const parentAuthor = parent.authorID
+        const replyingUser = author;
+        const repliedToUser = parent.authorID
           ? await retrieveUser(mongo, parent.tenantID, parent.authorID)
           : null;
 
-        if (parentAuthor) {
+        if (repliedToUser) {
           await externalNotifications.createReply({
-            from: author,
-            to: parentAuthor,
+            from: replyingUser,
+            to: repliedToUser,
             parent,
             reply: comment,
           });


### PR DESCRIPTION
## What does this PR do?

allows events to be forwarded to an external notifications service for external consumption

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

- `EXTERNAL_NOTIFICATIONS_API_URL`
- `EXTERNAL_NOTIFICATIONS_API_KEY`

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- set the `EXTERNAL_NOTIFICATIONS_API_URL` to the api url you want to forward notifications to
- set the `EXTERNAL_NOTIFICATIONS_API_KEY` to the value of the api key you will use with your external notifications service
- reply and rec content
- see that notifications calls are made to your external service

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
- release with other changes via `develop` into `main`
