### PR TITLE
External notifications - ability to disable per tenant and know which tenant sends through notification

### DIFF
--- a/server/src/core/server/graph/mutators/Comments.ts
+++ b/server/src/core/server/graph/mutators/Comments.ts
@@ -35,6 +35,7 @@ import {
   GQLCreateCommentReplyInput,
   GQLCreateIllegalContentInput,
   GQLEditCommentInput,
+  GQLFEATURE_FLAG,
   GQLFeatureCommentInput,
   GQLMarkCommentsAsSeenInput,
   GQLNOTIFICATION_TYPE,
@@ -48,7 +49,7 @@ import { MongoContext } from "coral-server/data/context";
 import { Comment } from "coral-server/models/comment";
 import { retrieveSite } from "coral-server/models/site";
 import { retrieveStory } from "coral-server/models/story";
-import { Tenant } from "coral-server/models/tenant";
+import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
 import { ExternalNotificationsService } from "coral-server/services/notifications/externalService";
 import { validateUserModerationScopes } from "./helpers";
 import { validateMaximumLength, WithoutMutationID } from "./util";
@@ -59,7 +60,16 @@ const sendExternalFeatureNotification = async (
   tenant: Tenant,
   comment: Comment
 ) => {
-  if (!externalNotifications.active() || !comment.authorID || !comment.siteID) {
+  const externalNotificationsDisabledOnTenant = hasFeatureFlag(
+    tenant,
+    GQLFEATURE_FLAG.DISABLE_EXTERNAL_NOTIFICATIONS
+  );
+  if (
+    !externalNotifications.active() ||
+    externalNotificationsDisabledOnTenant ||
+    !comment.authorID ||
+    !comment.siteID
+  ) {
     return;
   }
 

--- a/server/src/core/server/graph/resolvers/Settings.ts
+++ b/server/src/core/server/graph/resolvers/Settings.ts
@@ -6,6 +6,7 @@ import {
 import validFeatureFlagsFilter from "coral-server/models/settings/validFeatureFlagsFilter";
 import {
   areRepliesFlattened,
+  hasFeatureFlag,
   isAMPEnabled,
   isForReviewQueueEnabled,
   retrieveAnnouncementIfEnabled,
@@ -13,6 +14,7 @@ import {
 } from "coral-server/models/tenant";
 
 import {
+  GQLFEATURE_FLAG,
   GQLSettingsTypeResolver,
   GQLWEBHOOK_EVENT_NAME,
 } from "coral-server/graph/schema/__generated__/types";
@@ -88,7 +90,15 @@ export const Settings: GQLSettingsTypeResolver<Tenant> = {
   disposableEmailDomains: ({ disposableEmailDomains = { enabled: false } }) =>
     disposableEmailDomains,
   externalNotifications: (parent, args, ctx) => {
-    return { active: ctx.externalNotifications.active() };
+    const externalNotificationsDisabledOnTenant = hasFeatureFlag(
+      ctx.tenant,
+      GQLFEATURE_FLAG.DISABLE_EXTERNAL_NOTIFICATIONS
+    );
+    return {
+      active:
+        ctx.externalNotifications.active() &&
+        !externalNotificationsDisabledOnTenant,
+    };
   },
   inPageNotifications: (
     {

--- a/server/src/core/server/graph/schema/schema.graphql
+++ b/server/src/core/server/graph/schema/schema.graphql
@@ -595,6 +595,11 @@ enum FEATURE_FLAG {
   COUNTS_V2 will allow the use of the new /counts/v2 api endpoint to retrieve story comment counts.
   """
   COUNTS_V2
+
+  """
+  DISABLE_EXTERNAL_NOTIFICATIONS will disable the external notifications feature at the tenant level.
+  """
+  DISABLE_EXTERNAL_NOTIFICATIONS
 }
 
 # The moderation mode of the site.

--- a/server/src/core/server/queue/tasks/externalNotifications.ts
+++ b/server/src/core/server/queue/tasks/externalNotifications.ts
@@ -36,7 +36,7 @@ const createJobProcessor =
     log.info("attempting to send notifications for task");
 
     try {
-      await externalNotifications.sendMany(notifications);
+      await externalNotifications.sendMany(notifications, tenantID);
     } catch (err) {
       log.error(
         { taskID, tenantID, notifications },

--- a/server/src/core/server/services/comments/actions.ts
+++ b/server/src/core/server/services/comments/actions.ts
@@ -24,7 +24,7 @@ import {
 } from "coral-server/models/comment";
 import { getLatestRevision } from "coral-server/models/comment/helpers";
 import { retrieveSite } from "coral-server/models/site";
-import { Tenant } from "coral-server/models/tenant";
+import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
 import { isSiteBanned } from "coral-server/models/user/helpers";
 import { AugmentedRedis } from "coral-server/services/redis";
 import {
@@ -33,7 +33,10 @@ import {
 } from "coral-server/stacks/helpers";
 import { Request } from "coral-server/types/express";
 
-import { GQLCOMMENT_FLAG_REPORTED_REASON } from "coral-server/graph/schema/__generated__/types";
+import {
+  GQLCOMMENT_FLAG_REPORTED_REASON,
+  GQLFEATURE_FLAG,
+} from "coral-server/graph/schema/__generated__/types";
 
 import GraphContext from "coral-server/graph/context";
 import { User } from "coral-server/models/user";
@@ -360,7 +363,14 @@ export async function createReaction(
       logger.error({ err }, "could not publish comment flag created");
     });
 
-    if (externalNotifications.active()) {
+    const externalNotificationsDisabledOnTenant = hasFeatureFlag(
+      tenant,
+      GQLFEATURE_FLAG.DISABLE_EXTERNAL_NOTIFICATIONS
+    );
+    if (
+      externalNotifications.active() &&
+      !externalNotificationsDisabledOnTenant
+    ) {
       const reccingUser = author;
       const reccedUser = comment.authorID
         ? await context.loaders.Users.user.load(comment.authorID)
@@ -416,7 +426,14 @@ export async function removeReaction(
     }
   );
 
-  if (ctx.externalNotifications.active()) {
+  const externalNotificationsDisabledOnTenant = hasFeatureFlag(
+    ctx.tenant,
+    GQLFEATURE_FLAG.DISABLE_EXTERNAL_NOTIFICATIONS
+  );
+  if (
+    ctx.externalNotifications.active() &&
+    !externalNotificationsDisabledOnTenant
+  ) {
     const unReccedUser = result.authorID
       ? await ctx.loaders.Users.user.load(result.authorID)
       : null;

--- a/server/src/core/server/services/notifications/externalService.ts
+++ b/server/src/core/server/services/notifications/externalService.ts
@@ -211,7 +211,7 @@ export class ExternalNotificationsService {
         comment: this.commentToInput(input.comment, input.story),
       };
 
-      return await this.send(data);
+      return await this.send(data, input.comment.tenantID);
     } catch (err) {
       this.logger.warn(
         { err, input },
@@ -243,7 +243,7 @@ export class ExternalNotificationsService {
         comment: this.commentToInput(input.comment, input.story),
       };
 
-      return await this.send(data);
+      return await this.send(data, input.comment.tenantID);
     } catch (err) {
       this.logger.warn(
         { err, input },
@@ -287,7 +287,7 @@ export class ExternalNotificationsService {
     try {
       const data = this.buildReply(input);
 
-      return await this.send(data);
+      return await this.send(data, input.reply.tenantID);
     } catch (err) {
       this.logger.warn(
         { err, input },
@@ -320,7 +320,7 @@ export class ExternalNotificationsService {
     try {
       const data = this.buildApprove(input);
 
-      return await this.send(data);
+      return await this.send(data, input.comment.tenantID);
     } catch (err) {
       this.logger.warn(
         { err, input },
@@ -353,7 +353,7 @@ export class ExternalNotificationsService {
     try {
       const data = this.buildReject(input);
 
-      return await this.send(data);
+      return await this.send(data, input.comment.tenantID);
     } catch (err) {
       this.logger.warn(
         { err, input },
@@ -380,7 +380,7 @@ export class ExternalNotificationsService {
         comment: this.commentToInput(input.comment, input.story),
       };
 
-      return await this.send(data);
+      return await this.send(data, input.comment.tenantID);
     } catch (err) {
       this.logger.warn(
         { err, input },
@@ -391,15 +391,15 @@ export class ExternalNotificationsService {
     return false;
   }
 
-  public async send(notification: any) {
+  public async send(notification: any, tenantID: string) {
     if (!notification) {
       return false;
     }
 
-    return this.sendMany([notification]);
+    return this.sendMany([notification], tenantID);
   }
 
-  public async sendMany(notifications: any[]) {
+  public async sendMany(notifications: any[], tenantID: string) {
     if (!this.active()) {
       return false;
     }
@@ -418,6 +418,7 @@ export class ExternalNotificationsService {
       headers: {
         "Content-Type": "application/json",
         "x-notifications-api-key": this.apiKey!,
+        "x-notifications-coral-tenant-id": tenantID,
       },
       body: JSON.stringify(data),
     });

--- a/server/src/core/server/stacks/approveComment.ts
+++ b/server/src/core/server/stacks/approveComment.ts
@@ -5,7 +5,7 @@ import { CoralEventPublisherBroker } from "coral-server/events/publisher";
 import { getLatestRevision } from "coral-server/models/comment";
 import { Comment } from "coral-server/models/comment";
 import { retrieveNotificationByCommentReply } from "coral-server/models/notifications/notification";
-import { Tenant } from "coral-server/models/tenant";
+import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
 import { retrieveUser } from "coral-server/models/user";
 import { retrieveComment } from "coral-server/services/comments";
 import {
@@ -21,6 +21,7 @@ import { v4 as uuid } from "uuid";
 
 import {
   GQLCOMMENT_STATUS,
+  GQLFEATURE_FLAG,
   GQLNOTIFICATION_TYPE,
 } from "coral-server/graph/schema/__generated__/types";
 
@@ -37,7 +38,16 @@ const buildApproveNotification = async (
   tenant: Tenant,
   comment: Comment
 ) => {
-  if (!externalNotifications.active() || !comment.authorID || !comment.siteID) {
+  const externalNotificationsDisabledOnTenant = hasFeatureFlag(
+    tenant,
+    GQLFEATURE_FLAG.DISABLE_EXTERNAL_NOTIFICATIONS
+  );
+  if (
+    !externalNotifications.active() ||
+    externalNotificationsDisabledOnTenant ||
+    !comment.authorID ||
+    !comment.siteID
+  ) {
     return null;
   }
 

--- a/server/src/core/server/stacks/createComment.ts
+++ b/server/src/core/server/stacks/createComment.ts
@@ -186,7 +186,7 @@ export const sendExternalReplyNotification = async (
   );
 
   if (notification) {
-    await externalNotifications.send(notification);
+    await externalNotifications.send(notification, tenant.id);
   }
 };
 

--- a/server/src/core/server/stacks/createComment.ts
+++ b/server/src/core/server/stacks/createComment.ts
@@ -41,7 +41,11 @@ import {
   Story,
   updateStoryLastCommentedAt,
 } from "coral-server/models/story";
-import { ensureFeatureFlag, Tenant } from "coral-server/models/tenant";
+import {
+  ensureFeatureFlag,
+  hasFeatureFlag,
+  Tenant,
+} from "coral-server/models/tenant";
 import { retrieveUser, User } from "coral-server/models/user";
 import { isSiteBanned, roleIsStaff } from "coral-server/models/user/helpers";
 import {
@@ -109,8 +113,13 @@ export const buildExternalReplyNotification = async (
   tenant: Tenant,
   reply: Comment
 ) => {
+  const externalNotificationsDisabledOnTenant = hasFeatureFlag(
+    tenant,
+    GQLFEATURE_FLAG.DISABLE_EXTERNAL_NOTIFICATIONS
+  );
   if (
     !externalNotifications.active() ||
+    externalNotificationsDisabledOnTenant ||
     !reply.authorID ||
     !reply.siteID ||
     !reply.parentID

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -9,7 +9,7 @@ import {
   UpdateCommentStatus,
 } from "coral-server/models/comment";
 import { retrieveNotificationByCommentReply } from "coral-server/models/notifications/notification";
-import { Tenant } from "coral-server/models/tenant";
+import { hasFeatureFlag, Tenant } from "coral-server/models/tenant";
 import { retrieveUser } from "coral-server/models/user";
 import { removeTag } from "coral-server/services/comments";
 import { moderate } from "coral-server/services/comments/moderation";
@@ -22,6 +22,7 @@ import { v4 as uuid } from "uuid";
 
 import {
   GQLCOMMENT_STATUS,
+  GQLFEATURE_FLAG,
   GQLNOTIFICATION_TYPE,
   GQLREJECTION_REASON_CODE,
   GQLTAG,
@@ -85,7 +86,16 @@ export const buildExternalRejectNotification = async (
   tenant: Tenant,
   comment: Comment
 ) => {
-  if (!externalNotifications.active() || !comment.authorID || !comment.siteID) {
+  const externalNotificationsDisabledOnTenant = hasFeatureFlag(
+    tenant,
+    GQLFEATURE_FLAG.DISABLE_EXTERNAL_NOTIFICATIONS
+  );
+  if (
+    !externalNotifications.active() ||
+    externalNotificationsDisabledOnTenant ||
+    !comment.authorID ||
+    !comment.siteID
+  ) {
     return null;
   }
 

--- a/server/src/core/server/stacks/rejectComment.ts
+++ b/server/src/core/server/stacks/rejectComment.ts
@@ -136,7 +136,7 @@ export const sendExternalRejectNotification = async (
   );
 
   if (notification) {
-    await externalNotifications.send(notification);
+    await externalNotifications.send(notification, tenant.id);
   }
 };
 


### PR DESCRIPTION
## What does this PR do?

These changes make it so that:
* configured external notifications can be disabled per tenant if desired
* send through a header with external notifications requests that identifies the tenant

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?


## Does this PR introduce any new environment variables or feature flags?

adds a feature flag for disabling external notifications

## If any indexes were added, were they added to `INDEXES.md`?

<!--

In this section, check the `INDEXES.md` at the root of the repo and make sure you have added and commited any index changes necessary for this PR to be deployed. If you added any entries, indicate `Yes`in this section and list the index entries you added here.

-->

## How do I test this PR?


## Were any tests migrated to React Testing Library?

<!--
In this section, you should list the paths to and test names of any tests that were migrated to RTL.

 -->

## How do we deploy this PR?

disable on any necessary tenants
