### PR TITLE
fix: prevent authenticated GraphQL responses from being cached by CDNs

### DIFF
--- a/server/src/core/server/app/middleware/graphql/apolloServer.ts
+++ b/server/src/core/server/app/middleware/graphql/apolloServer.ts
@@ -6,6 +6,7 @@ import { CLIENT_ID_HEADER } from "coral-common/common/lib/constants";
 import { AppOptions } from "coral-server/app";
 import GraphContext, { GraphContextOptions } from "coral-server/graph/context";
 import {
+  CacheControlApolloServerPlugin,
   CommentSeenServerPlugin,
   ErrorApolloServerPlugin,
   LoggerApolloServerPlugin,
@@ -71,6 +72,7 @@ export const apolloGraphQLMiddleware = ({
   }
 
   const plugins: ApolloServerPlugin[] = [
+    CacheControlApolloServerPlugin,
     ErrorApolloServerPlugin,
     LoggerApolloServerPlugin,
     MetricsApolloServerPlugin(metrics),

--- a/server/src/core/server/graph/plugins/cacheControl.ts
+++ b/server/src/core/server/graph/plugins/cacheControl.ts
@@ -1,0 +1,40 @@
+import { ApolloServerPlugin } from "apollo-server-plugin-base";
+
+import GraphContext from "../context";
+
+/**
+ * CacheControlApolloServerPlugin sets HTTP cache headers on GraphQL responses
+ * to prevent authenticated responses from being shared across users by CDNs or
+ * reverse proxies.
+ *
+ * - All GraphQL responses get `Vary: Authorization` so that caches key
+ *   responses separately for authenticated vs unauthenticated requests.
+ * - Authenticated responses additionally get `Cache-Control: private, no-store`
+ *   so that shared caches (CDNs) never store user-specific data.
+ */
+export const CacheControlApolloServerPlugin: ApolloServerPlugin<GraphContext> =
+  {
+    requestDidStart() {
+      return {
+        willSendResponse({ context }) {
+          const res = context.req?.res;
+          if (!res) {
+            return;
+          }
+
+          // Always vary by Authorization so that caches never serve an
+          // unauthenticated (public) cached response to an authenticated user
+          // or vice versa.
+          res.vary("Authorization");
+
+          // For authenticated requests, mark the response as private so that
+          // shared caches (CDNs, reverse proxies) do not store it at all.
+          if (context.user) {
+            res.set("Cache-Control", "private, no-store");
+          }
+        },
+      };
+    },
+  };
+
+export default CacheControlApolloServerPlugin;

--- a/server/src/core/server/graph/plugins/index.ts
+++ b/server/src/core/server/graph/plugins/index.ts
@@ -1,3 +1,4 @@
+export * from "./cacheControl";
 export * from "./error";
 export * from "./logger";
 export * from "./metrics";


### PR DESCRIPTION
## What does this PR do?

Fixes #4856

When Coral is deployed behind a CDN or reverse proxy with shared caching enabled,
authenticated GraphQL responses may be served across users (e.g. `viewerReactionPresence`
from one user served to another).

This PR adds a new Apollo Server plugin (`CacheControlApolloServerPlugin`) that:
- Sets `Vary: Authorization` on all GraphQL responses so caches key responses
  separately for authenticated vs unauthenticated requests
- Sets `Cache-Control: private, no-store` on authenticated responses so shared
  caches never store user-specific data

## These changes will impact:

- [ ] commenters
- [ ] moderators
- [ ] admins
- [x] developers

## What changes to the GraphQL/Database Schema does this PR introduce?

None.

## Does this PR introduce any new environment variables or feature flags?

No.

## If any indexes were added, were they added to `INDEXES.md`?

No indexes were added.

## How do I test this PR?

1. Run Coral locally and sign in as a user
2. Open DevTools → Network → filter `graphql`
3. Click any GraphQL request → Response Headers
4. Verify `Cache-Control: private, no-store` and `Vary: Authorization` are present
5. Sign out and repeat — unauthenticated responses should only have `Vary: Authorization`

## Were any tests migrated to React Testing Library?

No.

## How do we deploy this PR?

No special deployment steps required.