### PR TITLE
fix: update to send through automatedModerator as "from" for moderation notifications to external notifications

### DIFF
--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -116,6 +116,14 @@ const CreateNotificationsMutation = `
   }
 `;
 
+export const automatedModerator = {
+  id: "00000000-0000-0000-0000-000000000002",
+  email: "automated-moderator",
+  username: "<automated-moderator>",
+  type: ProfileType,
+  createdAt: new Date(),
+};
+
 export class ExternalNotificationsService {
   private _active: boolean;
   private url?: string | null;
@@ -289,6 +297,7 @@ export class ExternalNotificationsService {
       const data = {
         source: NotificationSource,
         type: NotificationType.CoralCommentApproved,
+        from: automatedModerator,
         to: this.userToExternalProfile(input.to),
         story: this.storyToInput(input.story),
         site: this.siteToInput(input.site),
@@ -315,6 +324,7 @@ export class ExternalNotificationsService {
       const data = {
         source: NotificationSource,
         type: NotificationType.CoralCommentRejected,
+        from: automatedModerator,
         to: this.userToExternalProfile(input.to),
         story: this.storyToInput(input.story),
         site: this.siteToInput(input.site),
@@ -341,6 +351,7 @@ export class ExternalNotificationsService {
       const data = {
         source: NotificationSource,
         type: NotificationType.CoralCommentFeatured,
+        from: automatedModerator,
         to: this.userToExternalProfile(input.to),
         story: this.storyToInput(input.story),
         site: this.siteToInput(input.site),


### PR DESCRIPTION
## What does this PR do?

These changes update so that an `automatedModerator` user is sent through for the `from` (required) for moderation notifications that are sent to the external notifications if it's active.

## These changes will impact:

- [x] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

none

## Does this PR introduce any new environment variables or feature flags?

no

## If any indexes were added, were they added to `INDEXES.md`?

n/a

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
