### PR TITLE
add on/off env flags for the two notifications features

### DIFF
--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -499,11 +499,23 @@ const config = convict({
     default: ms("86400s"),
     env: "REDIS_CACHE_EXPIRY",
   },
+  internal_notifications: {
+    doc: "When true, will enable the in-page (internal) notifications systems",
+    format: Boolean,
+    default: false,
+    env: "INTERNAL_NOTIFICATIONS",
+  },
   notifications_poll_rate: {
     doc: "rate at which live notification updates should poll client side.",
     format: "ms",
     default: ms("3000s"),
     env: "NOTIFICATIONS_POLL_RATE",
+  },
+  external_notifications: {
+    doc: "When true, will enable the external, forwarded notifications systems",
+    format: Boolean,
+    default: false,
+    env: "EXTERNAL_NOTIFICATIONS",
   },
   external_notifications_api_url: {
     doc: "URL to forward notifications information to an external url.",

--- a/server/src/core/server/config.ts
+++ b/server/src/core/server/config.ts
@@ -502,7 +502,7 @@ const config = convict({
   internal_notifications: {
     doc: "When true, will enable the in-page (internal) notifications systems",
     format: Boolean,
-    default: false,
+    default: true,
     env: "INTERNAL_NOTIFICATIONS",
   },
   notifications_poll_rate: {

--- a/server/src/core/server/graph/context.ts
+++ b/server/src/core/server/graph/context.ts
@@ -166,9 +166,8 @@ export default class GraphContext {
       this.mongo,
       this.redis,
       this.logger,
-      // if external notifications are active, we
-      // turn off the internal notifications
-      !this.externalNotifications.active()
+      !!this.config.get("internal_notifications") ||
+        !this.externalNotifications.active()
     );
   }
 }

--- a/server/src/core/server/graph/resolvers/Settings.ts
+++ b/server/src/core/server/graph/resolvers/Settings.ts
@@ -97,14 +97,16 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
     args,
     ctx
   ) => {
-    // if external notifications are active, we disable the in-page notifications
-    if (ctx.externalNotifications.active()) {
-      return {
-        ...inPageNotifications,
-        active: false,
-      };
-    }
-    return { ...inPageNotifications, active: true };
+    // if we have the env var set to enable in-page (internal)
+    // notifications, we are active
+    //
+    // otherwise, the default behaviour is to disable in-page
+    // if we have external notifications enabled
+    const active =
+      !!ctx.config.get("internal_notifications") ||
+      !ctx.externalNotifications.active();
+
+    return { ...inPageNotifications, active };
   },
   showUnmoderatedCounts: ({ showUnmoderatedCounts = true }) =>
     showUnmoderatedCounts,

--- a/server/src/core/server/index.ts
+++ b/server/src/core/server/index.ts
@@ -278,7 +278,8 @@ class Server {
         this.mongo,
         this.redis,
         logger,
-        !externalNotifications.active()
+        !!this.config.get("internal_notifications") ||
+          !externalNotifications.active()
       ),
     });
 

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -78,6 +78,7 @@ const CreateNotificationsMutation = `
 `;
 
 export class ExternalNotificationsService {
+  private _active: boolean;
   private url?: string | null;
   private apiKey?: string | null;
   private logger: Logger;
@@ -85,12 +86,13 @@ export class ExternalNotificationsService {
   constructor(config: Config, logger: Logger) {
     this.logger = logger;
 
+    this._active = config.get("external_notifications");
     this.url = config.get("external_notifications_api_url");
     this.apiKey = config.get("external_notifications_api_key");
   }
 
   public active(): boolean {
-    return !!(this.url && this.apiKey);
+    return !!(this._active && this.url && this.apiKey);
   }
 
   private userToExternalProfile(user: User): ExternalUserProfile {


### PR DESCRIPTION
## What does this PR do?

- allows administrators to configure both internal (in page) and external (forwarded) notifications at the same time
- adds two new config options
  - `INTERNAL_NOTIFICATIONS`
      - defaults to `true`
          - this maintains existing functionality for all our tenants
  - `EXTERNAL_NOTIFICATIONS`

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [X] admins
- [X] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

- `INTERNAL_NOTIFICATIONS`
- `EXTERNAL_NOTIFICATIONS`

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- enable external/internal notifications and when they are set, ensure that the features for both are working/hooked up

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
- merge into `main`
  - be sure to set `INTERNAL_NOTIFICATIONS` and `EXTERNAL_NOTIFICATIONS` env vars appropriately for which tenants you want these features turned on for
