### PR TITLE
Hide internal notification preferences when external notifications are enabled

### DIFF
--- a/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
@@ -22,8 +22,7 @@ const PreferencesContainer: FunctionComponent<Props> = (props) => {
   const showInternalNotificationSettings =
     !props.settings.externalNotifications?.active;
   const showInPageNotificationSettings =
-    !!props.settings.inPageNotifications?.enabled &&
-    !!props.settings.inPageNotifications?.active;
+    !!props.settings.inPageNotifications?.enabled;
   return (
     <HorizontalGutter spacing={4}>
       <BioContainer viewer={props.viewer} settings={props.settings} />
@@ -47,7 +46,6 @@ const enhanced = withFragmentContainer<Props>({
     fragment PreferencesContainer_settings on Settings {
       inPageNotifications {
         enabled
-        active
       }
       externalNotifications {
         active

--- a/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
+++ b/client/src/core/client/stream/tabs/Profile/Preferences/PreferencesContainer.tsx
@@ -19,15 +19,22 @@ interface Props {
 }
 
 const PreferencesContainer: FunctionComponent<Props> = (props) => {
+  const showInternalNotificationSettings =
+    !props.settings.externalNotifications?.active;
   const showInPageNotificationSettings =
-    !!props.settings.inPageNotifications?.enabled;
+    !!props.settings.inPageNotifications?.enabled &&
+    !!props.settings.inPageNotifications?.active;
   return (
     <HorizontalGutter spacing={4}>
       <BioContainer viewer={props.viewer} settings={props.settings} />
-      {showInPageNotificationSettings ? (
-        <InPageNotificationSettingsContainer viewer={props.viewer} />
-      ) : (
-        <EmailNotificationSettingsContainer viewer={props.viewer} />
+      {showInternalNotificationSettings && (
+        <>
+          {showInPageNotificationSettings ? (
+            <InPageNotificationSettingsContainer viewer={props.viewer} />
+          ) : (
+            <EmailNotificationSettingsContainer viewer={props.viewer} />
+          )}
+        </>
       )}
       <MediaSettingsContainer viewer={props.viewer} settings={props.settings} />
       <IgnoreUserSettingsContainer viewer={props.viewer} />
@@ -40,6 +47,10 @@ const enhanced = withFragmentContainer<Props>({
     fragment PreferencesContainer_settings on Settings {
       inPageNotifications {
         enabled
+        active
+      }
+      externalNotifications {
+        active
       }
       ...MediaSettingsContainer_settings
       ...BioContainer_settings

--- a/server/src/core/server/graph/resolvers/Settings.ts
+++ b/server/src/core/server/graph/resolvers/Settings.ts
@@ -86,6 +86,13 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
   }) => protectedEmailDomains,
   disposableEmailDomains: ({ disposableEmailDomains = { enabled: false } }) =>
     disposableEmailDomains,
+  externalNotifications: (
+    { externalNotifications = { active: false } },
+    args,
+    ctx
+  ) => {
+    return { active: ctx.externalNotifications.active() };
+  },
   inPageNotifications: (
     {
       inPageNotifications = {

--- a/server/src/core/server/graph/resolvers/Settings.ts
+++ b/server/src/core/server/graph/resolvers/Settings.ts
@@ -86,11 +86,7 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
   }) => protectedEmailDomains,
   disposableEmailDomains: ({ disposableEmailDomains = { enabled: false } }) =>
     disposableEmailDomains,
-  externalNotifications: (
-    { externalNotifications = { active: false } },
-    args,
-    ctx
-  ) => {
+  externalNotifications: (parent, args, ctx) => {
     return { active: ctx.externalNotifications.active() };
   },
   inPageNotifications: (

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -2042,6 +2042,10 @@ type InPageNotificationsConfiguration {
   active: Boolean
 }
 
+type ExternalNotificationsConfiguration {
+  active: Boolean
+}
+
 input TooManyPeriodsConfigInput {
   """
   enabled decides whether the too many periods config is enabled or not.
@@ -2444,6 +2448,12 @@ type Settings @cacheControl(maxAge: 30) {
   whether it's enabled as an option for commenters.
   """
   inPageNotifications: InPageNotificationsConfiguration
+
+  """
+  externalNotifications is the configuration for external notifications, including
+  whether it's enabled as an option for commenters.
+  """
+  externalNotifications: ExternalNotificationsConfiguration
 
   """
   showUnmoderatedCounts is whether to show the unmoderated comment count in the

--- a/server/src/core/server/models/settings/settings.ts
+++ b/server/src/core/server/models/settings/settings.ts
@@ -320,11 +320,6 @@ export interface NewCommenterConfig {
 export interface InPageNotificationsConfig {
   enabled?: boolean;
   floatingBellIndicator?: boolean;
-  active?: boolean;
-}
-
-export interface ExternalNotificationsConfig {
-  active?: boolean;
 }
 
 export interface PremoderateEmailAddressConfig {
@@ -476,12 +471,6 @@ export type Settings = GlobalModerationSettings &
      * as an option for commenters
      */
     inPageNotifications?: InPageNotificationsConfig;
-
-    /**
-     * externalNotifications specifies whether or not external notifications are enabled
-     * as an option for commenters
-     */
-    externalNotifications?: ExternalNotificationsConfig;
 
     /**
      * showUnmoderatedCounts specifies whether or not the unmoderated comment count

--- a/server/src/core/server/models/settings/settings.ts
+++ b/server/src/core/server/models/settings/settings.ts
@@ -320,6 +320,11 @@ export interface NewCommenterConfig {
 export interface InPageNotificationsConfig {
   enabled?: boolean;
   floatingBellIndicator?: boolean;
+  active?: boolean;
+}
+
+export interface ExternalNotificationsConfig {
+  active?: boolean;
 }
 
 export interface PremoderateEmailAddressConfig {
@@ -471,6 +476,12 @@ export type Settings = GlobalModerationSettings &
      * as an option for commenters
      */
     inPageNotifications?: InPageNotificationsConfig;
+
+    /**
+     * externalNotifications specifies whether or not external notifications are enabled
+     * as an option for commenters
+     */
+    externalNotifications?: ExternalNotificationsConfig;
 
     /**
      * showUnmoderatedCounts specifies whether or not the unmoderated comment count


### PR DESCRIPTION
## What does this PR do?

When external notifications are enabled, then the internal notification preferences shown in `My Profile` --> `Preferences` shouldn't be shown because the external notifications are responsible for external notification preferences.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

Added external notifications to settings so we could know whether it's active or not to determine whether to show internal notifications of any sort (in-page or email).

## Does this PR introduce any new environment variables or feature flags?

<!--

In this section, note any new environment variables or feature flags introduced. Ensure you add them to internal documentation when your PR is merged.

-->

## If any indexes were added, were they added to `INDEXES.md`?

<!--

In this section, check the `INDEXES.md` at the root of the repo and make sure you have added and commited any index changes necessary for this PR to be deployed. If you added any entries, indicate `Yes`in this section and list the index entries you added here.

-->

## How do I test this PR?

You can test this by enabling external notifications and seeing that no notification preferences are shown under `My Profile`. 

Disable external notifications and the notification preferences should be shown again. They should correctly show either in-page notifications settings (if enabled) or email notification settings (if in-page are not enabled).

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
