### PR TITLE
feat: send unrec notifications to external notification service on unrec of comment

### DIFF
--- a/server/src/core/server/graph/mutators/Comments.ts
+++ b/server/src/core/server/graph/mutators/Comments.ts
@@ -170,20 +170,10 @@ export const Comments = (ctx: GraphContext) => ({
     commentID,
     commentRevisionID,
   }: GQLRemoveCommentReactionInput) =>
-    removeReaction(
-      ctx.mongo,
-      ctx.redis,
-      ctx.config,
-      ctx.i18n,
-      ctx.cache,
-      ctx.broker,
-      ctx.tenant,
-      ctx.user!,
-      {
-        commentID,
-        commentRevisionID,
-      }
-    ),
+    removeReaction(ctx, ctx.user!, {
+      commentID,
+      commentRevisionID,
+    }),
   createIllegalContent: async ({
     commentID,
     commentRevisionID,

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -33,6 +33,15 @@ interface CreateRecParams {
   comment: Comment;
 }
 
+interface CreateUnrecParams {
+  from: User;
+  to: User;
+
+  story: Readonly<Story>;
+  site: Readonly<Site>;
+  comment: Comment;
+}
+
 interface CreateApproveParams {
   to: User;
 
@@ -200,6 +209,38 @@ export class ExternalNotificationsService {
       this.logger.warn(
         { err, input },
         "an error occurred while sending a rec notification"
+      );
+    }
+
+    return false;
+  }
+
+  public async createUnrec(input: CreateUnrecParams) {
+    if (!this.active()) {
+      return false;
+    }
+
+    const shouldSend = shouldSendNotification(input.from.id, input.to);
+    if (!shouldSend) {
+      return false;
+    }
+
+    try {
+      const data = {
+        source: NotificationSource,
+        type: NotificationType.CoralUnRec,
+        from: this.userToExternalProfile(input.from),
+        to: this.userToExternalProfile(input.to),
+        story: this.storyToInput(input.story),
+        site: this.siteToInput(input.site),
+        comment: this.commentToInput(input.comment, input.story),
+      };
+
+      return await this.send(data);
+    } catch (err) {
+      this.logger.warn(
+        { err, input },
+        "an error occurred while sending an unrec notification"
       );
     }
 


### PR DESCRIPTION
## What does this PR do?

These changes update to send through unrec notifications to an external notifications service, if it's active, when a comment is unrec'd by a user.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
