### PR TITLE
fix: remove createdAt from automated mod from user for external notifications service

### DIFF
--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -121,7 +121,6 @@ export const automatedModerator = {
   email: "automated-moderator",
   username: "<automated-moderator>",
   type: ProfileType,
-  createdAt: new Date(),
 };
 
 export class ExternalNotificationsService {

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -213,16 +213,17 @@ const rejectComment = async (
 
   if (
     sendNotification &&
-    !(reason?.code === GQLREJECTION_REASON_CODE.BANNED_WORD) &&
-    tenant.dsa?.enabled
+    !(reason?.code === GQLREJECTION_REASON_CODE.BANNED_WORD)
   ) {
-    await notifications.create(tenant.id, tenant.locale, {
-      targetUserID: result.after.authorID!,
-      comment: result.after,
-      rejectionReason: reason,
-      type: GQLNOTIFICATION_TYPE.COMMENT_REJECTED,
-      previousStatus: result.before.status,
-    });
+    if (tenant.dsa?.enabled) {
+      await notifications.create(tenant.id, tenant.locale, {
+        targetUserID: result.after.authorID!,
+        comment: result.after,
+        rejectionReason: reason,
+        type: GQLNOTIFICATION_TYPE.COMMENT_REJECTED,
+        previousStatus: result.before.status,
+      });
+    }
 
     await sendExternalRejectNotification(
       mongo,


### PR DESCRIPTION
## What does this PR do?

When sending through notifications to external notifications service, if enabled, we don't want to include `createdAt`.

We also want to send rejected notifications to external notifications service even if dsa is not enabled.

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [ ] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

<!--

In this section, you should describe any changes to be made to the GraphQL
schema file (located https://github.com/coralproject/talk/blob/main/server/src/core/server/graph/schema/schema.graphql) or any
database model (located as types in the https://github.com/coralproject/talk/tree/main/server/src/core/server/models directory).

If no changes were added to the GraphQL/Database Schema as a part of this PR,
simply write "None".

-->

## Does this PR introduce any new environment variables or feature flags?

<!--

In this section, note any new environment variables or feature flags introduced. Ensure you add them to internal documentation when your PR is merged.

-->

## If any indexes were added, were they added to `INDEXES.md`?

<!--

In this section, check the `INDEXES.md` at the root of the repo and make sure you have added and commited any index changes necessary for this PR to be deployed. If you added any entries, indicate `Yes`in this section and list the index entries you added here.

-->

## How do I test this PR?

<!--

In this section, you should be describing any manual testing that can be used to
verify features introduced or bugs fixed in this PR.

 -->

## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

<!--

In this section, you should be describing any actions that will need to be taken upon deploy ex. purging caches, setting feature flags

 -->
