### PR TITLE
make external notifications filter by ignored users

### DIFF
--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -7,7 +7,7 @@ import { Config } from "coral-server/config";
 import { Comment, getLatestRevision } from "coral-server/models/comment";
 import { getURLWithCommentID, Story } from "coral-server/models/story";
 import { User } from "coral-server/models/user";
-import { shouldSendReplyNotification } from "./filters";
+import { shouldSendNotification } from "./filters";
 
 const NotificationSource = "Coral";
 const ProfileType = "Coral";
@@ -154,11 +154,8 @@ export class ExternalNotificationsService {
       return;
     }
 
-    const shouldNotifyReply = shouldSendReplyNotification(
-      input.from.id,
-      input.to
-    );
-    if (!shouldNotifyReply) {
+    const shouldSend = shouldSendNotification(input.from.id, input.to);
+    if (!shouldSend) {
       return false;
     }
 
@@ -189,11 +186,8 @@ export class ExternalNotificationsService {
       return false;
     }
 
-    const shouldNotifyReply = shouldSendReplyNotification(
-      input.from.id,
-      input.to
-    );
-    if (!shouldNotifyReply) {
+    const shouldSend = shouldSendNotification(input.from.id, input.to);
+    if (!shouldSend) {
       return false;
     }
 

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -154,6 +154,14 @@ export class ExternalNotificationsService {
       return;
     }
 
+    const shouldNotifyReply = shouldSendReplyNotification(
+      input.from.id,
+      input.to
+    );
+    if (!shouldNotifyReply) {
+      return false;
+    }
+
     try {
       const data = {
         source: NotificationSource,

--- a/server/src/core/server/services/notifications/filters.ts
+++ b/server/src/core/server/services/notifications/filters.ts
@@ -1,0 +1,18 @@
+import { User } from "coral-server/models/user";
+import { authorIsIgnored } from "coral-server/models/user/helpers";
+
+export const shouldSendReplyNotification = (
+  replyAuthorID: string | null,
+  targetUser: Readonly<User>
+) => {
+  if (replyAuthorID) {
+    // don't notify on replies to own comments
+    if (replyAuthorID === targetUser.id) {
+      return false;
+    }
+    // don't notify when ignored users reply
+    return !authorIsIgnored(replyAuthorID, targetUser);
+  }
+
+  return false;
+};

--- a/server/src/core/server/services/notifications/filters.ts
+++ b/server/src/core/server/services/notifications/filters.ts
@@ -1,7 +1,7 @@
 import { User } from "coral-server/models/user";
 import { authorIsIgnored } from "coral-server/models/user/helpers";
 
-export const shouldSendReplyNotification = (
+export const shouldSendNotification = (
   replyAuthorID: string | null,
   targetUser: Readonly<User>
 ) => {

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -22,7 +22,7 @@ import {
   GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 import { AugmentedRedis } from "coral-server/services/redis";
-import { shouldSendReplyNotification } from "../filters";
+import { shouldSendNotification } from "../filters";
 
 export interface DSALegality {
   legality: GQLDSAReportDecisionLegality;
@@ -177,7 +177,7 @@ export class InternalNotificationContext {
       );
       result.attempted = true;
     } else if (type === GQLNOTIFICATION_TYPE.REPLY && comment && reply) {
-      const shouldNotifyReply = shouldSendReplyNotification(
+      const shouldNotifyReply = shouldSendNotification(
         reply.authorID,
         targetUser
       );
@@ -195,7 +195,7 @@ export class InternalNotificationContext {
       );
       result.attempted = true;
     } else if (type === GQLNOTIFICATION_TYPE.REPLY_STAFF && comment && reply) {
-      const shouldNotifyReply = shouldSendReplyNotification(
+      const shouldNotifyReply = shouldSendNotification(
         reply.authorID,
         targetUser
       );

--- a/server/src/core/server/services/notifications/internal/context.ts
+++ b/server/src/core/server/services/notifications/internal/context.ts
@@ -12,9 +12,7 @@ import {
 import {
   defaultInPageNotificationSettings,
   retrieveUser,
-  User,
 } from "coral-server/models/user";
-import { authorIsIgnored } from "coral-server/models/user/helpers";
 
 import {
   GQLCOMMENT_STATUS,
@@ -24,6 +22,7 @@ import {
   GQLREJECTION_REASON_CODE,
 } from "coral-server/graph/schema/__generated__/types";
 import { AugmentedRedis } from "coral-server/services/redis";
+import { shouldSendReplyNotification } from "../filters";
 
 export interface DSALegality {
   legality: GQLDSAReportDecisionLegality;
@@ -55,22 +54,6 @@ interface CreationResult {
   notification: Notification | null;
   attempted: boolean;
 }
-
-const shouldSendReplyNotification = (
-  replyAuthorID: string | null,
-  targetUser: Readonly<User>
-) => {
-  if (replyAuthorID) {
-    // don't notify on replies to own comments
-    if (replyAuthorID === targetUser.id) {
-      return false;
-    }
-    // don't notify when ignored users reply
-    return !authorIsIgnored(replyAuthorID, targetUser);
-  }
-
-  return false;
-};
 
 export class InternalNotificationContext {
   private mongo: MongoContext;


### PR DESCRIPTION
## What does this PR do?

- if a user has ignored another user, they don't receive external notifications from the ignored user
  - includes replies and recs

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- ignore a user
- have that ignored user reply to you or rec your comment
- no notifications should be sent to you from/about that user

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
- merge `develop` into `main`
- cut a release from `main`
