### PR TITLE
make `commentToInput` work in external rec notifications

### DIFF
--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -120,10 +120,7 @@ export class ExternalNotificationsService {
     }
   }
 
-  private async commentToInput(
-    comment: Comment,
-    story: Story
-  ): Promise<CommentInput> {
+  private commentToInput(comment: Comment, story: Story): CommentInput {
     const url = getURLWithCommentID(story.url, comment.id);
 
     return {
@@ -199,8 +196,8 @@ export class ExternalNotificationsService {
         to: this.userToExternalProfile(input.to),
         story: this.storyToInput(input.story),
         site: this.siteToInput(input.site),
-        comment: await this.commentToInput(input.parent, input.story),
-        reply: await this.commentToInput(input.reply, input.story),
+        comment: this.commentToInput(input.parent, input.story),
+        reply: this.commentToInput(input.reply, input.story),
       };
 
       return await this.send(data);


### PR DESCRIPTION
## What does this PR do?

- make `commentToInput` work in external rec notifications
    - was awaiting a promise which is not necessary
    - removed async and updated for all external notifcations

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None

## Does this PR introduce any new environment variables or feature flags?

No

## If any indexes were added, were they added to `INDEXES.md`?

N/A

## How do I test this PR?

- rec stuff
- see that it sends rec notifications with a proper comment object 

## Were any tests migrated to React Testing Library?

No

## How do we deploy this PR?

- merge into `develop`
- release `develop` out to `main`
