### PR TITLE
replace twitter.com with x.com embeds

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "9.11.4",
+  "version": "9.11.5",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/common/package.json
+++ b/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "9.11.4",
+  "version": "9.11.5",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common",
-  "version": "9.11.4",
+  "version": "9.11.5",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/talk",
-  "version": "9.11.4",
+  "version": "9.11.5",
   "author": "The Coral Project",
   "homepage": "https://coralproject.net/",
   "sideEffects": [

--- a/server/src/core/server/services/oembed/oembed.ts
+++ b/server/src/core/server/services/oembed/oembed.ts
@@ -44,7 +44,7 @@ export async function fetchOEmbedResponse(
       break;
     }
     case "twitter": {
-      uri = `https://publish.twitter.com/oembed?url=${encodeURIComponent(url)}`;
+      uri = `https://publish.x.com/oembed?url=${encodeURIComponent(url)}`;
       break;
     }
     case "bluesky": {


### PR DESCRIPTION
twitter has moved it's oembed api from twitter.com to x.com, breaking our oembed usage. 