### PR TITLE
send the site and story info to external notifications

### DIFF
--- a/server/src/core/server/graph/context.ts
+++ b/server/src/core/server/graph/context.ts
@@ -159,8 +159,7 @@ export default class GraphContext {
 
     this.externalNotifications = new ExternalNotificationsService(
       this.config,
-      this.logger,
-      this.mongo
+      this.logger
     );
 
     this.notifications = new InternalNotificationContext(

--- a/server/src/core/server/graph/mutators/Comments.ts
+++ b/server/src/core/server/graph/mutators/Comments.ts
@@ -119,19 +119,12 @@ export const Comments = (ctx: GraphContext) => ({
     commentRevisionID,
   }: GQLCreateCommentReactionInput) =>
     createReaction(
-      ctx.mongo,
-      ctx.redis,
-      ctx.config,
-      ctx.i18n,
-      ctx.cache,
-      ctx.broker,
-      ctx.tenant,
+      ctx,
       ctx.user!,
       {
         commentID,
         commentRevisionID,
       },
-      ctx.externalNotifications,
       ctx.now
     ),
   removeReaction: ({

--- a/server/src/core/server/index.ts
+++ b/server/src/core/server/index.ts
@@ -262,8 +262,7 @@ class Server {
 
     const externalNotifications = new ExternalNotificationsService(
       this.config,
-      logger,
-      this.mongo
+      logger
     );
 
     // Create the Job Queue.

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -42,6 +42,7 @@ enum NotificationType {
 
 interface StoryInput {
   id: string;
+  title: string;
   url: string;
 }
 
@@ -135,6 +136,7 @@ export class ExternalNotificationsService {
   private storyToInput(story: Story): StoryInput {
     return {
       id: story.id,
+      title: story.metadata?.title ?? "",
       url: story.url,
     };
   }

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -1,6 +1,5 @@
 import Logger from "bunyan";
 import { Config } from "coral-server/config";
-import { MongoContext } from "coral-server/data/context";
 import { Comment, getLatestRevision } from "coral-server/models/comment";
 import { Site } from "coral-server/models/site";
 import { getURLWithCommentID, Story } from "coral-server/models/story";
@@ -82,11 +81,9 @@ export class ExternalNotificationsService {
   private url?: string | null;
   private apiKey?: string | null;
   private logger: Logger;
-  private mongo: MongoContext;
 
-  constructor(config: Config, logger: Logger, mongo: MongoContext) {
+  constructor(config: Config, logger: Logger) {
     this.logger = logger;
-    this.mongo = mongo;
 
     this.url = config.get("external_notifications_api_url");
     this.apiKey = config.get("external_notifications_api_key");

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -119,7 +119,7 @@ export class ExternalNotificationsService {
     }
   }
 
-  private async commentToPayload(
+  private async commentToInput(
     comment: Comment,
     story: Story
   ): Promise<CommentInput> {
@@ -161,7 +161,7 @@ export class ExternalNotificationsService {
         to: this.userToExternalProfile(input.to),
         story: this.storyToInput(input.story),
         site: this.siteToInput(input.site),
-        comment: this.commentToPayload(input.comment, input.story),
+        comment: this.commentToInput(input.comment, input.story),
       };
 
       return await this.send(data);
@@ -188,8 +188,8 @@ export class ExternalNotificationsService {
         to: this.userToExternalProfile(input.to),
         story: this.storyToInput(input.story),
         site: this.siteToInput(input.site),
-        comment: await this.commentToPayload(input.parent, input.story),
-        reply: await this.commentToPayload(input.reply, input.story),
+        comment: await this.commentToInput(input.parent, input.story),
+        reply: await this.commentToInput(input.reply, input.story),
       };
 
       return await this.send(data);

--- a/server/src/core/server/stacks/createComment.ts
+++ b/server/src/core/server/stacks/createComment.ts
@@ -454,12 +454,16 @@ export default async function create(
           ? await retrieveUser(mongo, parent.tenantID, parent.authorID)
           : null;
 
-        if (repliedToUser) {
+        const site = await retrieveSite(mongo, tenant.id, story.siteID!);
+
+        if (repliedToUser && site) {
           await externalNotifications.createReply({
             from: replyingUser,
             to: repliedToUser,
             parent,
             reply: comment,
+            story,
+            site,
           });
         }
       }


### PR DESCRIPTION
## Description

- send the site and story info via the external notifications outlet

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- spin up external notifications service
- config external notifications env vars
- reply and rec things in Coral
- see notifications come through with sites and story details on the notifications

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
